### PR TITLE
Handle texture updates better

### DIFF
--- a/include/mbgl/gfx/drawable.hpp
+++ b/include/mbgl/gfx/drawable.hpp
@@ -29,6 +29,7 @@ class ShaderProgramBase;
 using ShaderProgramBasePtr = std::shared_ptr<ShaderProgramBase>;
 using DrawPriority = int64_t;
 using DrawableTweakerPtr = std::shared_ptr<DrawableTweaker>;
+using Texture2DPtr = std::shared_ptr<Texture2D>;
 
 class Drawable {
 public:
@@ -104,6 +105,15 @@ public:
     /// @param location A sampler location in the shader being used with this drawable.
     void setTexture(std::shared_ptr<gfx::Texture2D> texture, int32_t location);
 
+    using TexSourceFunc = std::function<gfx::Texture2DPtr()>;
+
+    /// @brief Provide a function to get the current texture
+    void setTextureSource(int32_t location, TexSourceFunc);
+    const TexSourceFunc& getTextureSource(int32_t location) const;
+
+    /// @brief Provide all texture sources at once
+    void setTextureSources(std::vector<TexSourceFunc>);
+
     /// Whether the drawble should be drawn
     bool getEnabled() const { return enabled; }
     void setEnabled(bool value) { enabled = value; }
@@ -174,6 +184,7 @@ protected:
     std::unique_ptr<Impl> impl;
 
     Textures textures;
+    std::vector<TexSourceFunc> textureSources;
     std::vector<DrawableTweakerPtr> tweakers;
 };
 

--- a/include/mbgl/gfx/drawable_builder.hpp
+++ b/include/mbgl/gfx/drawable_builder.hpp
@@ -21,6 +21,7 @@ class ShaderProgramBase;
 
 using DrawableTweakerPtr = std::shared_ptr<DrawableTweaker>;
 using ShaderProgramBasePtr = std::shared_ptr<ShaderProgramBase>;
