### PR TITLE
Circle UBO fix

### DIFF
--- a/include/mbgl/shaders/gl/drawable_circle.hpp
+++ b/include/mbgl/shaders/gl/drawable_circle.hpp
@@ -14,13 +14,15 @@ struct ShaderSource<BuiltIn::CircleShader, gfx::Backend::Type::OpenGL> {
 out vec3 v_data;
 
 layout (std140) uniform CircleDrawableUBO {
-    mat4 u_matrix;
-    vec2 u_extrude_scale;
+    highp mat4 u_matrix;
+    highp vec2 u_extrude_scale;
+    lowp vec2 pad2_;
 };
 
 layout (std140) uniform CirclePaintParamsUBO {
     highp float u_camera_to_center_distance;
     lowp float u_device_pixel_ratio;
+    lowp vec2 pad3_;
 };
 
 layout (std140) uniform CircleEvaluatedPropsUBO {
@@ -33,6 +35,7 @@ layout (std140) uniform CircleEvaluatedPropsUBO {
     lowp float u_stroke_opacity;
     bool u_scale_with_map;
     bool u_pitch_with_map;
+    lowp float pad0_;
 };
 
 layout (std140) uniform CircleInterpolateUBO {
@@ -43,6 +46,7 @@ layout (std140) uniform CircleInterpolateUBO {
     lowp float u_stroke_color_t;
     lowp float u_stroke_width_t;
     lowp float u_stroke_opacity_t;
+    lowp float pad1_;
 };
 
 #ifndef HAS_UNIFORM_u_color
@@ -160,6 +164,7 @@ layout (std140) uniform CircleEvaluatedPropsUBO {
     lowp float u_stroke_opacity;
     bool u_scale_with_map;
     bool u_pitch_with_map;
+    lowp float pad0_;
 };
 
 #ifndef HAS_UNIFORM_u_color

--- a/shaders/drawable.background.vertex.glsl
+++ b/shaders/drawable.background.vertex.glsl
@@ -1,8 +1,6 @@
 layout (location = 0) in vec2 a_pos;
 layout (std140) uniform BackgroundDrawableUBO {
     mat4 u_matrix;
-    vec2 u_world;
-    vec2 pad;
 };
 
 void main() {

--- a/shaders/drawable.circle.fragment.glsl
+++ b/shaders/drawable.circle.fragment.glsl
@@ -2,14 +2,15 @@ in vec3 v_data;
 
 layout (std140) uniform CircleEvaluatedPropsUBO {
     highp vec4 u_color;
+    highp vec4 u_stroke_color;
     mediump float u_radius;
     lowp float u_blur;
     lowp float u_opacity;
-    highp vec4 u_stroke_color;
     mediump float u_stroke_width;
     lowp float u_stroke_opacity;
     bool u_scale_with_map;
     bool u_pitch_with_map;
+    lowp float pad0_;
 };
 
 #pragma mapbox: define highp vec4 color

--- a/shaders/drawable.circle.vertex.glsl
+++ b/shaders/drawable.circle.vertex.glsl
@@ -2,13 +2,15 @@ layout (location = 0) in vec2 a_pos;
 out vec3 v_data;
 
 layout (std140) uniform CircleDrawableUBO {
-    mat4 u_matrix;
-    vec2 u_extrude_scale;
+    highp mat4 u_matrix;
+    highp vec2 u_extrude_scale;
+    lowp vec2 pad2_;
 };
 
 layout (std140) uniform CirclePaintParamsUBO {
     highp float u_camera_to_center_distance;
     lowp float u_device_pixel_ratio;
+    lowp vec2 pad3_;
 };
 
 layout (std140) uniform CircleEvaluatedPropsUBO {
@@ -21,6 +23,7 @@ layout (std140) uniform CircleEvaluatedPropsUBO {
     lowp float u_stroke_opacity;
     bool u_scale_with_map;
     bool u_pitch_with_map;
+    lowp float pad0_;
 };
 
 layout (std140) uniform CircleInterpolateUBO {
@@ -31,6 +34,7 @@ layout (std140) uniform CircleInterpolateUBO {
     lowp float u_stroke_color_t;
     lowp float u_stroke_width_t;
     lowp float u_stroke_opacity_t;
+    lowp float pad1_;
 };
 
 #pragma mapbox: define highp vec4 color

--- a/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
@@ -20,7 +20,7 @@ static_assert(sizeof(CircleDrawableUBO) % 16 == 0);
 struct alignas(16) CirclePaintParamsUBO {
     float camera_to_center_distance;
     float device_pixel_ratio;
-    float padding[2];
+    std::array<float, 2> padding;
 };
 static_assert(sizeof(CirclePaintParamsUBO) % 16 == 0);
 

--- a/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
@@ -13,12 +13,14 @@ using namespace style;
 struct alignas(16) CircleDrawableUBO {
     std::array<float, 4 * 4> matrix;
     std::array<float, 2> extrude_scale;
+    std::array<float, 2> padding;
 };
 static_assert(sizeof(CircleDrawableUBO) % 16 == 0);
 
 struct alignas(16) CirclePaintParamsUBO {
     float camera_to_center_distance;
     float device_pixel_ratio;
+    float padding[2];
 };
 static_assert(sizeof(CirclePaintParamsUBO) % 16 == 0);
 
@@ -32,6 +34,7 @@ struct alignas(16) CircleEvaluatedPropsUBO {
     float stroke_opacity;
     int scale_with_map;
     int pitch_with_map;
+    float padding;
 };
 static_assert(sizeof(CircleEvaluatedPropsUBO) % 16 == 0);
 
@@ -43,6 +46,7 @@ struct alignas(16) CircleInterpolateUBO {
     float stroke_color_t;
     float stroke_width_t;
     float stroke_opacity_t;
+    float padding;
 };
 static_assert(sizeof(CircleInterpolateUBO) % 16 == 0);
 


### PR DESCRIPTION
Adds exact padding for drivers with strict conformance, fixes member in wrong location.