### PR TITLE
Fix drawable segment VAO leak

### DIFF
--- a/include/mbgl/gfx/drawable_impl.hpp
+++ b/include/mbgl/gfx/drawable_impl.hpp
@@ -9,7 +9,7 @@ struct Drawable::DrawSegment {
     DrawSegment(gfx::DrawMode mode_, Segment<void>&& segment_)
         : mode(mode_),
           segment(std::move(segment_)) {}
-    
+
     virtual ~DrawSegment() = default;
 
     const gfx::DrawMode& getMode() const { return mode; }

--- a/include/mbgl/gfx/drawable_impl.hpp
+++ b/include/mbgl/gfx/drawable_impl.hpp
@@ -9,6 +9,8 @@ struct Drawable::DrawSegment {
     DrawSegment(gfx::DrawMode mode_, Segment<void>&& segment_)
         : mode(mode_),
           segment(std::move(segment_)) {}
+    
+    virtual ~DrawSegment() = default;
 
     const gfx::DrawMode& getMode() const { return mode; }
 

--- a/src/mbgl/gl/drawable_gl_impl.hpp
+++ b/src/mbgl/gl/drawable_gl_impl.hpp
@@ -53,6 +53,8 @@ struct DrawableGL::DrawSegmentGL final : public gfx::Drawable::DrawSegment {
         : gfx::Drawable::DrawSegment(mode_, std::move(segment_)),
           vertexArray(std::move(vertexArray_)) {}
 
+   ~DrawSegmentGL() override = default;
+
     const VertexArray& getVertexArray() const { return vertexArray; }
     void setVertexArray(VertexArray&& value) { vertexArray = std::move(value); }
 

--- a/src/mbgl/gl/drawable_gl_impl.hpp
+++ b/src/mbgl/gl/drawable_gl_impl.hpp
@@ -53,7 +53,7 @@ struct DrawableGL::DrawSegmentGL final : public gfx::Drawable::DrawSegment {
         : gfx::Drawable::DrawSegment(mode_, std::move(segment_)),
           vertexArray(std::move(vertexArray_)) {}
 
-   ~DrawSegmentGL() override = default;
+    ~DrawSegmentGL() override = default;
 
     const VertexArray& getVertexArray() const { return vertexArray; }
     void setVertexArray(VertexArray&& value) { vertexArray = std::move(value); }


### PR DESCRIPTION
Missing virtual destructor on segments resulted in leaking vertex array objects, adding them resolves the issue.