### PR TITLE
Don't reuse git dir across runs node-ci and ios-ci

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+          path: ${{ github.sha }}
 
       - name: Install macos dependencies
         run: |

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -88,8 +88,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: recursive
+          submodules: true
           path: ${{ github.sha }}
+
+      - run: ls -R
+        if: runner.os == 'Linux'      
 
       - name: Get OS Architecture
         if: runner.os == 'MacOS' || runner.os == 'Linux'

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -88,10 +88,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-          path: ${{ github.sha }}
-
-      - run: ls -R
-        if: runner.os == 'Linux'      
+          path: ${{ github.sha }}    
 
       - name: Get OS Architecture
         if: runner.os == 'MacOS' || runner.os == 'Linux'

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -88,13 +88,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Setup submodules
-        shell: bash
-        run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-          git submodule sync --recursive
-          git -c core.longpaths=true -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive || true
+          submodules: true
+          path: ${{ github.sha }}
 
       - name: Get OS Architecture
         if: runner.os == 'MacOS' || runner.os == 'Linux'

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -80,7 +80,6 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./
         shell: bash
 
     steps:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: true
+          submodules: recursive
           path: ${{ github.sha }}
 
       - name: Get OS Architecture


### PR DESCRIPTION
We recently deleted a submodule, but the self-hosted runners for Node.js and macOS now fail with the message that the deleted submodule cannot be found in `.gitmodules`.

This can be avoided by not re-using the same git directory across runs.