### PR TITLE
Do not run tests for glInvalidateFramebuffer & glInvalidateSubFramebuffer on macOS

### DIFF
--- a/test/gl/gl_functions.test.cpp
+++ b/test/gl/gl_functions.test.cpp
@@ -251,10 +251,10 @@ TEST(GLFunctions, OpenGLES) {
     EXPECT_NE(glGetProgramBinary, nullptr);
     EXPECT_NE(glProgramBinary, nullptr);
     EXPECT_NE(glProgramParameteri, nullptr);
-    #if !defined(TARGET_OS_MAC)
+#if !defined(TARGET_OS_MAC)
     EXPECT_NE(glInvalidateFramebuffer, nullptr);
     EXPECT_NE(glInvalidateSubFramebuffer, nullptr);
-    #endif
+#endif
     EXPECT_NE(glTexStorage2D, nullptr);
     EXPECT_NE(glTexStorage3D, nullptr);
     EXPECT_NE(glGetInternalformativ, nullptr);

--- a/test/gl/gl_functions.test.cpp
+++ b/test/gl/gl_functions.test.cpp
@@ -251,8 +251,10 @@ TEST(GLFunctions, OpenGLES) {
     EXPECT_NE(glGetProgramBinary, nullptr);
     EXPECT_NE(glProgramBinary, nullptr);
     EXPECT_NE(glProgramParameteri, nullptr);
+    #if !defined(TARGET_OS_MAC)
     EXPECT_NE(glInvalidateFramebuffer, nullptr);
     EXPECT_NE(glInvalidateSubFramebuffer, nullptr);
+    #endif
     EXPECT_NE(glTexStorage2D, nullptr);
     EXPECT_NE(glTexStorage3D, nullptr);
     EXPECT_NE(glGetInternalformativ, nullptr);


### PR DESCRIPTION
They are available only on iOS and iOS Simulator if current platform is Darwin https://github.com/maplibre/maplibre-native/blob/f8c2c6c8b3f1fce6a3529b240d4d3c695a5edfb1/platform/darwin/src/gl_functions.cpp#L268. That's why locally I have such linker errors(for `cmake .. && make -j8 mbgl-test-runner`):
<img width="1729" alt="Screenshot 2023-05-06 at 12 47 15" src="https://user-images.githubusercontent.com/266271/236619855-e01fc43f-4b85-439c-a736-2e0f5f599454.png">

Not sure why it is green on existing macOS CI...