### PR TITLE
Render drawables in order

### DIFF
--- a/include/mbgl/gfx/drawable.hpp
+++ b/include/mbgl/gfx/drawable.hpp
@@ -208,12 +208,8 @@ struct DrawableLessByPriority {
         }
         return a.getId() < b.getId();
     }
-    bool operator()(const Drawable* left, const Drawable* right) const {
-        return operator()(*left, *right);
-    }
-    bool operator()(const UniqueDrawable& left, const UniqueDrawable& right) const {
-        return operator()(*left, *right);
-    }
+    bool operator()(const Drawable* left, const Drawable* right) const { return operator()(*left, *right); }
+    bool operator()(const UniqueDrawable& left, const UniqueDrawable& right) const { return operator()(*left, *right); }
     bool operator()(const DrawablePtr& left, const DrawablePtr& right) const {
         const auto& a = desc ? right : left;
         const auto& b = desc ? left : right;

--- a/include/mbgl/gfx/drawable.hpp
+++ b/include/mbgl/gfx/drawable.hpp
@@ -176,7 +176,7 @@ protected:
     bool enableStencil = false;
     bool is3D = false;
     std::string name;
-    util::SimpleIdentity uniqueID;
+    const util::SimpleIdentity uniqueID;
     gfx::ShaderProgramBasePtr shader;
     mbgl::RenderPass renderPass;
     std::optional<OverscaledTileID> tileID;
@@ -198,7 +198,7 @@ using UniqueDrawable = std::unique_ptr<Drawable>;
 
 /// Comparator for sorting drawable pointers primarily by draw priority
 struct DrawableLessByPriority {
-    DrawableLessByPriority(bool descending)
+    DrawableLessByPriority(bool descending = false)
         : desc(descending) {}
     bool operator()(const Drawable& left, const Drawable& right) const {
         const auto& a = desc ? right : left;
@@ -207,6 +207,12 @@ struct DrawableLessByPriority {
             return a.getDrawPriority() < b.getDrawPriority();
         }
         return a.getId() < b.getId();
+    }
+    bool operator()(const Drawable* left, const Drawable* right) const {
+        return operator()(*left, *right);
+    }
+    bool operator()(const UniqueDrawable& left, const UniqueDrawable& right) const {
+        return operator()(*left, *right);
     }
     bool operator()(const DrawablePtr& left, const DrawablePtr& right) const {
         const auto& a = desc ? right : left;

--- a/include/mbgl/renderer/layer_group.hpp
+++ b/include/mbgl/renderer/layer_group.hpp
@@ -108,7 +108,9 @@ public:
 
     /// Call the provided function for each drawable for the given tile
     void observeDrawables(mbgl::RenderPass, const OverscaledTileID&, const std::function<void(gfx::Drawable&)>&&);
-    void observeDrawables(mbgl::RenderPass, const OverscaledTileID&, const std::function<void(const gfx::Drawable&)>&&) const;
+    void observeDrawables(mbgl::RenderPass,
+                          const OverscaledTileID&,
+                          const std::function<void(const gfx::Drawable&)>&&) const;
 
     std::size_t clearDrawables() override;
 

--- a/include/mbgl/renderer/layer_group.hpp
+++ b/include/mbgl/renderer/layer_group.hpp
@@ -66,12 +66,14 @@ public:
     /// Called at the end of each frame
     virtual void postRender(RenderOrchestrator&, PaintParameters&) {}
 
-    /// Call the provided function for each drawable in undefined order
-    virtual void observeDrawables(std::function<void(gfx::Drawable&)>) = 0;
-    virtual void observeDrawables(std::function<void(const gfx::Drawable&)>) const = 0;
+    /// Call the provided function for each drawable in priority order
+    virtual void observeDrawables(const std::function<void(gfx::Drawable&)>&&) = 0;
+    virtual void observeDrawables(const std::function<void(const gfx::Drawable&)>&&) const = 0;
 
-    /// Call the provided function for each drawable in undefined order, allowing ownership to be taken.
-    virtual void observeDrawables(std::function<void(gfx::UniqueDrawable&)>) = 0;
+    /// Call the provided function for each drawable in undefined order, allowing for removal.
+    /// @param f A function called with each drawable, returning true to keep and false to discard it.
+    /// @return The number of items removed
+    virtual std::size_t observeDrawablesRemove(const std::function<bool(gfx::Drawable&)>&& f) = 0;
 
     /// Attach a tweaker to be run on this layer group for each frame
     void setLayerTweaker(LayerTweakerPtr tweaker) { layerTweaker = std::move(tweaker); }
@@ -100,13 +102,13 @@ public:
     std::vector<gfx::UniqueDrawable> removeDrawables(mbgl::RenderPass, const OverscaledTileID&);
     void addDrawable(mbgl::RenderPass, const OverscaledTileID&, gfx::UniqueDrawable&&);
 
-    void observeDrawables(std::function<void(gfx::Drawable&)>) override;
-    void observeDrawables(std::function<void(const gfx::Drawable&)>) const override;
-    void observeDrawables(std::function<void(gfx::UniqueDrawable&)>) override;
+    void observeDrawables(const std::function<void(gfx::Drawable&)>&&) override;
+    void observeDrawables(const std::function<void(const gfx::Drawable&)>&&) const override;
+    std::size_t observeDrawablesRemove(const std::function<bool(gfx::Drawable&)>&&) override;
 
     /// Call the provided function for each drawable for the given tile
-    void observeDrawables(mbgl::RenderPass, const OverscaledTileID&, std::function<void(gfx::Drawable&)>&&);
-    void observeDrawables(mbgl::RenderPass, const OverscaledTileID&, std::function<void(const gfx::Drawable&)>&&) const;
+    void observeDrawables(mbgl::RenderPass, const OverscaledTileID&, const std::function<void(gfx::Drawable&)>&&);
+    void observeDrawables(mbgl::RenderPass, const OverscaledTileID&, const std::function<void(const gfx::Drawable&)>&&) const;
 
     std::size_t clearDrawables() override;
 
@@ -129,9 +131,9 @@ public:
     std::vector<gfx::UniqueDrawable> removeDrawables(mbgl::RenderPass);
     void addDrawable(gfx::UniqueDrawable&&);
 
-    void observeDrawables(std::function<void(gfx::Drawable&)>) override;
-    void observeDrawables(std::function<void(const gfx::Drawable&)>) const override;
-    void observeDrawables(std::function<void(gfx::UniqueDrawable&)>) override;
+    void observeDrawables(const std::function<void(gfx::Drawable&)>&&) override;
+    void observeDrawables(const std::function<void(const gfx::Drawable&)>&&) const override;
+    std::size_t observeDrawablesRemove(const std::function<bool(gfx::Drawable&)>&&) override;
 
     std::size_t clearDrawables() override;
 

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -282,14 +282,14 @@ void RenderBackgroundLayer::update(gfx::ShaderRegistry& shaders,
 
     std::unique_ptr<gfx::DrawableBuilder> builder;
 
-    tileLayerGroup->observeDrawables([&](gfx::UniqueDrawable& drawable) {
+    tileLayerGroup->observeDrawables([&](gfx::Drawable& drawable) -> bool {
         // Has this tile dropped out of the cover set?
-        const auto tileID = drawable->getTileID();
+        const auto tileID = drawable.getTileID();
         if (tileID && newTileIDs.find(*tileID) == newTileIDs.end()) {
-            drawable.reset();
             ++stats.drawablesRemoved;
-            return;
+            return false;
         }
+        return true;
     });
 
     // For each tile in the cover set, add a tile drawable if one doesn't already exist.

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -315,13 +315,8 @@ void RenderCircleLayer::update(gfx::ShaderRegistry& shaders,
         return;
     }
 
-    tileLayerGroup->observeDrawables([&](gfx::UniqueDrawable& drawable) {
-        const auto tileID = drawable->getTileID();
-        if (tileID && newTileIDs.find(*tileID) == newTileIDs.end()) {
-            // remove it
-            drawable.reset();
-            ++stats.drawablesRemoved;
-        }
+    stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
+        return (!drawable.getTileID() || newTileIDs.find(*drawable.getTileID()) != newTileIDs.end());
     });
 
     const auto& evaluated = static_cast<const CircleLayerProperties&>(*evaluatedProperties).evaluated;

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -300,23 +300,17 @@ void RenderCircleLayer::update(gfx::ShaderRegistry& shaders,
         return;
     }
 
-    std::unordered_set<OverscaledTileID> newTileIDs(renderTiles->size());
-    std::transform(renderTiles->begin(),
-                   renderTiles->end(),
-                   std::inserter(newTileIDs, newTileIDs.begin()),
-                   [](const auto& renderTile) -> OverscaledTileID { return renderTile.get().getOverscaledTileID(); });
-
     std::unique_ptr<gfx::DrawableBuilder> circleBuilder;
     std::vector<gfx::DrawablePtr> newTiles;
     gfx::VertexAttributeArray circleVertexAttrs;
-    auto renderPass = RenderPass::Translucent;
+    constexpr auto renderPass = RenderPass::Translucent;
 
     if (!(mbgl::underlying_type(renderPass) & evaluatedProperties->renderPasses)) {
         return;
     }
 
     stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
-        return (!drawable.getTileID() || newTileIDs.find(*drawable.getTileID()) != newTileIDs.end());
+        return (!drawable.getTileID() || renderTileIDs.find(*drawable.getTileID()) != renderTileIDs.end());
     });
 
     const auto& evaluated = static_cast<const CircleLayerProperties&>(*evaluatedProperties).evaluated;

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -92,14 +92,6 @@ bool RenderFillExtrusionLayer::is3D() const {
     return true;
 }
 
-void RenderFillExtrusionLayer::prepare(const LayerPrepareParameters& params) {
-    RenderLayer::prepare(params);
-
-#if MLN_DRAWABLE_RENDERER
-    updateRenderTileIDs();
-#endif // MLN_DRAWABLE_RENDERER
-}
-
 #if MLN_LEGACY_RENDERER
 void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
     assert(renderTiles);

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -315,13 +315,9 @@ void RenderFillExtrusionLayer::update(gfx::ShaderRegistry& shaders,
     // in the "3D pass".
     constexpr auto drawPass = RenderPass::Translucent;
 
-    tileLayerGroup->observeDrawables([&](gfx::UniqueDrawable& drawable) {
+    stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
         // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
-        const auto tileID = drawable->getTileID();
-        if (drawable->getRenderPass() != drawPass || (tileID && renderTileIDs.find(*tileID) == renderTileIDs.end())) {
-            drawable.reset();
-            ++stats.drawablesRemoved;
-        }
+        return (drawable.getRenderPass() == drawPass && (!drawable.getTileID() || renderTileIDs.find(*drawable.getTileID()) != renderTileIDs.end()));
     });
 
     const auto zoom = static_cast<float>(state.getZoom());

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -317,7 +317,8 @@ void RenderFillExtrusionLayer::update(gfx::ShaderRegistry& shaders,
 
     stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
         // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
-        return (drawable.getRenderPass() == drawPass && (!drawable.getTileID() || renderTileIDs.find(*drawable.getTileID()) != renderTileIDs.end()));
+        return (drawable.getRenderPass() == drawPass &&
+                (!drawable.getTileID() || renderTileIDs.find(*drawable.getTileID()) != renderTileIDs.end()));
     });
 
     const auto zoom = static_cast<float>(state.getZoom());

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
@@ -23,7 +23,6 @@ private:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     bool is3D() const override;
-    void prepare(const LayerPrepareParameters&) override;
 
 #if MLN_LEGACY_RENDERER
     void render(PaintParameters&) override;

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -366,7 +366,8 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
 
     stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
         // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
-        return (drawable.getRenderPass() == renderPass && (!drawable.getTileID() || newTileIDs.find(*drawable.getTileID()) != newTileIDs.end()));
+        return (drawable.getRenderPass() == renderPass &&
+                (!drawable.getTileID() || newTileIDs.find(*drawable.getTileID()) != newTileIDs.end()));
     });
 
     for (const RenderTile& tile : *renderTiles) {

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -325,12 +325,6 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
         return;
     }
 
-    std::unordered_set<OverscaledTileID> newTileIDs(renderTiles->size());
-    std::transform(renderTiles->begin(),
-                   renderTiles->end(),
-                   std::inserter(newTileIDs, newTileIDs.begin()),
-                   [](const auto& renderTile) -> OverscaledTileID { return renderTile.get().getOverscaledTileID(); });
-
     std::unique_ptr<gfx::DrawableBuilder> fillBuilder;
     std::unique_ptr<gfx::DrawableBuilder> outlineBuilder;
     std::unique_ptr<gfx::DrawableBuilder> patternBuilder;
@@ -367,7 +361,7 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
     stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
         // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
         return (drawable.getRenderPass() == renderPass &&
-                (!drawable.getTileID() || newTileIDs.find(*drawable.getTileID()) != newTileIDs.end()));
+                (!drawable.getTileID() || renderTileIDs.find(*drawable.getTileID()) != renderTileIDs.end()));
     });
 
     for (const RenderTile& tile : *renderTiles) {

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -364,13 +364,9 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
         builder.setEnableStencil(true);
     };
 
