### PR TITLE
Update paths from maplibre-gl-native to maplibre-native

### DIFF
--- a/.github/workflows/node-ci-mac.yml
+++ b/.github/workflows/node-ci-mac.yml
@@ -169,7 +169,7 @@ jobs:
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}
 
-      - name: Configure maplibre-gl-native (MacOS)
+      - name: Configure maplibre-native (MacOS)
         if: runner.os == 'MacOS'
         run: |
           cmake . -B build \
@@ -177,7 +177,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
 
-      - name: Configure maplibre-gl-native (Linux)
+      - name: Configure maplibre-native (Linux)
         if: runner.os == 'Linux'
         run: |
           cmake . -B build \
@@ -205,7 +205,7 @@ jobs:
           key: |
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ hashFiles( '.git/modules/platform/windows/vendor/vcpkg/HEAD' ) }}-${{ hashFiles( 'platform/windows/Get-VendorPackages.ps1' ) }}
 
-      - name: Configure maplibre-gl-native (Windows)
+      - name: Configure maplibre-native (Windows)
         if: runner.os == 'Windows'
         run: |
           cmake . -B build \
@@ -213,12 +213,12 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
-      - name: Build maplibre-gl-native (MacOS/Linux)
+      - name: Build maplibre-native (MacOS/Linux)
         if: runner.os == 'MacOS' || runner.os == 'Linux'
         run: |
           cmake --build build -j $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)
 
-      - name: Build maplibre-gl-native (Windows)
+      - name: Build maplibre-native (Windows)
         if: runner.os == 'Windows'
         run: |
           cmake --build build

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -168,7 +168,7 @@ jobs:
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}
 
-      - name: Configure maplibre-gl-native (MacOS)
+      - name: Configure maplibre-native (MacOS)
         if: runner.os == 'MacOS'
         run: |
           cmake . -B build \
@@ -177,7 +177,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DMLN_WITH_NODE=ON
 
-      - name: Configure maplibre-gl-native (Linux)
+      - name: Configure maplibre-native (Linux)
         if: runner.os == 'Linux'
         run: |
           cmake . -B build \
@@ -206,7 +206,7 @@ jobs:
           key: |
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ hashFiles( '.git/modules/platform/windows/vendor/vcpkg/HEAD' ) }}-${{ hashFiles( 'platform/windows/Get-VendorPackages.ps1' ) }}
 
-      - name: Configure maplibre-gl-native (Windows)
+      - name: Configure maplibre-native (Windows)
         if: runner.os == 'Windows'
         run: |
           cmake . -B build \
@@ -215,12 +215,12 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
             -DMLN_WITH_NODE=ON
 
-      - name: Build maplibre-gl-native (MacOS/Linux)
+      - name: Build maplibre-native (MacOS/Linux)
         if: runner.os == 'MacOS' || runner.os == 'Linux'
         run: |
           cmake --build build -j $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)
 
-      - name: Build maplibre-gl-native (Windows)
+      - name: Build maplibre-native (Windows)
         if: runner.os == 'Windows'
         run: |
           cmake --build build

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -164,7 +164,7 @@ jobs:
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}
 
-      - name: Configure maplibre-gl-native (MacOS)
+      - name: Configure maplibre-native (MacOS)
         if: runner.os == 'MacOS'
         run: |
           cmake . -B build \
@@ -172,7 +172,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
 
-      - name: Configure maplibre-gl-native (Linux)
+      - name: Configure maplibre-native (Linux)
         if: runner.os == 'Linux'
         run: |
           cmake . -B build \
@@ -200,7 +200,7 @@ jobs:
           key: |
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ hashFiles( '.git/modules/platform/windows/vendor/vcpkg/HEAD' ) }}-${{ hashFiles( 'platform/windows/Get-VendorPackages.ps1' ) }}
 
-      - name: Configure maplibre-gl-native (Windows)
+      - name: Configure maplibre-native (Windows)
         if: runner.os == 'Windows'
         run: |
           cmake . -B build \
