### PR TITLE
Refactor shaders for drawables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -922,6 +922,7 @@ if(MLN_WITH_OPENGL)
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/prelude.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/background.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/drawable_background.hpp
+            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/drawable_fill.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/background_pattern.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/circle.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/clipping_mask.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -921,7 +921,7 @@ if(MLN_WITH_OPENGL)
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/shader_manifest.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/prelude.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/background.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/background_ubo.hpp
+            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/drawable_background.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/background_pattern.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/circle.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/clipping_mask.hpp

--- a/include/mbgl/gfx/renderer_backend.hpp
+++ b/include/mbgl/gfx/renderer_backend.hpp
@@ -6,6 +6,9 @@
 #include <mutex>
 
 namespace mbgl {
+
+class ProgramParameters;
+
 namespace gfx {
 
 class BackendScope;
@@ -42,7 +45,7 @@ public:
     virtual Renderable& getDefaultRenderable() = 0;
 
     /// One-time shader initialization
-    virtual void initShaders(gfx::ShaderRegistry&) = 0;
+    virtual void initShaders(gfx::ShaderRegistry&, const ProgramParameters&) = 0;
 
 protected:
     virtual std::unique_ptr<Context> createContext() = 0;

--- a/include/mbgl/gl/renderer_backend.hpp
+++ b/include/mbgl/gl/renderer_backend.hpp
@@ -6,6 +6,9 @@
 #include <mbgl/util/util.hpp>
 
 namespace mbgl {
+
+class ProgramParameters;
+
 namespace gl {
 
 using ProcAddress = void (*)();
@@ -20,7 +23,7 @@ public:
     virtual void updateAssumedState() = 0;
 
     /// One-time shader initialization
-    void initShaders(gfx::ShaderRegistry&) override;
+    void initShaders(gfx::ShaderRegistry&, const ProgramParameters& programParameters) override;
 
 protected:
     std::unique_ptr<gfx::Context> createContext() override;

--- a/include/mbgl/shaders/gl/background.hpp
+++ b/include/mbgl/shaders/gl/background.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::BackgroundProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "BackgroundProgram";
     static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
 uniform mat4 u_matrix;
 

--- a/include/mbgl/shaders/gl/background_pattern.hpp
+++ b/include/mbgl/shaders/gl/background_pattern.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::BackgroundPatternProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "BackgroundPatternProgram";
     static constexpr const char* vertex = R"(uniform mat4 u_matrix;
 uniform vec2 u_pattern_size_a;
 uniform vec2 u_pattern_size_b;

--- a/include/mbgl/shaders/gl/circle.hpp
+++ b/include/mbgl/shaders/gl/circle.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::CircleProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "CircleProgram";
     static constexpr const char* vertex = R"(uniform mat4 u_matrix;
 uniform bool u_scale_with_map;
 uniform bool u_pitch_with_map;

--- a/include/mbgl/shaders/gl/collision_box.hpp
+++ b/include/mbgl/shaders/gl/collision_box.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::CollisionBoxProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "CollisionBoxProgram";
     static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
 layout (location = 1) in vec2 a_anchor_pos;
 layout (location = 2) in vec2 a_extrude;

--- a/include/mbgl/shaders/gl/collision_circle.hpp
+++ b/include/mbgl/shaders/gl/collision_circle.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::CollisionCircleProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "CollisionCircleProgram";
     static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
 layout (location = 1) in vec2 a_anchor_pos;
 layout (location = 2) in vec2 a_extrude;

--- a/include/mbgl/shaders/gl/debug.hpp
+++ b/include/mbgl/shaders/gl/debug.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::DebugProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "DebugProgram";
     static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
 out vec2 v_uv;
 

--- a/include/mbgl/shaders/gl/drawable_background.hpp
+++ b/include/mbgl/shaders/gl/drawable_background.hpp
@@ -8,18 +8,27 @@ namespace mbgl {
 namespace shaders {
 
 template <>
-struct ShaderSource<BuiltIn::ClippingMaskProgram, gfx::Backend::Type::OpenGL> {
-    static constexpr const char* name = "ClippingMaskProgram";
+struct ShaderSource<BuiltIn::BackgroundShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "BackgroundShader";
     static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
-
-uniform mat4 u_matrix;
+layout (std140) uniform DrawableUBO {
+    mat4 u_matrix;
+};
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 }
 )";
-    static constexpr const char* fragment = R"(void main() {
+    static constexpr const char* fragment = R"(layout (std140) uniform BackgroundLayerUBO {
+    vec4 u_color;
+    float u_opacity;
+};
+
+void main() {
+    fragColor = u_color * u_opacity;
+#ifdef OVERDRAW_INSPECTOR
     fragColor = vec4(1.0);
+#endif
 }
 )";
 };

--- a/include/mbgl/shaders/gl/drawable_fill.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill.hpp
@@ -1,3 +1,6 @@
+// Generated code, do not modify this file!
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
+
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 
@@ -5,12 +8,9 @@ namespace mbgl {
 namespace shaders {
 
 template <>
-struct ShaderSource<BuiltIn::BackgroundProgramUBO, gfx::Backend::Type::OpenGL> {
-    static constexpr const char* vertex = R"(#version 300 es
-precision highp float;
-
-layout (location = 0) in vec2 a_pos;
-
+struct ShaderSource<BuiltIn::FillShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
 layout (std140) uniform DrawableUBO {
     mat4 u_matrix;
 };
@@ -19,19 +19,13 @@ void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 }
 )";
-    static constexpr const char* fragment = R"(#version 300 es
-precision highp float;
-
-layout (std140) uniform BackgroundLayerUBO {
+    static constexpr const char* fragment = R"(layout (std140) uniform BackgroundLayerUBO {
     vec4 u_color;
     float u_opacity;
 };
 
-out vec4 fragColor;
-
 void main() {
     fragColor = u_color * u_opacity;
-
 #ifdef OVERDRAW_INSPECTOR
     fragColor = vec4(1.0);
 #endif

--- a/include/mbgl/shaders/gl/fill.hpp
+++ b/include/mbgl/shaders/gl/fill.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::FillProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillProgram";
     static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
 
 uniform mat4 u_matrix;

--- a/include/mbgl/shaders/gl/fill_extrusion.hpp
+++ b/include/mbgl/shaders/gl/fill_extrusion.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::FillExtrusionProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillExtrusionProgram";
     static constexpr const char* vertex = R"(uniform mat4 u_matrix;
 uniform vec3 u_lightcolor;
 uniform lowp vec3 u_lightpos;

--- a/include/mbgl/shaders/gl/fill_extrusion_pattern.hpp
+++ b/include/mbgl/shaders/gl/fill_extrusion_pattern.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::FillExtrusionPatternProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillExtrusionPatternProgram";
     static constexpr const char* vertex = R"(uniform mat4 u_matrix;
 uniform vec2 u_pixel_coord_upper;
 uniform vec2 u_pixel_coord_lower;

--- a/include/mbgl/shaders/gl/fill_outline.hpp
+++ b/include/mbgl/shaders/gl/fill_outline.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::FillOutlineProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillOutlineProgram";
     static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
 
 uniform mat4 u_matrix;

--- a/include/mbgl/shaders/gl/fill_outline_pattern.hpp
+++ b/include/mbgl/shaders/gl/fill_outline_pattern.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::FillOutlinePatternProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillOutlinePatternProgram";
     static constexpr const char* vertex = R"(uniform mat4 u_matrix;
 uniform vec2 u_world;
 uniform vec2 u_pixel_coord_upper;

--- a/include/mbgl/shaders/gl/fill_pattern.hpp
+++ b/include/mbgl/shaders/gl/fill_pattern.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::FillPatternProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillPatternProgram";
     static constexpr const char* vertex = R"(uniform mat4 u_matrix;
 uniform vec2 u_pixel_coord_upper;
 uniform vec2 u_pixel_coord_lower;

--- a/include/mbgl/shaders/gl/heatmap.hpp
+++ b/include/mbgl/shaders/gl/heatmap.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::HeatmapProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "HeatmapProgram";
     static constexpr const char* vertex = R"(uniform mat4 u_matrix;
 uniform float u_extrude_scale;
 uniform float u_opacity;

--- a/include/mbgl/shaders/gl/heatmap_texture.hpp
+++ b/include/mbgl/shaders/gl/heatmap_texture.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::HeatmapTextureProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "HeatmapTextureProgram";
     static constexpr const char* vertex = R"(uniform mat4 u_matrix;
 uniform vec2 u_world;
 layout (location = 0) in vec2 a_pos;

--- a/include/mbgl/shaders/gl/hillshade.hpp
+++ b/include/mbgl/shaders/gl/hillshade.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::HillshadeProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "HillshadeProgram";
     static constexpr const char* vertex = R"(uniform mat4 u_matrix;
 
 layout (location = 0) in vec2 a_pos;

--- a/include/mbgl/shaders/gl/hillshade_prepare.hpp
+++ b/include/mbgl/shaders/gl/hillshade_prepare.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::HillshadePrepareProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "HillshadePrepareProgram";
     static constexpr const char* vertex = R"(uniform mat4 u_matrix;
 uniform vec2 u_dimension;
 

--- a/include/mbgl/shaders/gl/line.hpp
+++ b/include/mbgl/shaders/gl/line.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::LineProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "LineProgram";
     static constexpr const char* vertex = R"(// floor(127 / 2) == 63.0
 // the maximum allowed miter limit is 2.0 at the moment. the extrude normal is
 // stored in a byte (-128..127). we scale regular normals up to length 63, but

--- a/include/mbgl/shaders/gl/line_gradient.hpp
+++ b/include/mbgl/shaders/gl/line_gradient.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::LineGradientProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "LineGradientProgram";
     static constexpr const char* vertex = R"(
 // the attribute conveying progress along a line is scaled to [0, 2^15)
 #define MAX_LINE_DISTANCE 32767.0

--- a/include/mbgl/shaders/gl/line_pattern.hpp
+++ b/include/mbgl/shaders/gl/line_pattern.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::LinePatternProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "LinePatternProgram";
     static constexpr const char* vertex = R"(// floor(127 / 2) == 63.0
 // the maximum allowed miter limit is 2.0 at the moment. the extrude normal is
 // stored in a byte (-128..127). we scale regular normals up to length 63, but

--- a/include/mbgl/shaders/gl/line_sdf.hpp
+++ b/include/mbgl/shaders/gl/line_sdf.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::LineSDFProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "LineSDFProgram";
     static constexpr const char* vertex = R"(// floor(127 / 2) == 63.0
 // the maximum allowed miter limit is 2.0 at the moment. the extrude normal is
 // stored in a byte (-128..127). we scale regular normals up to length 63, but

--- a/include/mbgl/shaders/gl/prelude.hpp
+++ b/include/mbgl/shaders/gl/prelude.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::Prelude, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "Prelude";
     static constexpr const char* vertex = R"(#ifdef GL_ES
 precision highp float;
 #else

--- a/include/mbgl/shaders/gl/raster.hpp
+++ b/include/mbgl/shaders/gl/raster.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::RasterProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "RasterProgram";
     static constexpr const char* vertex = R"(uniform mat4 u_matrix;
 uniform vec2 u_tl_parent;
 uniform float u_scale_parent;

--- a/include/mbgl/shaders/gl/shader_program_gl.hpp
+++ b/include/mbgl/shaders/gl/shader_program_gl.hpp
@@ -6,6 +6,9 @@
 #include <mbgl/shaders/shader_program_base.hpp>
 
 namespace mbgl {
+
+class ProgramParameters;
+
 namespace gl {
 
 class ShaderProgramGL final : public gfx::ShaderProgramBase {
@@ -19,9 +22,11 @@ public:
     const std::string_view typeName() const noexcept override { return Name; }
 
     static std::shared_ptr<ShaderProgramGL> create(Context&,
-                                                   std::string_view name,
-                                                   std::string_view vertexSource,
-                                                   std::string_view fragmentSource) noexcept(false);
+                                                   const ProgramParameters& programParameters,
+                                                   const std::string& name,
+                                                   const std::string& vertexSource,
+                                                   const std::string& fragmentSource,
+                                                   const std::string& additionalDefines = "") noexcept(false);
 
     const gfx::UniformBlockArray& getUniformBlocks() const override { return uniformBlocks; }
 

--- a/include/mbgl/shaders/gl/symbol_icon.hpp
+++ b/include/mbgl/shaders/gl/symbol_icon.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::SymbolIconProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "SymbolIconProgram";
     static constexpr const char* vertex = R"(const float PI = 3.141592653589793;
 
 layout (location = 0) in vec4 a_pos_offset;

--- a/include/mbgl/shaders/gl/symbol_sdf_icon.hpp
+++ b/include/mbgl/shaders/gl/symbol_sdf_icon.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::SymbolSDFIconProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "SymbolSDFIconProgram";
     static constexpr const char* vertex = R"(const float PI = 3.141592653589793;
 
 layout (location = 0) in vec4 a_pos_offset;

--- a/include/mbgl/shaders/gl/symbol_sdf_text.hpp
+++ b/include/mbgl/shaders/gl/symbol_sdf_text.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::SymbolSDFTextProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "SymbolSDFTextProgram";
     static constexpr const char* vertex = R"(const float PI = 3.141592653589793;
 
 layout (location = 0) in vec4 a_pos_offset;

--- a/include/mbgl/shaders/gl/symbol_text_and_icon.hpp
+++ b/include/mbgl/shaders/gl/symbol_text_and_icon.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
@@ -9,6 +9,7 @@ namespace shaders {
 
 template <>
 struct ShaderSource<BuiltIn::SymbolTextAndIconProgram, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "SymbolTextAndIconProgram";
     static constexpr const char* vertex = R"(const float PI = 3.141592653589793;
 
 layout (location = 0) in vec4 a_pos_offset;

--- a/include/mbgl/shaders/shader_manifest.hpp
+++ b/include/mbgl/shaders/shader_manifest.hpp
@@ -1,10 +1,12 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 
 #ifdef MBGL_RENDER_BACKEND_OPENGL
+#include <mbgl/shaders/gl/drawable_background.hpp>
+#include <mbgl/shaders/gl/drawable_fill.hpp>
 #include <mbgl/shaders/gl/prelude.hpp>
 #include <mbgl/shaders/gl/background.hpp>
 #include <mbgl/shaders/gl/background_pattern.hpp>
@@ -32,6 +34,4 @@
 #include <mbgl/shaders/gl/symbol_sdf_text.hpp>
 #include <mbgl/shaders/gl/symbol_sdf_icon.hpp>
 #include <mbgl/shaders/gl/symbol_text_and_icon.hpp>
-
-#include <mbgl/shaders/gl/background_ubo.hpp>
 #endif

--- a/include/mbgl/shaders/shader_source.hpp
+++ b/include/mbgl/shaders/shader_source.hpp
@@ -1,5 +1,5 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
+// Generated on 2023-05-11T18:11:44.911Z by mwilsnd using shaders/generate_shader_code.js
 
 #pragma once
 #include <mbgl/gfx/backend.hpp>
@@ -11,6 +11,8 @@ namespace shaders {
 /// source code for the desired program and graphics back-end.
 enum class BuiltIn {
     None,
+    BackgroundShader,
+    FillShader,
     Prelude,
     BackgroundProgram,
     BackgroundPatternProgram,
@@ -37,9 +39,7 @@ enum class BuiltIn {
     SymbolIconProgram,
     SymbolSDFTextProgram,
     SymbolSDFIconProgram,
-    SymbolTextAndIconProgram,
-
-    BackgroundProgramUBO
+    SymbolTextAndIconProgram
 };
 
 /// @brief Select shader source based on a program type and a desired
@@ -53,6 +53,7 @@ struct ShaderSource;
 /// @brief A specialization of the ShaderSource template for no shader code.
 template <>
 struct ShaderSource<BuiltIn::None, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "";
     static constexpr const char* vertex = "";
     static constexpr const char* fragment = "";
 };

--- a/shaders/drawable.background.fragment.glsl
+++ b/shaders/drawable.background.fragment.glsl
@@ -1,0 +1,11 @@
+layout (std140) uniform BackgroundLayerUBO {
+    vec4 u_color;
+    float u_opacity;
+};
+
+void main() {
+    fragColor = u_color * u_opacity;
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.background.vertex.glsl
+++ b/shaders/drawable.background.vertex.glsl
@@ -1,0 +1,8 @@
+layout (location = 0) in vec2 a_pos;
+layout (std140) uniform DrawableUBO {
+    mat4 u_matrix;
+};
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+}

--- a/shaders/drawable.fill.fragment.glsl
+++ b/shaders/drawable.fill.fragment.glsl
@@ -1,0 +1,11 @@
+layout (std140) uniform BackgroundLayerUBO {
+    vec4 u_color;
+    float u_opacity;
+};
+
+void main() {
+    fragColor = u_color * u_opacity;
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.fill.vertex.glsl
+++ b/shaders/drawable.fill.vertex.glsl
@@ -1,0 +1,8 @@
+layout (location = 0) in vec2 a_pos;
+layout (std140) uniform DrawableUBO {
+    mat4 u_matrix;
+};
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+}

--- a/shaders/generate_shader_code.js
+++ b/shaders/generate_shader_code.js
@@ -116,6 +116,78 @@ ${precision} ${type} ${name} = u_${name};
     });
 };
 
+/// This variant does not emit any uniforms and instead controls access to UBOs
+const pragmaMapConvertOnlyVertexArrays = (source, pragmaMap, attribLocations, pipelineStage) => {
+    const re = /#pragma mapbox: ([\w]+) ([\w]+) ([\w]+) ([\w]+)/g;
+
+    if (pipelineStage == "fragment") {
+        return source.replace(re, (match, operation, precision, type, name) => {
+            pragmaMap[name] = true;
+            if (operation === 'define') {
+                return `#ifndef HAS_UNIFORM_u_${name}
+in ${precision} ${type} ${name};
+#endif`;
+            } else /* if (operation === 'initialize') */ {
+            return `#ifdef HAS_UNIFORM_u_${name}
+${precision} ${type} ${name} = u_${name};
+#endif`;
+            }
+        });
+    }
+
+    // else pipelineStage == "vertex"
+
+    return source.replace(re, (match, operation, precision, type, name) => {
+        const attrType = type === 'float' ? 'vec2' : 'vec4';
+        const unpackType = name.match(/color/) ? 'color' : attrType;
+        
+        if (pragmaMap[name]) {
+            if (operation === 'define') {
+                return `#ifndef HAS_UNIFORM_u_${name}
+layout (location = ${locationForAttrib(attribLocations, name)}) in ${precision} ${attrType} a_${name};
+out ${precision} ${type} ${name};
+#endif`;
+            } else /* if (operation === 'initialize') */ {
+                if (unpackType === 'vec4') {
+                    // vec4 attributes are only used for cross-faded properties, and are not packed
+                    return `#ifndef HAS_UNIFORM_u_${name}
+${name} = a_${name};
+#else
+${precision} ${type} ${name} = u_${name};
+#endif`;
+                } else {
+                    return `#ifndef HAS_UNIFORM_u_${name}
+${name} = unpack_mix_${unpackType}(a_${name}, u_${name}_t);
+#else
+${precision} ${type} ${name} = u_${name};
+#endif`;
+                }
+            }
+        } else {
+            if (operation === 'define') {
+                return `#ifndef HAS_UNIFORM_u_${name}
+layout (location = ${locationForAttrib(attribLocations, name)}) in ${precision} ${attrType} a_${name};
+#endif`;
+            } else /* if (operation === 'initialize') */ {
+                if (unpackType === 'vec4') {
+                    // vec4 attributes are only used for cross-faded properties, and are not packed
+                    return `#ifndef HAS_UNIFORM_u_${name}
+${precision} ${type} ${name} = a_${name};
+#else
+${precision} ${type} ${name} = u_${name};
+#endif`;
+                } else /* */{
+                    return `#ifndef HAS_UNIFORM_u_${name}
+${precision} ${type} ${name} = unpack_mix_${unpackType}(a_${name}, u_${name}_t);
+#else
+${precision} ${type} ${name} = u_${name};
+#endif`;
+                }
+            }
+        }
+    });
+};
+
 const strip = (source) => {
     return source
         .replace(/^\s+/gm, "\n") // indentation, leading whitespace
@@ -164,8 +236,12 @@ JSON.parse(fs.readFileSync(path.join(args.input, "manifest.json")))
         let pragmaMap = [];
         let attribMap = newAttribLocationMapping(vertexSource);
 
-        const frag = pragmaMapConvert(fragmentSource, pragmaMap, attribMap, "fragment");
-        const vert = pragmaMapConvert(vertexSource, pragmaMap, attribMap, "vertex");
+        const frag = elem.uses_ubos
+            ? pragmaMapConvertOnlyVertexArrays(fragmentSource, pragmaMap, attribMap, "fragment")
+            : pragmaMapConvert(fragmentSource, pragmaMap, attribMap, "fragment");
+        const vert = elem.uses_ubos
+            ? pragmaMapConvertOnlyVertexArrays(vertexSource, pragmaMap, attribMap, "vertex")
+            : pragmaMapConvert(vertexSource, pragmaMap, attribMap, "vertex");
 
         fs.writeFileSync(
             path.join(args.output, elem.header + ".hpp"),
@@ -177,6 +253,7 @@ namespace mbgl {
 namespace shaders {
 
 template <> struct ShaderSource<BuiltIn::${elem.name}, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "${elem.name}";
     static constexpr const char* vertex = R"(${args.strip ? strip(vert) : vert})";
     static constexpr const char* fragment = R"(${args.strip ? strip(frag) : frag})";
 };
@@ -225,6 +302,7 @@ template <BuiltIn T, gfx::Backend::Type> struct ShaderSource;
 
 /// @brief A specialization of the ShaderSource template for no shader code.
 template <> struct ShaderSource<BuiltIn::None, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "";
     static constexpr const char* vertex = "";
     static constexpr const char* fragment = "";
 };

--- a/shaders/manifest.json
+++ b/shaders/manifest.json
@@ -1,5 +1,20 @@
 [
     {
+        "name": "BackgroundShader",
+        "header": "drawable_background",
+        "glsl_vert": "drawable.background.vertex.glsl",
+        "glsl_frag": "drawable.background.fragment.glsl",
+        "uses_ubos": true
+    },
+    {
+        "name": "FillShader",
+        "header": "drawable_fill",
+        "glsl_vert": "drawable.fill.vertex.glsl",
+        "glsl_frag": "drawable.fill.fragment.glsl",
+        "uses_ubos": true
+    },
+
+    {
         "name": "Prelude",
         "header": "prelude",
         "glsl_vert": "_prelude.vertex.glsl",

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -196,8 +196,6 @@ void RenderBackgroundLayer::prepare(const LayerPrepareParameters& params) {
     }
 }
 
-constexpr auto shaderName = "BackgroundProgramUBO";
-
 void RenderBackgroundLayer::layerRemoved(UniqueChangeRequestVec& changes) {
     // TODO: This isn't happening on style change, so old tile drawables are being left active
 
@@ -220,7 +218,7 @@ void RenderBackgroundLayer::update(const int32_t layerIndex,
     std::unique_lock<std::mutex> guard(mutex);
 
     if (!shader) {
-        shader = context.getGenericShader(shaders, shaderName);
+        shader = context.getGenericShader(shaders, "BackgroundDrawable");
     }
 
     const auto& evaluated = getEvaluated<BackgroundLayerProperties>(evaluatedProperties);

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -260,8 +260,6 @@ bool RenderFillLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeo
                                                feature.getGeometries());
 }
 
-constexpr auto shaderName = "BackgroundProgramUBO";
-
 void RenderFillLayer::layerRemoved(UniqueChangeRequestVec& changes) {
     // Remove everything
     decltype(tileDrawables) localDrawables;
@@ -282,7 +280,7 @@ void RenderFillLayer::update(const int32_t layerIndex,
     std::unique_lock<std::mutex> guard(mutex);
 
     if (!shader) {
-        shader = context.getGenericShader(shaders, shaderName);
+        shader = context.getGenericShader(shaders, "FillDrawable");
     }
 
     // const auto& evaluated = getEvaluated<FillLayerProperties>(evaluatedProperties);

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -62,11 +62,13 @@ void Renderer::Impl::render(const RenderTree& renderTree) {
 
         // Initialize legacy shader programs
         staticData->programs.registerWith(*staticData->shaders);
-        observer->onRegisterShaders(*staticData->shaders);
 
         // Initialize shaders for drawables
         const auto programParameters = ProgramParameters{pixelRatio, false};
         backend.initShaders(*staticData->shaders, programParameters);
+
+        // Notify post-shader registration
+        observer->onRegisterShaders(*staticData->shaders);
     }
     staticData->has3D = renderTreeParameters.has3D;
 

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -53,21 +53,22 @@ void Renderer::Impl::render(const RenderTree& renderTree) {
     observer->onWillStartRenderingFrame();
     const auto& renderTreeParameters = renderTree.getParameters();
 
-    if (!staticData) {
-        staticData = std::make_unique<RenderStaticData>(pixelRatio, std::make_unique<gfx::ShaderRegistry>());
-        staticData->programs.registerWith(*staticData->shaders);
-        observer->onRegisterShaders(*staticData->shaders);
-    }
-    staticData->has3D = renderTreeParameters.has3D;
-
     auto& context = backend.getContext();
-
-    // Now that the shader registry is set up, do one-time shader init.
-    // TODO: Both should be done earlier.
-    backend.initShaders(*staticData->shaders);
-
     // Blocks execution until the renderable is available.
     backend.getDefaultRenderable().wait();
+
+    if (!staticData) {
+        staticData = std::make_unique<RenderStaticData>(pixelRatio, std::make_unique<gfx::ShaderRegistry>());
+
+        // Initialize legacy shader programs
+        staticData->programs.registerWith(*staticData->shaders);
+        observer->onRegisterShaders(*staticData->shaders);
+
+        // Initialize shaders for drawables
+        const auto programParameters = ProgramParameters{pixelRatio, false};
+        backend.initShaders(*staticData->shaders, programParameters);
+    }
+    staticData->has3D = renderTreeParameters.has3D;
 
     PaintParameters parameters{context,
                                pixelRatio,


### PR DESCRIPTION
Brings generated shaders to the drawables branch.

Generate shaders: `node shaders/generate_shader_code.js --i shaders --o shaders/out`
Add new shaders in `renderer_backend.cpp:initShaders` by adding the `BuiltIn` value to the template list in `registerTypes`

Updates `generate_shader_code.js` with a new pathway for manifest parameter `uses_ubos`; Does not emit `uniform` permutations but still references them if the permutation takes the uniform pathway. Uniform names must be preserved for this to work ie `uniform vec4 u_color` becomes a member vec4 of a UBO with the same name.

There is some extra stuff going on with color packing, the library can pack a 4 component color in two floats and interpolate between them. We'll address how to handle that when we run into it.