### PR TITLE
Fix concurrency

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -207,9 +207,6 @@ jobs:
 
   instrumentation-test:
     needs: build
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: false
 
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
We recently merged two workflows. 

Now the instrumentation tests are not running anymore due this error

```
Canceling since a deadlock for concurrency group '<group name>' was detected between 'top level workflow' and '<job name>'
```

https://github.com/github/vscode-github-actions/issues/135

Removed concurrency group from instrumentation-test