### PR TITLE
Fix usage of download-workflow-run-artifact

### DIFF
--- a/.github/workflows/pr-render-test-result.yml
+++ b/.github/workflows/pr-render-test-result.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event.workflow_run.event == 'pull_request'
     steps:
+      - uses: actions/checkout@v3
+
       - uses: .github/actions/download-workflow-run-artifact
         with:
           artifact-name: render-test-result

--- a/.github/workflows/pr-size-test-result.yml
+++ b/.github/workflows/pr-size-test-result.yml
@@ -10,31 +10,12 @@ jobs:
   comment-on-pr:
     runs-on: ubuntu-22.04
     steps:
-      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
-      # TODO: de-duplicate with re-usable action
-      - name: 'Download size-test-result artifact'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "size-test-result"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/size-test-result.zip`, Buffer.from(download.data));
+      - uses: actions/checkout@v3
 
-      - name: 'Unzip render-test-result artifact'
-        run: unzip size-test-result.zip
+      - uses: .github/actions/download-workflow-run-artifact
+        with:
+          artifact-name: size-test-result
+          expect-files: "./pr_number, ./size"
 
       - name: Show directory structure
         run: ls -R


### PR DESCRIPTION
Turns out you need to checkout the repo, otherwise it cannot find the action.