### PR TITLE
WIP: use c++17 std::filesystem instead of ghc

### DIFF
--- a/expression-test/filesystem.hpp
+++ b/expression-test/filesystem.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <ghc/filesystem.hpp>
+#include <filesystem>
 
 namespace mbgl {
 
-namespace filesystem = ghc::filesystem;
+namespace filesystem = std::filesystem;
 
 } // namespace mbgl

--- a/platform/glfw/test_writer.cpp
+++ b/platform/glfw/test_writer.cpp
@@ -3,7 +3,7 @@
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
-#include <ghc/filesystem.hpp>
+#include <filesystem>
 
 #include <cmath>
 #include <fstream>
@@ -113,7 +113,7 @@ TestWriter& TestWriter::withInitialSize(const mbgl::Size& size) {
 }
 
 bool TestWriter::write(const std::string& dir) const {
-    namespace fs = ghc::filesystem;
+    namespace fs = std::filesystem;
 
     fs::path rootDir(dir);
     if (!fs::exists(rootDir)) {

--- a/render-test/filesystem.hpp
+++ b/render-test/filesystem.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <ghc/filesystem.hpp>
+#include <filesystem>
 
 namespace mbgl {
 
-namespace filesystem = ghc::filesystem;
+namespace filesystem = std::filesystem;
 
 } // namespace mbgl


### PR DESCRIPTION
We currently use ghc::filesystem, which is a polyfill to make something like std::filesytem from c++ work in c++ 11 and c++ 14. By doubling down on c++17 we don't need it anymore.