### PR TITLE
Update Android SDK to Gradle 8

### DIFF
--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.0'
+        classpath 'com.android.tools.build:gradle:8.0.2'
         classpath dependenciesList.licensesPlugin
         classpath dependenciesList.kotlinPlugin
         // classpath dependenciesList.jacocoPlugin

--- a/platform/android/gradle.properties
+++ b/platform/android/gradle.properties
@@ -2,3 +2,6 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.http.connectionTimeout=360000
 systemProp.org.gradle.internal.http.socketTimeout=360000
 org.gradle.jvmargs=-Xmx4096M
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/platform/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Dec 15 15:24:50 PST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Release notes [here](https://gradle.org/whats-new/gradle-8/)

Apart from some performance this will allow us to replace the Groovy config with Kotlin DSL.