### PR TITLE
apply color attributes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -928,6 +928,7 @@ if(MLN_WITH_OPENGL)
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/background.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/drawable_background.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/drawable_fill.hpp
+            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/drawable_fill_outline.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/background_pattern.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/circle.hpp
             ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/clipping_mask.hpp

--- a/include/mbgl/gfx/drawable.hpp
+++ b/include/mbgl/gfx/drawable.hpp
@@ -91,7 +91,8 @@ public:
     virtual void setVertexAttributes(const gfx::VertexAttributeArray&) = 0;
     virtual void setVertexAttributes(gfx::VertexAttributeArray&&) = 0;
 
-    virtual std::vector<std::uint16_t>& getIndexData() const = 0;
+    virtual std::vector<std::uint16_t>& getLineIndexData() const = 0;
+    virtual std::vector<std::uint16_t>& getTriangleIndexData() const = 0;
 
     /// Attach a tweaker to be run on this drawable for each frame
     void addTweaker(DrawableTweakerPtr tweaker) { tweakers.emplace_back(std::move(tweaker)); }

--- a/include/mbgl/gfx/drawable.hpp
+++ b/include/mbgl/gfx/drawable.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/util/color.hpp>
 #include <mbgl/util/identity.hpp>
+#include <mbgl/util/traits.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -54,9 +55,15 @@ public:
 
     /// Test whether to draw this drawable in a given render pass.
     /// If multiple render pass bits are set, all must be present.
