### PR TITLE
Make reusable action for downloading workflow run artifact

### DIFF
--- a/.github/actions/download-workflow-run-artifact/action.yml
+++ b/.github/actions/download-workflow-run-artifact/action.yml
@@ -1,0 +1,44 @@
+name: 'Download workflow_run artifact'
+description: 'Downloads and unzips artifact from workflow that triggered workflow_run'
+inputs:
+  artifact-name:
+    description: 'Name of artifact'
+    required: true
+  expect-files:
+    description: 'Check for existence of expected files'
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - run: echo Hello ${{ inputs.who-to-greet }}.
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
+      - name: 'Download render-test-result artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == ${{ inputs.artifact-name }}
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${{ inputs.artifact-name }}.zip`, Buffer.from(download.data));
+
+      - name: Unzip artifact
+        run: unzip ${{ inputs.artifact-name }}.zip
+
+      - name: "Check file existence"
+        uses: andstor/file-existence-action@v2.0.0
+        if: ${{ inputs.expect-files }}
+        with:
+          fail: true
+          files: ${{ inputs.expect-files }}

--- a/.github/workflows/pr-render-test-result.yml
+++ b/.github/workflows/pr-render-test-result.yml
@@ -15,37 +15,17 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event.workflow_run.event == 'pull_request'
     steps:
-      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
-      - name: 'Download render-test-result artifact'
-        uses: actions/github-script@v6
+      - uses: .github/actions/download-workflow-run-artifact
         with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "render-test-result"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/render-test-result.zip`, Buffer.from(download.data));
-
+          artifact-name: render-test-result
+          expect-files: "./pr_number, metrics/linux-gcc8-release-style.html"
+  
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-west-2
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
-
-      - name: 'Unzip render-test-result artifact'
-        run: unzip render-test-result.zip
 
       - name: Upload render test results to S3
         id: upload_render_test_results


### PR DESCRIPTION
I am going to make more workflows where a PR workflow triggers a priviledged workflow. E.g. I want to upload the render test app for iOS and Android to AWS Device Farm from a PR, not just in main.

This makes the rather verbose JavaScript to download and unzip the artifact into a reusable action. 