### PR TITLE
Update existing UBOs instead of replacing

### DIFF
--- a/include/mbgl/gfx/uniform_buffer.hpp
+++ b/include/mbgl/gfx/uniform_buffer.hpp
@@ -18,6 +18,7 @@ protected:
 
 public:
     virtual ~UniformBuffer() = default;
+    virtual void update(const void* data, std::size_t size_) = 0;
 
     std::size_t getSize() const { return size; }
 

--- a/include/mbgl/gl/uniform_buffer_gl.hpp
+++ b/include/mbgl/gl/uniform_buffer_gl.hpp
@@ -16,6 +16,7 @@ public:
     ~UniformBufferGL() override;
 
     BufferID getID() const { return id; }
+    void update(const void* data, std::size_t size_) override;
 
 protected:
     BufferID id = 0;

--- a/src/mbgl/gl/uniform_buffer_gl.cpp
+++ b/src/mbgl/gl/uniform_buffer_gl.cpp
@@ -1,7 +1,8 @@
-
 #include <mbgl/gl/uniform_buffer_gl.hpp>
 #include <mbgl/gl/defines.hpp>
 #include <mbgl/platform/gl_functions.hpp>
+
+#include <cassert>
 
 namespace mbgl {
 namespace gl {
@@ -12,7 +13,7 @@ UniformBufferGL::UniformBufferGL(const void* data, std::size_t size_)
     : UniformBuffer(size_) {
     MBGL_CHECK_ERROR(glGenBuffers(1, &id));
     MBGL_CHECK_ERROR(glBindBuffer(GL_UNIFORM_BUFFER, id));
-    MBGL_CHECK_ERROR(glBufferData(GL_UNIFORM_BUFFER, size, data, GL_STATIC_DRAW));
+    MBGL_CHECK_ERROR(glBufferData(GL_UNIFORM_BUFFER, size, data, GL_DYNAMIC_DRAW));
     MBGL_CHECK_ERROR(glBindBuffer(GL_UNIFORM_BUFFER, 0));
 }
 
@@ -21,6 +22,13 @@ UniformBufferGL::~UniformBufferGL() {
         MBGL_CHECK_ERROR(glDeleteBuffers(1, &id));
         id = 0;
     }
+}
+
+void UniformBufferGL::update(const void* data, std::size_t size_) {
+    assert(size == size_);
+    MBGL_CHECK_ERROR(glBindBuffer(GL_UNIFORM_BUFFER, id));
+    MBGL_CHECK_ERROR(glBufferSubData(GL_UNIFORM_BUFFER, 0, size_, data));
+    MBGL_CHECK_ERROR(glBindBuffer(GL_UNIFORM_BUFFER, 0));
 }
 
 } // namespace gl

--- a/src/mbgl/gl/uniform_buffer_gl.cpp
+++ b/src/mbgl/gl/uniform_buffer_gl.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/gl/uniform_buffer_gl.hpp>
 #include <mbgl/gl/defines.hpp>
 #include <mbgl/platform/gl_functions.hpp>
+#include <mbgl/util/logging.hpp>
 
 #include <cassert>
 
