### PR TITLE
Ensure offline manager `@Before` is completed before tests are run

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/org/maplibre/android/testapp/offline/OfflineManagerTest.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/org/maplibre/android/testapp/offline/OfflineManagerTest.kt
@@ -37,14 +37,17 @@ class OfflineManagerTest : AppCenter() {
     @Before
     @After
     fun resetDatabase() {
+        val latch = CountDownLatch(1)
         OfflineManager.getInstance(context).resetDatabase(object : OfflineManager.FileSourceCallback {
             override fun onSuccess() {
+                latch.countDown()
             }
 
             override fun onError(message: String) {
                 throw IOException("Unable to reset database before / after tests.")
             }
         })
+        latch.await()
     }
 
     @Test(timeout = 30_000)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/org/maplibre/android/testapp/style/RuntimeStyleTests.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/org/maplibre/android/testapp/style/RuntimeStyleTests.java
@@ -128,6 +128,7 @@ public class RuntimeStyleTests extends EspressoTest {
     });
   }
 
+  @Test
   public void testAddLayerAt() {
     validateTestSetup();
     onView(withId(R.id.mapView)).perform(new BaseViewAction() {


### PR DESCRIPTION
Small oversight in #1250. Because the deletion of the db is async, it is not expected to finish before the first tests are called. Use the same latch pattern as in the other tests to ensure `@Before` / `@After` is complete before running the tests.

Also the other remaining failing test is missing a `@Test` annotation. Maybe it helps to add it? Probably not. But I'll consider it a code improvement anyhow.