@@ -208,12 +208,12 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
-      - name: Build maplibre-gl-native (MacOS/Linux)
+      - name: Build maplibre-native (MacOS/Linux)
         if: runner.os == 'MacOS' || runner.os == 'Linux'
         run: |
           cmake --build build -j $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)
 
-      - name: Build maplibre-gl-native (Windows)
+      - name: Build maplibre-native (Windows)
         if: runner.os == 'Windows'
         run: |
           cmake --build build

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -182,7 +182,7 @@ jobs:
         with:
           key: Qt_${{ matrix.name }}_${{ matrix.qt_version }}
 
-      - name: Build maplibre-gl-native (macOS)
+      - name: Build maplibre-native (macOS)
         if: runner.os == 'macOS' && matrix.qt_target == 'desktop'
         run: |
           mkdir build && cd build
@@ -200,15 +200,15 @@ jobs:
           ninja
           ninja install
 
-      - name: Build maplibre-gl-native (Linux, Qt5)
+      - name: Build maplibre-native (Linux, Qt5)
         if: runner.os == 'Linux' && matrix.qt_version == '5.15.2'
         uses: ./source/.github/actions/qt5-build
 
-      - name: Build maplibre-gl-native (Linux, Qt6)
+      - name: Build maplibre-native (Linux, Qt6)
         if: runner.os == 'Linux' && matrix.qt_version != '5.15.2'
         uses: ./source/.github/actions/qt6-build
 
-      - name: Build maplibre-gl-native (Windows)
+      - name: Build maplibre-native (Windows)
         if: runner.os == 'Windows'
         shell: bash
         run: |
@@ -240,14 +240,14 @@ jobs:
           QT_VERSION: ${{ matrix.qt_version }}
         run: |
           pushd install
-          tar cjvf ../maplibre-gl-native_${QT_ARCH}_Qt${QT_VERSION}.tar.bz2 *
+          tar cjvf ../maplibre-native_${QT_ARCH}_Qt${QT_VERSION}.tar.bz2 *
           popd
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: maplibre-gl-native_${{ matrix.name }}_Qt${{ matrix.qt_version }}
-          path: maplibre-gl-native_${{ matrix.name }}_Qt${{ matrix.qt_version }}.tar.bz2
+          name: maplibre-native_${{ matrix.name }}_Qt${{ matrix.qt_version }}
+          path: maplibre-native_${{ matrix.name }}_Qt${{ matrix.qt_version }}.tar.bz2
 
   test-tarball:
     needs: build
@@ -277,7 +277,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
-          name: maplibre-gl-native_${{ matrix.name }}_Qt${{ matrix.qt_version }}
+          name: maplibre-native_${{ matrix.name }}_Qt${{ matrix.qt_version }}
 
       - name: Download Qt
         uses: jurplel/install-qt-action@v3
@@ -296,7 +296,7 @@ jobs:
       - name: Build test app
         run: |
           mkdir install && cd install
-          tar xf ../maplibre-gl-native_${QT_ARCH}_Qt${QT_VERSION}.tar.bz2
+          tar xf ../maplibre-native_${QT_ARCH}_Qt${QT_VERSION}.tar.bz2
           cd ..
           export CMAKE_PREFIX_PATH=$PWD/install
           mkdir build && cd build
@@ -320,7 +320,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v3
       with:
-        name: maplibre-gl-native_${{ matrix.name }}_Qt${{ matrix.qt_version }}
+        name: maplibre-native_${{ matrix.name }}_Qt${{ matrix.qt_version }}
 
     - name: Name tarball
       env:
@@ -328,7 +328,7 @@ jobs:
         TAG_PLATFORM: ${{ matrix.name }}
         QT_VERSION: ${{ matrix.qt_version }}
       run: |
