### PR TITLE
Only keep one PR comment

### DIFF
--- a/.github/workflows/pr-render-test-result.yml
+++ b/.github/workflows/pr-render-test-result.yml
@@ -61,7 +61,5 @@ jobs:
         with:
           header: render-test-result
           number: ${{ env.pr_number }}
-          hide_and_recreate: true
-          hide_classify: "OUTDATED"
           message: |
             Render test results at https://maplibre-native-test-artifacts.s3.eu-central-1.amazonaws.com/${{ github.run_id }}-linux-gcc8-release-style.html

--- a/.github/workflows/pr-size-test-result.yml
+++ b/.github/workflows/pr-size-test-result.yml
@@ -75,8 +75,6 @@ jobs:
         with:
           header: size-test-result
           number: ${{ env.pr_number }}
-          hide_and_recreate: true
-          hide_classify: "OUTDATED"
           message: |
             ### Size test result
 


### PR DESCRIPTION
The PR comments are causing too much noise in long-lived PRs, even though the old comments are being hidden.

This creates one comment and then updates it as more commits are pushed to the PR branch.