### PR TITLE
Fix 3D stencil mode incrementing for each drawable

### DIFF
--- a/src/mbgl/gl/drawable_gl.cpp
+++ b/src/mbgl/gl/drawable_gl.cpp
@@ -46,7 +46,10 @@ void DrawableGL::draw(PaintParameters& parameters) const {
     // force disable depth test for debugging
     // context.setDepthMode({gfx::DepthFunctionType::Always, gfx::DepthMaskType::ReadOnly, {0,1}});
 
-    context.setStencilMode(makeStencilMode(parameters));
+    // For 3D mode, stenciling is handled by the layer group
+    if (!is3D) {
+        context.setStencilMode(makeStencilMode(parameters));
+    }
 
     context.setColorMode(getColorMode());
     context.setCullFaceMode(getCullFaceMode());
@@ -211,9 +214,7 @@ gfx::ColorMode DrawableGL::makeColorMode(PaintParameters& parameters) const {
 
 gfx::StencilMode DrawableGL::makeStencilMode(PaintParameters& parameters) const {
     if (enableStencil) {
-        if (is3D) {
-            return parameters.stencilModeFor3D();
-        } else if (tileID) {
+        if (!is3D && tileID) {
             return parameters.stencilModeForClipping(tileID->toUnwrapped());
         }
         assert(false);


### PR DESCRIPTION
Stefan's Pattern Line test style shows a problem with fill extrusions at tile boundaries:

<img src="https://github.com/maplibre/maplibre-native/assets/71895881/b280f393-9b01-4ccc-80f1-bcd717bfb37b" width="300"/>

The problem is that `Context::stencilModeFor3D` is not idempotent like `stencilModeForClipping`, and needs to be called only once for all the tiles in the layer.

The translucent 3D extrusions use a not-equal stencil test to prevent the layer from drawing to the same pixel more than once.  So unlike the tile clipping where each tile's drawing is constrained to that tile's bound, the edges of each tile's extrusions may actually be drawn by the overflow from the previous tile.

This is separate from depth testing, which is also important.  When extrusions are translucent, they are first drawn to the depth buffer to accumulate the largest value and then drawn to the color buffer with only that depth value so that only the extruded surfaces nearest to the eye position are drawn, and the back sides don't show through.