### PR TITLE
[Windows] Remove non-existent header from gl_functions.cpp

### DIFF
--- a/platform/windows/src/gl_functions.cpp
+++ b/platform/windows/src/gl_functions.cpp
@@ -7,7 +7,6 @@
 #endif
 
 #include <GLES3/gl3.h>
-#include <GLES3/gl3ext.h>
 
 namespace mbgl {
 namespace platform {


### PR DESCRIPTION
There was a reference to `gl2ext.h` in `platform/windows/src/gl_functions.cpp`. However, when the support for OpenGL ES 3.0, this reference was changed to `gl3ext.h`, which does not exist. Removing it does not cause any problem, because the needed functions are provided by `gl3.h`.