### PR TITLE
Fix LayerTweaker warning on CI

### DIFF
--- a/include/mbgl/renderer/layer_tweaker.hpp
+++ b/include/mbgl/renderer/layer_tweaker.hpp
@@ -18,10 +18,10 @@ class LayerGroup;
  */
 class LayerTweaker {
 protected:
-    LayerTweaker() = delete;
     LayerTweaker(Immutable<style::LayerProperties> properties);
 
 public:
+    LayerTweaker() = delete;
     virtual ~LayerTweaker() = default;
 
     virtual void execute(LayerGroup&, const PaintParameters&) = 0;


### PR DESCRIPTION
GCC warns on deleted constructors that aren't public