### PR TITLE
Share identical uniform buffers across drawables for background, line.

### DIFF
--- a/include/mbgl/gfx/uniform_buffer.hpp
+++ b/include/mbgl/gfx/uniform_buffer.hpp
@@ -62,8 +62,9 @@ public:
     void createOrUpdate(std::string_view name, const std::vector<uint8_t>& data, gfx::Context&);
     void createOrUpdate(std::string_view name, const void* data, std::size_t size, gfx::Context&);
     template <typename T>
-    std::enable_if_t<!std::is_pointer_v<T>>
-    createOrUpdate(std::string_view name, const T* data, gfx::Context& context) {
+    std::enable_if_t<!std::is_pointer_v<T>> createOrUpdate(std::string_view name,
+                                                           const T* data,
+                                                           gfx::Context& context) {
         createOrUpdate(name, data, sizeof(T), context);
     }
 

--- a/include/mbgl/gfx/uniform_buffer.hpp
+++ b/include/mbgl/gfx/uniform_buffer.hpp
@@ -62,7 +62,8 @@ public:
     void createOrUpdate(std::string_view name, const std::vector<uint8_t>& data, gfx::Context&);
     void createOrUpdate(std::string_view name, const void* data, std::size_t size, gfx::Context&);
     template <typename T>
-    void createOrUpdate(std::string_view name, const T* data, gfx::Context& context) {
+    std::enable_if_t<!std::is_pointer_v<T>>
+    createOrUpdate(std::string_view name, const T* data, gfx::Context& context) {
         createOrUpdate(name, data, sizeof(T), context);
     }
 

--- a/include/mbgl/renderer/layer_group.hpp
+++ b/include/mbgl/renderer/layer_group.hpp
@@ -107,7 +107,9 @@ public:
     std::size_t observeDrawablesRemove(const std::function<bool(gfx::Drawable&)>&&) override;
 
     /// Call the provided function for each drawable for the given tile
-    std::size_t observeDrawables(mbgl::RenderPass, const OverscaledTileID&, const std::function<void(gfx::Drawable&)>&&);
+    std::size_t observeDrawables(mbgl::RenderPass,
+                                 const OverscaledTileID&,
+                                 const std::function<void(gfx::Drawable&)>&&);
     std::size_t observeDrawables(mbgl::RenderPass,
                                  const OverscaledTileID&,
                                  const std::function<void(const gfx::Drawable&)>&&) const;

--- a/include/mbgl/renderer/layer_group.hpp
+++ b/include/mbgl/renderer/layer_group.hpp
@@ -67,8 +67,8 @@ public:
     virtual void postRender(RenderOrchestrator&, PaintParameters&) {}
 
     /// Call the provided function for each drawable in priority order
-    virtual void observeDrawables(const std::function<void(gfx::Drawable&)>&&) = 0;
-    virtual void observeDrawables(const std::function<void(const gfx::Drawable&)>&&) const = 0;
+    virtual std::size_t observeDrawables(const std::function<void(gfx::Drawable&)>&&) = 0;
+    virtual std::size_t observeDrawables(const std::function<void(const gfx::Drawable&)>&&) const = 0;
 
     /// Call the provided function for each drawable in undefined order, allowing for removal.
     /// @param f A function called with each drawable, returning true to keep and false to discard it.
@@ -102,15 +102,15 @@ public:
     std::vector<gfx::UniqueDrawable> removeDrawables(mbgl::RenderPass, const OverscaledTileID&);
     void addDrawable(mbgl::RenderPass, const OverscaledTileID&, gfx::UniqueDrawable&&);
 
-    void observeDrawables(const std::function<void(gfx::Drawable&)>&&) override;
-    void observeDrawables(const std::function<void(const gfx::Drawable&)>&&) const override;
+    std::size_t observeDrawables(const std::function<void(gfx::Drawable&)>&&) override;
+    std::size_t observeDrawables(const std::function<void(const gfx::Drawable&)>&&) const override;
     std::size_t observeDrawablesRemove(const std::function<bool(gfx::Drawable&)>&&) override;
 
     /// Call the provided function for each drawable for the given tile
-    void observeDrawables(mbgl::RenderPass, const OverscaledTileID&, const std::function<void(gfx::Drawable&)>&&);
-    void observeDrawables(mbgl::RenderPass,
-                          const OverscaledTileID&,
-                          const std::function<void(const gfx::Drawable&)>&&) const;
+    std::size_t observeDrawables(mbgl::RenderPass, const OverscaledTileID&, const std::function<void(gfx::Drawable&)>&&);
+    std::size_t observeDrawables(mbgl::RenderPass,
+                                 const OverscaledTileID&,
+                                 const std::function<void(const gfx::Drawable&)>&&) const;
 
     std::size_t clearDrawables() override;
 
@@ -133,8 +133,8 @@ public:
     std::vector<gfx::UniqueDrawable> removeDrawables(mbgl::RenderPass);
     void addDrawable(gfx::UniqueDrawable&&);
 
-    void observeDrawables(const std::function<void(gfx::Drawable&)>&&) override;
-    void observeDrawables(const std::function<void(const gfx::Drawable&)>&&) const override;
+    std::size_t observeDrawables(const std::function<void(gfx::Drawable&)>&&) override;
+    std::size_t observeDrawables(const std::function<void(const gfx::Drawable&)>&&) const override;
     std::size_t observeDrawablesRemove(const std::function<bool(gfx::Drawable&)>&&) override;
 
     std::size_t clearDrawables() override;

--- a/src/mbgl/renderer/layer_group.cpp
+++ b/src/mbgl/renderer/layer_group.cpp
@@ -27,20 +27,22 @@ void LayerGroup::addDrawable(gfx::UniqueDrawable&& drawable) {
     impl->drawables.emplace(std::move(drawable));
 }
 
-void LayerGroup::observeDrawables(const std::function<void(gfx::Drawable&)>&& f) {
+std::size_t LayerGroup::observeDrawables(const std::function<void(gfx::Drawable&)>&& f) {
     for (const auto& item : impl->drawables) {
         if (item) {
             f(*item);
         }
     }
+    return impl->drawables.size();
 }
 
-void LayerGroup::observeDrawables(const std::function<void(const gfx::Drawable&)>&& f) const {
+std::size_t LayerGroup::observeDrawables(const std::function<void(const gfx::Drawable&)>&& f) const {
     for (const auto& item : impl->drawables) {
         if (item) {
             f(*item);
         }
     }
+    return impl->drawables.size();
 }
 
 std::size_t LayerGroup::observeDrawablesRemove(const std::function<bool(gfx::Drawable&)>&& f) {

--- a/src/mbgl/renderer/layers/background_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/background_layer_tweaker.cpp
@@ -138,12 +138,16 @@ void BackgroundLayerTweaker::execute(LayerGroupBase& layerGroup, const RenderTre
             };
             uniforms.createOrUpdate(BackgroundLayerUBOName, &layerUBO, context);
         } else {
-            const BackgroundLayerUBO layerUBO = {/* .color = */ evaluated.get<BackgroundColor>(),
-                                                 /* .opacity = */ evaluated.get<BackgroundOpacity>(),
-                                                 /* .pad = */ 0,
-                                                 0,
-                                                 0};
-            uniforms.createOrUpdate(BackgroundLayerUBOName, &layerUBO, context);
+            // UBOs can be shared
+            if (!backgroundLayerBuffer) {
+                const BackgroundLayerUBO layerUBO = {/* .color = */ evaluated.get<BackgroundColor>(),
+                                                     /* .opacity = */ evaluated.get<BackgroundOpacity>(),
+                                                     /* .pad = */ 0,
+                                                     0,
+                                                     0};
+                backgroundLayerBuffer = context.createUniformBuffer(&layerUBO, sizeof(layerUBO));
+            }
+            uniforms.addOrReplace(BackgroundLayerUBOName, backgroundLayerBuffer);
         }
     });
 }

--- a/src/mbgl/renderer/layers/background_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/background_layer_tweaker.hpp
@@ -28,6 +28,7 @@ public:
     void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
 
 protected:
+    gfx::UniformBufferPtr backgroundLayerBuffer;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
@@ -44,6 +44,7 @@ static constexpr std::string_view FillDrawablePropsUBOName = "FillDrawablePropsU
 void FillLayerTweaker::execute(LayerGroupBase& layerGroup,
                                const RenderTree& renderTree,
                                const PaintParameters& parameters) {
+    auto& context = parameters.context;
     const auto& props = static_cast<const FillLayerProperties&>(*evaluatedProperties);
     const auto& evaluated = props.evaluated;
     const auto& crossfade = props.crossfade;
@@ -65,11 +66,12 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup,
             /* .padding = */ 0,
             0,
             0};
-        propsBuffer = parameters.context.createUniformBuffer(&paramsUBO, sizeof(paramsUBO));
+        propsBuffer = context.createUniformBuffer(&paramsUBO, sizeof(paramsUBO));
     }
 
     layerGroup.observeDrawables([&](gfx::Drawable& drawable) {
-        drawable.mutableUniformBuffers().addOrReplace(FillDrawablePropsUBOName, propsBuffer);
+        auto& uniforms = drawable.mutableUniformBuffers();
+        uniforms.addOrReplace(FillDrawablePropsUBOName, propsBuffer);
 
         if (!drawable.getTileID()) {
             return;
@@ -114,7 +116,7 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup,
             /*.texsize=*/{static_cast<float>(textureSize.width), static_cast<float>(textureSize.height)},
         };
 
-        drawable.mutableUniformBuffers().createOrUpdate(FillDrawableUBOName, &drawableUBO, parameters.context);
+        uniforms.createOrUpdate(FillDrawableUBOName, &drawableUBO, context);
     });
 }
 

