### PR TITLE
[WIP] replace mbgl::variant with std::variant

### DIFF
--- a/include/mbgl/style/sources/raster_dem_source.hpp
+++ b/include/mbgl/style/sources/raster_dem_source.hpp
@@ -2,7 +2,8 @@
 
 #include <mbgl/style/sources/raster_source.hpp>
 #include <mbgl/util/tileset.hpp>
-#include <mbgl/util/variant.hpp>
+
+#include <variant>
 
 namespace mbgl {
 
@@ -12,7 +13,7 @@ namespace style {
 
 class RasterDEMSource : public RasterSource {
 public:
-    RasterDEMSource(std::string id, variant<std::string, Tileset> urlOrTileset, uint16_t tileSize);
+    RasterDEMSource(std::string id, std::variant<std::string, Tileset> urlOrTileset, uint16_t tileSize);
     bool supportsLayerType(const mbgl::style::LayerTypeInfo*) const override;
 };
 

--- a/include/mbgl/style/sources/raster_source.hpp
+++ b/include/mbgl/style/sources/raster_source.hpp
@@ -2,7 +2,8 @@
 
 #include <mbgl/style/source.hpp>
 #include <mbgl/util/tileset.hpp>
-#include <mbgl/util/variant.hpp>
+
+#include <variant>
 
 namespace mbgl {
 
@@ -13,12 +14,12 @@ namespace style {
 class RasterSource : public Source {
 public:
     RasterSource(std::string id,
-                 variant<std::string, Tileset> urlOrTileset,
+                 std::variant<std::string, Tileset> urlOrTileset,
                  uint16_t tileSize,
                  SourceType sourceType = SourceType::Raster);
     ~RasterSource() override;
 
-    const variant<std::string, Tileset>& getURLOrTileset() const;
+    const std::variant<std::string, Tileset>& getURLOrTileset() const;
     std::optional<std::string> getURL() const;
 
     uint16_t getTileSize() const;
@@ -36,7 +37,7 @@ protected:
     Mutable<Source::Impl> createMutable() const noexcept final;
 
 private:
-    const variant<std::string, Tileset> urlOrTileset;
+    const std::variant<std::string, Tileset> urlOrTileset;
     std::unique_ptr<AsyncRequest> req;
     mapbox::base::WeakPtrFactory<Source> weakFactory{this};
 };

--- a/include/mbgl/style/sources/vector_source.hpp
+++ b/include/mbgl/style/sources/vector_source.hpp
@@ -2,7 +2,8 @@
 
 #include <mbgl/style/source.hpp>
 #include <mbgl/util/tileset.hpp>
-#include <mbgl/util/variant.hpp>
+
+#include <variant>
 
 namespace mbgl {
 
@@ -13,12 +14,12 @@ namespace style {
 class VectorSource final : public Source {
 public:
     VectorSource(std::string id,
-                 variant<std::string, Tileset> urlOrTileset,
+                 std::variant<std::string, Tileset> urlOrTileset,
                  std::optional<float> maxZoom = std::nullopt,
                  std::optional<float> minZoom = std::nullopt);
     ~VectorSource() final;
 
-    const variant<std::string, Tileset>& getURLOrTileset() const;
+    const std::variant<std::string, Tileset>& getURLOrTileset() const;
     std::optional<std::string> getURL() const;
 
     class Impl;
@@ -34,7 +35,7 @@ protected:
     Mutable<Source::Impl> createMutable() const noexcept final;
 
 private:
-    const variant<std::string, Tileset> urlOrTileset;
+    const std::variant<std::string, Tileset> urlOrTileset;
     std::unique_ptr<AsyncRequest> req;
     mapbox::base::WeakPtrFactory<Source> weakFactory{this};
     std::optional<float> maxZoom;

--- a/include/mbgl/util/overloaded.hpp
+++ b/include/mbgl/util/overloaded.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace mbgl
+{
+namespace util
+{
+    
+template <typename... Ts>
+struct Overload : Ts... {
+    using Ts::operator()...;
+};
+
+template <class... Ts>
+Overload(Ts...) -> Overload<Ts...>;
+
+} // namespace util
+} // namespace mbgl

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/style/sources/raster_dem_source.cpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/style/sources/raster_dem_source.cpp
@@ -5,8 +5,6 @@
 #include "../conversion/url_or_tileset.hpp"
 #include "source.hpp"
 
-#include <mbgl/util/variant.hpp>
-
 #include <string>
 
 namespace mbgl {

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/style/sources/raster_source.cpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/style/sources/raster_source.cpp
@@ -4,8 +4,6 @@
 #include "../value.hpp"
 #include "../conversion/url_or_tileset.hpp"
 
-#include <mbgl/util/variant.hpp>
-
 #include <string>
 
 namespace mbgl {

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/style/sources/vector_source.cpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/style/sources/vector_source.cpp
@@ -12,8 +12,6 @@
 #include "../../geojson/feature.hpp"
 #include "../conversion/url_or_tileset.hpp"
 
-#include <mbgl/util/variant.hpp>
-
 #include <string>
 #include <vector>
 

--- a/platform/default/src/mbgl/storage/offline_download.cpp
+++ b/platform/default/src/mbgl/storage/offline_download.cpp
@@ -150,14 +150,14 @@ OfflineRegionStatus OfflineDownload::getStatus() const {
     for (const auto& source : parser.sources) {
         SourceType type = source->getType();
 
-        auto handleTiledSource = [&](const variant<std::string, Tileset>& urlOrTileset, const uint16_t tileSize) {
-            if (urlOrTileset.is<Tileset>()) {
-                uint64_t tileSourceCount = tileCount(definition, type, tileSize, urlOrTileset.get<Tileset>().zoomRange);
+        auto handleTiledSource = [&](const std::variant<std::string, Tileset>& urlOrTileset, const uint16_t tileSize) {
+            if (std::holds_alternative<Tileset>(urlOrTileset)) {
+                uint64_t tileSourceCount = tileCount(definition, type, tileSize, std::get<Tileset>(urlOrTileset).zoomRange);
                 result->requiredTileCount += tileSourceCount;
                 result->requiredResourceCount += tileSourceCount;
             } else {
                 result->requiredResourceCount += 1;
-                const auto& url = urlOrTileset.get<std::string>();
+                const auto& url = std::get<std::string>(urlOrTileset);
                 std::optional<Response> sourceResponse = offlineDatabase.get(Resource::source(url));
                 if (sourceResponse) {
                     style::conversion::Error error;
@@ -252,11 +252,11 @@ void OfflineDownload::activateDownload() {
         for (const auto& source : parser.sources) {
             SourceType type = source->getType();
 
-            auto handleTiledSource = [&](const variant<std::string, Tileset>& urlOrTileset, const uint16_t tileSize) {
-                if (urlOrTileset.is<Tileset>()) {
-                    queueTiles(type, tileSize, urlOrTileset.get<Tileset>());
+            auto handleTiledSource = [&](const std::variant<std::string, Tileset>& urlOrTileset, const uint16_t tileSize) {
+                if (std::holds_alternative<Tileset>(urlOrTileset)) {
+                    queueTiles(type, tileSize, std::get<Tileset>(urlOrTileset));
                 } else {
-                    const auto& rawUrl = urlOrTileset.get<std::string>();
+                    const auto& rawUrl = std::get<std::string>(urlOrTileset);
                     const auto& url = util::mapbox::canonicalizeSourceURL(tileServerOptions, rawUrl);
 
                     status.requiredResourceCountIsPrecise = false;

--- a/platform/ios/platform/darwin/src/MLNRasterDEMSource.mm
+++ b/platform/ios/platform/darwin/src/MLNRasterDEMSource.mm
@@ -7,7 +7,7 @@
 
 @implementation MLNRasterDEMSource
 
-- (std::unique_ptr<mbgl::style::RasterSource>)pendingSourceWithIdentifier:(NSString *)identifier urlOrTileset:(mbgl::variant<std::string, mbgl::Tileset>)urlOrTileset tileSize:(uint16_t)tileSize {
+- (std::unique_ptr<mbgl::style::RasterSource>)pendingSourceWithIdentifier:(NSString *)identifier urlOrTileset:(std::variant<std::string, mbgl::Tileset>)urlOrTileset tileSize:(uint16_t)tileSize {
     auto source = std::make_unique<mbgl::style::RasterDEMSource>(identifier.UTF8String,
                                                                  urlOrTileset,
                                                                  tileSize);

--- a/render-test/manifest_parser.cpp
+++ b/render-test/manifest_parser.cpp
@@ -59,10 +59,10 @@ std::vector<std::pair<std::string, std::string>> parseIgnores(const std::vector<
     std::vector<std::pair<std::string, std::string>> ignores;
     for (const auto& path : ignoresPaths) {
         auto maybeIgnores = readJson(path);
-        if (!maybeIgnores.is<mbgl::JSDocument>()) {
+        if (!std::holds_alternative<mbgl::JSDocument>(maybeIgnores)) {
             continue;
         }
-        for (const auto& property : maybeIgnores.get<mbgl::JSDocument>().GetObject()) {
+        for (const auto& property : std::get<mbgl::JSDocument>(maybeIgnores).GetObject()) {
             const std::string ignore = {property.name.GetString(), property.name.GetStringLength()};
             const std::string reason = {property.value.GetString(), property.value.GetStringLength()};
             ignores.emplace_back(std::make_pair(ignore, reason));
@@ -106,13 +106,13 @@ std::optional<Manifest> ManifestParser::parseManifest(const std::string& manifes
     manifest.manifestPath = manifestPath.substr(0, manifestPath.find(filePath.filename()));
 
     auto contents = readJson(filePath);
-    if (!contents.is<mbgl::JSDocument>()) {
+    if (!std::holds_alternative<mbgl::JSDocument>(contents)) {
         mbgl::Log::Error(mbgl::Event::General,
                          "Provided manifest file: " + std::string(filePath) + " is not a valid json");
         return std::nullopt;
     }
 
-    auto document = std::move(contents.get<mbgl::JSDocument>());
+    auto document = std::move(std::get<mbgl::JSDocument>(contents));
     if (document.HasMember("result_path")) {
         const auto& resultPathValue = document["result_path"];
         if (!resultPathValue.IsString()) {

--- a/render-test/parser.cpp
+++ b/render-test/parser.cpp
@@ -328,11 +328,11 @@ TestMetrics readExpectedMetrics(const mbgl::filesystem::path& path) {
     TestMetrics result;
 
     auto maybeJson = readJson(path.string());
-    if (!maybeJson.is<mbgl::JSDocument>()) { // NOLINT
+    if (!std::holds_alternative<mbgl::JSDocument>(maybeJson)) { // NOLINT
         return result;
     }
 
-    const auto& document = maybeJson.get<mbgl::JSDocument>();
+    const auto& document = std::get<mbgl::JSDocument>(maybeJson);
 
     if (document.HasMember("file-size")) {
         const mbgl::JSValue& fileSizeValue = document["file-size"];
@@ -452,12 +452,12 @@ TestMetadata parseTestMetadata(const TestPaths& paths) {
     metadata.paths = paths;
 
     auto maybeJson = readJson(paths.stylePath.string());
-    if (!maybeJson.is<mbgl::JSDocument>()) { // NOLINT
+    if (!std::holds_alternative<mbgl::JSDocument>(maybeJson)) { // NOLINT
         metadata.errorMessage = std::string("Unable to parse: ") + metadata.paths.stylePath.string();
         return metadata;
     }
 
-    metadata.document = std::move(maybeJson.get<mbgl::JSDocument>());
+    metadata.document = std::move(std::get<mbgl::JSDocument>(maybeJson));
     if (!metadata.document.HasMember("metadata")) {
         mbgl::Log::Warning(mbgl::Event::ParseStyle, "Style has no 'metadata': " + paths.stylePath.string());
         return metadata;

--- a/render-test/parser.hpp
+++ b/render-test/parser.hpp
@@ -3,16 +3,16 @@
 #include "metadata.hpp"
 
 #include <mbgl/util/rapidjson.hpp>
-#include <mbgl/util/variant.hpp>
 
 #include <string>
 #include <tuple>
 #include <vector>
+#include <variant>
 
 class Manifest;
 
 using ErrorMessage = std::string;
-using JSONReply = mbgl::variant<mbgl::JSDocument, ErrorMessage>;
+using JSONReply = std::variant<mbgl::JSDocument, ErrorMessage>;
 
 JSONReply readJson(const mbgl::filesystem::path&);
 std::string serializeJsonValue(const mbgl::JSValue&);

--- a/render-test/runner.cpp
+++ b/render-test/runner.cpp
@@ -173,8 +173,8 @@ void TestRunner::checkQueryTestResults(mbgl::PremultipliedImage&& actualImage,
 
     for (const auto& entry : expectedJsonPaths) {
         auto maybeExpectedJson = readJson(entry);
-        if (maybeExpectedJson.is<mbgl::JSDocument>()) {
-            auto& expected = maybeExpectedJson.get<mbgl::JSDocument>();
+        if (std::holds_alternative<mbgl::JSDocument>(maybeExpectedJson)) {
+            auto& expected = std::get<mbgl::JSDocument>(maybeExpectedJson);
 
             mbgl::JSDocument actual;
             actual.Parse<0>(metadata.actualJson);

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/math/minmax.hpp>
 #include <mbgl/util/hash.hpp>
 #include <mbgl/util/logging.hpp>
+#include <mbgl/util/overloaded.hpp>
 #include <mbgl/util/platform.hpp>
 
 namespace mbgl {
@@ -206,15 +207,15 @@ DashPatternTexture::DashPatternTexture(const std::vector<float>& from_,
 }
 
 void DashPatternTexture::upload(gfx::UploadPass& uploadPass) {
-    if (texture.is<AlphaImage>()) {
-        texture = uploadPass.createTexture(texture.get<AlphaImage>());
+    if (std::holds_alternative<AlphaImage>(texture)) {
+        texture = uploadPass.createTexture(std::get<AlphaImage>(texture));
     }
 }
 
 gfx::TextureBinding DashPatternTexture::textureBinding() const {
     // The texture needs to have been uploaded already.
-    assert(texture.is<gfx::Texture>());
-    return {texture.get<gfx::Texture>().getResource(),
+    assert(std::holds_alternative<gfx::Texture>(texture));
+    return {std::get<gfx::Texture>(texture).getResource(),
             gfx::TextureFilterType::Linear,
             gfx::TextureMipMapType::No,
             gfx::TextureWrapType::Repeat,
@@ -222,7 +223,7 @@ gfx::TextureBinding DashPatternTexture::textureBinding() const {
 }
 
 Size DashPatternTexture::getSize() const {
-    return texture.match([](const auto& obj) { return obj.size; });
+    return std::visit([](const auto& obj) { return obj.size; }, texture);
 }
 
 LineAtlas::LineAtlas() = default;

--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -2,12 +2,12 @@
 
 #include <mbgl/gfx/texture.hpp>
 #include <mbgl/util/image.hpp>
-#include <mbgl/util/variant.hpp>
 
 #include <map>
 #include <memory>
-#include <vector>
 #include <optional>
+#include <variant>
+#include <vector>
 
 namespace mbgl {
 
@@ -54,7 +54,7 @@ public:
 
 private:
     LinePatternPos from, to;
-    variant<AlphaImage, gfx::Texture> texture;
+    std::variant<AlphaImage, gfx::Texture> texture;
 };
 
 class LineAtlas {

--- a/src/mbgl/gfx/color_mode.hpp
+++ b/src/mbgl/gfx/color_mode.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <mbgl/gfx/types.hpp>
-#include <mbgl/util/variant.hpp>
 #include <mbgl/util/color.hpp>
+
+#include <variant>
 
 namespace mbgl {
 namespace gfx {
@@ -33,7 +34,7 @@ public:
     using Subtract = LinearBlend<ColorBlendEquationType::Subtract>;
     using ReverseSubtract = LinearBlend<ColorBlendEquationType::ReverseSubtract>;
 
-    using BlendFunction = variant<Replace, Add, Subtract, ReverseSubtract>;
+    using BlendFunction = std::variant< Replace, Add, Subtract, ReverseSubtract>;
 
     BlendFunction blendFunction;
     Color blendColor;

--- a/src/mbgl/gfx/stencil_mode.hpp
+++ b/src/mbgl/gfx/stencil_mode.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <mbgl/gfx/types.hpp>
-#include <mbgl/util/variant.hpp>
+
+#include <variant>
 
 namespace mbgl {
 namespace gfx {
@@ -29,7 +30,7 @@ public:
     using GreaterEqual = MaskedTest<StencilFunctionType::GreaterEqual>;
     using Always = SimpleTest<StencilFunctionType::Always>;
 
-    using Test = variant<Never, Less, Equal, LessEqual, Greater, NotEqual, GreaterEqual, Always>;
+    using Test = std::variant< Never, Less, Equal, LessEqual, Greater, NotEqual, GreaterEqual, Always>;
 
     Test test;
     int32_t ref;

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -10,7 +10,6 @@
 #include <mbgl/renderer/possibly_evaluated_property_value.hpp>
 #include <mbgl/renderer/paint_property_statistics.hpp>
 #include <mbgl/renderer/cross_faded_property_evaluator.hpp>
-#include <mbgl/util/variant.hpp>
 #include <mbgl/renderer/image_atlas.hpp>
 #include <mbgl/util/indexed_tuple.hpp>
 #include <mbgl/layout/pattern_layout.hpp>

--- a/src/mbgl/renderer/possibly_evaluated_property_value.hpp
+++ b/src/mbgl/renderer/possibly_evaluated_property_value.hpp
@@ -26,7 +26,7 @@ public:
     bool isConstant() const { return std::holds_alternative<T>(value); }
 
     std::optional<T> constant() const {
-        return std::visit(util::Overload{
+        return std::visit(util::Overloaded{
             [&] (const T& t) { return std::optional<T>(t); },
             [&] (const auto&) { return std::optional<T>(); }},
             value);
@@ -36,7 +36,7 @@ public:
 
     template <class... Ts>
     auto match(Ts&&... ts) const {
-        return std::visit(util::Overload{std::forward<Ts>(ts)...}, value);
+        return std::visit(util::Overloaded{std::forward<Ts>(ts)...}, value);
     }
 
     template <class Feature>
@@ -81,7 +81,7 @@ public:
     }
 
     std::optional<Faded<T>> constant() const {
-        return std::visit(util::Overload{
+        return std::visit(util::Overloaded{
             [&] (const Faded<T>& t) { return std::optional<Faded<T>>(t); },
             [&] (const auto&) { return std::optional<Faded<T>>(); }},
             value);
@@ -91,7 +91,7 @@ public:
 
     template <class... Ts>
     auto match(Ts&&... ts) const {
-        return std::visit(util::Overload{std::forward<Ts>(ts)...}, value);
+        return std::visit(util::Overloaded{std::forward<Ts>(ts)...}, value);
     }
 
     template <class Feature>

--- a/src/mbgl/renderer/style_diff.cpp
+++ b/src/mbgl/renderer/style_diff.cpp
@@ -1,7 +1,6 @@
 #include <mbgl/renderer/style_diff.hpp>
 #include <mbgl/style/layer_impl.hpp>
 #include <mbgl/util/immutable.hpp>
-#include <mbgl/util/variant.hpp>
 #include <mbgl/util/longest_common_subsequence.hpp>
 
 namespace mbgl {

--- a/src/mbgl/renderer/style_diff.hpp
+++ b/src/mbgl/renderer/style_diff.hpp
@@ -4,7 +4,6 @@
 #include <mbgl/style/source_impl.hpp>
 #include <mbgl/style/layer_impl.hpp>
 #include <mbgl/util/immutable.hpp>
-#include <mbgl/util/variant.hpp>
 
 #include <unordered_map>
 

--- a/src/mbgl/style/conversion/source.cpp
+++ b/src/mbgl/style/conversion/source.cpp
@@ -16,7 +16,7 @@ namespace style {
 namespace conversion {
 
 // A tile source can either specify a URL to TileJSON, or inline TileJSON.
-static std::optional<variant<std::string, Tileset>> convertURLOrTileset(const Convertible& value, Error& error) {
+static std::optional<std::variant<std::string, Tileset>> convertURLOrTileset(const Convertible& value, Error& error) {
     auto urlVal = objectMember(value, "url");
     if (!urlVal) {
         std::optional<Tileset> tileset = convert<Tileset>(value, error);
@@ -38,7 +38,7 @@ static std::optional<variant<std::string, Tileset>> convertURLOrTileset(const Co
 static std::optional<std::unique_ptr<Source>> convertRasterSource(const std::string& id,
                                                                   const Convertible& value,
                                                                   Error& error) {
-    std::optional<variant<std::string, Tileset>> urlOrTileset = convertURLOrTileset(value, error);
+    std::optional<std::variant<std::string, Tileset>> urlOrTileset = convertURLOrTileset(value, error);
     if (!urlOrTileset) {
         return std::nullopt;
     }
@@ -60,7 +60,7 @@ static std::optional<std::unique_ptr<Source>> convertRasterSource(const std::str
 static std::optional<std::unique_ptr<Source>> convertRasterDEMSource(const std::string& id,
                                                                      const Convertible& value,
                                                                      Error& error) {
-    std::optional<variant<std::string, Tileset>> urlOrTileset = convertURLOrTileset(value, error);
+    std::optional<std::variant<std::string, Tileset>> urlOrTileset = convertURLOrTileset(value, error);
     if (!urlOrTileset) {
         return std::nullopt;
     }
@@ -82,7 +82,7 @@ static std::optional<std::unique_ptr<Source>> convertRasterDEMSource(const std::
 static std::optional<std::unique_ptr<Source>> convertVectorSource(const std::string& id,
                                                                   const Convertible& value,
                                                                   Error& error) {
-    std::optional<variant<std::string, Tileset>> urlOrTileset = convertURLOrTileset(value, error);
+    std::optional<std::variant<std::string, Tileset>> urlOrTileset = convertURLOrTileset(value, error);
     if (!urlOrTileset) {
         return std::nullopt;
     }

--- a/src/mbgl/style/expression/find_zoom_curve.cpp
+++ b/src/mbgl/style/expression/find_zoom_curve.cpp
@@ -4,10 +4,6 @@
 #include <mbgl/style/expression/coalesce.hpp>
 #include <mbgl/style/expression/is_constant.hpp>
 
-#include <mbgl/util/variant.hpp>
-
-#include <optional>
-
 namespace mbgl {
 namespace style {
 namespace expression {

--- a/src/mbgl/style/sources/raster_dem_source.cpp
+++ b/src/mbgl/style/sources/raster_dem_source.cpp
@@ -11,7 +11,7 @@
 namespace mbgl {
 namespace style {
 
-RasterDEMSource::RasterDEMSource(std::string id, variant<std::string, Tileset> urlOrTileset_, uint16_t tileSize)
+RasterDEMSource::RasterDEMSource(std::string id, std::variant<std::string, Tileset> urlOrTileset_, uint16_t tileSize)
     : RasterSource(std::move(id), std::move(urlOrTileset_), tileSize, SourceType::RasterDEM) {}
 
 bool RasterDEMSource::supportsLayerType(const mbgl::style::LayerTypeInfo* info) const {

--- a/src/mbgl/style/sources/raster_source.cpp
+++ b/src/mbgl/style/sources/raster_source.cpp
@@ -14,7 +14,7 @@ namespace mbgl {
 namespace style {
 
 RasterSource::RasterSource(std::string id,
-                           variant<std::string, Tileset> urlOrTileset_,
+                           std::variant<std::string, Tileset> urlOrTileset_,
                            uint16_t tileSize,
                            SourceType sourceType)
     : Source(makeMutable<Impl>(sourceType, std::move(id), tileSize)),
@@ -26,16 +26,16 @@ const RasterSource::Impl& RasterSource::impl() const {
     return static_cast<const Impl&>(*baseImpl);
 }
 
-const variant<std::string, Tileset>& RasterSource::getURLOrTileset() const {
+const std::variant<std::string, Tileset>& RasterSource::getURLOrTileset() const {
     return urlOrTileset;
 }
 
 std::optional<std::string> RasterSource::getURL() const {
-    if (urlOrTileset.is<Tileset>()) {
+    if (std::holds_alternative<Tileset>(urlOrTileset)) {
         return {};
     }
 
-    return urlOrTileset.get<std::string>();
+    return std::get<std::string>(urlOrTileset);
 }
 
 uint16_t RasterSource::getTileSize() const {
@@ -43,8 +43,8 @@ uint16_t RasterSource::getTileSize() const {
 }
 
 void RasterSource::loadDescription(FileSource& fileSource) {
-    if (urlOrTileset.is<Tileset>()) {
-        baseImpl = makeMutable<Impl>(impl(), urlOrTileset.get<Tileset>());
+    if (std::holds_alternative<Tileset>(urlOrTileset)) {
+        baseImpl = makeMutable<Impl>(impl(), std::get<Tileset>(urlOrTileset));
         loaded = true;
         observer->onSourceLoaded(*this);
         return;
@@ -54,7 +54,7 @@ void RasterSource::loadDescription(FileSource& fileSource) {
         return;
     }
 
-    const auto& rawURL = urlOrTileset.get<std::string>();
+    const auto& rawURL = std::get<std::string>(urlOrTileset);
     const auto& url = util::mapbox::canonicalizeSourceURL(fileSource.getResourceOptions().tileServerOptions(), rawURL);
 
     req = fileSource.request(Resource::source(url), [this, url, &fileSource](const Response& res) {

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -15,7 +15,7 @@ namespace mbgl {
 namespace style {
 
 VectorSource::VectorSource(std::string id,
-                           variant<std::string, Tileset> urlOrTileset_,
+                           std::variant<std::string, Tileset> urlOrTileset_,
                            std::optional<float> maxZoom_,
                            std::optional<float> minZoom_)
     : Source(makeMutable<Impl>(std::move(id))),
@@ -29,21 +29,21 @@ const VectorSource::Impl& VectorSource::impl() const {
     return static_cast<const Impl&>(*baseImpl);
 }
 
-const variant<std::string, Tileset>& VectorSource::getURLOrTileset() const {
+const std::variant<std::string, Tileset>& VectorSource::getURLOrTileset() const {
     return urlOrTileset;
 }
 
 std::optional<std::string> VectorSource::getURL() const {
-    if (urlOrTileset.is<Tileset>()) {
+    if (std::holds_alternative<Tileset>(urlOrTileset)) {
         return {};
     }
 
-    return urlOrTileset.get<std::string>();
+    return std::get<std::string>(urlOrTileset);
 }
 
 void VectorSource::loadDescription(FileSource& fileSource) {
-    if (urlOrTileset.is<Tileset>()) {
-        baseImpl = makeMutable<Impl>(impl(), urlOrTileset.get<Tileset>());
+    if (std::holds_alternative<Tileset>(urlOrTileset)) {
+        baseImpl = makeMutable<Impl>(impl(), std::get<Tileset>(urlOrTileset));
         loaded = true;
         observer->onSourceLoaded(*this);
         return;
@@ -53,7 +53,7 @@ void VectorSource::loadDescription(FileSource& fileSource) {
         return;
     }
 
-    const auto& rawURL = urlOrTileset.get<std::string>();
+    const auto& rawURL = std::get<std::string>(urlOrTileset);
     const auto& url = util::mapbox::canonicalizeSourceURL(fileSource.getResourceOptions().tileServerOptions(), rawURL);
 
     req = fileSource.request(Resource::source(url), [this, url, &fileSource](const Response& res) {

--- a/src/mbgl/util/overloaded.hpp
+++ b/src/mbgl/util/overloaded.hpp
@@ -6,12 +6,12 @@ namespace util
 {
     
 template <typename... Ts>
-struct Overload : Ts... {
+struct Overloaded : Ts... {
     using Ts::operator()...;
 };
 
 template <class... Ts>
-Overload(Ts...) -> Overload<Ts...>;
+Overloaded(Ts...) -> Overloaded<Ts...>;
 
 } // namespace util
 } // namespace mbgl

--- a/test/algorithm/update_renderables.test.cpp
+++ b/test/algorithm/update_renderables.test.cpp
@@ -1,10 +1,9 @@
 #include <mbgl/test/util.hpp>
 #include <mbgl/test/mock.hpp>
-#include <mbgl/util/variant.hpp>
-
-#include <mapbox/variant_io.hpp>
 
 #include <mbgl/algorithm/update_renderables.hpp>
+
+#include <variant>
 
 using namespace mbgl;
 
@@ -69,7 +68,8 @@ std::ostream& operator<<(std::ostream& os, const RenderTileAction& action) {
               << action.tileData.tileID.canonical.y << " }\n";
 }
 
-using ActionLogEntry = variant<GetTileDataAction, CreateTileDataAction, RetainTileDataAction, RenderTileAction>;
+using ActionLogEntry =
+    std::variant<GetTileDataAction, CreateTileDataAction, RetainTileDataAction, RenderTileAction>;
 using ActionLog = std::vector<ActionLogEntry>;
 
 template <typename T>


### PR DESCRIPTION
This is part 1/n of a series of commits (or PRs?) towards solving: #893 

My idea for this PR is to not aim at fully resolving this issue, as I believe it would be too much for one PR, but rather make small increments towards that goal (solve the simple things first, etc...)

My decision was to split into at a couple commits since I have some concerns regarding replacing some of the functionality of mbgl::variant with std::variant equivalents (.match and some of its operator== semantics come to mind)

Please let me know if my decision suits what you have envisioned for this task

Thanks!