@@ -26,6 +27,13 @@ UniformBufferGL::~UniformBufferGL() {
 
 void UniformBufferGL::update(const void* data, std::size_t size_) {
     assert(size == size_);
+    if (size != size_) {
+        Log::Error(
+            Event::General,
+            "Mismatched size given to UBO update, expected " + std::to_string(size) + ", got " + std::to_string(size_));
+        return;
+    }
+
     MBGL_CHECK_ERROR(glBindBuffer(GL_UNIFORM_BUFFER, id));
     MBGL_CHECK_ERROR(glBufferSubData(GL_UNIFORM_BUFFER, 0, size_, data));
     MBGL_CHECK_ERROR(glBindBuffer(GL_UNIFORM_BUFFER, 0));

--- a/src/mbgl/renderer/layers/background_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/background_layer_tweaker.cpp
@@ -82,8 +82,13 @@ void BackgroundLayerTweaker::execute(LayerGroup& layerGroup, const RenderTree&, 
 
         BackgroundDrawableUBO drawableUBO;
         drawableUBO.matrix = util::cast<float>(matrix);
-        auto drawableUniformBuffer = parameters.context.createUniformBuffer(&drawableUBO, sizeof(drawableUBO));
-        drawable.mutableUniformBuffers().addOrReplace("BackgroundDrawableUBO", std::move(drawableUniformBuffer));
+        
+        if (auto& ubo = drawable.mutableUniformBuffers().get("BackgroundDrawableUBO")) {
+            ubo->update(&drawableUBO, sizeof(drawableUBO));
+        } else {
+            drawable.mutableUniformBuffers().addOrReplace("BackgroundDrawableUBO",
+                parameters.context.createUniformBuffer(&drawableUBO, sizeof(drawableUBO)));
+        }
 
         gfx::UniformBufferPtr layerUniformBuffer;
         if (hasPattern) {
@@ -117,17 +122,27 @@ void BackgroundLayerTweaker::execute(LayerGroup& layerGroup, const RenderTree&, 
                 /* .opacity = */ evaluated.get<BackgroundOpacity>(),
                 /* .pad = */ {0},
             };
-            // TODO: Update UBOs in-place
-            layerUniformBuffer = parameters.context.createUniformBuffer(&layerUBO, sizeof(layerUBO));
+
+            if (auto& ubo = drawable.mutableUniformBuffers().get("BackgroundLayerUBO"); ubo->getSize() == sizeof(layerUBO)) {
+                ubo->update(&drawableUBO, sizeof(drawableUBO));
+            } else {
+                drawable.mutableUniformBuffers().addOrReplace("BackgroundLayerUBO",
+                    parameters.context.createUniformBuffer(&layerUBO, sizeof(layerUBO)));
+            }
         } else {
             const BackgroundLayerUBO layerUBO = {
                 /* .color = */ evaluated.get<BackgroundColor>(),
                 /* .opacity = */ evaluated.get<BackgroundOpacity>(),
                 /* .pad = */ {0, 0, 0},
             };
-            layerUniformBuffer = parameters.context.createUniformBuffer(&layerUBO, sizeof(layerUBO));
+
+            if (auto& ubo = drawable.mutableUniformBuffers().get("BackgroundLayerUBO"); ubo->getSize() == sizeof(layerUBO)) {
+                ubo->update(&drawableUBO, sizeof(drawableUBO));
+            } else {
+                drawable.mutableUniformBuffers().addOrReplace("BackgroundLayerUBO",
+                    parameters.context.createUniformBuffer(&layerUBO, sizeof(layerUBO)));
+            }
         }
-        drawable.mutableUniformBuffers().addOrReplace("BackgroundLayerUBO", std::move(layerUniformBuffer));
     });
 }
 

--- a/src/mbgl/renderer/layers/background_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/background_layer_tweaker.cpp
@@ -90,7 +90,6 @@ void BackgroundLayerTweaker::execute(LayerGroup& layerGroup, const RenderTree&, 
                 "BackgroundDrawableUBO", parameters.context.createUniformBuffer(&drawableUBO, sizeof(drawableUBO)));
         }
 