+using Texture2DPtr = std::shared_ptr<Texture2D>;
 
 /**
     Base class for drawable builders, which construct Drawables from primitives
@@ -111,7 +112,12 @@ public:
     /// @brief Attach the given texture at the given sampler location.
     /// @param texture Texture2D instance
     /// @param location A sampler location in the shader being used.
-    void setTexture(const std::shared_ptr<gfx::Texture2D>& texture, int32_t location);
+    void setTexture(const gfx::Texture2DPtr&, int32_t location);
+
+    using TexSourceFunc = std::function<gfx::Texture2DPtr()>;
+
+    /// @brief Provide a function to get the current texture
+    void setTextureSource(int32_t location, TexSourceFunc);
 
     /// Add a triangle
     void addTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2);
@@ -171,6 +177,7 @@ protected:
     ColorAttrMode colorAttrMode = ColorAttrMode::PerVertex;
     VertexAttributeArray vertexAttrs;
     gfx::Drawable::Textures textures;
+    std::vector<TexSourceFunc> textureSources;
 
     struct Impl;
     std::unique_ptr<Impl> impl;

--- a/src/mbgl/gfx/drawable.cpp
+++ b/src/mbgl/gfx/drawable.cpp
@@ -46,5 +46,22 @@ void Drawable::removeTexture(int32_t location) {
     }
 }
 
+/// @brief Provide a function to get the current texture
+void Drawable::setTextureSource(int32_t location, TexSourceFunc source) {
+    textureSources.resize(std::max(textureSources.size(), static_cast<size_t>(location + 1)));
+    textureSources[location] = std::move(source);
+}
+
+static const Drawable::TexSourceFunc noSource;
+
+const Drawable::TexSourceFunc& Drawable::getTextureSource(int32_t location) const {
+    return (static_cast<std::size_t>(location) < textureSources.size()) ? textureSources[location] : noSource;
+}
+
+/// @brief Provide all texture sources at once
+void Drawable::setTextureSources(std::vector<TexSourceFunc> sources) {
+    textureSources = std::move(sources);
+}
+
 } // namespace gfx
 } // namespace mbgl

--- a/src/mbgl/gfx/drawable_builder.cpp
+++ b/src/mbgl/gfx/drawable_builder.cpp
@@ -50,6 +50,7 @@ void DrawableBuilder::flush() {
         draw->setCullFaceMode(impl->cullFaceMode);
         draw->setShader(shader);
         draw->setTextures(textures);
+        draw->setTextureSources(textureSources);
 
         if (auto drawAttrs = getVertexAttributes().clone()) {
             vertexAttrs.observeAttributes([&](const std::string& iName, const VertexAttribute& iAttr) {
@@ -110,6 +111,11 @@ void DrawableBuilder::setTexture(const std::shared_ptr<gfx::Texture2D>& texture,
         }
     }
     textures.emplace_back(texture, location);
+}
+
+void DrawableBuilder::setTextureSource(int32_t location, TexSourceFunc source) {
+    textureSources.resize(std::max(textureSources.size(), static_cast<size_t>(location + 1)));
+    textureSources[location] = std::move(source);
 }
 
 void DrawableBuilder::addTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2) {

--- a/src/mbgl/gl/drawable_gl.cpp
+++ b/src/mbgl/gl/drawable_gl.cpp
@@ -176,6 +176,12 @@ void DrawableGL::upload(gfx::UploadPass& uploadPass) {
         };
     }
 
+    for (std::size_t i = 0; i < textureSources.size(); ++i) {
+        if (const auto& source = textureSources[i]) {
+            setTexture(source(), static_cast<int32_t>(i));
+        }
+    }
+    
     const bool texturesNeedUpload = std::any_of(
         textures.begin(), textures.end(), [](const auto& tex) { return tex.texture->needsUpload(); });
 

--- a/src/mbgl/gl/drawable_gl.cpp
+++ b/src/mbgl/gl/drawable_gl.cpp
@@ -39,7 +39,7 @@ void DrawableGL::draw(const PaintParameters& parameters) const {
     context.setDepthMode(parameters.depthModeForSublayer(getSubLayerIndex(), getDepthType()));
 
     // force disable depth test for debugging
-    //context.setDepthMode({gfx::DepthFunctionType::Always, gfx::DepthMaskType::ReadOnly, {0,1}});
+    // context.setDepthMode({gfx::DepthFunctionType::Always, gfx::DepthMaskType::ReadOnly, {0,1}});
 
     if (needsStencil && tileID) {
         context.setStencilMode(parameters.stencilModeForClipping(tileID->toUnwrapped()));
@@ -181,7 +181,7 @@ void DrawableGL::upload(gfx::UploadPass& uploadPass) {
             setTexture(source(), static_cast<int32_t>(i));
         }
     }
-    
+
     const bool texturesNeedUpload = std::any_of(
         textures.begin(), textures.end(), [](const auto& tex) { return tex.texture->needsUpload(); });
 

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -288,16 +288,21 @@ using FloatVertex = gfx::detail::VertexType<FloatAttr>;
 using FloatPairVertex = gfx::detail::VertexType<FloatPairAttr>;
 using UShortQuadVertex = gfx::detail::VertexType<UShortQuadAttr>;
 using FloatBinder = PaintPropertyBinder<float, float, mbgl::PossiblyEvaluatedPropertyValue<float>, FloatAttr>;
-using FloatPairBinder = PaintPropertyBinder<FloatPair, FloatPair, mbgl::PossiblyEvaluatedPropertyValue<FloatPair>, FloatPairAttr>;
+using FloatPairBinder =
+    PaintPropertyBinder<FloatPair, FloatPair, mbgl::PossiblyEvaluatedPropertyValue<FloatPair>, FloatPairAttr>;
 using ColorBinder = PaintPropertyBinder<Color, Color, mbgl::PossiblyEvaluatedPropertyValue<Color>, FloatPairAttr>;
-using ImageBinder = PaintPropertyBinder<style::expression::Image, UShortQuad, PossiblyEvaluatedPropertyValue<mbgl::Faded<mbgl::style::expression::Image>>, UShortQuadAttr, UShortQuadAttr>;
+using ImageBinder = PaintPropertyBinder<style::expression::Image,
+                                        UShortQuad,
+                                        PossiblyEvaluatedPropertyValue<mbgl::Faded<mbgl::style::expression::Image>>,
+                                        UShortQuadAttr,
+                                        UShortQuadAttr>;
 
 bool bindFloat(const FloatBinder& binder, gfx::VertexAttributeArray& attrs, std::string attributeName) {
     const auto count = binder.getVertexCount();
     if (auto& attr = attrs.getOrAdd(std::move(attributeName))) {
         for (std::size_t i = 0; i < count; ++i) {
             const auto& value = static_cast<const FloatVertex*>(binder.getVertexValue(i))->a1;
-            const auto& from = value;   // TODO: should be two different values, right?
+            const auto& from = value; // TODO: should be two different values, right?
             const auto& to = value;
             attr->set(i, util::concat(from, to));
         }
@@ -305,7 +310,9 @@ bool bindFloat(const FloatBinder& binder, gfx::VertexAttributeArray& attrs, std:
     }
     return false;
 }
-bool bindFloat(const std::unique_ptr<FloatBinder>& binder, gfx::VertexAttributeArray& attrs, std::string attributeName) {
+bool bindFloat(const std::unique_ptr<FloatBinder>& binder,
+               gfx::VertexAttributeArray& attrs,
+               std::string attributeName) {
     return binder && bindFloat(*binder, attrs, std::move(attributeName));
 }
 
@@ -315,7 +322,7 @@ bool bindFloatPair(const FloatPairBinder& binder, gfx::VertexAttributeArray& att
     if (auto& attr = attrs.getOrAdd(std::move(attributeName))) {
         for (std::size_t i = 0; i < count; ++i) {
             const auto& value = static_cast<const FloatPairVertex*>(binder.getVertexValue(i))->a1;
-            const auto& from = value;   // TODO: should be two different values, right?
+            const auto& from = value; // TODO: should be two different values, right?
             const auto& to = value;
             attr->set(i, util::concat(from, to));
         }
@@ -323,7 +330,9 @@ bool bindFloatPair(const FloatPairBinder& binder, gfx::VertexAttributeArray& att
     }
     return false;
 }
-bool bindFloatPair(const std::unique_ptr<FloatPairBinder>& binder, gfx::VertexAttributeArray& attrs, std::string attributeName) {
+bool bindFloatPair(const std::unique_ptr<FloatPairBinder>& binder,
+                   gfx::VertexAttributeArray& attrs,
+                   std::string attributeName) {
     return binder && bindFloatPair(*binder, attrs, std::move(attributeName));
 }
 
@@ -333,7 +342,7 @@ bool bindColor(const ColorBinder& binder, gfx::VertexAttributeArray& attrs, std:
     if (auto& attr = attrs.getOrAdd(std::move(attributeName))) {
         for (std::size_t i = 0; i < count; ++i) {
             const auto& value = static_cast<const FloatPairVertex*>(binder.getVertexValue(i))->a1;
-            const auto& from = value;  // TODO: should be two different values, right?
+            const auto& from = value; // TODO: should be two different values, right?
             const auto& to = value;
             attr->set(i, util::concat(from, to));
         }
@@ -341,7 +350,9 @@ bool bindColor(const ColorBinder& binder, gfx::VertexAttributeArray& attrs, std:
     }
     return false;
 }
-bool bindColor(const std::unique_ptr<ColorBinder>& binder, gfx::VertexAttributeArray& attrs, std::string attributeName) {
+bool bindColor(const std::unique_ptr<ColorBinder>& binder,
+               gfx::VertexAttributeArray& attrs,
+               std::string attributeName) {
     return binder && bindColor(*binder, attrs, std::move(attributeName));
 }
 
@@ -357,7 +368,9 @@ bool bindImage(const ImageBinder& binder, gfx::VertexAttributeArray& attrs, std:
     }
     return false;
 }
-bool bindImage(const std::unique_ptr<ImageBinder>& binder, gfx::VertexAttributeArray& attrs, std::string attributeName) {
+bool bindImage(const std::unique_ptr<ImageBinder>& binder,
+               gfx::VertexAttributeArray& attrs,
+               std::string attributeName) {
     return binder && bindImage(*binder, attrs, std::move(attributeName));
 }
 
@@ -426,7 +439,7 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
             ++stats.tileDrawablesAdded;
         }
     };
-    
+
     const auto commonInit = [&](gfx::DrawableBuilder& builder) {
         builder.setColorAttrMode(gfx::DrawableBuilder::ColorAttrMode::None);
         builder.setCullFaceMode(gfx::CullFaceMode::disabled());
@@ -436,8 +449,7 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
     tileLayerGroup->observeDrawables([&](gfx::UniqueDrawable& drawable) {
         // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
         const auto tileID = drawable->getTileID();
-        if (drawable->getRenderPass() != renderPass ||
-            (tileID && newTileIDs.find(*tileID) == newTileIDs.end())) {
+        if (drawable->getRenderPass() != renderPass || (tileID && newTileIDs.find(*tileID) == newTileIDs.end())) {
             drawable.reset();
             ++stats.tileDrawablesRemoved;
         }
@@ -516,20 +528,18 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
                 buildVertices();
                 fillBuilder->setVertexAttributes(fillVertexAttrs);
                 fillBuilder->addVertices(rawVerts, 0, rawVerts.size());
-                fillBuilder->setSegments(
-                    gfx::Triangles(),
-                    bucket.triangles.vector(),
-                    reinterpret_cast<const std::vector<Segment<void>>&>(bucket.triangleSegments));
+                fillBuilder->setSegments(gfx::Triangles(),
+                                         bucket.triangles.vector(),
+                                         reinterpret_cast<const std::vector<Segment<void>>&>(bucket.triangleSegments));
                 finish(*fillBuilder, tileID);
             }
             if (outlineBuilder) {
                 buildVertices();
                 outlineBuilder->setVertexAttributes(outlineVertexAttrs);
                 outlineBuilder->addVertices(rawVerts, 0, rawVerts.size());
-                outlineBuilder->setSegments(
-                    gfx::Lines(2),
-                    bucket.lines.vector(),
-                    reinterpret_cast<const std::vector<Segment<void>>&>(bucket.lineSegments));
+                outlineBuilder->setSegments(gfx::Lines(2),
+                                            bucket.lines.vector(),
+                                            reinterpret_cast<const std::vector<Segment<void>>&>(bucket.lineSegments));
                 finish(*outlineBuilder, tileID);
             }
         } else { // FillPattern is defined
@@ -538,10 +548,8 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
             }
 
             // Outline does not default to fill in the pattern case
-            const auto doOutline = evaluated.get<FillAntialias>() &&
-                                   unevaluated.get<FillOutlineColor>().isUndefined();
-            const auto& fillPatternValue = evaluated.get<FillPattern>().constantOr(
-                Faded<expression::Image>{"", ""});
+            const auto doOutline = evaluated.get<FillAntialias>() && unevaluated.get<FillOutlineColor>().isUndefined();
+            const auto& fillPatternValue = evaluated.get<FillPattern>().constantOr(Faded<expression::Image>{"", ""});
             const auto patternPosA = tile.getPattern(fillPatternValue.from.id());
             const auto patternPosB = tile.getPattern(fillPatternValue.to.id());
             paintPropertyBinders.setPatternParameters(patternPosA, patternPosB, crossfade);
@@ -566,9 +574,7 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
                     builder->setSubLayerIndex(1);
                     builder->setRenderPass(RenderPass::Translucent);
                     if (const auto& atlases = tile.getAtlasTextures()) {
-                        builder->setTextureSource(samplerLocation, [=](){
-                            return atlases ? atlases->icon : nullptr;
-                        });
+                        builder->setTextureSource(samplerLocation, [=]() { return atlases ? atlases->icon : nullptr; });
                     }
                     patternBuilder = std::move(builder);
                 }
@@ -582,9 +588,7 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
                     builder->setSubLayerIndex(2);
                     builder->setRenderPass(RenderPass::Translucent);
                     if (const auto& atlases = tile.getAtlasTextures()) {
-                        builder->setTextureSource(samplerLocation, [=](){
-                            return atlases ? atlases->icon : nullptr;
-                        });
+                        builder->setTextureSource(samplerLocation, [=]() { return atlases ? atlases->icon : nullptr; });
                     }
                     outlinePatternBuilder = std::move(builder);
                 }

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -124,6 +124,11 @@ gfx::TextureBinding RenderTile::getIconAtlasTextureBinding(gfx::TextureFilterTyp
     return {getIconAtlasTexture()->getResource(), filter};
 }
 
+static const std::shared_ptr<TileAtlasTextures> noAtlas;
+const std::shared_ptr<TileAtlasTextures>& RenderTile::getAtlasTextures() const {
+    return renderData ? renderData->getAtlasTextures() : noAtlas;
+}
+
 void RenderTile::upload(gfx::UploadPass& uploadPass) const {
     assert(renderData);
     renderData->upload(uploadPass);

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -27,6 +27,7 @@ class PaintParameters;
 class DebugBucket;
 class SourcePrepareParameters;
 class FeatureIndex;
+class TileAtlasTextures;
 class TileRenderData;
 
 class RenderTile final {
@@ -65,6 +66,8 @@ public:
     bool hasIconAtlasTexture() const;
     const gfx::Texture2DPtr& getIconAtlasTexture() const;
     gfx::TextureBinding getIconAtlasTextureBinding(gfx::TextureFilterType) const;
+
+    const std::shared_ptr<TileAtlasTextures>& getAtlasTextures() const;
 
     void upload(gfx::UploadPass&) const;
     void prepare(const SourcePrepareParameters&);

--- a/src/mbgl/renderer/tile_render_data.hpp
+++ b/src/mbgl/renderer/tile_render_data.hpp
@@ -30,6 +30,7 @@ public:
     virtual ~TileRenderData();
     const gfx::Texture2DPtr& getGlyphAtlasTexture() const;
     const gfx::Texture2DPtr& getIconAtlasTexture() const;
+    const std::shared_ptr<TileAtlasTextures>& getAtlasTextures() const { return atlasTextures; }
     // To be implemented for concrete tile types.
     virtual std::optional<ImagePosition> getPattern(const std::string&) const;
     virtual const LayerRenderData* getLayerRenderData(const style::Layer::Impl&) const;

--- a/src/mbgl/util/std.hpp
+++ b/src/mbgl/util/std.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 namespace util {
 
 template <typename Container, typename ForwardIterator, typename Predicate>
-void erase_if(Container &container, ForwardIterator it, Predicate pred) {
+void erase_if(Container& container, ForwardIterator it, Predicate pred) {
     while (it != container.end()) {
         if (pred(*it)) {
             it = container.erase(it);
@@ -19,7 +19,7 @@ void erase_if(Container &container, ForwardIterator it, Predicate pred) {
 }
 
 template <typename Container, typename Predicate>
-void erase_if(Container &container, Predicate pred) {
+void erase_if(Container& container, Predicate pred) {
     erase_if(container, container.begin(), pred);
 }
 


### PR DESCRIPTION
I got fill-patterns working but, since `RenderTiles` isn't available in the tweaker,  it required the `RenderLayer::update` pushing the result of `tile.getIconAtlasTexture` to each tile drawable.

The tile keeps the atlas textures in a more stable `TileAtlasTextures` object with shared ownership, and indirectly passing that through the drawables with a lambda capture also works, and helps make the drawables more independent of `update`.  This might be better done using an abstract interface rather than a lambda.

Thoughts?