### PR TITLE
Run iOS size test on CI

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -57,6 +57,7 @@ jobs:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
+      APPLE_DEVELOPER_TEAM_ID: TC45MCF93C
     defaults:
       run:
         working-directory: platform/ios
@@ -140,3 +141,22 @@ jobs:
 
       - name: Build and run SDK unit tests with the static analyzer
         run: make ios-static-analyzer
+
+      - name: Run iOS size test
+        run: scripts/size-check.sh $APPLE_DEVELOPER_TEAM_ID
+        continue-on-error: true
+
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > ./pr_number
+
+      - name: Upload size test result
+        uses: actions/upload-artifact@v3
+        with:
+          name: size-test-result
+          path: |
+            platform/ios/.size-test-result
+            platform/ios/pr_number

--- a/.github/workflows/process-size-test-result.yml
+++ b/.github/workflows/process-size-test-result.yml
@@ -1,0 +1,54 @@
+name: process-size-test-result
+
+on:
+  workflow_run:
+    workflows: [ios-ci]
+    types:
+      - completed
+
+jobs:
+  comment-on-pr:
+    runs-on: ubuntu-22.04
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
+      # TODO: de-duplicate with re-usable action
+      - name: 'Download size-test-result artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "size-test-result"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/size-test-result.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip render-test-result artifact'
+        run: unzip size-test-result.zip
+
+      - name: Show directory structure
+        run: ls -R
+
+      # - name: 'Leave comment on PR with test results'
+      #   uses: actions/github-script@v6
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     script: |
+      #       let fs = require('fs');
+      #       await github.rest.issues.createComment({
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #         issue_number:  Number(fs.readFileSync('./pr_number')),
+      #         body: `Test results at https://maplibre-native-test-artifacts.s3.eu-central-1.amazonaws.com/${context.runId}-linux-gcc8-release-style.html`
+      #       });

--- a/platform/ios/.gitignore
+++ b/platform/ios/.gitignore
@@ -38,6 +38,8 @@ test/fixtures/storage/assets.zip
 buck-out
 .buckd
 
+.size-test-result
+
 # Visual Studio Code
 .vscode
 mapbox-gl-native.code-workspace

--- a/platform/ios/Makefile
+++ b/platform/ios/Makefile
@@ -157,10 +157,6 @@ ios-lint: ios-pod-lint
 ios-pod-lint:
 	./platform/ios/scripts/lint-podspecs.js
 
-#  make ios-sizetest
-.PHONY: ios-sizetest
-ios-sizetest:
-	./scripts/size-check.sh ${DEV_TEAM}
 
 #  make ios-uitest
 .PHONY: ios-uitest