-    tileLayerGroup->observeDrawables([&](gfx::UniqueDrawable& drawable) {
+    stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
         // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
-        const auto tileID = drawable->getTileID();
-        if (drawable->getRenderPass() != renderPass || (tileID && newTileIDs.find(*tileID) == newTileIDs.end())) {
-            drawable.reset();
-            ++stats.drawablesRemoved;
-        }
+        return (drawable.getRenderPass() == renderPass && (!drawable.getTileID() || newTileIDs.find(*drawable.getTileID()) != newTileIDs.end()));
     });
 
     for (const RenderTile& tile : *renderTiles) {

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -332,13 +332,8 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
         return;
     }
 
-    tileLayerGroup->observeDrawables([&](gfx::UniqueDrawable& drawable) {
-        const auto tileID = drawable->getTileID();
-        if (tileID && newTileIDs.find(*tileID) == newTileIDs.end()) {
-            // remove it
-            drawable.reset();
-            ++stats.drawablesRemoved;
-        }
+    stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
+        return (!drawable.getTileID() || newTileIDs.find(*drawable.getTileID()) != newTileIDs.end());
     });
 
     const auto& evaluated = static_cast<const HeatmapLayerProperties&>(*evaluatedProperties).evaluated;

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -317,12 +317,6 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
         return;
     }
 
