### PR TITLE
Create security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+To report a vulnerability in MapLibre Native, create a [security advisory](https://github.com/maplibre/maplibre-gl-native/security/advisories/new).
+You will be able to privately discuss the issue with the maintainers of MapLibre Native and we can collaborate on a fix.
+
+We highly appreciate your reports, but we do not pay out bug bounties at this time.
+
+We will acknowledge your report in our newsletter with your consent.


### PR DESCRIPTION
I named it `SECURITY.md`  because it is the default filename GitHub expects for a security policy.

It is a bit simpeler than the 'default' security policy because things like CSRF are not relevant in the context of MapLibre Native.

Instead of reporting by e-mail we should use the built-in functionality of GitHub, because it is more secure, will reach the right persons quicker, and allows for better collaboration with the reporter to fix the issue.