### PR TITLE
Add Rennovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "enabledManagers": ["gradle-wrapper", "bazel"]
+}


### PR DESCRIPTION
There is a whole bunch of managers: https://docs.renovatebot.com/modules/manager/#supported-managers

For now I just want to enable `gradle-wrapper` and `bazel`. The rest can be handled by Dependabot (and npm manually until we clean up the dependencies).