### PR TITLE
Add Windows support to MBTiles file source

### DIFF
--- a/platform/android/android.cmake
+++ b/platform/android/android.cmake
@@ -66,6 +66,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/sqlite3.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/text/bidi.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/compression.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/filesystem.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/monotonic_timer.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/png_writer.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/thread_local.cpp

--- a/platform/default/BUILD.bazel
+++ b/platform/default/BUILD.bazel
@@ -50,6 +50,7 @@ cc_library(
         "src/mbgl/storage/sqlite3.cpp",
         "src/mbgl/text/bidi.cpp",
         "src/mbgl/util/compression.cpp",
+        "src/mbgl/util/filesystem.cpp",
         "src/mbgl/util/monotonic_timer.cpp",
         "src/mbgl/util/png_writer.cpp",
         "src/mbgl/util/thread_local.cpp",

--- a/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
@@ -14,6 +14,7 @@
 #include <mbgl/util/url.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/compression.hpp>
+#include <mbgl/util/filesystem.hpp>
 
 #include <mbgl/storage/sqlite3.hpp>
 
@@ -283,7 +284,8 @@ std::unique_ptr<AsyncRequest> MBTilesFileSource::request(const Resource &resourc
         return req;
     }
 
-    if (resource.url.find(":///") == std::string::npos) {
+    if (resource.url.find("://") == std::string::npos ||
+        !util::is_absolute_path(resource.url.substr(resource.url.find("://") + 3))) {
         Response response;
         response.noContent = true;
         response.error = std::make_unique<Response::Error>(Response::Error::Reason::Other,

--- a/platform/default/src/mbgl/util/filesystem.cpp
+++ b/platform/default/src/mbgl/util/filesystem.cpp
@@ -1,0 +1,13 @@
+#include <mbgl/util/filesystem.hpp>
+
+#if defined(USE_STD_FILESYSTEM)
+#include <filesystem>
+
+bool mbgl::util::is_absolute_path(std::string path) {
+    return std::filesystem::path(path).is_absolute();
+}
+#else
+bool mbgl::util::is_absolute_path(std::string path) {
+    return path.at(0) == '/';
+}
+#endif

--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -73,6 +73,7 @@ list(APPEND
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/sqlite3.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/text/bidi.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/compression.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/filesystem.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/monotonic_timer.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/png_writer.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/thread_local.cpp

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -42,6 +42,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/text/local_glyph_rasterizer.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/async_task.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/compression.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/filesystem.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/image.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/jpeg_reader.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/logging_stderr.cpp

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -65,6 +65,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/sqlite3.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/text/bidi.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/compression.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/filesystem.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/monotonic_timer.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/png_writer.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/thread_local.cpp

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -91,6 +91,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/online_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/$<IF:$<BOOL:${MLN_QT_WITH_INTERNAL_SQLITE}>,default/src/mbgl/storage/sqlite3.cpp,qt/src/mbgl/sqlite3.cpp>
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/compression.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/filesystem.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/monotonic_timer.cpp
         $<$<BOOL:${MLN_QT_WITH_HEADLESS}>:${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/headless_backend_qt.cpp>
         ${PROJECT_SOURCE_DIR}/platform/qt/src/mbgl/async_task.cpp

--- a/platform/windows/windows.cmake
+++ b/platform/windows/windows.cmake
@@ -54,6 +54,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/text/local_glyph_rasterizer.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/async_task.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/compression.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/filesystem.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/image.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/jpeg_reader.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/logging_stderr.cpp
@@ -72,6 +73,7 @@ target_compile_definitions(
     mbgl-core
     PRIVATE
         CURL_STATICLIB
+        USE_STD_FILESYSTEM
 )
 
 if(MLN_WITH_EGL)

--- a/src/mbgl/util/filesystem.hpp
+++ b/src/mbgl/util/filesystem.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+namespace mbgl {
+namespace util {
+bool is_absolute_path(std::string path);
+}
+} // namespace mbgl


### PR DESCRIPTION
MBTiles file source requires absolute URIs using the scheme `mbtiles://`. In Linux it works with something like `mbtiles:///home/user/map/tiles.mbtiles`, but in Windows it would be something like `mbtiles:///C:/Users/user/map/tiles.mbtiles` (local files) or `mbtiles:////computer/share/map/tiles.mbtiles` (UNC paths), but it does not work, because the path does not start with a slash. This PR aims to correct this situation allowing validation of Windows absolute paths.