### PR TITLE
Revert GLES3 changes for OSMesa in Windows

### DIFF
--- a/platform/node/cmake/module.cmake
+++ b/platform/node/cmake/module.cmake
@@ -218,7 +218,7 @@ function(add_node_module NAME)
                     TARGET ${_TARGET}
                     POST_BUILD
                     COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/platform/windows/vendor/mesa3d/${_ARCH}/libglapi.dll"  "${_OUTPUT_PATH}"
-                    COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/platform/windows/vendor/mesa3d/${_ARCH}/libGLESv3.dll" "${_OUTPUT_PATH}"
+                    COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/platform/windows/vendor/mesa3d/${_ARCH}/libGLESv2.dll" "${_OUTPUT_PATH}"
                     COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/platform/windows/vendor/mesa3d/${_ARCH}/osmesa.dll"    "${_OUTPUT_PATH}"
                 )
             endif()

--- a/platform/windows/FindOSMesa.cmake
+++ b/platform/windows/FindOSMesa.cmake
@@ -16,10 +16,10 @@ else()
 endif()
 
 find_library(OSMesa_osmesa_LIBRARY     NAMES osmesa        PATHS ${OSMesa_DIR}/lib PATH_SUFFIXES ${_ARCH} NO_DEFAULT_PATH)
-find_library(OSMesa_libGLESv3_LIBRARY  NAMES libGLESv3     PATHS ${OSMesa_DIR}/lib PATH_SUFFIXES ${_ARCH} NO_DEFAULT_PATH)
+find_library(OSMesa_libGLESv2_LIBRARY  NAMES libGLESv2     PATHS ${OSMesa_DIR}/lib PATH_SUFFIXES ${_ARCH} NO_DEFAULT_PATH)
 
 find_file(OSMesa_osmesa_LIBRARY_DLL    NAMES osmesa.dll    PATHS ${OSMesa_DIR} PATH_SUFFIXES ${_ARCH} NO_DEFAULT_PATH)
-find_file(OSMesa_libGLESv3_LIBRARY_DLL NAMES libGLESv3.dll PATHS ${OSMesa_DIR} PATH_SUFFIXES ${_ARCH} NO_DEFAULT_PATH)
+find_file(OSMesa_libGLESv2_LIBRARY_DLL NAMES libGLESv2.dll PATHS ${OSMesa_DIR} PATH_SUFFIXES ${_ARCH} NO_DEFAULT_PATH)
 
 unset(_ARCH)
 
@@ -29,18 +29,18 @@ include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(OSMesa
                                   REQUIRED_VARS
                                   OSMesa_osmesa_LIBRARY
-                                  OSMesa_libGLESv3_LIBRARY
+                                  OSMesa_libGLESv2_LIBRARY
                                   OSMesa_INCLUDE_DIR)
 
 # Hide internal variables
-mark_as_advanced(OSMesa_INCLUDE_DIR OSMesa_osmesa_LIBRARY OSMesa_libGLESv3_LIBRARY)
+mark_as_advanced(OSMesa_INCLUDE_DIR OSMesa_osmesa_LIBRARY OSMesa_libGLESv2_LIBRARY)
 
 # Set standard variables
 if(OSMesa_FOUND)
     set(OSMesa_INCLUDE_DIRS "${OSMesa_INCLUDE_DIR}")
     set(OSMesa_LIBRARIES
         "${OSMesa_osmesa_LIBRARY}"
-        "${OSMesa_libGLESv3_LIBRARY}"
+        "${OSMesa_libGLESv2_LIBRARY}"
     )
 
     add_library(OSMesa::osmesa SHARED IMPORTED)
@@ -53,13 +53,13 @@ if(OSMesa_FOUND)
             IMPORTED_LOCATION             ${OSMesa_osmesa_LIBRARY_DLL}
     )
 
-    add_library(OSMesa::libGLESv3 SHARED IMPORTED)
+    add_library(OSMesa::libGLESv2 SHARED IMPORTED)
 
     set_target_properties(
-        OSMesa::libGLESv3
+        OSMesa::libGLESv2
         PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES ${OSMesa_INCLUDE_DIRS}
-            IMPORTED_IMPLIB               ${OSMesa_libGLESv3_LIBRARY}
-            IMPORTED_LOCATION             ${OSMesa_libGLESv3_LIBRARY_DLL}
+            IMPORTED_IMPLIB               ${OSMesa_libGLESv2_LIBRARY}
+            IMPORTED_LOCATION             ${OSMesa_libGLESv2_LIBRARY_DLL}
     )
 endif()

--- a/platform/windows/README.md
+++ b/platform/windows/README.md
@@ -43,7 +43,7 @@ To configure build with OSMesa (software rendering), use the following command:
 cmake . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DMLN_WITH_OSMESA=ON
 ```
 
-**WARNING:** as OSMesa doesn't have static libraries, it's necessary to copy `libglapi.dll`, `libGLESv3.dll` and `osmesa.dll` from `platform\windows\vendor\mesa3d\<arch>` to executable/dll directory you want to use, otherwise it won't run.
+**WARNING:** as OSMesa doesn't have static libraries, it's necessary to copy `libglapi.dll`, `libGLESv2.dll` and `osmesa.dll` from `platform\windows\vendor\mesa3d\<arch>` to executable/dll directory you want to use, otherwise it won't run.
 
 ## Building
 

--- a/platform/windows/windows.cmake
+++ b/platform/windows/windows.cmake
@@ -91,7 +91,7 @@ if(MLN_WITH_EGL)
         mbgl-core
         PRIVATE
             unofficial::angle::libEGL
-            unofficial::angle::libGLESv3
+            unofficial::angle::libGLESv2
     )
 elseif(MLN_WITH_OSMESA)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
@@ -114,7 +114,7 @@ elseif(MLN_WITH_OSMESA)
         mbgl-core
         PRIVATE
             OSMesa::osmesa
-            OSMesa::libGLESv3
+            OSMesa::libGLESv2
     )
 else()
     find_package(OpenGL REQUIRED)


### PR DESCRIPTION
The PR #995 bring us the long awaited support for OpenGL ES 3.0. But for OSMesa, which does have support for OpenGL ES 3.0, a reference to the file `libGLESv2.dll` was changed to `libGLESv3.dll`, but the latter file doesn't exist. Support for OpenGL ES 3.0 is provided by `libGLESv2.dll`, so I'm reverting these changes for the reference to this file. The other changes are good and work well, so I kept all of them.