### PR TITLE
Tweak test results comments on PRs

### DIFF
--- a/.github/workflows/pr-render-test-result.yml
+++ b/.github/workflows/pr-render-test-result.yml
@@ -59,6 +59,7 @@ jobs:
       - name: 'Leave comment on PR with test results'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: render-test-result
           number: ${{ env.pr_number }}
           hide_and_recreate: true
           hide_classify: "OUTDATED"

--- a/.github/workflows/pr-size-test-result.yml
+++ b/.github/workflows/pr-size-test-result.yml
@@ -66,13 +66,14 @@ jobs:
           echo pr_number="$(cat ./pr_number)" >> "$GITHUB_ENV"
           echo old_size="$(cat ./size_main)" >> "$GITHUB_ENV"
           echo new_size="$(cat ./size)" >> "$GITHUB_ENV"
-          echo percentage_change=$(awk 'NR==FNR{a=$0;next}{printf "%+.2f%%\n", 100*($0-a)/a}' $new_size $old_size) >> "$GITHUB_ENV"
+          echo percentage_change=$(awk 'NR==FNR{a=$0;next}{printf "%+.2f%%\n", 100*($0-a)/a}' ./size ./size_main) >> "$GITHUB_ENV"
         if: github.event.workflow_run.event == 'pull_request'
 
       - name: 'Leave comment on PR with test results'
         if: github.event.workflow_run.event == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: size-test-result
           number: ${{ env.pr_number }}
           hide_and_recreate: true
           hide_classify: "OUTDATED"


### PR DESCRIPTION
Makes sure the size test comment doesn't hide the render test comment and vice versa.

Also fixes showing the percentage size difference.