### PR TITLE
Update Android SDK to Gradle 8

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -65,6 +65,11 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       
       - name: Cache node modules
         uses: actions/cache@v3

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -20,6 +20,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      
       - name: Ensure source code revision
         run: scripts/ensure-code-revision.sh        
         working-directory: platform/android

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.0'
+        classpath 'com.android.tools.build:gradle:8.0.2'
         classpath dependenciesList.licensesPlugin
         classpath dependenciesList.kotlinPlugin
         // classpath dependenciesList.jacocoPlugin

--- a/platform/android/gradle.properties
+++ b/platform/android/gradle.properties
@@ -2,3 +2,6 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.http.connectionTimeout=360000
 systemProp.org.gradle.internal.http.socketTimeout=360000
 org.gradle.jvmargs=-Xmx4096M
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/platform/android/gradle/gradle-lint.gradle
+++ b/platform/android/gradle/gradle-lint.gradle
@@ -20,11 +20,3 @@ def isLocalBuild() {
     }
     return true
 }
-
-lint.dependsOn ciLint
-
-tasks.whenTaskAdded { task ->
-    if (task.name == 'lintVitalRelease') {
-        task.dependsOn ciLint
-    }
-}

--- a/platform/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Dec 15 15:24:50 PST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Release notes [here](https://gradle.org/whats-new/gradle-8/)

Apart from some performance this will allow us to replace the Groovy config with Kotlin DSL.

... the PR doesn't reflect changes to the branch it was made from for some reason. Don't have any way to update it except closing and opening a new one.