### PR TITLE
Drawable LayerGroup sorting, depth buffer, split view

### DIFF
--- a/include/mbgl/renderer/change_request.hpp
+++ b/include/mbgl/renderer/change_request.hpp
@@ -9,6 +9,7 @@
 namespace mbgl {
 class ChangeRequest;
 class LayerGroup;
+class TileLayerGroup;
 class RenderOrchestrator;
 
 using ChangeRequestPtr = std::shared_ptr<ChangeRequest>;
@@ -74,6 +75,18 @@ public:
 
 protected:
     int32_t layerIndex;
+};
+
+class UpdateLayerGroupIndexRequest : public ChangeRequest {
+public:
+    UpdateLayerGroupIndexRequest(std::shared_ptr<TileLayerGroup> tileLayerGroup_, int32_t newLayerIndex_);
+    UpdateLayerGroupIndexRequest(const UpdateLayerGroupIndexRequest &) = delete;
+
+    void execute(RenderOrchestrator &) override;
+
+protected:
+    std::shared_ptr<TileLayerGroup> tileLayerGroup;
+    int32_t newLayerIndex;
 };
 
 } // namespace mbgl

--- a/include/mbgl/renderer/layer_group.hpp
+++ b/include/mbgl/renderer/layer_group.hpp
@@ -76,6 +76,7 @@ public:
     TileLayerGroup(int32_t layerIndex, std::size_t initialCapacity);
     ~TileLayerGroup() override;
 
+    void updateLayerIndex(int32_t newLayerIndex);
     std::size_t getDrawableCount() const;
 
     const gfx::UniqueDrawable& getDrawable(mbgl::RenderPass, const OverscaledTileID&) const;

--- a/src/mbgl/gl/layer_group_gl.cpp
+++ b/src/mbgl/gl/layer_group_gl.cpp
@@ -56,7 +56,7 @@ void TileLayerGroupGL::render(RenderOrchestrator&, PaintParameters& parameters) 
 
     // TODO: figure out how to make drawables participate in the depth system
     // Maybe make it a function mapping draw priority to the depth range (always (0,1)?)
-    parameters.depthRangeSize = 1 - (1 + 2) * parameters.numSublayers * parameters.depthEpsilon;
+    // parameters.depthRangeSize = 1 - (1 + 2) * parameters.numSublayers * parameters.depthEpsilon;
 
     // TODO: Render tile masks
     // for (auto& layer : renderLayers) {

