### PR TITLE
Avoid running privileged workflows on forks

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -209,7 +209,7 @@ jobs:
     needs: build
 
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ios-render-test.yml
+++ b/.github/workflows/ios-render-test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   ios-render-test:
     runs-on: ubuntu-22.04
+    if: secrets.MAPLIBRE_NATIVE_BOT_APP_ID
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
These workflows run on forks, where the needed secrets are not available.

This PR prevents that.