### PR TITLE
Skip flaky test `MainResourceLoader.CachedResourceLowPriority`

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -135,8 +135,6 @@ jobs:
         run: make ios-uitest
 
       # size test
-      - name: Copy example config
-        run: cp bazel/example_config.bzl bazel/config.bzl
 
       - name: Build app for size test & output size 
         working-directory: ./
@@ -152,30 +150,6 @@ jobs:
             ./size
             ./pr_number
       
-      # render test
-
-      - name: Build RenderTest .ipa and .xctest for AWS Device Farm
-        run: |
-          bazel run //platform/ios:xcodeproj
-          build_dir="$(mktemp -d)"
-          xcodebuild build-for-testing  -scheme RenderTest -project MapLibre.xcodeproj -derivedDataPath "$build_dir"
-          render_test_app_dir="$(dirname "$(find $DIR -name RenderTestApp.app)")"
-          cd "$render_test_app_dir"
-          mkdir Payload
-          mv RenderTestApp.app Payload
-          zip -r RenderTestApp.zip Payload
-          mv RenderTestApp.zip RenderTestApp.ipa
-          cd Payload/RenderTestApp.app/PlugIns
-          zip -r "$render_test_app_dir"/RenderTest.xctest.zip RenderTest.xctest
-          echo render_test_artifacts_dir="$render_test_app_dir" >> $GITHUB_ENV
-      
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ios-render-test
-          path: |
-            ${{ env.render_test_artifacts_dir }}/RenderTest.xctest.zip
-            ${{ env.render_test_artifacts_dir }}/RenderTestApp.zip
-
       # ---
 
       - name: Build and run SDK unit tests with thread and undefined behavior sanitizers

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -135,6 +135,8 @@ jobs:
         run: make ios-uitest
 
       # size test
+      - name: Copy example config
+        run: cp bazel/example_config.bzl bazel/config.bzl
 
       - name: Build app for size test & output size 
         working-directory: ./

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -152,6 +152,30 @@ jobs:
             ./size
             ./pr_number
       
+      # render test
+
+      - name: Build RenderTest .ipa and .xctest for AWS Device Farm
+        run: |
+          bazel run //platform/ios:xcodeproj
+          build_dir="$(mktemp -d)"
+          xcodebuild build-for-testing  -scheme RenderTest -project MapLibre.xcodeproj -derivedDataPath "$build_dir"
+          render_test_app_dir="$(dirname "$(find $DIR -name RenderTestApp.app)")"
+          cd "$render_test_app_dir"
+          mkdir Payload
+          mv RenderTestApp.app Payload
+          zip -r RenderTestApp.zip Payload
+          mv RenderTestApp.zip RenderTestApp.ipa
+          cd Payload/RenderTestApp.app/PlugIns
+          zip -r "$render_test_app_dir"/RenderTest.xctest.zip RenderTest.xctest
+          echo render_test_artifacts_dir="$render_test_app_dir" >> $GITHUB_ENV
+      
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ios-render-test
+          path: |
+            ${{ env.render_test_artifacts_dir }}/RenderTest.xctest.zip
+            ${{ env.render_test_artifacts_dir }}/RenderTestApp.zip
+
       # ---
 
       - name: Build and run SDK unit tests with thread and undefined behavior sanitizers

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -26,6 +26,7 @@ cc_library(
         "src/mbgl/test/*.hpp",
     ]),
     copts = CPP_FLAGS + MAPLIBRE_FLAGS,
+    defines = ["CI_BUILD"],
     strip_include_prefix = "src",
     deps = [
         "testutils",

--- a/test/storage/main_resource_loader.test.cpp
+++ b/test/storage/main_resource_loader.test.cpp
@@ -716,6 +716,8 @@ TEST(MainResourceLoader, TEST_REQUIRES_SERVER(RespondToStaleMustRevalidate)) {
 
 // Test that requests for expired resources have lower priority than requests for new resources
 TEST(MainResourceLoader, TEST_REQUIRES_SERVER(CachedResourceLowPriority)) {
+    GTEST_SKIP() << "Skipping MainResourceLoader.CachedResourceLowPriority. "
+                 << "See https://github.com/maplibre/maplibre-native/issues/1071";
     util::RunLoop loop;
     MainResourceLoader fs(ResourceOptions{}, ClientOptions{});
 


### PR DESCRIPTION
This test is failing a lot: https://github.com/maplibre/maplibre-native/issues/1071

Until it is reworked it should be disabled.

Also adds the `CI_BUILD` define, because `timer.test.cpp` requires accurate timing, which does not seem to be available on CI.

```
#if !TEST_IS_SIMULATOR && !CI_BUILD
#define TEST_REQUIRES_ACCURATE_TIMING(name) name
#else
#define TEST_REQUIRES_ACCURATE_TIMING(name) DISABLED_##name
#endif
```