--- a/src/mbgl/gl/layer_group_gl.cpp
+++ b/src/mbgl/gl/layer_group_gl.cpp
@@ -54,10 +54,6 @@ void TileLayerGroupGL::upload(gfx::Context& context, gfx::UploadPass& uploadPass
 void TileLayerGroupGL::render(RenderOrchestrator&, PaintParameters& parameters) {
     auto& context = parameters.context;
 
-    // TODO: figure out how to make drawables participate in the depth system
-    // Maybe make it a function mapping draw priority to the depth range (always (0,1)?)
-    // parameters.depthRangeSize = 1 - (1 + 2) * parameters.numSublayers * parameters.depthEpsilon;
-
     // TODO: Render tile masks
     // for (auto& layer : renderLayers) {
     //    parameters.renderTileClippingMasks(renderTiles);

--- a/src/mbgl/renderer/change_request.cpp
+++ b/src/mbgl/renderer/change_request.cpp
@@ -18,4 +18,16 @@ void RemoveLayerGroupRequest::execute(RenderOrchestrator &orchestrator) {
     orchestrator.removeLayerGroup(layerIndex);
 }
 
+UpdateLayerGroupIndexRequest::UpdateLayerGroupIndexRequest(std::shared_ptr<TileLayerGroup> tileLayerGroup_,
+                                                           int32_t newLayerIndex_)
+    : tileLayerGroup(std::move(tileLayerGroup_)),
+      newLayerIndex(newLayerIndex_) {}
+
+void UpdateLayerGroupIndexRequest::execute(RenderOrchestrator &orchestrator) {
+    // Update the index of a tile layer group and indicate to the orchestator that it must rebuild the map of ordered
+    // layer groups
+    tileLayerGroup->updateLayerIndex(newLayerIndex);
+    orchestrator.markLayerGroupOrderDirty();
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/layer_group.cpp
+++ b/src/mbgl/renderer/layer_group.cpp
@@ -38,6 +38,13 @@ TileLayerGroup::TileLayerGroup(int32_t layerIndex_, std::size_t initialCapacity)
 
 TileLayerGroup::~TileLayerGroup() {}
 
+void TileLayerGroup::updateLayerIndex(int32_t newLayerIndex) {
+    layerIndex = newLayerIndex;
+    for (auto& it : impl->tileDrawables) {
+        it.second->setLayerIndex(newLayerIndex);
+    }
+}
+
 std::size_t TileLayerGroup::getDrawableCount() const {
     return impl->tileDrawables.size();
 }

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -75,15 +75,9 @@ bool RenderBackgroundLayer::hasCrossfade() const {
     return getCrossfade<BackgroundLayerProperties>(evaluatedProperties).t != 1;
 }
 
-static bool enableDefaultRender = false;
-
 void RenderBackgroundLayer::render(PaintParameters& parameters) {
     // Note that for bottommost layers without a pattern, the background color
     // is drawn with glClear rather than this method.
-
-    if (!enableDefaultRender) {
-        return;
-    }
 
     // Ensure programs are available
     if (!parameters.shaders.populate(backgroundProgram)) return;

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -181,8 +181,7 @@ std::optional<Color> RenderBackgroundLayer::getSolidBackground() const {
         return std::nullopt;
     }
 
-    return std::nullopt;
-    // return { evaluated.get<BackgroundColor>() * evaluated.get<BackgroundOpacity>() };
+    return { evaluated.get<BackgroundColor>() * evaluated.get<BackgroundOpacity>() };
 }
 
 namespace {

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -181,7 +181,7 @@ std::optional<Color> RenderBackgroundLayer::getSolidBackground() const {
         return std::nullopt;
     }
 
-    return { evaluated.get<BackgroundColor>() * evaluated.get<BackgroundOpacity>() };
+    return {evaluated.get<BackgroundColor>() * evaluated.get<BackgroundOpacity>()};
 }
 
 namespace {
@@ -216,11 +216,7 @@ void RenderBackgroundLayer::update(gfx::ShaderRegistry& shaders,
                                    gfx::Context& context,
                                    const TransformState& state,
                                    [[maybe_unused]] const RenderTree& renderTree,
-                                   UniqueChangeRequestVec& changes) {
-    if (enableDefaultRender) {
-        return;
-    }
-
+                                   [[maybe_unused]] UniqueChangeRequestVec& changes) {
     std::unique_lock<std::mutex> guard(mutex);
 
     if (!shader) {

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -213,8 +213,7 @@ void RenderBackgroundLayer::layerRemoved(UniqueChangeRequestVec& changes) {
     }
 }
 
-void RenderBackgroundLayer::update(const int32_t layerIndex,
-                                   gfx::ShaderRegistry& shaders,
+void RenderBackgroundLayer::update(gfx::ShaderRegistry& shaders,
                                    gfx::Context& context,
                                    const TransformState& state,
                                    UniqueChangeRequestVec& changes) {

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -216,6 +216,7 @@ void RenderBackgroundLayer::layerRemoved(UniqueChangeRequestVec& changes) {
 void RenderBackgroundLayer::update(gfx::ShaderRegistry& shaders,
                                    gfx::Context& context,
                                    const TransformState& state,
+                                   [[maybe_unused]] const RenderTree& renderTree,
                                    UniqueChangeRequestVec& changes) {
     if (enableDefaultRender) {
         return;
@@ -270,7 +271,6 @@ void RenderBackgroundLayer::update(gfx::ShaderRegistry& shaders,
             return;
         }
         tileLayerGroup->setLayerTweaker(std::make_shared<BackgroundLayerTweaker>(evaluatedProperties));
-        changes.emplace_back(std::make_unique<AddLayerGroupRequest>(tileLayerGroup, /*canReplace=*/true));
     }
 
     // Drawables per overscaled or canonical tile?

--- a/src/mbgl/renderer/layers/render_background_layer.hpp
+++ b/src/mbgl/renderer/layers/render_background_layer.hpp
@@ -29,6 +29,7 @@ public:
     void update(gfx::ShaderRegistry&,
                 gfx::Context&,
                 const TransformState&,
+                const RenderTree&,
                 UniqueChangeRequestVec&) override;
 
 private:

--- a/src/mbgl/renderer/layers/render_background_layer.hpp
+++ b/src/mbgl/renderer/layers/render_background_layer.hpp
@@ -26,8 +26,7 @@ public:
     void layerRemoved(UniqueChangeRequestVec&) override;
 
     /// Generate any changes needed by the layer
-    void update(int32_t layerIndex,
-                gfx::ShaderRegistry&,
+    void update(gfx::ShaderRegistry&,
                 gfx::Context&,
                 const TransformState&,
                 UniqueChangeRequestVec&) override;

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -261,10 +261,10 @@ void RenderCircleLayer::removeTile(RenderPass renderPass, const OverscaledTileID
     stats.tileDrawablesRemoved += tileLayerGroup->removeDrawables(renderPass, tileID).size();
 }
 
-void RenderCircleLayer::update(const int32_t layerIndex,
-                               gfx::ShaderRegistry& shaders,
+void RenderCircleLayer::update(gfx::ShaderRegistry& shaders,
                                gfx::Context& context,
                                const TransformState& /*state*/,
+                               [[maybe_unused]] const RenderTree& renderTree,
                                UniqueChangeRequestVec& changes) {
     if (enableDefaultRender) {
         return;

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -85,14 +85,8 @@ bool RenderCircleLayer::hasCrossfade() const {
     return false;
 }
 
-static bool enableDefaultRender = false;
-
 void RenderCircleLayer::render(PaintParameters& parameters) {
     assert(renderTiles);
-
-    if (!enableDefaultRender) {
-        return;
-    }
 
     if (parameters.pass == RenderPass::Opaque) {
         return;
@@ -266,10 +260,6 @@ void RenderCircleLayer::update(gfx::ShaderRegistry& shaders,
                                const TransformState& /*state*/,
                                [[maybe_unused]] const RenderTree& renderTree,
                                UniqueChangeRequestVec& changes) {
-    if (enableDefaultRender) {
-        return;
-    }
-
     std::unique_lock<std::mutex> guard(mutex);
 
     if (!renderTiles || renderTiles->empty()) {

--- a/src/mbgl/renderer/layers/render_circle_layer.hpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.hpp
@@ -16,10 +16,10 @@ public:
     void layerRemoved(UniqueChangeRequestVec&) override;
 
     /// Generate any changes needed by the layer
-    void update(int32_t layerIndex,
-                gfx::ShaderRegistry&,
+    void update(gfx::ShaderRegistry&,
                 gfx::Context&,
                 const TransformState&,
+                const RenderTree&,
                 UniqueChangeRequestVec&) override;
 
 private:

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -78,7 +78,7 @@ bool RenderFillLayer::hasCrossfade() const {
     return getCrossfade<FillLayerProperties>(evaluatedProperties).t != 1;
 }
 
-static bool enableDefaultRender = false;
+static bool enableDefaultRender = true;
 
 void RenderFillLayer::render(PaintParameters& parameters) {
     assert(renderTiles);

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -78,14 +78,8 @@ bool RenderFillLayer::hasCrossfade() const {
     return getCrossfade<FillLayerProperties>(evaluatedProperties).t != 1;
 }
 
-static bool enableDefaultRender = true;
-
 void RenderFillLayer::render(PaintParameters& parameters) {
     assert(renderTiles);
-
-    if (!enableDefaultRender) {
-        return;
-    }
 
     if (!parameters.shaders.populate(fillProgram)) return;
     if (!parameters.shaders.populate(fillPatternProgram)) return;

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -288,11 +288,7 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
                              gfx::Context& context,
                              const TransformState& /*state*/,
                              [[maybe_unused]] const RenderTree& renderTree,
-                             UniqueChangeRequestVec& changes) {
-    if (enableDefaultRender) {
-        return;
-    }
-
+                             [[maybe_unused]] UniqueChangeRequestVec& changes) {
     std::unique_lock<std::mutex> guard(mutex);
 
     if (!renderTiles || renderTiles->empty()) {

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -284,8 +284,7 @@ void RenderFillLayer::removeTile(RenderPass renderPass, const OverscaledTileID& 
     stats.tileDrawablesRemoved += tileLayerGroup->removeDrawables(renderPass, tileID).size();
 }
 
-void RenderFillLayer::update(const int32_t layerIndex,
-                             gfx::ShaderRegistry& shaders,
+void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
                              gfx::Context& context,
                              const TransformState& /*state*/,
                              UniqueChangeRequestVec& changes) {

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -287,6 +287,7 @@ void RenderFillLayer::removeTile(RenderPass renderPass, const OverscaledTileID& 
 void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
                              gfx::Context& context,
                              const TransformState& /*state*/,
+                             [[maybe_unused]] const RenderTree& renderTree,
                              UniqueChangeRequestVec& changes) {
     if (enableDefaultRender) {
         return;
@@ -309,7 +310,6 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
             return;
         }
         tileLayerGroup->setLayerTweaker(std::make_shared<FillLayerTweaker>(evaluatedProperties));
-        changes.emplace_back(std::make_unique<AddLayerGroupRequest>(tileLayerGroup, /*canReplace=*/true));
     }
 
     if (!fillShader) {

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -25,8 +25,7 @@ public:
     void layerRemoved(UniqueChangeRequestVec&) override;
 
     /// Generate any changes needed by the layer
-    void update(int32_t layerIndex,
-                gfx::ShaderRegistry&,
+    void update(gfx::ShaderRegistry&,
                 gfx::Context&,
                 const TransformState&,
                 UniqueChangeRequestVec&) override;

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -28,6 +28,7 @@ public:
     void update(gfx::ShaderRegistry&,
                 gfx::Context&,
                 const TransformState&,
+                const RenderTree&,
                 UniqueChangeRequestVec&) override;
 
 private:

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -31,6 +31,10 @@ const std::string& RenderLayer::getID() const {
     return baseImpl->id;
 }
 
+const int32_t RenderLayer::getLayerIndex() const noexcept {
+    return layerIndex;
+}
+
 bool RenderLayer::hasRenderPass(RenderPass pass) const {
     return passes & pass;
 }
@@ -105,6 +109,15 @@ const LayerRenderData* RenderLayer::getRenderDataForPass(const RenderTile& tile,
         return bool(RenderPass(renderData->layerProperties->renderPasses) & pass) ? renderData : nullptr;
     }
     return nullptr;
+}
+
+void RenderLayer::layerIndexChanged(int32_t newLayerIndex, UniqueChangeRequestVec& changes) {
+    layerIndex = newLayerIndex;
+
+    // Submit a change request to update the layer index of our tile layer group
+    if (tileLayerGroup) {
+        changes.emplace_back(std::make_unique<UpdateLayerGroupIndexRequest>(tileLayerGroup, newLayerIndex));
+    }
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -125,12 +125,12 @@ void RenderLayer::markLayerRenderable(bool willRender, UniqueChangeRequestVec& c
     if (!tileLayerGroup) {
         return;
     }
-    if (renderable == willRender) {
+    if (isRenderable == willRender) {
         return;
     }
 
     // This layer is either being freshly included in the renderable set or excluded
-    renderable = willRender;
+    isRenderable = willRender;
     if (willRender) {
         // The RenderTree has determined this layer should be included in the renderable set for a frame
         changes.emplace_back(std::make_unique<AddLayerGroupRequest>(tileLayerGroup, /*canReplace=*/true));

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -21,6 +21,7 @@ class PropertyEvaluationParameters;
 class PaintParameters;
 class PatternAtlas;
 class RenderTile;
+class RenderTree;
 class SymbolBucket;
 class TileLayerGroup;
 class TransformState;
@@ -101,7 +102,7 @@ public:
 
     const std::string& getID() const;
 
-    const int32_t getLayerIndex() const noexcept;
+    int32_t getLayerIndex() const noexcept;
 
     // Checks whether this layer needs to be rendered in the given render pass.
     bool hasRenderPass(RenderPass) const;
@@ -145,11 +146,21 @@ public:
 
     /// Generate any changes needed by the layer
     virtual void update(
-        gfx::ShaderRegistry&, gfx::Context&, const TransformState&, UniqueChangeRequestVec&) {}
+        gfx::ShaderRegistry&, gfx::Context&, const TransformState&, const RenderTree&, UniqueChangeRequestVec&) {}
 
     virtual void layerRemoved(UniqueChangeRequestVec&) {}
 
-    virtual void layerIndexChanged(int32_t newLayerIndex, UniqueChangeRequestVec&);
+    /// @brief Called by the RenderOrchestrator during RenderTree construction.
+    /// This event is run when a layer is added or removed from the style.
+    /// @param newLayerIndex The new layer index for this layer
+    /// @param changes The collection of current pending change requests
+    virtual void layerIndexChanged(int32_t newLayerIndex, UniqueChangeRequestVec& changes);
+
+    /// @brief Called by the RenderOrchestrator during RenderTree construction.
+    /// This event is run to indicate if the layer should render or not for the current frame.
+    /// @param willRender Indicates if this layer should render or not
+    /// @param changes The collection of current pending change requests
+    virtual void markLayerRenderable(bool willRender, UniqueChangeRequestVec& changes);
 
 protected:
     // Checks whether the current hardware can render this layer. If it can't,
@@ -171,7 +182,10 @@ protected:
     LayerPlacementData placementData;
 
     TileLayerGroupPtr tileLayerGroup;
+    // Current layer index as specified by the layerIndexChanged event
     int32_t layerIndex{0};
+    // Curent renderable status as specified by the markLayerRenderable event
+    bool renderable{false};
 
     std::mutex mutex;
 

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -101,6 +101,8 @@ public:
 
     const std::string& getID() const;
 
+    const int32_t getLayerIndex() const noexcept;
+
     // Checks whether this layer needs to be rendered in the given render pass.
     bool hasRenderPass(RenderPass) const;
 
@@ -143,9 +145,11 @@ public:
 
     /// Generate any changes needed by the layer
     virtual void update(
-        int32_t /*layerIndex*/, gfx::ShaderRegistry&, gfx::Context&, const TransformState&, UniqueChangeRequestVec&) {}
+        gfx::ShaderRegistry&, gfx::Context&, const TransformState&, UniqueChangeRequestVec&) {}
 
     virtual void layerRemoved(UniqueChangeRequestVec&) {}
+
+    virtual void layerIndexChanged(int32_t newLayerIndex, UniqueChangeRequestVec&);
 
 protected:
     // Checks whether the current hardware can render this layer. If it can't,
@@ -167,6 +171,7 @@ protected:
     LayerPlacementData placementData;
 
     TileLayerGroupPtr tileLayerGroup;
+    int32_t layerIndex{0};
 
     std::mutex mutex;
 

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -184,8 +184,8 @@ protected:
     TileLayerGroupPtr tileLayerGroup;
     // Current layer index as specified by the layerIndexChanged event
     int32_t layerIndex{0};
-    // Curent renderable status as specified by the markLayerRenderable event
-    bool renderable{false};
+    // Current renderable status as specified by the markLayerRenderable event
+    bool isRenderable{false};
 
     std::mutex mutex;
 

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -364,7 +364,9 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
     // @TODO: Optimize this logic, combine with the above
     for (size_t i = 0; i < orderedLayers.size(); ++i) {
         RenderLayer& layer = orderedLayers[i];
-        layer.markLayerRenderable(layerRenderItems.find(LayerRenderItem(layer, nullptr, static_cast<uint32_t>(i))) != layerRenderItems.end(), changes);
+        layer.markLayerRenderable(
+            layerRenderItems.find(LayerRenderItem(layer, nullptr, static_cast<uint32_t>(i))) != layerRenderItems.end(),
+            changes);
     }
 
     // Add all change requests up to this point

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -312,8 +312,6 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
     }
 
     // Update all sources and initialize renderItems.
-
-    // @NOTE: Here, we need to indicate which layer groups are going to be rendered by the tree.
     for (const auto& sourceImpl : *sourceImpls) {
         RenderSource* source = renderSources.at(sourceImpl->id).get();
         bool sourceNeedsRendering = false;
@@ -362,6 +360,8 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         filteredLayersForSource.clear();
     }
 
+    // Mark layers included in the renderable set as renderable
+    // @TODO: Optimize this logic, combine with the above
     for (size_t i = 0; i < orderedLayers.size(); ++i) {
         RenderLayer& layer = orderedLayers[i];
         layer.markLayerRenderable(layerRenderItems.find(LayerRenderItem(layer, nullptr, static_cast<uint32_t>(i))) != layerRenderItems.end(), changes);

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -103,6 +103,7 @@ public:
 
     bool addLayerGroup(LayerGroupPtr, bool replace);
     bool removeLayerGroup(const int32_t layerIndex);
+    size_t numLayerGroups() const noexcept;
     const LayerGroupPtr& getLayerGroup(const int32_t layerIndex) const;
     void observeLayerGroups(std::function<void(LayerGroup&)>);
     void observeLayerGroups(std::function<void(const LayerGroup&)>) const;

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -114,6 +114,8 @@ public:
                       const RenderTree&);
 
     void processChanges();
+    /// @brief Indicate that the orchestrator needs to re-sort layer groups when processing changes
+    void markLayerGroupOrderDirty();
 
     const ZoomHistory& getZoomHistory() const { return zoomHistory; }
 
@@ -151,6 +153,8 @@ private:
 
     void onRemoveLayerGroup(LayerGroup&);
 
+    void updateLayerGroupOrder();
+
     RendererObserver* observer;
 
     ZoomHistory zoomHistory;
@@ -187,6 +191,7 @@ private:
 
     using LayerGroupMap = std::map<int32_t, LayerGroupPtr>;
     LayerGroupMap layerGroupsByLayerIndex;
+    bool layerGroupOrderDirty = false;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -39,7 +39,8 @@ void Renderer::render(const std::shared_ptr<UpdateParameters>& updateParameters)
         if (impl->staticData && impl->staticData->shaders) {
             auto& context = impl->backend.getContext();
             auto& shaders = *impl->staticData->shaders;
-            impl->orchestrator.updateLayers(shaders, context, state, updateParameters, *renderTree);
+            impl->orchestrator.updateLayers(
+                shaders, context, state, updateParameters, *renderTree);
         }
 
         impl->render(*renderTree);

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -39,8 +39,7 @@ void Renderer::render(const std::shared_ptr<UpdateParameters>& updateParameters)
         if (impl->staticData && impl->staticData->shaders) {
             auto& context = impl->backend.getContext();
             auto& shaders = *impl->staticData->shaders;
-            impl->orchestrator.updateLayers(
-                shaders, context, state, updateParameters, *renderTree);
+            impl->orchestrator.updateLayers(shaders, context, state, updateParameters, *renderTree);
         }
 
         impl->render(*renderTree);

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -21,13 +21,12 @@
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/logging.hpp>
 
-// Enable a debugging split view to compare drawables and vanilla rendering pathways
+// DEBUG: Enable a debugging split view to compare drawables and vanilla rendering pathways
 // Drawables will be on the left, vanilla rendering on the right
-#define SPLIT_VIEW
+// #define SPLIT_VIEW
 // If using SPLIT_VIEW, QUAD_SPLIT_VIEW will split each half, showing just the opaque
 // pass on top and then a composited opaque+translucent pass on the bottom
-#define QUAD_SPLIT_VIEW
-
+// #define QUAD_SPLIT_VIEW
 #ifdef SPLIT_VIEW
 #include <mbgl/gl/context.hpp>
 #endif
@@ -204,7 +203,6 @@ void Renderer::Impl::render(const RenderTree& renderTree) {
         parameters.currentLayer = 0;
         parameters.depthRangeSize = 1 - (orchestrator.numLayerGroups() + 2) * parameters.numSublayers *
                                             parameters.depthEpsilon;
-        parameters.opaquePassCutoff = renderTreeParameters.opaquePassCutOff;
 
         // draw layer groups, opaque pass
         orchestrator.observeLayerGroups([&](LayerGroup& layerGroup) {
@@ -234,7 +232,6 @@ void Renderer::Impl::render(const RenderTree& renderTree) {
         parameters.pass = RenderPass::Opaque;
         parameters.depthRangeSize = 1 -
                                     (layerRenderItems.size() + 2) * parameters.numSublayers * parameters.depthEpsilon;
-        parameters.opaquePassCutoff = renderTreeParameters.opaquePassCutOff;
 
         uint32_t i = 0;
         for (auto it = layerRenderItems.rbegin(); it != layerRenderItems.rend(); ++it, ++i) {

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -220,9 +220,10 @@ void Renderer::Impl::render(const RenderTree& renderTree) {
 
         // draw layer groups, translucent pass
         orchestrator.observeLayerGroups([&](LayerGroup& layerGroup) {
-            assert(parameters.currentLayer >= 0);
             layerGroup.render(orchestrator, parameters);
-            parameters.currentLayer--;
+            if (parameters.currentLayer != 0) {
+                parameters.currentLayer--;
+            }
         });
     };
 


### PR DESCRIPTION
Ensures drawable layer groups are re-sorted when the layer stack is modified, keeping layer group map indices synchronized with the intended style ordering. Additionally informs layer groups when the renderer is or isn't going to render them, enabling:
* Layer groups hide correctly when marked not visible or when the owning style layer no longer fits the map zoom level.
* Layer groups map correctly with `layerRenderItems` from the RenderTree, allowing for the existing depth system to function correctly.

Also included in this PR is split view, useful for comparing the rendering results of drawables with the existing render layer implementations. Pass `-DSPLIT_VIEW` or uncomment `#define SPLIT_VIEW` in `renderer_impl.cpp` to enable. Re-enables previosuly disabled render layer functionality, use the split view going forward to compare without the two systems overlapping.

Stacked on PR #1147

Split View, drawable layer groups to the left, render layers to the right:
![image](https://github.com/maplibre/maplibre-native/assets/53413200/af153fee-085b-435b-967b-0fc5d63a7a63)