-        gfx::UniformBufferPtr layerUniformBuffer;
         if (hasPattern) {
             // TODO: add when raster is merged
             // curShader->getSamplerLocation("u_image");

--- a/src/mbgl/renderer/layers/background_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/background_layer_tweaker.cpp
@@ -82,7 +82,7 @@ void BackgroundLayerTweaker::execute(LayerGroup& layerGroup, const RenderTree&, 
 
         BackgroundDrawableUBO drawableUBO;
         drawableUBO.matrix = util::cast<float>(matrix);
-        
+
         if (auto& ubo = drawable.mutableUniformBuffers().get("BackgroundDrawableUBO")) {
             ubo->update(&drawableUBO, sizeof(drawableUBO));
         } else {
@@ -123,11 +123,12 @@ void BackgroundLayerTweaker::execute(LayerGroup& layerGroup, const RenderTree&, 
                 /* .pad = */ {0},
             };
 
-            if (auto& ubo = drawable.mutableUniformBuffers().get("BackgroundLayerUBO"); ubo->getSize() == sizeof(layerUBO)) {
+            if (auto& ubo = drawable.mutableUniformBuffers().get("BackgroundLayerUBO");
+                ubo->getSize() == sizeof(layerUBO)) {
                 ubo->update(&drawableUBO, sizeof(drawableUBO));
             } else {
-                drawable.mutableUniformBuffers().addOrReplace("BackgroundLayerUBO",
-                    parameters.context.createUniformBuffer(&layerUBO, sizeof(layerUBO)));
+                drawable.mutableUniformBuffers().addOrReplace(
+                    "BackgroundLayerUBO", parameters.context.createUniformBuffer(&layerUBO, sizeof(layerUBO)));
             }
         } else {
             const BackgroundLayerUBO layerUBO = {
@@ -136,11 +137,12 @@ void BackgroundLayerTweaker::execute(LayerGroup& layerGroup, const RenderTree&, 
                 /* .pad = */ {0, 0, 0},
             };
 
-            if (auto& ubo = drawable.mutableUniformBuffers().get("BackgroundLayerUBO"); ubo->getSize() == sizeof(layerUBO)) {
+            if (auto& ubo = drawable.mutableUniformBuffers().get("BackgroundLayerUBO");
+                ubo->getSize() == sizeof(layerUBO)) {
                 ubo->update(&drawableUBO, sizeof(drawableUBO));
             } else {
-                drawable.mutableUniformBuffers().addOrReplace("BackgroundLayerUBO",
-                    parameters.context.createUniformBuffer(&layerUBO, sizeof(layerUBO)));
+                drawable.mutableUniformBuffers().addOrReplace(
+                    "BackgroundLayerUBO", parameters.context.createUniformBuffer(&layerUBO, sizeof(layerUBO)));
             }
         }
     });

--- a/src/mbgl/renderer/layers/background_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/background_layer_tweaker.cpp
@@ -86,8 +86,8 @@ void BackgroundLayerTweaker::execute(LayerGroup& layerGroup, const RenderTree&, 
         if (auto& ubo = drawable.mutableUniformBuffers().get("BackgroundDrawableUBO")) {
             ubo->update(&drawableUBO, sizeof(drawableUBO));
         } else {
-            drawable.mutableUniformBuffers().addOrReplace("BackgroundDrawableUBO",
-                parameters.context.createUniformBuffer(&drawableUBO, sizeof(drawableUBO)));
+            drawable.mutableUniformBuffers().addOrReplace(
+                "BackgroundDrawableUBO", parameters.context.createUniformBuffer(&drawableUBO, sizeof(drawableUBO)));
         }
 
         gfx::UniformBufferPtr layerUniformBuffer;

--- a/src/mbgl/renderer/layers/circle_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/circle_layer_tweaker.hpp
@@ -23,7 +23,9 @@ public:
     void execute(LayerGroup&, const RenderTree&, const PaintParameters&) override;
 
 protected:
+    gfx::UniformBufferPtr paintParamsUniformBuffer = nullptr;
     gfx::UniformBufferPtr evaluatedPropsUniformBuffer = nullptr;
+    gfx::UniformBufferPtr interpolateUniformBuffer = nullptr;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
@@ -115,9 +115,12 @@ void FillLayerTweaker::execute(LayerGroup& layerGroup,
             /*.image=*/ // TextureAttachment(tile.getIconAtlasTexture().getResource(), Linear)
         };
 
-        auto drawableUniformBuffer = parameters.context.createUniformBuffer(&drawableUBO, sizeof(drawableUBO));
-        drawable.mutableUniformBuffers().addOrReplace("FillDrawableUBO", drawableUniformBuffer);
+        if (auto& ubo = drawable.mutableUniformBuffers().get("FillDrawableUBO")) {
+            ubo->update(&drawableUBO, sizeof(drawableUBO));
+        } else {
+            drawable.mutableUniformBuffers().addOrReplace("FillDrawableUBO",
+                parameters.context.createUniformBuffer(&drawableUBO, sizeof(drawableUBO)));
+        }
     });
 }
-
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
@@ -118,8 +118,8 @@ void FillLayerTweaker::execute(LayerGroup& layerGroup,
         if (auto& ubo = drawable.mutableUniformBuffers().get("FillDrawableUBO")) {
             ubo->update(&drawableUBO, sizeof(drawableUBO));
         } else {
-            drawable.mutableUniformBuffers().addOrReplace("FillDrawableUBO",
-                parameters.context.createUniformBuffer(&drawableUBO, sizeof(drawableUBO)));
+            drawable.mutableUniformBuffers().addOrReplace(
+                "FillDrawableUBO", parameters.context.createUniformBuffer(&drawableUBO, sizeof(drawableUBO)));
         }
     });
 }


### PR DESCRIPTION
Update UBO contents in-place if a suitable buffer is found already present.