-    std::unordered_set<OverscaledTileID> newTileIDs(renderTiles->size());
-    std::transform(renderTiles->begin(),
-                   renderTiles->end(),
-                   std::inserter(newTileIDs, newTileIDs.begin()),
-                   [](const auto& renderTile) -> OverscaledTileID { return renderTile.get().getOverscaledTileID(); });
-
     std::unique_ptr<gfx::DrawableBuilder> heatmapBuilder;
     std::vector<gfx::DrawablePtr> newTiles;
     gfx::VertexAttributeArray heatmapVertexAttrs;
@@ -333,7 +327,7 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
     }
 
     stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
-        return (!drawable.getTileID() || newTileIDs.find(*drawable.getTileID()) != newTileIDs.end());
+        return (!drawable.getTileID() || renderTileIDs.find(*drawable.getTileID()) != renderTileIDs.end());
     });
 
     const auto& evaluated = static_cast<const HeatmapLayerProperties&>(*evaluatedProperties).evaluated;

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -452,7 +452,8 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
 
     stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
         // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
-        return (drawable.getRenderPass() == renderPass && (!drawable.getTileID() || newTileIDs.find(*drawable.getTileID()) != newTileIDs.end()));
+        return (drawable.getRenderPass() == renderPass &&
+                (!drawable.getTileID() || newTileIDs.find(*drawable.getTileID()) != newTileIDs.end()));
     });
 
     auto createLineBuilder = [&](const std::string& name,

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -90,7 +90,7 @@ void RenderLineLayer::prepare(const LayerPrepareParameters& params) {
         const auto& evaluated = getEvaluated<LineLayerProperties>(renderData->layerProperties);
         if (evaluated.get<LineDasharray>().from.empty()) continue;
 
-        auto& bucket = static_cast<LineBucket&>(*renderData->bucket);
+        const auto& bucket = static_cast<const LineBucket&>(*renderData->bucket);
         const LinePatternCap cap = bucket.layout.get<LineCap>() == LineCapType::Round ? LinePatternCap::Round
                                                                                       : LinePatternCap::Square;
         // Ensures that the dash data gets added to the atlas.
@@ -441,19 +441,13 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
         lineSDFShaderGroup = shaders.getShaderGroup("LineSDFShader");
     }
 
-    std::unordered_set<OverscaledTileID> newTileIDs(renderTiles->size());
-    std::transform(renderTiles->begin(),
-                   renderTiles->end(),
-                   std::inserter(newTileIDs, newTileIDs.begin()),
-                   [](const auto& renderTile) -> OverscaledTileID { return renderTile.get().getOverscaledTileID(); });
-
     const RenderPass renderPass = static_cast<RenderPass>(evaluatedProperties->renderPasses &
                                                           ~mbgl::underlying_type(RenderPass::Opaque));
 
     stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
         // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
         return (drawable.getRenderPass() == renderPass &&
-                (!drawable.getTileID() || newTileIDs.find(*drawable.getTileID()) != newTileIDs.end()));
+                (!drawable.getTileID() || renderTileIDs.find(*drawable.getTileID()) != renderTileIDs.end()));
     });
 
     auto createLineBuilder = [&](const std::string& name,

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -450,13 +450,9 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
     const RenderPass renderPass = static_cast<RenderPass>(evaluatedProperties->renderPasses &
                                                           ~mbgl::underlying_type(RenderPass::Opaque));
 
-    tileLayerGroup->observeDrawables([&](gfx::UniqueDrawable& drawable) {
+    stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
         // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
-        const auto tileID = drawable->getTileID();
-        if (drawable->getRenderPass() != renderPass || (tileID && newTileIDs.find(*tileID) == newTileIDs.end())) {
-            drawable.reset();
-            ++stats.drawablesRemoved;
-        }
+        return (drawable.getRenderPass() == renderPass && (!drawable.getTileID() || newTileIDs.find(*drawable.getTileID()) != newTileIDs.end()));
     });
 
     auto createLineBuilder = [&](const std::string& name,

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -416,19 +416,14 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
         }
     } else if (renderTiles) {
         if (layerGroup) {
-            layerGroup->observeDrawables([&](gfx::UniqueDrawable& drawable) {
+            stats.drawablesRemoved += layerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
                 // Has this tile dropped out of the cover set?
-                if (const auto it = std::find_if(renderTiles->begin(),
-                                                 renderTiles->end(),
-                                                 [&drawable](const auto& renderTile) {
-                                                     return drawable->getTileID() ==
-                                                            renderTile.get().getOverscaledTileID();
-                                                 });
-                    it == renderTiles->end()) {
-                    // remove it
-                    drawable.reset();
-                    ++stats.drawablesRemoved;
-                }
+                const auto hit = std::find_if(renderTiles->begin(),
+                                              renderTiles->end(),
+                                              [&drawable](const auto& renderTile) {
+                                                  return drawable.getTileID() ==
+                    renderTile.get().getOverscaledTileID(); });
+                return (hit != renderTiles->end());
             });
         } else {
             // Set up a tile layer group

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -418,11 +418,10 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
         if (layerGroup) {
             stats.drawablesRemoved += layerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
                 // Has this tile dropped out of the cover set?
-                const auto hit = std::find_if(renderTiles->begin(),
-                                              renderTiles->end(),
-                                              [&drawable](const auto& renderTile) {
-                                                  return drawable.getTileID() ==
-                    renderTile.get().getOverscaledTileID(); });
+                const auto hit = std::find_if(
+                    renderTiles->begin(), renderTiles->end(), [&drawable](const auto& renderTile) {
+                        return drawable.getTileID() == renderTile.get().getOverscaledTileID();
+                    });
                 return (hit != renderTiles->end());
             });
         } else {

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -97,6 +97,10 @@ void RenderRasterLayer::prepare(const LayerPrepareParameters& params) {
     imageData = params.source->getImageRenderData();
     // It is possible image data is not available until the source loads it.
     assert(renderTiles || imageData || !params.source->isEnabled());
+
+#if MLN_DRAWABLE_RENDERER
+    updateRenderTileIDs();
+#endif // MLN_DRAWABLE_RENDERER
 }
 
 #if MLN_LEGACY_RENDERER
@@ -418,11 +422,7 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
         if (layerGroup) {
             stats.drawablesRemoved += layerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
                 // Has this tile dropped out of the cover set?
-                const auto hit = std::find_if(
-                    renderTiles->begin(), renderTiles->end(), [&drawable](const auto& renderTile) {
-                        return drawable.getTileID() == renderTile.get().getOverscaledTileID();
-                    });
-                return (hit != renderTiles->end());
+                return (!drawable.getTileID() || renderTileIDs.find(*drawable.getTileID()) != renderTileIDs.end());
             });
         } else {
             // Set up a tile layer group

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -831,14 +831,14 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
     }
 
     auto* tileLayerGroup = static_cast<TileLayerGroup*>(layerGroup.get());