-        mv maplibre-gl-native_${TAG_PLATFORM}_Qt${QT_VERSION}.tar.bz2 QMapLibreGL_${TAG_NAME//qt-/}_Qt${QT_VERSION}_${TAG_PLATFORM}.tar.bz2
+        mv maplibre-native_${TAG_PLATFORM}_Qt${QT_VERSION}.tar.bz2 QMapLibreGL_${TAG_NAME//qt-/}_Qt${QT_VERSION}_${TAG_PLATFORM}.tar.bz2
 
     - name: Release
       uses: ncipollo/release-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 ### ✨ New features
 
 - *...Add new stuff here...*
-- [core] All CMake properties are now prefixed `MLN_*` [1054](https://github.com/maplibre/maplibre-gl-native/pull/1054).
-- [windows] Added windows build support for core applications and node [#707](https://github.com/maplibre/maplibre-gl-native/pull/707)
-- [core] Add `ClientOptions` to configure client information [#365](https://github.com/maplibre/maplibre-gl-native/pull/365).
-- [node] Add workflow to create node binary releases for Ubuntu 20.04 x64 and MacOS 12 x64/arm64 [#378](https://github.com/maplibre/maplibre-gl-native/pull/378), [#459](https://github.com/maplibre/maplibre-gl-native/pull/459).
+- [core] All CMake properties are now prefixed `MLN_*` [1054](https://github.com/maplibre/maplibre-native/pull/1054).
+- [windows] Added windows build support for core applications and node [#707](https://github.com/maplibre/maplibre-native/pull/707)
+- [core] Add `ClientOptions` to configure client information [#365](https://github.com/maplibre/maplibre-native/pull/365).
+- [node] Add workflow to create node binary releases for Ubuntu 20.04 x64 and MacOS 12 x64/arm64 [#378](https://github.com/maplibre/maplibre-native/pull/378), [#459](https://github.com/maplibre/maplibre-native/pull/459).
 
 ### ✨ Technical Improvements
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1099,7 +1099,7 @@ set_target_properties(
     mbgl-core
     PROPERTIES
         INTERFACE_MAPBOX_NAME "Mapbox GL Native"
-        INTERFACE_MAPBOX_URL "https://github.com/maplibre/maplibre-gl-native"
+        INTERFACE_MAPBOX_URL "https://github.com/maplibre/maplibre-native"
         INTERFACE_MAPBOX_AUTHOR "Mapbox"
         INTERFACE_MAPBOX_LICENSE ${PROJECT_SOURCE_DIR}/LICENSE.md
 )

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ MapLibre Native is being actively developed. Our big goal for 2023 is to modular
 Your help in preparing the codebase for the latest graphics backends is more than welcome. Feel free to reach out if you are interested in joining the effort!
 
 - Check out the [news](https://maplibre.org/news/) on MapLibre's website.
-- See the [Design Proposals](https://github.com/louwers/maplibre-gl-native/tree/main/design-proposals) that have been accepted and are being worked on, the most recent ones being the [Rendering Modularization Design Proposal](design-proposals/2022-10-27-rendering-modularization.md) and the [Metal Port Design Proposal](design-proposals/2022-11-29-metal-port.md).
+- See the [Design Proposals](https://github.com/maplibre/maplibre-native/tree/main/design-proposals) that have been accepted and are being worked on, the most recent ones being the [Rendering Modularization Design Proposal](design-proposals/2022-10-27-rendering-modularization.md) and the [Metal Port Design Proposal](design-proposals/2022-11-29-metal-port.md).
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-To report a vulnerability in MapLibre Native, create a [security advisory](https://github.com/maplibre/maplibre-gl-native/security/advisories/new).
+To report a vulnerability in MapLibre Native, create a [security advisory](https://github.com/maplibre/maplibre-native/security/advisories/new).
 You will be able to privately discuss the issue with the maintainers of MapLibre Native and we can collaborate on a fix.
 
 We highly appreciate your reports, but we do not pay out bug bounties at this time.

--- a/design-proposals/2022-10-27-rendering-modularization.md
+++ b/design-proposals/2022-10-27-rendering-modularization.md
@@ -42,7 +42,7 @@ It is useful to split our goals into three sections to articulate what this prop
 ### <a name="core">Core Functionality</a>
 
 1. Shader (program) code will be implemented in a modular fashion, such that replacement of any given shader can happen without impacting other shaders.
-2. Shader (program) code may no longer be compiled from the [webgl source](https://github.com/maplibre/maplibre-gl-js/tree/main/src/shaders), and should be organized within the maplibre-gl-native repo (as a compile time option).
+2. Shader (program) code may no longer be compiled from the [webgl source](https://github.com/maplibre/maplibre-gl-js/tree/main/src/shaders), and should be organized within the maplibre-native repo (as a compile time option).
 3. Layer rendering logic should be replaceable at the dev level.  All the necessary support should be exposed and a developer should be able to take over representation of any given layer.
 4. Developers should be able to associate specific styles with specific layer rendering.  The style sheet should be able to call out the type of representation it would like beyond the default.
 5. Developers should be able to add new visual representations fed by existing geometry types.  Such as data display driven by tile sets or animated markers.

--- a/docs/doxygen/MAINPAGE.md
+++ b/docs/doxygen/MAINPAGE.md
@@ -2,4 +2,4 @@
 
 This is the documentation of the public C++ API of MapLibre Native Core. You would normally only use this API if you are a contributor to one of the platform specific APIs. If you want to intergrate use MapLibre Native in your project, you are better served by [documentation specific to your platform](https://maplibre.org/projects/maplibre-native/), unless you are interested in the internals of MapLibre Native.
 
-The source code can be found [on GitHub](https://github.com/maplibre/maplibre-gl-native) (the `include` directory contains the public API).
+The source code can be found [on GitHub](https://github.com/maplibre/maplibre-native) (the `include` directory contains the public API).

--- a/docs/doxygen/footer.html
+++ b/docs/doxygen/footer.html
@@ -4,7 +4,7 @@
 <div id="nav-path" class="navpath"><!-- id is needed for treeview function! -->
   <ul>
     $navpath
-		<li class="footer"><a href="https://maplibre.org/">MapLibre website</a> | <a href="https://github.com/maplibre/maplibre-gl-native">GitHub repository</a></li>
+		<li class="footer"><a href="https://maplibre.org/">MapLibre website</a> | <a href="https://github.com/maplibre/maplibre-native">GitHub repository</a></li>
   </ul>
 </div>
 <!--END GENERATE_TREEVIEW-->

--- a/docs/mdbook/src/introduction.md
+++ b/docs/mdbook/src/introduction.md
@@ -1,5 +1,5 @@
 # Introduction
 
-*[MapLibre Native](https://github.com/maplibre/maplibre-gl-native)* is a community led fork of *Mapbox GL Native*. It's a C++ library that powers 
+*[MapLibre Native](https://github.com/maplibre/maplibre-native)* is a community led fork of *Mapbox GL Native*. It's a C++ library that powers 
 vector maps in native applications on multiple platforms by taking stylesheets that conform to the *MapLibre Style Specification,* a fork of the 
 Mapbox Style Specification. Since it is derived from Mapbox's original work it also uses *Mapbox Vector Tile Specification* as its choice of vector tile format.

--- a/platform/android/DEVELOPING.md
+++ b/platform/android/DEVELOPING.md
@@ -27,7 +27,7 @@ $ ./gradlew formatKotlin
 Clone the git repository and pull in submodules:
 
 ```bash
-git clone git@github.com:maplibre/maplibre-gl-native.git
+git clone git@github.com:maplibre/maplibre-native.git
 git submodule update --init --recursive
 cd platform/android
 ```

--- a/platform/android/gradle/artifact-settings.gradle
+++ b/platform/android/gradle/artifact-settings.gradle
@@ -5,8 +5,8 @@ ext {
     mapLibreArtifactDescription = 'MapLibre Maps SDK for Android'
     mapLibreDeveloperName = 'MapLibre'
     mapLibreDeveloperId = 'maplibre'
-    mapLibreArtifactUrl = 'https://github.com/maplibre/maplibre-gl-native'
-    mapLibreArtifactScmUrl = 'scm:git@github.com:maplibre/maplibre-gl-native.git'
+    mapLibreArtifactUrl = 'https://github.com/maplibre/maplibre-native'
+    mapLibreArtifactScmUrl = 'scm:git@github.com:maplibre/maplibre-native.git'
     mapLibreArtifactLicenseName = 'BSD'
     mapLibreArtifactLicenseUrl = 'https://opensource.org/licenses/BSD-2-Clause'
     versionName = project.hasProperty('VERSION_NAME') ? project.property('VERSION_NAME') : System.getenv('VERSION_NAME')

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Each MapLibre Native SDK has a separate changelog that highlights changes relevant to their respective platforms:
 
-* [MapLibre Maps SDK for Android](../../platform/android/CHANGELOG.md)
-* [MapLibre Maps SDK for iOS](platform/ios/CHANGELOG.md)
-* [MapLibre Maps SDK for macOS](platform/macos/CHANGELOG.md)
-* [node-maplibre-gl-native](../../platform/node/CHANGELOG.md)
+* [MapLibre Native for Android](../../platform/android/CHANGELOG.md)
+* [MapLibre Native for iOS](platform/ios/CHANGELOG.md)
+* [MapLibre Native for macOS](platform/macos/CHANGELOG.md)
+* [MapLibre Native for Node](../../platform/node/CHANGELOG.md)

--- a/platform/ios/platform/ios/INSTALL.md
+++ b/platform/ios/platform/ios/INSTALL.md
@@ -40,8 +40,8 @@ Before building, follow these steps to install prerequisites:
 ### Build the iOS Demo App
 
 ```
-git clone --recurse-submodules git@github.com:maplibre/maplibre-gl-native.git
-cd maplibre-gl-native/platform/ios 
+git clone --recurse-submodules git@github.com:maplibre/maplibre-native.git
+cd maplibre-native/platform/ios 
 make iproj
 ```
 
@@ -58,7 +58,7 @@ If you wish to deploy on attached hardware, you need to setup your Apple Develop
 1. Clone the git repository:
    ```bash
    git clone --recurse-submodules https://github.com/maplibre/maplibre-native.git
-   cd maplibre-gl-native
+   cd maplibre-native
    ```
    Note that you must check out the project's git submodules to build. If you did not include `--recurse-submodules` in the clone, you can later run `git submodule update --init`.
 1. Run `make iframework BUILDTYPE=Release`. The packaging script will produce a `build/ios/pkg/` folder containing:

--- a/platform/ios/platform/ios/README.md
+++ b/platform/ios/platform/ios/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Action build status](https://github.com/maplibre/maplibre-native/workflows/ios-ci/badge.svg)](https://github.com/maplibre/maplibre-native/actions/workflows/ios-ci.yml) [![GitHub Action build status](https://github.com/maplibre/maplibre-native/workflows/ios-release/badge.svg)](https://github.com/maplibre/maplibre-native/actions/workflows/ios-release.yml)
 
-A library based on [MapLibre Native](https://github.com/maplibre/maplibre-gl-native) for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS using Objective-C, Swift, or Interface Builder.
+A library based on [MapLibre Native](https://github.com/maplibre/maplibre-native) for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS using Objective-C, Swift, or Interface Builder.
 
 * [Learn about custom builds](INSTALL.md)
 
@@ -12,7 +12,7 @@ A library based on [MapLibre Native](https://github.com/maplibre/maplibre-gl-nat
 
 1. To add a package dependency to your Xcode project, select File > Swift Packages > Add Package Dependency and enter its repository URL. You can also navigate to your target’s General pane, and in the “Frameworks, Libraries, and Embedded Content” section, click the + button, select Add Other, and choose Add Package Dependency.
 
-2. Either add MapLibre GitHub distribution URL (https://github.com/maplibre/maplibre-gl-native-distribution) or search for `maplibre-gl-native` package.
+2. Either add MapLibre GitHub distribution URL (https://github.com/maplibre/maplibre-gl-native-distribution) or search for `maplibre-native` package.
 
 3. Choose "next". Xcode should clone the distribution repository and download the binaries.
 

--- a/platform/ios/platform/ios/docs/pod-README.md
+++ b/platform/ios/platform/ios/docs/pod-README.md
@@ -2,7 +2,7 @@
 
 MapLibre Native for iOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [MapLibre Style Specification](https://maplibre.org/maplibre-gl-js-docs/style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://docs.mapbox.com/data/tilesets/guides/vector-tiles-standards/), and renders them using OpenGL.
 
-For more information, check out the [MapLibre Native for iOS repository](https://github.com/maplibre/maplibre-gl-native) and the [full changelog](https://github.com/maplibre/maplibre-native/blob/main/platform/ios/platform/ios/CHANGELOG.md) online.
+For more information, check out the [MapLibre Native for iOS repository](https://github.com/maplibre/maplibre-native) and the [full changelog](https://github.com/maplibre/maplibre-native/blob/main/platform/ios/platform/ios/CHANGELOG.md) online.
 
 [![](https://raw.githubusercontent.com/mapbox/mapbox-gl-native-ios/master/platform/ios/docs/img/screenshot.png)]()
 

--- a/platform/ios/platform/ios/jazzy.yml
+++ b/platform/ios/platform/ios/jazzy.yml
@@ -1,7 +1,7 @@
 module: MapLibre
 author: MapLibre Contributors
 author_url: https://maplibre.org/
-github_url: https://github.com/maplibre/maplibre-gl-native
+github_url: https://github.com/maplibre/maplibre-native
 copyright: '[License](https://github.com/maplibre/maplibre-native/blob/main/platform/ios/LICENSE.md)'
 
 head: |

--- a/platform/ios/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/platform/ios/scripts/deploy-packages.sh
@@ -46,7 +46,7 @@ buildPackageStyle() {
 }
 
 export GITHUB_USER=maplibre
-export GITHUB_REPO=maplibre-gl-native
+export GITHUB_REPO=maplibre-native
 export BUILDTYPE=Release
 export PACKAGE_FORMAT=xcframework
 

--- a/platform/ios/platform/ios/scripts/deploy-swift-package.sh
+++ b/platform/ios/platform/ios/scripts/deploy-swift-package.sh
@@ -17,7 +17,7 @@ function finish { >&2 echo -en "\033[0m"; }
 trap finish EXIT
 
 export GITHUB_USER=maplibre
-export GITHUB_REPO=maplibre-gl-native
+export GITHUB_REPO=maplibre-native
 export BUILDTYPE=Release
 export DISTRIBUTION_GITHUB_REPO=https://api.github.com/repos/maplibre/maplibre-gl-native-distribution
 

--- a/platform/ios/platform/ios/scripts/publish.sh
+++ b/platform/ios/platform/ios/scripts/publish.sh
@@ -18,7 +18,7 @@ else
     PUBLISH_STYLE=""
 fi
 
-GITHUB_REPO=${GITHUB_REPO:-'maplibre-gl-native'}
+GITHUB_REPO=${GITHUB_REPO:-'maplibre-native'}
 
 #
 # zip

--- a/platform/ios/platform/ios/scripts/update-swift-package.sh
+++ b/platform/ios/platform/ios/scripts/update-swift-package.sh
@@ -17,7 +17,7 @@ rm -f Package.swift
 cp platform/ios/scripts/swift_package_template.swift Package.swift
 
 export GITHUB_USER=maplibre
-export GITHUB_REPO=maplibre-gl-native
+export GITHUB_REPO=maplibre-native
 export BUILDTYPE=Release
 export DISTRIBUTION_GITHUB_REPO=https://api.github.com/repos/maplibre/maplibre-gl-native-distribution
 

--- a/platform/ios/platform/macos/INSTALL.md
+++ b/platform/ios/platform/macos/INSTALL.md
@@ -39,7 +39,7 @@ To build the SDK from source:
 1. Clone the git repository:
    ```bash
    git clone https://github.com/maplibre/maplibre-native.git
-   cd maplibre-gl-native
+   cd maplibre-native
    ```
    Note that this repository uses Git submodules. They'll be automatically checked out when you first run a `make` command,
    but are not updated automatically. We recommended that you run `git submodule update` after pulling down new commits to

--- a/platform/ios/platform/macos/scripts/deploy-packages.sh
+++ b/platform/ios/platform/macos/scripts/deploy-packages.sh
@@ -77,7 +77,7 @@ publish() {
 }
 
 export GITHUB_USER=maplibre
-export GITHUB_REPO=maplibre-gl-native
+export GITHUB_REPO=maplibre-native
 export BUILDTYPE=Release
 
 

--- a/platform/linux/README.md
+++ b/platform/linux/README.md
@@ -35,7 +35,7 @@ First, clone the repository. This repository uses git submodules, which are also
 
 ```bash
 git clone --recurse-submodules -j8 https://github.com/maplibre/maplibre-native.git
-cd maplibre-gl-native
+cd maplibre-native
 ```
 
 To create the build, run the following commands.
@@ -45,7 +45,7 @@ cmake . -B build -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILE
 cmake --build build -j $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)
 ```
 
-If all went well, there should now be a `maplibre-gl-native/build/bin/mbgl-render` binary that you can run to generate map tile images. To test that it is working properly, run the following command.
+If all went well, there should now be a `maplibre-native/build/bin/mbgl-render` binary that you can run to generate map tile images. To test that it is working properly, run the following command.
 
 ```bash
 ./build/bin/mbgl-render --style https://raw.githubusercontent.com/maplibre/demotiles/gh-pages/style.json --output out.png
@@ -150,7 +150,7 @@ For the purposes of this exercise, you can use the `zurich_switzerland.mbtiles` 
 
 Note that this style is totally inadequate for any real use beyond testing your custom setup. Don't forget to replace the source URL `"mbtiles:///path/to/zurich_switzerland.mbtiles"` with the actual path to your mbtiles file.
 
-From your `maplibre-gl-native/` dir, run the following command.
+From your `maplibre-native/` dir, run the following command.
 
 ```bash
 ./build/bin/mbgl-render --style /path/to/style.json --output out.png

--- a/platform/qt/README.md
+++ b/platform/qt/README.md
@@ -29,7 +29,7 @@ A minimal set of commands to build and install is
 
 ```shell
 mkdir build && cd build
-cmake ../maplibre-gl-native/ \
+cmake ../maplibre-native/ \
   -GNinja \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=<installation_prefix> \

--- a/platform/qt/scripts/configure_Qt5_Android_static.sh
+++ b/platform/qt/scripts/configure_Qt5_Android_static.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z ${1+x} ]]; then
-  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  echo "Error: Pass the path to maplibre-native as first argument" 1>&2
   exit 1
 fi
 

--- a/platform/qt/scripts/configure_Qt5_Linux.sh
+++ b/platform/qt/scripts/configure_Qt5_Linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z ${1+x} ]]; then
-  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  echo "Error: Pass the path to maplibre-native as first argument" 1>&2
   exit 1
 fi
 

--- a/platform/qt/scripts/configure_Qt5_iOS_static.sh
+++ b/platform/qt/scripts/configure_Qt5_iOS_static.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z ${1+x} ]]; then
-  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  echo "Error: Pass the path to maplibre-native as first argument" 1>&2
   exit 1
 fi
 

--- a/platform/qt/scripts/configure_Qt5_macOS.sh
+++ b/platform/qt/scripts/configure_Qt5_macOS.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z ${1+x} ]]; then
-  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  echo "Error: Pass the path to maplibre-native as first argument" 1>&2
   exit 1
 fi
 

--- a/platform/qt/scripts/configure_Qt5_macOS_static.sh
+++ b/platform/qt/scripts/configure_Qt5_macOS_static.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z ${1+x} ]]; then
-  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  echo "Error: Pass the path to maplibre-native as first argument" 1>&2
   exit 1
 fi
 

--- a/platform/qt/scripts/configure_Qt6_macOS.sh
+++ b/platform/qt/scripts/configure_Qt6_macOS.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z ${1+x} ]]; then
-  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  echo "Error: Pass the path to maplibre-native as first argument" 1>&2
   exit 1
 fi
 

--- a/platform/qt/scripts/configure_Qt6_macOS_static.sh
+++ b/platform/qt/scripts/configure_Qt6_macOS_static.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z ${1+x} ]]; then
-  echo "Error: Pass the path to maplibre-gl-native as first argument" 1>&2
+  echo "Error: Pass the path to maplibre-native as first argument" 1>&2
   exit 1
 fi
 

--- a/platform/windows/README.md
+++ b/platform/windows/README.md
@@ -16,7 +16,7 @@ Open `x64 Native Tools Command Prompt for VS 2022` and then clone the repository
 
 ```cmd
 git clone --recurse-submodules -j8 https://github.com/maplibre/maplibre-native.git
-cd maplibre-gl-native
+cd maplibre-native
 ```
 
 ## Configuring
@@ -75,7 +75,7 @@ Once configure is done, open the file `build\Mapbox GL Native.sln`. Build the ta
 
 ## Testing
 
-If all went well and target `mbgl-render` or `ALL_BUILD` was chosen, there should now be a `maplibre-gl-native\build\bin\mbgl-render.exe` binary that you can run to generate map tile images. To test that it is working properly, run the following command.
+If all went well and target `mbgl-render` or `ALL_BUILD` was chosen, there should now be a `maplibre-native\build\bin\mbgl-render.exe` binary that you can run to generate map tile images. To test that it is working properly, run the following command.
 
 ```cmd
 .\build\bin\mbgl-render.exe --style https://raw.githubusercontent.com/maplibre/demotiles/gh-pages/style.json --output out.png
@@ -172,7 +172,7 @@ For the purposes of this exercise, you can use the `zurich_switzerland.mbtiles` 
 
 Note that this style is totally inadequate for any real use beyond testing your custom setup. Don't forget to replace the source URL `"mbtiles:///path/to/zurich_switzerland.mbtiles"` with the actual path to your mbtiles file.
 
-From your `maplibre-gl-native/` dir, run the following command.
+From your `maplibre-native/` dir, run the following command.
 
 ```cmd
 .\build\bin\mbgl-render --style path\to\style.json --output out.png

--- a/qt_attribution.json
+++ b/qt_attribution.json
@@ -5,7 +5,7 @@
   "QtUsage": "Used in the MapLibre backend of Qt Location.",
 
   "Description": "MapLibre Native is a community led fork derived from mapbox-gl-native.",
-  "Homepage": "https://github.com/maplibre/maplibre-gl-native",
+  "Homepage": "https://github.com/maplibre/maplibre-native",
   "LicenseId": "BSD-2-Clause",
   "License": "BSD 2-Clause License",
   "LicenseFile": "LICENSE.md",


### PR DESCRIPTION
Continuation of #1083 

Every `maplibre-gl-native` with a few exceptions are now updated to `maplibre-native`.

The exceptions are:
- maplibre-gl-native-boost
- maplibre-gl-native-distribution
- `@maplibre/maplibre-gl-native` node package
- the Id of the qt attribution 'maplibre-gl-native'
- echoing "maplibre-gl-native-ios" in the ios/scrips folder.. this is actually likely obsolete