### PR TITLE
Trigger workflows on changes to Bazel files

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -24,6 +24,10 @@ on:
       - "vendor/**"
       - ".gitmodules"
       - "!**/*.md"
+      - WORKSPACE
+      - BUILD.bazel
+      - .bazelrc
+      - .bazelversion
   
   pull_request:
     branches:
@@ -45,6 +49,10 @@ on:
       - "vendor/**"
       - ".gitmodules"
       - "!**/*.md"
+      - WORKSPACE
+      - BUILD.bazel
+      - .bazelrc
+      - .bazelversion
 
 jobs:
   build:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -15,6 +15,10 @@ on:
       - "vendor/**"
       - "CMakeLists.txt"
       - metrics/linux-gcc8-release-style.json
+      - WORKSPACE
+      - BUILD.bazel
+      - .bazelrc
+      - .bazelversion
 
   pull_request:
     branches:
@@ -29,6 +33,10 @@ on:
       - "vendor/**"
       - "CMakeLists.txt"
       - metrics/linux-gcc8-release-style.json
+      - WORKSPACE
+      - BUILD.bazel
+      - .bazelrc
+      - .bazelversion
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The `paths` workflow triggers need to be updated to include Bazel files.