-    tileLayerGroup->observeDrawables([&](gfx::UniqueDrawable& drawable) {
+    stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
         // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
-        const auto tileID = drawable->getTileID();
-        if (drawable->getRenderPass() != passes || (tileID && renderTileIDs.find(*tileID) == renderTileIDs.end())) {
-            drawable.reset();
+        const auto& tileID = drawable.getTileID();
+        if (drawable.getRenderPass() != passes || (tileID && renderTileIDs.find(*tileID) == renderTileIDs.end())) {
             tileBucketInstances.erase(*tileID);
-            ++stats.drawablesRemoved;
+            return false;
         }
+        return true;
     });
 
     const bool sortFeaturesByKey = !impl_cast(baseImpl).layout.get<SymbolSortKey>().isUndefined();

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -58,6 +58,10 @@ void RenderLayer::prepare(const LayerPrepareParameters& params) {
     assert(params.source->isEnabled());
     renderTiles = params.source->getRenderTiles();
     addRenderPassesFromTiles();
+
+#if MLN_DRAWABLE_RENDERER
+    updateRenderTileIDs();
+#endif // MLN_DRAWABLE_RENDERER
 }
 
 std::optional<Color> RenderLayer::getSolidBackground() const {

--- a/src/mbgl/renderer/tile_layer_group.cpp
+++ b/src/mbgl/renderer/tile_layer_group.cpp
@@ -23,11 +23,12 @@ struct TileLayerGroupTileKey {
 };
 
 struct TileLayerGroup::Impl {
-    Impl(std::size_t initialCapacity) : drawablesByTile(initialCapacity) {}
+    Impl(std::size_t initialCapacity)
+        : drawablesByTile(initialCapacity) {}
 
     using TileMap = std::unordered_multimap<TileLayerGroupTileKey, gfx::UniqueDrawable, TileLayerGroupTileKey::hash>;
     TileMap drawablesByTile;
-    
+
     using DrawableMap = std::set<gfx::Drawable*, gfx::DrawableLessByPriority>;
     DrawableMap sortedDrawables;
 };
@@ -63,7 +64,7 @@ std::vector<gfx::UniqueDrawable> TileLayerGroup::removeDrawables(mbgl::RenderPas
             return std::move(pair.second);
         });
     impl->drawablesByTile.erase(range.first, range.second);
-    std::for_each(result.begin(), result.end(), [&](const auto& item){
+    std::for_each(result.begin(), result.end(), [&](const auto& item) {
         const auto hit = impl->sortedDrawables.find(item.get());
         assert(hit != impl->sortedDrawables.end());
         if (hit != impl->sortedDrawables.end()) {
@@ -84,7 +85,7 @@ void TileLayerGroup::addDrawable(mbgl::RenderPass pass, const OverscaledTileID& 
 
 void TileLayerGroup::observeDrawables(const std::function<void(gfx::Drawable&)>&& f) {
     assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
-    for (auto* drawable  : impl->sortedDrawables) {
+    for (auto* drawable : impl->sortedDrawables) {
         f(*drawable);
     }
 }

--- a/src/mbgl/renderer/tile_layer_group.cpp
+++ b/src/mbgl/renderer/tile_layer_group.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/renderer/render_orchestrator.hpp>
 
 #include <unordered_map>
+#include <set>
 
 namespace mbgl {
 
@@ -22,11 +23,13 @@ struct TileLayerGroupTileKey {
 };
 
 struct TileLayerGroup::Impl {
-    Impl(std::size_t capacity)
-        : tileDrawables(capacity) {}
+    Impl(std::size_t initialCapacity) : drawablesByTile(initialCapacity) {}
 
     using TileMap = std::unordered_multimap<TileLayerGroupTileKey, gfx::UniqueDrawable, TileLayerGroupTileKey::hash>;
-    TileMap tileDrawables;
+    TileMap drawablesByTile;
+    
+    using DrawableMap = std::set<gfx::Drawable*, gfx::DrawableLessByPriority>;
+    DrawableMap sortedDrawables;
 };
 
 LayerGroupBase::LayerGroupBase(int32_t layerIndex_, std::string name_)
@@ -40,80 +43,97 @@ TileLayerGroup::TileLayerGroup(int32_t layerIndex_, std::size_t initialCapacity,
 TileLayerGroup::~TileLayerGroup() = default;
 
 std::size_t TileLayerGroup::getDrawableCount() const {
-    return impl->tileDrawables.size();
+    return impl->drawablesByTile.size();
 }
 
 static const gfx::UniqueDrawable no_tile;
 
 std::size_t TileLayerGroup::getDrawableCount(mbgl::RenderPass pass, const OverscaledTileID& id) const {
-    const auto range = impl->tileDrawables.equal_range({pass, id});
+    assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
+    const auto range = impl->drawablesByTile.equal_range({pass, id});
     return std::distance(range.first, range.second);
 }
 
 std::vector<gfx::UniqueDrawable> TileLayerGroup::removeDrawables(mbgl::RenderPass pass, const OverscaledTileID& id) {
-    const auto range = impl->tileDrawables.equal_range({pass, id});
+    assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
+    const auto range = impl->drawablesByTile.equal_range({pass, id});
     std::vector<gfx::UniqueDrawable> result(std::distance(range.first, range.second));
     std::transform(
         std::make_move_iterator(range.first), std::make_move_iterator(range.second), result.begin(), [](auto&& pair) {
             return std::move(pair.second);
         });
-    impl->tileDrawables.erase(range.first, range.second);
+    impl->drawablesByTile.erase(range.first, range.second);
+    std::for_each(result.begin(), result.end(), [&](const auto& item){
+        const auto hit = impl->sortedDrawables.find(item.get());
+        assert(hit != impl->sortedDrawables.end());
+        if (hit != impl->sortedDrawables.end()) {
+            impl->sortedDrawables.erase(hit);
+        }
+    });
     return result;
 }
 
 void TileLayerGroup::addDrawable(mbgl::RenderPass pass, const OverscaledTileID& id, gfx::UniqueDrawable&& drawable) {
-    impl->tileDrawables.insert(std::make_pair(TileLayerGroupTileKey{pass, id}, std::move(drawable)));
-}
-
-void TileLayerGroup::observeDrawables(std::function<void(gfx::Drawable&)> f) {
-    for (auto& pair : impl->tileDrawables) {
-        if (pair.second) {
-            f(*pair.second);
-        }
+    assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
+    if (drawable) {
+        [[maybe_unused]] const auto result = impl->sortedDrawables.insert(drawable.get());
+        assert(result.second);
+        impl->drawablesByTile.insert(std::make_pair(TileLayerGroupTileKey{pass, id}, std::move(drawable)));
     }
 }
 
-void TileLayerGroup::observeDrawables(std::function<void(const gfx::Drawable&)> f) const {
-    for (const auto& pair : impl->tileDrawables) {
-        if (pair.second) {
-            f(*pair.second);
-        }
+void TileLayerGroup::observeDrawables(const std::function<void(gfx::Drawable&)>&& f) {
+    assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
+    for (auto* drawable  : impl->sortedDrawables) {
+        f(*drawable);
     }
 }
 
-void TileLayerGroup::observeDrawables(std::function<void(gfx::UniqueDrawable&)> f) {
-    for (auto i = impl->tileDrawables.begin(); i != impl->tileDrawables.end();) {
+void TileLayerGroup::observeDrawables(const std::function<void(const gfx::Drawable&)>&& f) const {
+    assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
+    for (const auto* drawable : impl->sortedDrawables) {
+        f(*drawable);
+    }
+}
+
+std::size_t TileLayerGroup::observeDrawablesRemove(const std::function<bool(gfx::Drawable&)>&& f) {
+    const auto oldSize = impl->drawablesByTile.size();
+    for (auto i = impl->drawablesByTile.begin(); i != impl->drawablesByTile.end();) {
         auto& drawable = i->second;
-        if (drawable) {
-            f(drawable);
-        }
-        if (drawable) {
+        if (f(*drawable)) {
             // Not removed, keep going
             ++i;
         } else {
-            // Removed, take it out of the map
-            i = impl->tileDrawables.erase(i);
+            // Removed, take it out of the collections
+            impl->sortedDrawables.erase(drawable.get());
+            i = impl->drawablesByTile.erase(i);
         }
+        assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
     }
+    return (oldSize - impl->drawablesByTile.size());
 }
 
 void TileLayerGroup::observeDrawables(mbgl::RenderPass pass,
                                       const OverscaledTileID& tileID,
-                                      std::function<void(gfx::Drawable&)>&& f) {
-    const auto range = impl->tileDrawables.equal_range({pass, tileID});
+                                      const std::function<void(gfx::Drawable&)>&& f) {
+    assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
+    const auto range = impl->drawablesByTile.equal_range({pass, tileID});
     std::for_each(range.first, range.second, [&f](const auto& pair) { f(*pair.second); });
 }
 
 void TileLayerGroup::observeDrawables(mbgl::RenderPass pass,
                                       const OverscaledTileID& tileID,
-                                      std::function<void(const gfx::Drawable&)>&& f) const {
-    const auto range = impl->tileDrawables.equal_range({pass, tileID});
+                                      const std::function<void(const gfx::Drawable&)>&& f) const {
+    assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
+    const auto range = impl->drawablesByTile.equal_range({pass, tileID});
     std::for_each(range.first, range.second, [&f](const auto& pair) { f(*pair.second); });
 }
 
 std::size_t TileLayerGroup::clearDrawables() {
-    const auto count = impl->tileDrawables.size();
-    impl->tileDrawables.clear();
+    const auto count = impl->drawablesByTile.size();
+    assert(count == impl->sortedDrawables.size());
+    impl->sortedDrawables.clear();
+    impl->drawablesByTile.clear();
     return count;
 }
 


### PR DESCRIPTION
Layer groups store drawables in priority order, and by tile ID in the case of the tile layer group, and ensure that the collections stay synchronized.  Rendering occurs in priority order, currently the order that the drawables are produced because layers are not setting priority values, which replicates the order of the legacy rendering.

Somewhat complicated by the semantics of `std::set`, and I changed the way observe-and-remove works so that the drawable hasn't already been destroyed when the callback returns, which further complicates things.

before/after
<img src="https://github.com/maplibre/maplibre-native/assets/71895881/5762d0a1-2e45-447a-8d3e-c4b882acef50" width="300"/> <img src="https://github.com/maplibre/maplibre-native/assets/71895881/ddda212f-3dd9-4e7d-9fec-6d412e6b446d" width="300"/>