--- a/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.cpp
@@ -41,7 +41,7 @@ void HeatmapTextureLayerTweaker::execute(LayerGroupBase& layerGroup,
         const auto& size = parameters.staticData.backendSize;
         mat4 viewportMat;
         matrix::ortho(viewportMat, 0, size.width, size.height, 0, 0, 1);
-        HeatmapTextureDrawableUBO drawableUBO = {
+        const HeatmapTextureDrawableUBO drawableUBO = {
             /* .matrix = */ util::cast<float>(viewportMat),
             /* .world = */ {static_cast<float>(size.width), static_cast<float>(size.height)},
             /* .opacity = */ evaluated.get<HeatmapOpacity>(),

--- a/src/mbgl/renderer/layers/line_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.cpp
@@ -124,9 +124,7 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
     const auto& evaluated = static_cast<const LineLayerProperties&>(*evaluatedProperties).evaluated;
     const auto& crossfade = static_cast<const LineLayerProperties&>(*evaluatedProperties).crossfade;
 
-
-
-    const auto getLinePropsBuffer = [&](){
+    const auto getLinePropsBuffer = [&]() {
         if (!linePropertiesBuffer) {
             const LinePropertiesUBO linePropertiesUBO{
                 /*color =*/evaluated.get<LineColor>().constantOr(LineColor::defaultValue()),
@@ -141,7 +139,7 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
         }
         return linePropertiesBuffer;
     };
-    const auto getLineGradientPropsBuffer = [&](){
+    const auto getLineGradientPropsBuffer = [&]() {
         if (!lineGradientPropertiesBuffer) {
             const LineGradientPropertiesUBO lineGradientPropertiesUBO{
                 /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
@@ -151,11 +149,12 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
                 /*width =*/evaluated.get<LineWidth>().constantOr(LineWidth::defaultValue()),
                 0,
                 {0, 0}};
-            lineGradientPropertiesBuffer = context.createUniformBuffer(&lineGradientPropertiesUBO, sizeof(lineGradientPropertiesUBO));
+            lineGradientPropertiesBuffer = context.createUniformBuffer(&lineGradientPropertiesUBO,
+                                                                       sizeof(lineGradientPropertiesUBO));
         }
         return lineGradientPropertiesBuffer;
     };
-    const auto getLineSDFPropsBuffer = [&](){
+    const auto getLineSDFPropsBuffer = [&]() {
         if (!lineSDFPropertiesBuffer) {
             const LineSDFPropertiesUBO lineSDFPropertiesUBO{
                 /*color =*/evaluated.get<LineColor>().constantOr(LineColor::defaultValue()),
@@ -170,7 +169,7 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
         }
         return lineSDFPropertiesBuffer;
     };
-    
+
     layerGroup.observeDrawables([&](gfx::Drawable& drawable) {
         const auto shader = drawable.getShader();
         if (!drawable.getTileID() || !shader) {

--- a/src/mbgl/renderer/layers/line_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.cpp
@@ -120,36 +120,57 @@ static constexpr std::string_view LineSDFPropertiesUBOName = "LineSDFPropertiesU
 void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
                                const RenderTree& renderTree,
                                const PaintParameters& parameters) {
+    auto& context = parameters.context;
     const auto& evaluated = static_cast<const LineLayerProperties&>(*evaluatedProperties).evaluated;
     const auto& crossfade = static_cast<const LineLayerProperties&>(*evaluatedProperties).crossfade;
 
-    const LinePropertiesUBO linePropertiesUBO{
-        /*color =*/evaluated.get<LineColor>().constantOr(LineColor::defaultValue()),
-        /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
-        /*opacity =*/evaluated.get<LineOpacity>().constantOr(LineOpacity::defaultValue()),
-        /*gapwidth =*/evaluated.get<LineGapWidth>().constantOr(LineGapWidth::defaultValue()),
-        /*offset =*/evaluated.get<LineOffset>().constantOr(LineOffset::defaultValue()),
-        /*width =*/evaluated.get<LineWidth>().constantOr(LineWidth::defaultValue()),
-        0,
-        {0, 0}};
-    const LineGradientPropertiesUBO lineGradientPropertiesUBO{
-        /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
-        /*opacity =*/evaluated.get<LineOpacity>().constantOr(LineOpacity::defaultValue()),
-        /*gapwidth =*/evaluated.get<LineGapWidth>().constantOr(LineGapWidth::defaultValue()),
-        /*offset =*/evaluated.get<LineOffset>().constantOr(LineOffset::defaultValue()),
-        /*width =*/evaluated.get<LineWidth>().constantOr(LineWidth::defaultValue()),
-        0,
-        {0, 0}};
-    const LineSDFPropertiesUBO lineSDFPropertiesUBO{
-        /*color =*/evaluated.get<LineColor>().constantOr(LineColor::defaultValue()),
-        /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
-        /*opacity =*/evaluated.get<LineOpacity>().constantOr(LineOpacity::defaultValue()),
-        /*gapwidth =*/evaluated.get<LineGapWidth>().constantOr(LineGapWidth::defaultValue()),
-        /*offset =*/evaluated.get<LineOffset>().constantOr(LineOffset::defaultValue()),
-        /*width =*/evaluated.get<LineWidth>().constantOr(LineWidth::defaultValue()),
-        /*floorwidth =*/evaluated.get<LineFloorWidth>().constantOr(LineFloorWidth::defaultValue()),
-        {0, 0}};
 
+
+    const auto getLinePropsBuffer = [&](){
+        if (!linePropertiesBuffer) {
+            const LinePropertiesUBO linePropertiesUBO{
+                /*color =*/evaluated.get<LineColor>().constantOr(LineColor::defaultValue()),
+                /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
+                /*opacity =*/evaluated.get<LineOpacity>().constantOr(LineOpacity::defaultValue()),
+                /*gapwidth =*/evaluated.get<LineGapWidth>().constantOr(LineGapWidth::defaultValue()),
+                /*offset =*/evaluated.get<LineOffset>().constantOr(LineOffset::defaultValue()),
+                /*width =*/evaluated.get<LineWidth>().constantOr(LineWidth::defaultValue()),
+                0,
+                {0, 0}};
+            linePropertiesBuffer = context.createUniformBuffer(&linePropertiesUBO, sizeof(linePropertiesUBO));
+        }
+        return linePropertiesBuffer;
+    };
+    const auto getLineGradientPropsBuffer = [&](){
+        if (!lineGradientPropertiesBuffer) {
+            const LineGradientPropertiesUBO lineGradientPropertiesUBO{
+                /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
+                /*opacity =*/evaluated.get<LineOpacity>().constantOr(LineOpacity::defaultValue()),
+                /*gapwidth =*/evaluated.get<LineGapWidth>().constantOr(LineGapWidth::defaultValue()),
+                /*offset =*/evaluated.get<LineOffset>().constantOr(LineOffset::defaultValue()),
+                /*width =*/evaluated.get<LineWidth>().constantOr(LineWidth::defaultValue()),
+                0,
+                {0, 0}};
+            lineGradientPropertiesBuffer = context.createUniformBuffer(&lineGradientPropertiesUBO, sizeof(lineGradientPropertiesUBO));
+        }
+        return lineGradientPropertiesBuffer;
+    };
+    const auto getLineSDFPropsBuffer = [&](){
+        if (!lineSDFPropertiesBuffer) {
+            const LineSDFPropertiesUBO lineSDFPropertiesUBO{
+                /*color =*/evaluated.get<LineColor>().constantOr(LineColor::defaultValue()),
+                /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
+                /*opacity =*/evaluated.get<LineOpacity>().constantOr(LineOpacity::defaultValue()),
+                /*gapwidth =*/evaluated.get<LineGapWidth>().constantOr(LineGapWidth::defaultValue()),
+                /*offset =*/evaluated.get<LineOffset>().constantOr(LineOffset::defaultValue()),
+                /*width =*/evaluated.get<LineWidth>().constantOr(LineWidth::defaultValue()),
+                /*floorwidth =*/evaluated.get<LineFloorWidth>().constantOr(LineFloorWidth::defaultValue()),
+                {0, 0}};
+            lineSDFPropertiesBuffer = context.createUniformBuffer(&lineSDFPropertiesUBO, sizeof(lineSDFPropertiesUBO));
+        }
+        return lineSDFPropertiesBuffer;
+    };
+    
     layerGroup.observeDrawables([&](gfx::Drawable& drawable) {
         const auto shader = drawable.getShader();
         if (!drawable.getTileID() || !shader) {
@@ -175,11 +196,10 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
                 /*units_to_pixels = */ {1.0f / parameters.pixelsToGLUnits[0], 1.0f / parameters.pixelsToGLUnits[1]},
                 /*ratio = */ 1.0f / tileID.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom())),
                 /*device_pixel_ratio = */ parameters.pixelRatio};
-            uniforms.createOrUpdate(LineUBOName, &lineUBO, sizeof(lineUBO), parameters.context);
+            uniforms.createOrUpdate(LineUBOName, &lineUBO, context);
 
             // properties UBO
-            uniforms.createOrUpdate(
-                LinePropertiesUBOName, &linePropertiesUBO, sizeof(linePropertiesUBO), parameters.context);
+            uniforms.addOrReplace(LinePropertiesUBOName, getLinePropsBuffer());
         }
         // gradient line
         else if (shaderUniforms.get(std::string(LineGradientUBOName))) {
@@ -189,13 +209,10 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
                 /*units_to_pixels = */ {1.0f / parameters.pixelsToGLUnits[0], 1.0f / parameters.pixelsToGLUnits[1]},
                 /*ratio = */ 1.0f / tileID.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom())),
                 /*device_pixel_ratio = */ parameters.pixelRatio};
-            uniforms.createOrUpdate(LineGradientUBOName, &lineGradientUBO, sizeof(lineGradientUBO), parameters.context);
+            uniforms.createOrUpdate(LineGradientUBOName, &lineGradientUBO, context);
 
             // properties UBO
-            uniforms.createOrUpdate(LineGradientPropertiesUBOName,
-                                    &lineGradientPropertiesUBO,
-                                    sizeof(lineGradientPropertiesUBO),
-                                    parameters.context);
+            uniforms.addOrReplace(LineGradientPropertiesUBOName, getLineGradientPropsBuffer());
         }
         // pattern line
         else if (shaderUniforms.get(std::string(LinePatternUBOName))) {
@@ -219,7 +236,7 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
                 /*device_pixel_ratio =*/parameters.pixelRatio,
                 /*fade =*/crossfade.t,
                 0};
-            uniforms.createOrUpdate(LinePatternUBOName, &linePatternUBO, sizeof(linePatternUBO), parameters.context);
+            uniforms.createOrUpdate(LinePatternUBOName, &linePatternUBO, context);
 
             // properties UBO
             const LinePatternPropertiesUBO linePatternPropertiesUBO{
@@ -230,10 +247,7 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
                 /*width =*/evaluated.get<LineWidth>().constantOr(LineWidth::defaultValue()),
                 0,
                 {0, 0}};
-            uniforms.createOrUpdate(LinePatternPropertiesUBOName,
-                                    &linePatternPropertiesUBO,
-                                    sizeof(linePatternPropertiesUBO),
-                                    parameters.context);
+            uniforms.createOrUpdate(LinePatternPropertiesUBOName, &linePatternPropertiesUBO, context);
         }
         // SDF line
         else if (shaderUniforms.get(std::string(LineSDFUBOName))) {
@@ -273,11 +287,10 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
                     /* sdfgamma = */ static_cast<float>(dashPatternTexture.getSize().width) /
                         (std::min(widthA, widthB) * 256.0f * parameters.pixelRatio) / 2.0f,
                     /* mix = */ crossfade.t};
-                uniforms.createOrUpdate(LineSDFUBOName, &lineSDFUBO, sizeof(lineSDFUBO), parameters.context);
+                uniforms.createOrUpdate(LineSDFUBOName, &lineSDFUBO, context);
 
                 // properties UBO
-                uniforms.createOrUpdate(
-                    LineSDFPropertiesUBOName, &lineSDFPropertiesUBO, sizeof(lineSDFPropertiesUBO), parameters.context);
+                uniforms.addOrReplace(LineSDFPropertiesUBOName, getLineSDFPropsBuffer());
             }
         }
     });

--- a/src/mbgl/renderer/layers/line_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.hpp
@@ -22,7 +22,7 @@ public:
     ~LineLayerTweaker() override = default;
 
     void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
-    
+
 protected:
     gfx::UniformBufferPtr linePropertiesBuffer;
     gfx::UniformBufferPtr lineGradientPropertiesBuffer;

--- a/src/mbgl/renderer/layers/line_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.hpp
@@ -19,10 +19,14 @@ public:
     LineLayerTweaker(Immutable<style::LayerProperties> properties)
         : LayerTweaker(properties){};
 
-public:
     ~LineLayerTweaker() override = default;
 
     void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
+    
+protected:
+    gfx::UniformBufferPtr linePropertiesBuffer;
+    gfx::UniformBufferPtr lineGradientPropertiesBuffer;
+    gfx::UniformBufferPtr lineSDFPropertiesBuffer;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/raster_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/raster_layer_tweaker.cpp
@@ -38,7 +38,7 @@ void RasterLayerTweaker::execute([[maybe_unused]] LayerGroupBase& layerGroup,
     const auto& evaluated = static_cast<const RasterLayerProperties&>(*evaluatedProperties).evaluated;
 
     layerGroup.observeDrawables([&](gfx::Drawable& drawable) {
-        auto spinWeights = [](float spin) -> std::array<float, 4> {
+        const auto spinWeights = [](float spin) -> std::array<float, 4> {
             spin = util::deg2radf(spin);
             const float s = std::sin(spin);
             const float c = std::cos(spin);
@@ -46,14 +46,14 @@ void RasterLayerTweaker::execute([[maybe_unused]] LayerGroupBase& layerGroup,
                 {(2 * c + 1) / 3, (-std::sqrt(3.0f) * s - c + 1) / 3, (std::sqrt(3.0f) * s - c + 1) / 3, 0}};
             return spin_weights;
         };
-        auto saturationFactor = [](float saturation) -> float {
+        const auto saturationFactor = [](float saturation) -> float {
             if (saturation > 0) {
                 return 1.f - 1.f / (1.001f - saturation);
             } else {
                 return -saturation;
             }
         };
-        auto contrastFactor = [](float contrast) -> float {
+        const auto contrastFactor = [](float contrast) -> float {
             if (contrast > 0) {
                 return 1 / (1 - contrast);
             } else {
@@ -93,7 +93,7 @@ void RasterLayerTweaker::execute([[maybe_unused]] LayerGroupBase& layerGroup,
             0,
             0};
         auto& uniforms = drawable.mutableUniformBuffers();
-        uniforms.createOrUpdate("RasterDrawableUBO", &drawableUBO, sizeof(drawableUBO), parameters.context);
+        uniforms.createOrUpdate("RasterDrawableUBO", &drawableUBO, parameters.context);
     });
 }
 

--- a/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
@@ -121,11 +121,11 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup,
         const auto isText = (symbolData.symbolType == SymbolType::Text);
 
         if (isText && !textPaintBuffer) {
-            auto props = buildPaintUBO(true, evaluated);
+            const auto props = buildPaintUBO(true, evaluated);
             textPaintBuffer = parameters.context.createUniformBuffer(&props, sizeof(props));
         }
         if (!isText && !iconPaintBuffer) {
-            auto props = buildPaintUBO(false, evaluated);
+            const auto props = buildPaintUBO(false, evaluated);
             iconPaintBuffer = parameters.context.createUniformBuffer(&props, sizeof(props));
         }
 

--- a/src/mbgl/renderer/tile_layer_group.cpp
+++ b/src/mbgl/renderer/tile_layer_group.cpp
@@ -83,18 +83,20 @@ void TileLayerGroup::addDrawable(mbgl::RenderPass pass, const OverscaledTileID& 
     }
 }
 
-void TileLayerGroup::observeDrawables(const std::function<void(gfx::Drawable&)>&& f) {
+std::size_t TileLayerGroup::observeDrawables(const std::function<void(gfx::Drawable&)>&& f) {
     assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
     for (auto* drawable : impl->sortedDrawables) {
         f(*drawable);
     }
+    return impl->sortedDrawables.size();
 }
 
-void TileLayerGroup::observeDrawables(const std::function<void(const gfx::Drawable&)>&& f) const {
+std::size_t TileLayerGroup::observeDrawables(const std::function<void(const gfx::Drawable&)>&& f) const {
     assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
     for (const auto* drawable : impl->sortedDrawables) {
         f(*drawable);
     }
+    return impl->sortedDrawables.size();
 }
 
 std::size_t TileLayerGroup::observeDrawablesRemove(const std::function<bool(gfx::Drawable&)>&& f) {
@@ -114,20 +116,22 @@ std::size_t TileLayerGroup::observeDrawablesRemove(const std::function<bool(gfx:
     return (oldSize - impl->drawablesByTile.size());
 }
 
-void TileLayerGroup::observeDrawables(mbgl::RenderPass pass,
-                                      const OverscaledTileID& tileID,
-                                      const std::function<void(gfx::Drawable&)>&& f) {
+std::size_t TileLayerGroup::observeDrawables(mbgl::RenderPass pass,
+                                             const OverscaledTileID& tileID,
+                                             const std::function<void(gfx::Drawable&)>&& f) {
     assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
     const auto range = impl->drawablesByTile.equal_range({pass, tileID});
     std::for_each(range.first, range.second, [&f](const auto& pair) { f(*pair.second); });
+    return std::distance(range.first, range.second);
 }
 
-void TileLayerGroup::observeDrawables(mbgl::RenderPass pass,
-                                      const OverscaledTileID& tileID,
-                                      const std::function<void(const gfx::Drawable&)>&& f) const {
+std::size_t TileLayerGroup::observeDrawables(mbgl::RenderPass pass,
+                                             const OverscaledTileID& tileID,
+                                             const std::function<void(const gfx::Drawable&)>&& f) const {
     assert(impl->drawablesByTile.size() == impl->sortedDrawables.size());
     const auto range = impl->drawablesByTile.equal_range({pass, tileID});
     std::for_each(range.first, range.second, [&f](const auto& pair) { f(*pair.second); });
+    return std::distance(range.first, range.second);
 }
 
 std::size_t TileLayerGroup::clearDrawables() {

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -378,7 +378,8 @@ void GeometryTileWorker::parse() {
             continue;
         }
 
-        std::vector<std::string> layerIDs(group.size());
+        std::vector<std::string> layerIDs;
+        layerIDs.reserve(group.size());
         for (const auto& layer : group) {
             layerIDs.push_back(layer->baseImpl->id);
         }


### PR DESCRIPTION
Return item count from tile-matching `observeDrawables` to eliminate a second key search. Eliminate extra blank entries in layer IDs.