### PR TITLE
Drop author & timestamp from generated shader code

### DIFF
--- a/include/mbgl/shaders/gl/background.hpp
+++ b/include/mbgl/shaders/gl/background.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/background_pattern.hpp
+++ b/include/mbgl/shaders/gl/background_pattern.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/circle.hpp
+++ b/include/mbgl/shaders/gl/circle.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/clipping_mask.hpp
+++ b/include/mbgl/shaders/gl/clipping_mask.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/collision_box.hpp
+++ b/include/mbgl/shaders/gl/collision_box.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/collision_circle.hpp
+++ b/include/mbgl/shaders/gl/collision_circle.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/debug.hpp
+++ b/include/mbgl/shaders/gl/debug.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/drawable_background.hpp
+++ b/include/mbgl/shaders/gl/drawable_background.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-24T21:16:59.579Z by timsylvester using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/drawable_circle.hpp
+++ b/include/mbgl/shaders/gl/drawable_circle.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-17T18:24:20.170Z by alex using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/drawable_fill.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-25T15:19:24.210Z by timsylvester using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/drawable_fill_outline.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill_outline.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-25T15:19:24.210Z by timsylvester using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/drawable_fill_outline_pattern.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill_outline_pattern.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-25T14:44:39.644Z by timsylvester using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/drawable_fill_pattern.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill_pattern.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-25T14:44:39.644Z by timsylvester using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/fill.hpp
+++ b/include/mbgl/shaders/gl/fill.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/fill_extrusion.hpp
+++ b/include/mbgl/shaders/gl/fill_extrusion.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/fill_extrusion_pattern.hpp
+++ b/include/mbgl/shaders/gl/fill_extrusion_pattern.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/fill_outline.hpp
+++ b/include/mbgl/shaders/gl/fill_outline.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/fill_outline_pattern.hpp
+++ b/include/mbgl/shaders/gl/fill_outline_pattern.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/fill_pattern.hpp
+++ b/include/mbgl/shaders/gl/fill_pattern.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/heatmap.hpp
+++ b/include/mbgl/shaders/gl/heatmap.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/heatmap_texture.hpp
+++ b/include/mbgl/shaders/gl/heatmap_texture.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/hillshade.hpp
+++ b/include/mbgl/shaders/gl/hillshade.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/hillshade_prepare.hpp
+++ b/include/mbgl/shaders/gl/hillshade_prepare.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/line.hpp
+++ b/include/mbgl/shaders/gl/line.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/line_gradient.hpp
+++ b/include/mbgl/shaders/gl/line_gradient.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/line_pattern.hpp
+++ b/include/mbgl/shaders/gl/line_pattern.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/line_sdf.hpp
+++ b/include/mbgl/shaders/gl/line_sdf.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/prelude.hpp
+++ b/include/mbgl/shaders/gl/prelude.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/raster.hpp
+++ b/include/mbgl/shaders/gl/raster.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/symbol_icon.hpp
+++ b/include/mbgl/shaders/gl/symbol_icon.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/symbol_sdf_icon.hpp
+++ b/include/mbgl/shaders/gl/symbol_sdf_icon.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/symbol_sdf_text.hpp
+++ b/include/mbgl/shaders/gl/symbol_sdf_text.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/gl/symbol_text_and_icon.hpp
+++ b/include/mbgl/shaders/gl/symbol_text_and_icon.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-12T17:51:34.322Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/shader_manifest.hpp
+++ b/include/mbgl/shaders/shader_manifest.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-23T18:10:10.798Z by timsylvester using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 

--- a/include/mbgl/shaders/shader_source.hpp
+++ b/include/mbgl/shaders/shader_source.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-05-23T18:10:10.798Z by timsylvester using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/gfx/backend.hpp>
 

--- a/shaders/generate_shader_code.js
+++ b/shaders/generate_shader_code.js
@@ -6,9 +6,7 @@ const path = require("node:path");
 const fs = require("node:fs")
 const os = require("node:os");
 
-const generatedHeader = `// Generated code, do not modify this file!
-// Generated on ${new Date().toISOString()} by ${os.userInfo().username} using shaders/generate_shader_code.js
-`;
+const generatedHeader = `// Generated code, do not modify this file!`;
 
 const newAttribLocationMapping = (source) => {
     return {
@@ -252,7 +250,8 @@ JSON.parse(fs.readFileSync(path.join(args.input, "manifest.json")))
 namespace mbgl {
 namespace shaders {
 
-template <> struct ShaderSource<BuiltIn::${elem.name}, gfx::Backend::Type::OpenGL> {
+template <>
+struct ShaderSource<BuiltIn::${elem.name}, gfx::Backend::Type::OpenGL> {
     static constexpr const char* name = "${elem.name}";
     static constexpr const char* vertex = R"(${args.strip ? strip(vert) : vert})";
     static constexpr const char* fragment = R"(${args.strip ? strip(frag) : frag})";
@@ -298,10 +297,12 @@ enum class BuiltIn {
 /// @tparam T One of the built-in shader types available in the BuiltIn enum
 /// @tparam The desired graphics API to request shader code for. One of
 /// gfx::Backend::Type enums.
-template <BuiltIn T, gfx::Backend::Type> struct ShaderSource;
+template <BuiltIn T, gfx::Backend::Type>
+struct ShaderSource;
 
 /// @brief A specialization of the ShaderSource template for no shader code.
-template <> struct ShaderSource<BuiltIn::None, gfx::Backend::Type::OpenGL> {
+template <>
+struct ShaderSource<BuiltIn::None, gfx::Backend::Type::OpenGL> {
     static constexpr const char* name = "";
     static constexpr const char* vertex = "";
     static constexpr const char* fragment = "";


### PR DESCRIPTION
Helps reduce merge conflicts by dropping this, we can look at the blame if we need to know.

Recreated from #1177, was force-pushed during rebase at just the ~~right~~ wrong time.