### PR TITLE
Remove TLS limitation for cURL in Windows

### DIFF
--- a/platform/default/src/mbgl/storage/http_file_source.cpp
+++ b/platform/default/src/mbgl/storage/http_file_source.cpp
@@ -278,11 +278,6 @@ HTTPRequest::HTTPRequest(HTTPFileSource::Impl *context_, Resource resource_, Fil
         curl_easy_setopt(handle, CURLOPT_HTTPHEADER, headers);
     }
 
-#ifdef WIN32
-    // Windows has issues with TLSv1.3, so we limit to TLSv1.2. Should be
-    // resolved in a later cURL release https://github.com/curl/curl/issues/9431
-    handleError(curl_easy_setopt(handle, CURLOPT_SSLVERSION, CURL_SSLVERSION_MAX_TLSv1_2));
-#endif
     handleError(curl_easy_setopt(handle, CURLOPT_PRIVATE, this));
     handleError(curl_easy_setopt(handle, CURLOPT_ERRORBUFFER, error));
     handleError(curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1));


### PR DESCRIPTION
There was a [issue](https://github.com/curl/curl/issues/9431) with TLS in cURL in Windows and as workaround TLS version was limited to 1.2 in Windows (leaving version 1.3 out). Since vcpkg was updated in #1073, cURL now has the correction for this issue, so the workaround is not needed anymore.