### PR TITLE
Fix Texture2D upload unpack alignment, filtering

### DIFF
--- a/include/mbgl/gfx/texture2d.hpp
+++ b/include/mbgl/gfx/texture2d.hpp
@@ -20,10 +20,8 @@ class TextureResource;
 class Texture2D {
 public:
     struct SamplerState {
-        /// Minification filter within a single mip level
-        TextureFilterType minification{TextureFilterType::Nearest};
-        /// Magnification filter within a single mip level
-        TextureFilterType magnification{TextureFilterType::Nearest};
+        /// Minification and magnification filter within a single mip level
+        TextureFilterType filter{TextureFilterType::Nearest};
         /// Wrapping behavior along U coordinate
         TextureWrapType wrapU{TextureWrapType::Clamp};
         /// Wrapping behavior along V coordinate
@@ -78,11 +76,15 @@ public:
     /// @brief Upload image data to the texture resource
     /// @param pixelData Image data to transfer
     virtual void upload(const void* pixelData, const Size& size_) noexcept = 0;
+
+    /// @brief Upload image data to the texture resource
+    /// @tparam Image Image object type
+    /// @param img Image to transfer
     template <typename Image>
     void upload(const Image& img) noexcept {
         setFormat(Image::channels == 1 ? gfx::TexturePixelType::Alpha : gfx::TexturePixelType::RGBA,
                   gfx::TextureChannelDataType::UnsignedByte);
-        upload(&img.data[0], img.size);
+        upload(img.data ? img.data.get() : nullptr, img.size);
     }
 
     virtual void uploadSubRegion(const void* pixelData,
@@ -95,7 +97,7 @@ public:
         assert(Image::channels == getPixelStride());
         assert(img.size.width + xOffset <= getSize().width);
         assert(img.size.height + yOffset <= getSize().height);
-        uploadSubRegion(&img.data[0], img.size, xOffset, yOffset);
+        uploadSubRegion(img.data ? img.data.get() : nullptr, img.size, xOffset, yOffset);
     }
 
     /// @brief Upload staged image data if present and required.

--- a/include/mbgl/gl/texture2d.hpp
+++ b/include/mbgl/gl/texture2d.hpp
@@ -78,6 +78,7 @@ private:
     std::shared_ptr<PremultipliedImage> image{nullptr};
     Size size{0, 0};
     bool samplerStateDirty{false};
+    bool storageDirty{false};
 
     int32_t boundTextureUnit{-1};
     int32_t boundLocation{-1};

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -86,8 +86,12 @@ void GeometryTileRenderData::upload(gfx::UploadPass& uploadPass) {
 
     assert(atlasTextures);
 
-    if (layoutResult->glyphAtlasImage) {
+    if (layoutResult->glyphAtlasImage && layoutResult->glyphAtlasImage->valid()) {
         atlasTextures->glyph = uploadPass.getContext().createTexture2D();
+        atlasTextures->glyph->setSamplerConfiguration({
+               gfx::TextureFilterType::Linear,
+               gfx::TextureWrapType::Clamp,
+               gfx::TextureWrapType::Clamp});
         atlasTextures->glyph->upload(*layoutResult->glyphAtlasImage);
         layoutResult->glyphAtlasImage = {};
     }


### PR DESCRIPTION
Fixes issues seen in glyph atlas textures during startup, caused by an incorrect unpack alignment. Also makes a greater effort to ensure texture filtering is correct in usage and is reflected to the underlying legacy texture resource object.