--- a/platform/ios/scripts/size-check.sh
+++ b/platform/ios/scripts/size-check.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 
+echoerr() {
+	echo "$@" 1>&2
+}
+
 if [ $# -eq 0 ]; then
-    echo "Give development team as argument, eg. '484D8S5C7M'"
-    exit 1
+	echoerr "Give development team as argument, eg. '484D8S5C7M'"
+	exit 1
 fi
+
+result=".size-test-result"
+rm -f $result
 
 RED=$'\033[1;31m'
 GREEN=$'\033[1;32m'
@@ -29,70 +36,74 @@ SCHEME_NAME="iosapp"
 ARCHIVE_NAME="${SCHEME_NAME}.xcarchive"
 
 if [[ ! -d $XCODE_WORKSPACE_PATH ]]; then
-  echo "${RED}iOS workspace not found: $XCODE_WORKSPACE_PATH${NORMAL}"
-  exit 2
+	echoerr "${RED}iOS workspace not found: $XCODE_WORKSPACE_PATH${NORMAL}"
+	exit 2
 fi
 
 # Clean up any old builds
 make clean
 if [ ! $? -eq 0 ]; then
-  echo "${RED}Failed cleaning up the build folder${NORMAL}"
-  exit 3
+	echoerr "${RED}Failed cleaning up the build folder${NORMAL}"
+	exit 3
 fi
 
 # Set up the Xcode workspace
 make iproj CI=1
 if [ ! $? -eq 0 ]; then
-  echo "${RED}Failed setting up the Xcode workspace${NORMAL}"
-  exit 4
+	echoerr "${RED}Failed setting up the Xcode workspace${NORMAL}"
+	exit 4
 fi
 
 TOTAL_TESTS=${#BUILD_CONFIGURATIONS[@]}
 PASSED_TESTS=0
 FAILED_TESTS=0
 
-for ((i=0; i<${TOTAL_TESTS}; i++)); do
-  BUILD_CONFIGURATION=${BUILD_CONFIGURATIONS[i]}
-  INITIAL_LIB_SIZE=${INITIAL_LIB_SIZES[i]}
+for ((i = 0; i < ${TOTAL_TESTS}; i++)); do
+	BUILD_CONFIGURATION=${BUILD_CONFIGURATIONS[i]}
+	INITIAL_LIB_SIZE=${INITIAL_LIB_SIZES[i]}
 
-  echo -e "\n** ${BOLD}Building size test $((i+1)) on configuration: ${BUILD_CONFIGURATION}, initial size was ${INITIAL_LIB_SIZE} bytes${NORMAL} **\n"
+	echoerr -e "\n** ${BOLD}Building size test $((i + 1)) on configuration: ${BUILD_CONFIGURATION}, initial size was ${INITIAL_LIB_SIZE} bytes${NORMAL} **\n"
 
-  # The output directory for the archive
-  OUTPUT_DIR="build/ios/archive/${BUILD_CONFIGURATION}"
-  
-  # Build the app
-  xcodebuild archive -quiet -workspace "${XCODE_WORKSPACE_PATH}" -scheme "${SCHEME_NAME}" -configuration "${BUILD_CONFIGURATION}" -archivePath "${OUTPUT_DIR}/${ARCHIVE_NAME}" DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM}"
-  if [ ! $? -eq 0 ]; then
-    echo "${RED}Failed to compile the scheme: ${SCHEME_NAME}${NORMAL}"
-    exit 5
-  fi
+	# The output directory for the archive
+	OUTPUT_DIR="build/ios/archive/${BUILD_CONFIGURATION}"
 
-  # The path to the maplibre dynamic lib
-  LIB_PATH="${OUTPUT_DIR}/${ARCHIVE_NAME}/Products/Applications/MapLibre GL.app/Frameworks/Mapbox.framework/Mapbox"
-  if [[ ! -f "$LIB_PATH" ]]; then
-      echo "${RED}MapLibre dynamic lib not found: $LIB_PATH${NORMAL}"
-      exit 6
-  fi
+	# Build the app
+	xcodebuild archive -quiet -workspace "${XCODE_WORKSPACE_PATH}" -scheme "${SCHEME_NAME}" -configuration "${BUILD_CONFIGURATION}" -archivePath "${OUTPUT_DIR}/${ARCHIVE_NAME}" DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM}"
 
-  # Current lib size in bytes
-  CURRENT_LIB_SIZE=$(wc -c "${LIB_PATH}" | awk '{print $1}')
-  if [ -z $CURRENT_LIB_SIZE ]; then
-    echo "${RED}Failed to compute the size of MapLibre: ${LIB_PATH}${NORMAL}"
-    exit 7
-  fi
+	if [ ! $? -eq 0 ]; then
+		echoerr "${RED}Failed to compile the scheme: ${SCHEME_NAME}${NORMAL}"
+		exit 5
+	fi
 