-    bool hasRenderPass(mbgl::RenderPass value) const {
-        using T = std::underlying_type<mbgl::RenderPass>::type;
-        return (static_cast<T>(renderPass) & static_cast<T>(value)) == static_cast<T>(value);
+    bool hasRenderPass(const mbgl::RenderPass value) const {
+        return (mbgl::underlying_type(renderPass) & mbgl::underlying_type(value)) != 0;
+    }
+
+    /// Test whether to draw this drawable in a given render pass.
+    /// If multiple render pass bits are set, all must be present.
+    bool hasAllRenderPasses(const mbgl::RenderPass value) const {
+        const auto underlying_value = mbgl::underlying_type(value);
+        return (mbgl::underlying_type(renderPass) & underlying_value) == underlying_value;
     }
 
     /// not used for anything yet

--- a/include/mbgl/gfx/drawable_builder.hpp
+++ b/include/mbgl/gfx/drawable_builder.hpp
@@ -109,6 +109,23 @@ public:
     void setVertexAttributes(const VertexAttributeArray&);
     void setVertexAttributes(VertexAttributeArray&&);
 
+    /// Add some vertex elements, returns the index of the first one added
+    std::size_t addVertices(const std::vector<std::array<int16_t, 2>>& vertices,
+                            std::size_t vertexOffset,
+                            std::size_t vertexLength);
+
+    /// Add lines based on existing vertices
+    void addLines(const std::vector<uint16_t>& indexes,
+                  std::size_t indexOffset,
+                  std::size_t indexLength,
+                  std::size_t baseIndex = 0);
+
+    /// Add triangles based on existing vertices
+    void addTriangles(const std::vector<uint16_t>& indexes,
+                      std::size_t indexOffset,
+                      std::size_t indexLength,
+                      std::size_t baseIndex = 0);
+
     /// Add already-set-up triangles directly
     void addTriangles(const std::vector<std::array<int16_t, 2>>& vertices,
                       std::size_t vertexOffset,

--- a/include/mbgl/gl/drawable_gl.hpp
+++ b/include/mbgl/gl/drawable_gl.hpp
@@ -26,8 +26,11 @@ public:
 
     void draw(const PaintParameters&) const override;
 
-    void setIndexData(std::vector<uint16_t> indexes, std::size_t indexOffset = 0, std::size_t indexLength = 0);
-    std::vector<std::uint16_t>& getIndexData() const override;
+    void setLineIndexData(std::vector<uint16_t> indexes);
+    void setTriangleIndexData(std::vector<uint16_t> indexes);
+
+    std::vector<std::uint16_t>& getLineIndexData() const override;
+    std::vector<std::uint16_t>& getTriangleIndexData() const override;
 
     const gfx::VertexAttributeArray& getVertexAttributes() const override;
     void setVertexAttributes(const gfx::VertexAttributeArray& value) override;

--- a/include/mbgl/shaders/gl/drawable_fill_outline.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill_outline.hpp
@@ -7,7 +7,8 @@
 namespace mbgl {
 namespace shaders {
 
-template <> struct ShaderSource<BuiltIn::FillOutlineShader, gfx::Backend::Type::OpenGL> {
+template <>
+struct ShaderSource<BuiltIn::FillOutlineShader, gfx::Backend::Type::OpenGL> {
     static constexpr const char* name = "FillOutlineShader";
     static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
 

--- a/include/mbgl/shaders/gl/drawable_fill_outline.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill_outline.hpp
@@ -1,0 +1,83 @@
+// Generated code, do not modify this file!
+// Generated on 2023-05-18T18:41:48.652Z by timsylvester using shaders/generate_shader_code.js
+
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <> struct ShaderSource<BuiltIn::FillOutlineShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillOutlineShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
+
+uniform mat4 u_matrix;
+uniform vec2 u_world;
+
+out vec2 v_pos;
+
+#ifndef HAS_UNIFORM_u_outline_color
+uniform lowp float u_outline_color_t;
+layout (location = 1) in highp vec4 a_outline_color;
+out highp vec4 outline_color;
+#else
+uniform highp vec4 u_outline_color;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+uniform lowp float u_opacity_t;
+layout (location = 2) in lowp vec2 a_opacity;
+out lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_outline_color
+outline_color = unpack_mix_color(a_outline_color, u_outline_color_t);
+#else
+highp vec4 outline_color = u_outline_color;
+#endif
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+    v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
+}
+)";
+    static constexpr const char* fragment = R"(in vec2 v_pos;
+
+#ifndef HAS_UNIFORM_u_outline_color
+in highp vec4 outline_color;
+#else
+uniform highp vec4 u_outline_color;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#else
+uniform lowp float u_opacity;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_outline_color
+highp vec4 outline_color = u_outline_color;
+#endif
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+
+    float dist = length(v_pos - gl_FragCoord.xy);
+    float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
+    fragColor = outline_color * (alpha * opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/shader_manifest.hpp
+++ b/include/mbgl/shaders/shader_manifest.hpp
@@ -7,6 +7,7 @@
 #ifdef MBGL_RENDER_BACKEND_OPENGL
 #include <mbgl/shaders/gl/drawable_background.hpp>
 #include <mbgl/shaders/gl/drawable_fill.hpp>
+#include <mbgl/shaders/gl/drawable_fill_outline.hpp>
 #include <mbgl/shaders/gl/prelude.hpp>
 #include <mbgl/shaders/gl/background.hpp>
 #include <mbgl/shaders/gl/background_pattern.hpp>

--- a/include/mbgl/shaders/shader_source.hpp
+++ b/include/mbgl/shaders/shader_source.hpp
@@ -13,6 +13,7 @@ enum class BuiltIn {
     None,
     BackgroundShader,
     FillShader,
+    FillOutlineShader,
     Prelude,
     BackgroundProgram,
     BackgroundPatternProgram,

--- a/shaders/drawable.fill_outline.fragment.glsl
+++ b/shaders/drawable.fill_outline.fragment.glsl
@@ -1,0 +1,17 @@
+in vec2 v_pos;
+
+#pragma mapbox: define highp vec4 outline_color
+#pragma mapbox: define lowp float opacity
+
+void main() {
+    #pragma mapbox: initialize highp vec4 outline_color
+    #pragma mapbox: initialize lowp float opacity
+
+    float dist = length(v_pos - gl_FragCoord.xy);
+    float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
+    fragColor = outline_color * (alpha * opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.fill_outline.vertex.glsl
+++ b/shaders/drawable.fill_outline.vertex.glsl
@@ -1,0 +1,17 @@
+layout (location = 0) in vec2 a_pos;
+
+uniform mat4 u_matrix;
+uniform vec2 u_world;
+
+out vec2 v_pos;
+
+#pragma mapbox: define highp vec4 outline_color
+#pragma mapbox: define lowp float opacity
+
+void main() {
+    #pragma mapbox: initialize highp vec4 outline_color
+    #pragma mapbox: initialize lowp float opacity
+
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+    v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
+}

--- a/shaders/manifest.json
+++ b/shaders/manifest.json
@@ -13,6 +13,13 @@
         "glsl_frag": "drawable.fill.fragment.glsl",
         "uses_ubos": false 
     },
+    {
+        "name": "FillOutlineShader",
+        "header": "drawable_fill_outline",
+        "glsl_vert": "drawable.fill_outline.vertex.glsl",
+        "glsl_frag": "drawable.fill_outline.fragment.glsl",
+        "uses_ubos": false 
+    },
 
     {
         "name": "Prelude",

--- a/src/mbgl/gfx/drawable_builder.cpp
+++ b/src/mbgl/gfx/drawable_builder.cpp
@@ -126,8 +126,8 @@ void DrawableBuilder::setVertexAttributes(VertexAttributeArray&& attrs) {
 }
 
 std::size_t DrawableBuilder::addVertices(const std::vector<std::array<int16_t, 2>>& vertices,
-                                  std::size_t vertexOffset,
-                                  std::size_t vertexLength) {
+                                         std::size_t vertexOffset,
+                                         std::size_t vertexLength) {
     const auto baseIndex = impl->vertices.elements();
     std::for_each(std::next(vertices.begin(), vertexOffset),
                   std::next(vertices.begin(), vertexOffset + vertexLength),

--- a/src/mbgl/gfx/drawable_builder.cpp
+++ b/src/mbgl/gfx/drawable_builder.cpp
@@ -97,7 +97,7 @@ void DrawableBuilder::addTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1
     impl->vertices.emplace_back(Impl::VT({{{x0, y0}}}));
     impl->vertices.emplace_back(Impl::VT({{{x1, y1}}}));
     impl->vertices.emplace_back(Impl::VT({{{x2, y2}}}));
-    impl->indexes.emplace_back(n, n + 1, n + 2);
+    impl->triangleIndexes.emplace_back(n, n + 1, n + 2);
     if (colorMode == ColorMode::PerVertex) {
         impl->colors.insert(impl->colors.end(), 3, impl->currentColor);
     }
@@ -106,7 +106,7 @@ void DrawableBuilder::addTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1
 void DrawableBuilder::appendTriangle(int16_t x0, int16_t y0) {
     const auto n = (uint16_t)impl->vertices.elements();
     impl->vertices.emplace_back(Impl::VT({{{x0, y0}}}));
-    impl->indexes.emplace_back(n - 2, n - 1, n);
+    impl->triangleIndexes.emplace_back(n - 2, n - 1, n);
     if (colorMode == ColorMode::PerVertex) {
         impl->colors.emplace_back(impl->currentColor);
     }
@@ -125,6 +125,44 @@ void DrawableBuilder::setVertexAttributes(VertexAttributeArray&& attrs) {
     vertexAttrs = attrs;
 }
 
+std::size_t DrawableBuilder::addVertices(const std::vector<std::array<int16_t, 2>>& vertices,
+                                  std::size_t vertexOffset,
+                                  std::size_t vertexLength) {
+    const auto baseIndex = impl->vertices.elements();
+    std::for_each(std::next(vertices.begin(), vertexOffset),
+                  std::next(vertices.begin(), vertexOffset + vertexLength),
+                  [&](const std::array<int16_t, 2>& x) { impl->vertices.emplace_back(Impl::VT({{x}})); });
+    if (colorMode == ColorMode::PerVertex) {
+        for (size_t i = 0; i < vertexLength; ++i) {
+            impl->colors.emplace_back(impl->currentColor);
+        }
+    }
+    return baseIndex;
+}
+
+void DrawableBuilder::addLines(const std::vector<uint16_t>& indexes,
+                               std::size_t indexOffset,
+                               std::size_t indexLength,
+                               std::size_t baseIndex) {
+    for (auto i = std::next(indexes.begin(), indexOffset);
+         i != std::next(indexes.begin(), indexOffset + indexLength);) {
+        impl->lineIndexes.emplace_back(static_cast<uint16_t>(*i++ + baseIndex),
+                                       static_cast<uint16_t>(*i++ + baseIndex));
+    }
+}
+
+void DrawableBuilder::addTriangles(const std::vector<uint16_t>& indexes,
+                                   std::size_t indexOffset,
+                                   std::size_t indexLength,
+                                   std::size_t baseIndex) {
+    for (auto i = std::next(indexes.begin(), indexOffset);
+         i != std::next(indexes.begin(), indexOffset + indexLength);) {
+        impl->triangleIndexes.emplace_back(static_cast<uint16_t>(*i++ + baseIndex),
+                                           static_cast<uint16_t>(*i++ + baseIndex),
+                                           static_cast<uint16_t>(*i++ + baseIndex));
+    }
+}
+
 void DrawableBuilder::addTriangles(const std::vector<std::array<int16_t, 2>>& vertices,
                                    std::size_t vertexOffset,
                                    std::size_t vertexLength,
@@ -139,21 +177,8 @@ void DrawableBuilder::addTriangles(const std::vector<std::array<int16_t, 2>>& ve
     //                     std::next(indexes.begin(), indexOffset),
     //                     std::next(indexes.begin(), indexOffset + indexLength));
 
-    const auto baseIndex = impl->vertices.elements();
-    std::for_each(std::next(vertices.begin(), vertexOffset),
-                  std::next(vertices.begin(), vertexOffset + vertexLength),
-                  [&](const std::array<int16_t, 2>& x) { impl->vertices.emplace_back(Impl::VT({{x}})); });
-    for (auto i = std::next(indexes.begin(), indexOffset);
-         i != std::next(indexes.begin(), indexOffset + indexLength);) {
-        impl->indexes.emplace_back(static_cast<uint16_t>(*i++ + baseIndex),
-                                   static_cast<uint16_t>(*i++ + baseIndex),
-                                   static_cast<uint16_t>(*i++ + baseIndex));
-    }
-    if (colorMode == ColorMode::PerVertex) {
-        for (size_t i = 0; i < vertexLength; ++i) {
-            impl->colors.emplace_back(impl->currentColor);
-        }
-    }
+    const auto baseIndex = addVertices(vertices, vertexOffset, vertexLength);
+    addTriangles(indexes, indexOffset, indexLength, baseIndex);
 }
 
 } // namespace gfx

--- a/src/mbgl/gfx/drawable_builder.cpp
+++ b/src/mbgl/gfx/drawable_builder.cpp
@@ -1,6 +1,8 @@
 #include <mbgl/gfx/drawable_builder.hpp>
+
 #include <mbgl/gfx/drawable_builder_impl.hpp>
 #include <mbgl/renderer/render_pass.hpp>
+#include <mbgl/util/logging.hpp>
 
 namespace mbgl {
 namespace gfx {
@@ -42,8 +44,18 @@ void DrawableBuilder::flush() {
         if (auto drawAttrs = getVertexAttributes().clone()) {
             vertexAttrs.observeAttributes([&](const std::string& iName, const VertexAttribute& iAttr) {
                 if (auto& drawAttr = drawAttrs->getOrAdd(iName)) {
-                    for (std::size_t i = 0; i < impl->vertices.elements(); ++i) {
-                        drawAttr->setVariant(i, iAttr.get(0));
+                    if (iAttr.getCount() == 1) {
+                        // Apply the value to all vertexes
+                        for (std::size_t i = 0; i < impl->vertices.elements(); ++i) {
+                            drawAttr->setVariant(i, iAttr.get(0));
+                        }
+                    } else if (iAttr.getCount() == impl->vertices.elements()) {
+                        for (std::size_t i = 0; i < impl->vertices.elements(); ++i) {
+                            drawAttr->setVariant(i, iAttr.get(i));
+                        }
+                    } else {
+                        // throw?
+                        Log::Warning(Event::General, "Invalid attribute count");
                     }
                 }
             });

--- a/src/mbgl/gfx/drawable_builder_impl.hpp
+++ b/src/mbgl/gfx/drawable_builder_impl.hpp
@@ -14,7 +14,6 @@ struct DrawableBuilder::Impl {
     gfx::VertexVector<VT> vertices;
     gfx::IndexVector<gfx::Triangles> triangleIndexes;
     gfx::IndexVector<gfx::Lines> lineIndexes;
-    // SegmentVector<TypeList<void>> segments;
     Color currentColor = Color::white();
     std::vector<Color> colors;
 };

--- a/src/mbgl/gfx/drawable_builder_impl.hpp
+++ b/src/mbgl/gfx/drawable_builder_impl.hpp
@@ -14,7 +14,7 @@ struct DrawableBuilder::Impl {
     gfx::VertexVector<VT> vertices;
     gfx::IndexVector<gfx::Triangles> triangleIndexes;
     gfx::IndexVector<gfx::Lines> lineIndexes;
-    //SegmentVector<TypeList<void>> segments;
+    // SegmentVector<TypeList<void>> segments;
     Color currentColor = Color::white();
     std::vector<Color> colors;
 };

--- a/src/mbgl/gfx/drawable_builder_impl.hpp
+++ b/src/mbgl/gfx/drawable_builder_impl.hpp
@@ -12,8 +12,9 @@ namespace gfx {
 struct DrawableBuilder::Impl {
     using VT = gfx::detail::VertexType<gfx::AttributeType<std::int16_t, 2>>;
     gfx::VertexVector<VT> vertices;
-    gfx::IndexVector<gfx::Triangles> indexes;
-    SegmentVector<TypeList<void>> segments;
+    gfx::IndexVector<gfx::Triangles> triangleIndexes;
+    gfx::IndexVector<gfx::Lines> lineIndexes;
+    //SegmentVector<TypeList<void>> segments;
     Color currentColor = Color::white();
     std::vector<Color> colors;
 };

--- a/src/mbgl/gfx/vertex_vector.hpp
+++ b/src/mbgl/gfx/vertex_vector.hpp
@@ -22,6 +22,10 @@ public:
         assert(n < v.size());
         return v.at(n);
     }
+    const Vertex& at(std::size_t n) const {
+        assert(n < v.size());
+        return v.at(n);
+    }
 
     std::size_t elements() const { return v.size(); }
 

--- a/src/mbgl/gl/drawable_gl.cpp
+++ b/src/mbgl/gl/drawable_gl.cpp
@@ -23,16 +23,20 @@ void DrawableGL::draw(const PaintParameters& parameters) const {
     unbindUniformBuffers();
 }
 
-void DrawableGL::setIndexData(std::vector<std::uint16_t> indexes,
-                              const std::size_t indexOffset,
-                              const std::size_t indexLength) {
-    impl->indexes = std::move(indexes);
-    impl->indexOffset = indexOffset;
-    impl->indexLength = indexLength;
+void DrawableGL::setLineIndexData(std::vector<std::uint16_t> indexes) {
+    impl->lineIndexes = std::move(indexes);
 }
 
-std::vector<std::uint16_t>& DrawableGL::getIndexData() const {
-    return impl->indexes;
+void DrawableGL::setTriangleIndexData(std::vector<std::uint16_t> indexes) {
+    impl->triangleIndexes = std::move(indexes);
+}
+
+std::vector<std::uint16_t>& DrawableGL::getLineIndexData() const {
+    return impl->lineIndexes;
+}
+
+std::vector<std::uint16_t>& DrawableGL::getTriangleIndexData() const {
+    return impl->triangleIndexes;
 }
 
 const gl::VertexArray& DrawableGL::getVertexArray() const {
@@ -67,7 +71,6 @@ void DrawableGL::setVertexArray(gl::VertexArray&& vertexArray_,
                                 gfx::IndexBuffer&& indexBuffer_) {
     impl->vertexArray = std::move(vertexArray_);
     impl->attributeBuffer = std::move(attributeBuffer_);
-    impl->attributeOffset = 0;
     impl->indexBuffer = std::move(indexBuffer_);
 }
 

--- a/src/mbgl/gl/drawable_gl_builder.cpp
+++ b/src/mbgl/gl/drawable_gl_builder.cpp
@@ -41,11 +41,11 @@ void DrawableGLBuilder::init() {
         }
     }
 
-    constexpr auto indexOffset = 0;
-    const auto indexCount = impl->indexes.elements();
-    drawableGL.setIndexData(impl->indexes.vector(), indexOffset, indexCount);
+    drawableGL.setLineIndexData(impl->lineIndexes.vector());
+    drawableGL.setTriangleIndexData(impl->triangleIndexes.vector());
 
-    impl->indexes.clear();
+    impl->lineIndexes.clear();
+    impl->triangleIndexes.clear();
     impl->vertices.clear();
     impl->colors.clear();
 }

--- a/src/mbgl/gl/drawable_gl_impl.hpp
+++ b/src/mbgl/gl/drawable_gl_impl.hpp
@@ -37,9 +37,6 @@ public:
         }
     }
 
-    // const gfx::Triangles drawMode;
-    //  const gfx::DrawModeType type = gfx::DrawModeType::Triangles;
-
     // ShaderID shaderId;
     // RenderbufferID renderTarget;
     std::vector<TextureID> textures;

--- a/src/mbgl/gl/drawable_gl_impl.hpp
+++ b/src/mbgl/gl/drawable_gl_impl.hpp
@@ -37,8 +37,8 @@ public:
         }
     }
 
-    //const gfx::Triangles drawMode;
-    // const gfx::DrawModeType type = gfx::DrawModeType::Triangles;
+    // const gfx::Triangles drawMode;
+    //  const gfx::DrawModeType type = gfx::DrawModeType::Triangles;
 
     // ShaderID shaderId;
     // RenderbufferID renderTarget;

--- a/src/mbgl/gl/drawable_gl_impl.hpp
+++ b/src/mbgl/gl/drawable_gl_impl.hpp
@@ -29,18 +29,23 @@ public:
 
     void draw(const PaintParameters& parameters) const {
         auto& glContext = static_cast<gl::Context&>(parameters.context);
-        glContext.draw(drawMode, indexOffset, indexLength);
+        if (!triangleIndexes.empty()) {
+            glContext.draw(gfx::Triangles(), lineIndexes.size(), triangleIndexes.size());
+        }
+        if (!lineIndexes.empty()) {
+            glContext.draw(gfx::Lines(1), 0, lineIndexes.size());
+        }
     }
 
-    const gfx::Triangles drawMode;
+    //const gfx::Triangles drawMode;
     // const gfx::DrawModeType type = gfx::DrawModeType::Triangles;
 
     // ShaderID shaderId;
     // RenderbufferID renderTarget;
     std::vector<TextureID> textures;
 
-    // std::vector<std::uint8_t> vertData;
-    std::vector<std::uint16_t> indexes;
+    std::vector<std::uint16_t> lineIndexes;
+    std::vector<std::uint16_t> triangleIndexes;
 
     VertexAttributeArrayGL vertexAttributes;
 
@@ -50,9 +55,6 @@ public:
 
     UniformBufferArrayGL uniformBuffers;
 
-    std::size_t indexOffset = 0;
-    std::size_t indexLength = 0;
-    std::size_t attributeOffset = 0;
     gfx::DepthMode depthMode = gfx::DepthMode::disabled();
     gfx::StencilMode stencilMode;
     gfx::ColorMode colorMode;

--- a/src/mbgl/gl/layer_group_gl.cpp
+++ b/src/mbgl/gl/layer_group_gl.cpp
@@ -25,7 +25,8 @@ void TileLayerGroupGL::upload(gfx::Context& context, gfx::UploadPass& uploadPass
             const auto usage = gfx::BufferUsageType::StaticDraw;
 
             // Build index buffer
-            const auto& indexData = drawable.getIndexData();
+            auto indexData = drawable.getLineIndexData();
+            indexData.insert(indexData.end(), drawable.getTriangleIndexData().begin(), drawable.getTriangleIndexData().end());
             auto indexBuffer = gfx::IndexBuffer{
                 indexData.size(),
                 uploadPass.createIndexBufferResource(indexData.data(), indexData.size() * sizeof(indexData[0]), usage)};

--- a/src/mbgl/gl/layer_group_gl.cpp
+++ b/src/mbgl/gl/layer_group_gl.cpp
@@ -26,7 +26,8 @@ void TileLayerGroupGL::upload(gfx::Context& context, gfx::UploadPass& uploadPass
 
             // Build index buffer
             auto indexData = drawable.getLineIndexData();
-            indexData.insert(indexData.end(), drawable.getTriangleIndexData().begin(), drawable.getTriangleIndexData().end());
+            indexData.insert(
+                indexData.end(), drawable.getTriangleIndexData().begin(), drawable.getTriangleIndexData().end());
             auto indexBuffer = gfx::IndexBuffer{
                 indexData.size(),
                 uploadPass.createIndexBufferResource(indexData.data(), indexData.size() * sizeof(indexData[0]), usage)};

--- a/src/mbgl/gl/renderer_backend.cpp
+++ b/src/mbgl/gl/renderer_backend.cpp
@@ -93,8 +93,9 @@ void registerTypes(gfx::ShaderRegistry& registry, gl::Context& glContext, const 
 }
 
 void RendererBackend::initShaders(gfx::ShaderRegistry& shaders, const ProgramParameters& programParameters) {
-    registerTypes<shaders::BuiltIn::BackgroundShader, shaders::BuiltIn::FillShader, shaders::BuiltIn::FillOutlineShader>(
-        shaders, static_cast<gl::Context&>(*context), programParameters);
+    registerTypes<shaders::BuiltIn::BackgroundShader,
+                  shaders::BuiltIn::FillShader,
+                  shaders::BuiltIn::FillOutlineShader>(shaders, static_cast<gl::Context&>(*context), programParameters);
 }
 
 } // namespace gl

--- a/src/mbgl/gl/renderer_backend.cpp
+++ b/src/mbgl/gl/renderer_backend.cpp
@@ -93,7 +93,7 @@ void registerTypes(gfx::ShaderRegistry& registry, gl::Context& glContext, const 
 }
 
 void RendererBackend::initShaders(gfx::ShaderRegistry& shaders, const ProgramParameters& programParameters) {
-    registerTypes<shaders::BuiltIn::BackgroundShader, shaders::BuiltIn::FillShader>(
+    registerTypes<shaders::BuiltIn::BackgroundShader, shaders::BuiltIn::FillShader, shaders::BuiltIn::FillOutlineShader>(
         shaders, static_cast<gl::Context&>(*context), programParameters);
 }
 

--- a/src/mbgl/renderer/layers/render_background_layer.hpp
+++ b/src/mbgl/renderer/layers/render_background_layer.hpp
@@ -48,6 +48,8 @@ private:
     // Programs
     std::shared_ptr<BackgroundProgram> backgroundProgram;
     std::shared_ptr<BackgroundPatternProgram> backgroundPatternProgram;
+    
+    gfx::ShaderProgramBasePtr shader;
 };
 
 struct alignas(16) BackgroundLayerUBO {

--- a/src/mbgl/renderer/layers/render_background_layer.hpp
+++ b/src/mbgl/renderer/layers/render_background_layer.hpp
@@ -48,7 +48,7 @@ private:
     // Programs
     std::shared_ptr<BackgroundProgram> backgroundProgram;
     std::shared_ptr<BackgroundPatternProgram> backgroundPatternProgram;
-    
+
     gfx::ShaderProgramBasePtr shader;
 };
 

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -285,11 +285,14 @@ void RenderFillLayer::update(const int32_t layerIndex,
                              UniqueChangeRequestVec& changes) {
     std::unique_lock<std::mutex> guard(mutex);
 
-    if (!shader) {
-        shader = context.getGenericShader(shaders, "FillShader");
+    if (!fillShader) {
+        fillShader = context.getGenericShader(shaders, "FillShader");
+    }
+    if (!outlineShader) {
+        outlineShader = context.getGenericShader(shaders, "FillOutlineShader");
     }
 
-    if (!shader || !renderTiles || renderTiles->empty()) {
+    if (!fillShader || !outlineShader || !renderTiles || renderTiles->empty()) {
         if (tileLayerGroup) {
             stats.tileDrawablesRemoved += tileLayerGroup->getDrawableCount();
             tileLayerGroup->clearDrawables();
@@ -413,7 +416,7 @@ void RenderFillLayer::update(const int32_t layerIndex,
 
                 if (!builder) {
                     builder = context.createDrawableBuilder("fill");
-                    builder->setShader(shader);
+                    builder->setShader(fillShader);
                     builder->addTweaker(context.createDrawableTweaker());
                     builder->setColorMode(gfx::DrawableBuilder::ColorMode::None);
                     builder->setDepthType(gfx::DepthMaskType::ReadWrite);

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -64,7 +64,7 @@ void RenderFillLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     }
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
-    
+
     evaluatedPropertiesChange = true;
 }
 
@@ -314,7 +314,7 @@ void RenderFillLayer::update(const int32_t layerIndex,
         if (!(mbgl::underlying_type(renderPass) & evaluatedProperties->renderPasses)) {
             continue;
         }
-            
+
         tileLayerGroup->observeDrawables([&](gfx::UniqueDrawable& drawable) {
             // Has this tile dropped out of the cover set?
             const auto tileID = drawable->getTileID();
@@ -370,8 +370,11 @@ void RenderFillLayer::update(const int32_t layerIndex,
                     // check that vertexVector.elements() == sum(segments.vertexLength)
                     if (auto& attr = vertexAttrs.getOrAdd("a_color")) {
                         for (std::size_t i = 0; i < count; ++i) {
-                            const auto& packed = static_cast<const gfx::detail::VertexType<gfx::AttributeType<float, 2>>*>(p1->getVertexValue(i))->a1;
-                            attr->set<gfx::VertexAttribute::float4>(i, { packed[0], packed[1], packed[0], packed[1] });
+                            const auto& packed =
+                                static_cast<const gfx::detail::VertexType<gfx::AttributeType<float, 2>>*>(
+                                    p1->getVertexValue(i))
+                                    ->a1;
+                            attr->set<gfx::VertexAttribute::float4>(i, {packed[0], packed[1], packed[0], packed[1]});
                         }
                     }
                 }
@@ -379,8 +382,11 @@ void RenderFillLayer::update(const int32_t layerIndex,
                     const auto count = p1->getVertexCount();
                     if (auto& attr = vertexAttrs.getOrAdd("a_opacity")) {
                         for (std::size_t i = 0; i < count; ++i) {
-                            const auto& opacity = static_cast<const gfx::detail::VertexType<gfx::AttributeType<float, 1>>*>(p1->getVertexValue(i))->a1;
-                            attr->set<gfx::VertexAttribute::float2>(i, { opacity[0], opacity[0] });
+                            const auto& opacity =
+                                static_cast<const gfx::detail::VertexType<gfx::AttributeType<float, 1>>*>(
+                                    p1->getVertexValue(i))
+                                    ->a1;
+                            attr->set<gfx::VertexAttribute::float2>(i, {opacity[0], opacity[0]});
                         }
                     }
                 }

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -366,24 +366,22 @@ void RenderFillLayer::update(const int32_t layerIndex,
                 const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
 
                 if (auto& p1 = paintPropertyBinders.get<FillColor>()) {
-                    auto& p2 = reinterpret_cast<mbgl::SourceFunctionPaintPropertyBinder<mbgl::Color, gfx::AttributeType<float, 2>>&>(*p1);
+                    const auto count = p1->getVertexCount();
                     // check that vertexVector.elements() == sum(segments.vertexLength)
                     if (auto& attr = vertexAttrs.getOrAdd("a_color")) {
-                        for (std::size_t i = 0; i < p2.vertexVector.elements(); ++i) {
-                            const auto& packed = p2.vertexVector.at(i).a1;
+                        for (std::size_t i = 0; i < count; ++i) {
+                            const auto& packed = static_cast<const gfx::detail::VertexType<gfx::AttributeType<float, 2>>*>(p1->getVertexValue(i))->a1;
                             attr->set<gfx::VertexAttribute::float4>(i, { packed[0], packed[1], packed[0], packed[1] });
                         }
                     }
                 }
                 if (auto& p1 = paintPropertyBinders.get<FillOpacity>()) {
-                    //auto& p2 = reinterpret_cast<mbgl::CompositeFunctionPaintPropertyBinder<float, gfx::AttributeType<float, 1>>&>(*p1);
+                    const auto count = p1->getVertexCount();
                     if (auto& attr = vertexAttrs.getOrAdd("a_opacity")) {
-                    //    for (std::size_t i = 0; i < p2.vertexVector.elements(); ++i) {
-                    //        attr->set(i, p2.vertexVector.at(i).a1[0]);
-                    //    }
-                    //    if (!p2.vertexVector.elements()) {
-                        attr->set<gfx::VertexAttribute::float2>(0, { fillOpacity, fillOpacity});
-                    //    }
+                        for (std::size_t i = 0; i < count; ++i) {
+                            const auto& opacity = static_cast<const gfx::detail::VertexType<gfx::AttributeType<float, 1>>*>(p1->getVertexValue(i))->a1;
+                            attr->set<gfx::VertexAttribute::float2>(i, { opacity[0], opacity[0] });
+                        }
                     }
                 }
 

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -275,7 +275,7 @@ void RenderFillLayer::layerRemoved(UniqueChangeRequestVec& changes) {
 void RenderFillLayer::update(const int32_t layerIndex,
                              gfx::ShaderRegistry& shaders,
                              gfx::Context& context,
-                             const TransformState& state,
+                             const TransformState& /*state*/,
                              UniqueChangeRequestVec& changes) {
     std::unique_lock<std::mutex> guard(mutex);
 

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -434,17 +434,13 @@ void RenderFillLayer::update(const int32_t layerIndex,
                 builder->addVertices(rawVerts, 0, rawVerts.size());
 
                 for (const auto& seg : bucket.triangleSegments) {
-                    builder->addTriangles(bucket.triangles.vector(),
-                                          seg.indexOffset,
-                                          seg.indexLength);
+                    builder->addTriangles(bucket.triangles.vector(), seg.indexOffset, seg.indexLength);
                 }
 
                 if (fillAA) {
                     // TODO: Different drawable?  Multiple concurrent builders?
                     for (const auto& seg : bucket.lineSegments) {
-                        builder->addLines(bucket.lines.vector(),
-                                          seg.indexOffset,
-                                          seg.indexLength);
+                        builder->addLines(bucket.lines.vector(), seg.indexOffset, seg.indexLength);
                     }
                 }
                 //            evaluated.get<FillTranslate>(),
@@ -488,8 +484,8 @@ void RenderFillLayer::update(const int32_t layerIndex,
                     // Track it.
                     tileLayerGroup->addDrawable(renderPass, tileID, std::move(drawable));
                     ++stats.tileDrawablesAdded;
-                    //Log::Warning(Event::General, "Adding drawable for " + util::toString(tileID) + " total " +
-                    // std::to_string(stats.tileDrawablesAdded+1));
+                    // Log::Warning(Event::General, "Adding drawable for " + util::toString(tileID) + " total " +
+                    //  std::to_string(stats.tileDrawablesAdded+1));
                 }
             }
         } else {

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -54,6 +54,9 @@ private:
     std::shared_ptr<FillPatternProgram> fillPatternProgram;
     std::shared_ptr<FillOutlineProgram> fillOutlineProgram;
     std::shared_ptr<FillOutlinePatternProgram> fillOutlinePatternProgram;
+    
+    gfx::ShaderProgramBasePtr fillShader;
+    gfx::ShaderProgramBasePtr outlineShader;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -54,7 +54,7 @@ private:
     std::shared_ptr<FillPatternProgram> fillPatternProgram;
     std::shared_ptr<FillOutlineProgram> fillOutlineProgram;
     std::shared_ptr<FillOutlinePatternProgram> fillOutlinePatternProgram;
-    
+
     gfx::ShaderProgramBasePtr fillShader;
     gfx::ShaderProgramBasePtr outlineShader;
 };

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -129,7 +129,8 @@ public:
         const PossiblyEvaluatedType& currentValue) const = 0;
 
     virtual std::size_t getVertexCount() const = 0;
-    virtual const /*std::tuple<ExpandToType<As, UniformValueType>...>&*/ void* getVertexValue(std::size_t index) const = 0;
+    virtual const /*std::tuple<ExpandToType<As, UniformValueType>...>&*/ void* getVertexValue(
+        std::size_t index) const = 0;
 
     static std::unique_ptr<PaintPropertyBinder> create(const PossiblyEvaluatedType& value, float zoom, T defaultValue);
 
@@ -167,9 +168,7 @@ public:
     }
 
     std::size_t getVertexCount() const override { return 1; }
-    const /*std::tuple<ExpandToType<A, T>>&*/ void* getVertexValue(std::size_t) const override {
-        return &constant;
-    }
+    const /*std::tuple<ExpandToType<A, T>>&*/ void* getVertexValue(std::size_t) const override { return &constant; }
 
 private:
     T constant;
@@ -559,9 +558,7 @@ public:
     }
 
     std::size_t getVertexCount() const override { return 0; }
-    const /*std::tuple<ExpandToType<A, T>>&*/ void* getVertexValue(std::size_t) const override {
-        return nullptr;
-    }
+    const /*std::tuple<ExpandToType<A, T>>&*/ void* getVertexValue(std::size_t) const override { return nullptr; }
 
 private:
     style::PropertyExpression<T> expression;

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -306,7 +306,7 @@ public:
         }
     }
 
-private:
+//private:
     style::PropertyExpression<T> expression;
     T defaultValue;
     gfx::VertexVector<BaseVertex> vertexVector;
@@ -425,7 +425,7 @@ public:
         }
     }
 
-private:
+//private:
     style::PropertyExpression<T> expression;
     T defaultValue;
     Range<float> zoomRange;
@@ -696,6 +696,11 @@ public:
             binders.template get<Ps>()->interpolationFactor(currentZoom)...,
             // uniform values
             binders.template get<Ps>()->uniformValue(currentProperties.template get<Ps>())...));
+    }
+
+    template <class P>
+    const auto& get() const {
+        return binders.template get<P>();
     }
 
     template <class P>

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -128,6 +128,9 @@ public:
     virtual std::tuple<ExpandToType<As, UniformValueType>...> uniformValue(
         const PossiblyEvaluatedType& currentValue) const = 0;
 
+    virtual std::size_t getVertexCount() const = 0;
+    virtual const /*std::tuple<ExpandToType<As, UniformValueType>...>&*/ void* getVertexValue(std::size_t index) const = 0;
+
     static std::unique_ptr<PaintPropertyBinder> create(const PossiblyEvaluatedType& value, float zoom, T defaultValue);
 
     PaintPropertyStatistics<T> statistics;
@@ -161,6 +164,11 @@ public:
 
     std::tuple<T> uniformValue(const PossiblyEvaluatedPropertyValue<T>& currentValue) const override {
         return std::tuple<T>{currentValue.constantOr(constant)};
+    }
+
+    std::size_t getVertexCount() const override { return 1; }
+    const /*std::tuple<ExpandToType<A, T>>&*/ void* getVertexValue(std::size_t) const override {
+        return &constant;
     }
 
 private:
@@ -206,6 +214,11 @@ public:
     std::tuple<std::array<uint16_t, 4>, std::array<uint16_t, 4>> uniformValue(
         const PossiblyEvaluatedPropertyValue<Faded<T>>&) const override {
         return constantPatternPositions;
+    }
+
+    std::size_t getVertexCount() const override { return 0; }
+    const /*std::tuple<ExpandToType<A, T>>&*/ void* getVertexValue(std::size_t) const override {
+        return nullptr; // ?
     }
 
 private:
@@ -306,7 +319,12 @@ public:
         }
     }
 
-//private:
+    std::size_t getVertexCount() const override { return vertexVector.elements(); }
+    const /*std::tuple<ExpandToType<A, T>>&*/ void* getVertexValue(std::size_t index) const override {
+        return &vertexVector.at(index);
+    }
+
+private:
     style::PropertyExpression<T> expression;
     T defaultValue;
     gfx::VertexVector<BaseVertex> vertexVector;
@@ -425,7 +443,12 @@ public:
         }
     }
 
-//private:
+    std::size_t getVertexCount() const override { return vertexVector.elements(); }
+    const /*std::tuple<ExpandToType<A, T>>&*/ void* getVertexValue(std::size_t index) const override {
+        return &vertexVector.at(index);
+    }
+
+private:
     style::PropertyExpression<T> expression;
     T defaultValue;
     Range<float> zoomRange;
@@ -533,6 +556,11 @@ public:
         const PossiblyEvaluatedPropertyValue<Faded<T>>&) const override {
         // Uniform values for vertex attribute arrays are unused.
         return {};
+    }
+
+    std::size_t getVertexCount() const override { return 0; }
+    const /*std::tuple<ExpandToType<A, T>>&*/ void* getVertexValue(std::size_t) const override {
+        return nullptr;
     }
 
 private:

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -169,7 +169,6 @@ protected:
     TileLayerGroupPtr tileLayerGroup;
 
     std::mutex mutex;
-    gfx::ShaderProgramBasePtr shader;
     bool evaluatedPropertiesChange = false;
     gfx::UniformBufferPtr uniformBuffer = nullptr;
 


### PR DESCRIPTION
I got the colors applied in the fill layer, but only with a terrible downcast on `PaintPropertyBinder` that depends on the style.

I looked at instead adding a virtual method to `PaintPropertyBinder` but I couldn't figure out how to construct the return value type from the type parameter pack.  So I fell back on a `void*`, which is only slightly less bad.

Any ideas on a better way to do this are welcome.