-  if (($CURRENT_LIB_SIZE > $INITIAL_LIB_SIZE)); then
-    FAILED_TESTS=$((FAILED_TESTS+1))
-    echo -e "${RED}\n[FAILED] MapLibre size is ${CURRENT_LIB_SIZE} bytes. This is larger than the initial size of ${INITIAL_LIB_SIZE} bytes.\n${NORMAL}"
-  else
-    PASSED_TESTS=$((PASSED_TESTS+1))
-    if (($CURRENT_LIB_SIZE == $INITIAL_LIB_SIZE)); then
-      echo -e "${GREEN}\n[PASSED] MapLibre size is ${CURRENT_LIB_SIZE} bytes. This is equal with the initial size of ${INITIAL_LIB_SIZE} bytes.\n${NORMAL}"
-    else 
-      echo -e "${GREEN}\n[PASSED] MapLibre size is ${CURRENT_LIB_SIZE} bytes. This is smaller than the initial size of ${INITIAL_LIB_SIZE} bytes.\n${NORMAL}"
-    fi
-  fi
+	# The path to the maplibre dynamic lib
+	LIB_PATH="${OUTPUT_DIR}/${ARCHIVE_NAME}/Products/Applications/MapLibre GL.app/Frameworks/Mapbox.framework/Mapbox"
+	if [[ ! -f "$LIB_PATH" ]]; then
+		echoerr "${RED}MapLibre dynamic lib not found: $LIB_PATH${NORMAL}"
+		exit 6
+	fi
+
+	# Current lib size in bytes
+	CURRENT_LIB_SIZE=$(wc -c "${LIB_PATH}" | awk '{print $1}')
+	if [ -z $CURRENT_LIB_SIZE ]; then
+		echoerr "${RED}Failed to compute the size of MapLibre: ${LIB_PATH}${NORMAL}"
+		exit 7
+	fi
+
+	echo "BASELINE_$BUILD_CONFIGURATION=$INITIAL_LIB_SIZE" >>$result
+	echo "CURRENT_$BUILD_CONFIGURATION=$CURRENT_LIB_SIZE" >>$result
+
+	if (($CURRENT_LIB_SIZE > $INITIAL_LIB_SIZE)); then
+		FAILED_TESTS=$((FAILED_TESTS + 1))
+		echoerr -e "${RED}\n[FAILED] MapLibre size is ${CURRENT_LIB_SIZE} bytes. This is larger than the initial size of ${INITIAL_LIB_SIZE} bytes.\n${NORMAL}"
+	else
+		PASSED_TESTS=$((PASSED_TESTS + 1))
+		if (($CURRENT_LIB_SIZE == $INITIAL_LIB_SIZE)); then
+			echoerr -e "${GREEN}\n[PASSED] MapLibre size is ${CURRENT_LIB_SIZE} bytes. This is equal with the initial size of ${INITIAL_LIB_SIZE} bytes.\n${NORMAL}"
+		else
+			echoerr -e "${GREEN}\n[PASSED] MapLibre size is ${CURRENT_LIB_SIZE} bytes. This is smaller than the initial size of ${INITIAL_LIB_SIZE} bytes.\n${NORMAL}"
+		fi
+	fi
 done
 
-echo -e "${GREEN}PASSED TESTS: ${PASSED_TESTS} of ${TOTAL_TESTS}${NORMAL}"
-echo -e "${RED}FAILED TESTS: ${FAILED_TESTS} of ${TOTAL_TESTS}${NORMAL}"
+echoerr -e "${GREEN}PASSED TESTS: ${PASSED_TESTS} of ${TOTAL_TESTS}${NORMAL}"
+echoerr -e "${RED}FAILED TESTS: ${FAILED_TESTS} of ${TOTAL_TESTS}${NORMAL}"


### PR DESCRIPTION
Runs iOS size test on CI (#1092).

When this is merged I need to install the provisioning profile on the CI runners and make another PR to comment the size test results on the PR.

A `.size-test-result` file is generated that looks like this:

```
BASELINE_Release=5504352
CURRENT_Release=5654368
BASELINE_MinSizeRel=4249952
CURRENT_MinSizeRel=4383408
```

I am uploading this file as an artifact. I want to comment the change compared to the original baseline and the latest recorded value for `main`.