### PR TITLE
Bug/fill attributes

### DIFF
--- a/include/mbgl/gfx/drawable.hpp
+++ b/include/mbgl/gfx/drawable.hpp
@@ -48,7 +48,7 @@ public:
     struct DrawSegment;
     using UniqueDrawSegment = std::unique_ptr<DrawSegment>;
 
-    const util::SimpleIdentity& getId() const { return uniqueID; }
+    const util::SimpleIdentity& getID() const { return uniqueID; }
 
     /// Draw the drawable
     virtual void draw(PaintParameters&) const = 0;
@@ -208,7 +208,7 @@ struct DrawableLessByPriority {
         if (a.getDrawPriority() != b.getDrawPriority()) {
             return a.getDrawPriority() < b.getDrawPriority();
         }
-        return a.getId() < b.getId();
+        return a.getID() < b.getID();
     }
     bool operator()(const Drawable* left, const Drawable* right) const { return operator()(*left, *right); }
     bool operator()(const UniqueDrawable& left, const UniqueDrawable& right) const { return operator()(*left, *right); }

--- a/src/mbgl/gfx/drawable_builder.cpp
+++ b/src/mbgl/gfx/drawable_builder.cpp
@@ -73,7 +73,7 @@ void DrawableBuilder::flush() {
 }
 
 util::SimpleIdentity DrawableBuilder::getDrawableId() {
-    return currentDrawable ? currentDrawable->getId() : util::SimpleIdentity::Empty;
+    return currentDrawable ? currentDrawable->getID() : util::SimpleIdentity::Empty;
 }
 
 DrawPriority DrawableBuilder::getDrawPriority() const {

--- a/src/mbgl/gl/drawable_gl.cpp
+++ b/src/mbgl/gl/drawable_gl.cpp
@@ -35,7 +35,7 @@ void DrawableGL::draw(PaintParameters& parameters) const {
         }
     }
     if (!shader || context.program.getCurrentValue() == 0) {
-        mbgl::Log::Warning(Event::General, "Missing shader for drawable " + util::toString(getId()) + "/" + getName());
+        mbgl::Log::Warning(Event::General, "Missing shader for drawable " + util::toString(getID()) + "/" + getName());
         assert(false);
         return;
     }

--- a/src/mbgl/gl/texture2d.cpp
+++ b/src/mbgl/gl/texture2d.cpp
@@ -114,7 +114,7 @@ void Texture2D::create() noexcept {
 }
 
 platform::GLuint Texture2D::getTextureID() const noexcept {
-    return static_cast<gl::TextureResource&>(*textureResource).texture;
+    return textureResource ? static_cast<gl::TextureResource&>(*textureResource).texture : 0;
 }
 
 void Texture2D::updateSamplerConfiguration() noexcept {

--- a/src/mbgl/layermanager/fill_layer_factory.cpp
+++ b/src/mbgl/layermanager/fill_layer_factory.cpp
@@ -14,7 +14,7 @@ const style::LayerTypeInfo* FillLayerFactory::getTypeInfo() const noexcept {
 std::unique_ptr<style::Layer> FillLayerFactory::createLayer(const std::string& id,
                                                             const style::conversion::Convertible& value) noexcept {
     const auto source = getSource(value);
-    return std::unique_ptr<style::Layer>(source ? new(std::nothrow) style::FillLayer(id, *source) : nullptr);
+    return std::unique_ptr<style::Layer>(source ? new (std::nothrow) style::FillLayer(id, *source) : nullptr);
 }
 
 std::unique_ptr<Layout> FillLayerFactory::createLayout(

--- a/src/mbgl/layermanager/fill_layer_factory.cpp
+++ b/src/mbgl/layermanager/fill_layer_factory.cpp
@@ -13,12 +13,8 @@ const style::LayerTypeInfo* FillLayerFactory::getTypeInfo() const noexcept {
 
 std::unique_ptr<style::Layer> FillLayerFactory::createLayer(const std::string& id,
                                                             const style::conversion::Convertible& value) noexcept {
-    std::optional<std::string> source = getSource(value);
-    if (!source) {
-        return nullptr;
-    }
-
-    return std::unique_ptr<style::Layer>(new style::FillLayer(id, *source));
+    const auto source = getSource(value);
+    return std::unique_ptr<style::Layer>(source ? new(std::nothrow) style::FillLayer(id, *source) : nullptr);
 }
 
 std::unique_ptr<Layout> FillLayerFactory::createLayout(

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -4,6 +4,8 @@
 #include <mbgl/style/image_impl.hpp>
 #include <mbgl/renderer/image_atlas.hpp>
 #include <mbgl/style/layer_impl.hpp>
+#include <mbgl/util/identity.hpp>
+
 #include <atomic>
 
 namespace mbgl {
@@ -65,9 +67,13 @@ public:
     virtual void updateVertices(
         const Placement&, bool /*updateOpacities*/, const TransformState&, const RenderTile&, std::set<uint32_t>&) {}
 
+    const util::SimpleIdentity& getID() const { return bucketID; }
+
 protected:
     Bucket() = default;
     std::atomic<bool> uploaded{false};
+    
+    util::SimpleIdentity bucketID;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -72,7 +72,7 @@ public:
 protected:
     Bucket() = default;
     std::atomic<bool> uploaded{false};
-    
+
     util::SimpleIdentity bucketID;
 };
 

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -283,7 +283,7 @@ void RenderBackgroundLayer::update(gfx::ShaderRegistry& shaders,
 
     tileLayerGroup->observeDrawables([&](gfx::Drawable& drawable) -> bool {
         // Has this tile dropped out of the cover set?
-        return (!drawable.getTileID() || renderTileIDs.find(*drawable.getTileID()) != renderTileIDs.end());
+        return (!drawable.getTileID() || hasRenderTile(*drawable.getTileID()));
     });
 
     // For each tile in the cover set, add a tile drawable if one doesn't already exist.

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -319,9 +319,8 @@ void RenderCircleLayer::update(gfx::ShaderRegistry& shaders,
         return;
     }
 
-    stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
-        return (!drawable.getTileID() || hasRenderTile(*drawable.getTileID()));
-    });
+    stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove(
+        [&](gfx::Drawable& drawable) { return (!drawable.getTileID() || hasRenderTile(*drawable.getTileID())); });
 
     const auto& evaluated = static_cast<const CircleLayerProperties&>(*evaluatedProperties).evaluated;
 

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -320,7 +320,7 @@ void RenderCircleLayer::update(gfx::ShaderRegistry& shaders,
     }
 
     stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
-        return (!drawable.getTileID() || renderTileIDs.find(*drawable.getTileID()) != renderTileIDs.end());
+        return (!drawable.getTileID() || hasRenderTile(*drawable.getTileID()));
     });
 
     const auto& evaluated = static_cast<const CircleLayerProperties&>(*evaluatedProperties).evaluated;
@@ -329,7 +329,7 @@ void RenderCircleLayer::update(gfx::ShaderRegistry& shaders,
         const auto& tileID = tile.getOverscaledTileID();
 
         const LayerRenderData* renderData = getRenderDataForPass(tile, renderPass);
-        if (!renderData) {
+        if (!renderData || !renderData->bucket || !renderData->bucket->hasData()) {
             removeTile(renderPass, tileID);
             continue;
         }
@@ -337,6 +337,13 @@ void RenderCircleLayer::update(gfx::ShaderRegistry& shaders,
         const auto& bucket = static_cast<const CircleBucket&>(*renderData->bucket);
         const auto vertexCount = bucket.vertices.elements();
         const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
+
+        const auto prevBucketID = getRenderTileBucketID(tileID);
+        if (prevBucketID != util::SimpleIdentity::Empty && prevBucketID != bucket.getID()) {
+            // This tile was previously set up from a different bucket, drop and re-create any drawables for it.
+            removeTile(renderPass, tileID);
+        }
+        setRenderTileBucketID(tileID, bucket.getID());
 
         const float zoom = static_cast<float>(state.getZoom());
         const CircleInterpolateUBO interpolateUBO = {

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -364,9 +364,7 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
 
     stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
         // If the render pass has changed or the tile has dropped out of the cover set, remove it.
-        return drawable.getRenderPass() == renderPass &&
-               drawable.getTileID() &&
-               hasRenderTile(*drawable.getTileID());
+        return drawable.getRenderPass() == renderPass && drawable.getTileID() && hasRenderTile(*drawable.getTileID());
     });
 
     for (const RenderTile& tile : *renderTiles) {

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -339,7 +339,7 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
     }
 
     stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
-        return (!drawable.getTileID() || renderTileIDs.find(*drawable.getTileID()) != renderTileIDs.end());
+        return (!drawable.getTileID() || hasRenderTile(*drawable.getTileID()));
     });
 
     const auto& evaluated = static_cast<const HeatmapLayerProperties&>(*evaluatedProperties).evaluated;
@@ -356,6 +356,13 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
         const auto& bucket = static_cast<HeatmapBucket&>(*renderData->bucket);
         const auto vertexCount = bucket.vertices.elements();
         const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
+
+        const auto prevBucketID = getRenderTileBucketID(tileID);
+        if (prevBucketID != util::SimpleIdentity::Empty && prevBucketID != bucket.getID()) {
+            // This tile was previously set up from a different bucket, drop and re-create any drawables for it.
+            removeTile(renderPass, tileID);
+        }
+        setRenderTileBucketID(tileID, bucket.getID());
 
         const float zoom = static_cast<float>(state.getZoom());
         const HeatmapInterpolateUBO interpolateUBO = {

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -338,9 +338,8 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
         return;
     }
 
-    stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
-        return (!drawable.getTileID() || hasRenderTile(*drawable.getTileID()));
-    });
+    stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove(
+        [&](gfx::Drawable& drawable) { return (!drawable.getTileID() || hasRenderTile(*drawable.getTileID())); });
 
     const auto& evaluated = static_cast<const HeatmapLayerProperties&>(*evaluatedProperties).evaluated;
 

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -324,9 +324,8 @@ void RenderHillshadeLayer::update(gfx::ShaderRegistry& shaders,
         return;
     }
 
-    stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
-        return (!drawable.getTileID() || hasRenderTile(*drawable.getTileID()));
-    });
+    stats.drawablesRemoved += tileLayerGroup->observeDrawablesRemove(
+        [&](gfx::Drawable& drawable) { return (!drawable.getTileID() || hasRenderTile(*drawable.getTileID())); });
 
     if (!staticDataSharedVertices) {
         staticDataSharedVertices = std::make_shared<HillshadeVertexVector>(RenderStaticData::rasterVertices());

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -271,7 +271,7 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
         return builder;
     };
 
-    auto setTextures = [&context, &filter, this](std::unique_ptr<gfx::DrawableBuilder>& builder, RasterBucket& bucket) {
+    auto setTextures = [&context, &filter, this](std::unique_ptr<gfx::DrawableBuilder>& builder, const RasterBucket& bucket) {
         // textures
         auto location0 = rasterShader->getSamplerLocation("u_image0");
         if (location0.has_value()) {
@@ -289,7 +289,7 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
         }
     };
 
-    auto buildTileDrawables = [&setTextures](std::unique_ptr<gfx::DrawableBuilder>& builder, RasterBucket& bucket) {
+    auto buildTileDrawables = [&setTextures](std::unique_ptr<gfx::DrawableBuilder>& builder, const RasterBucket& bucket) {
         auto buildRenderData = [](const TileMask& mask,
                                   std::vector<std::array<int16_t, 2>>& vertices,
                                   std::vector<std::array<int16_t, 2>>& attributes,
@@ -422,7 +422,7 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
         if (layerGroup) {
             stats.drawablesRemoved += layerGroup->observeDrawablesRemove([&](gfx::Drawable& drawable) {
                 // Has this tile dropped out of the cover set?
-                return (!drawable.getTileID() || renderTileIDs.find(*drawable.getTileID()) != renderTileIDs.end());
+                return (!drawable.getTileID() || hasRenderTile(*drawable.getTileID()));
             });
         } else {
             // Set up a tile layer group
@@ -437,12 +437,21 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
         auto builder = createBuilder();
         for (const RenderTile& tile : *renderTiles) {
             const auto& tileID = tile.getOverscaledTileID();
-            auto* bucket_ = tile.getBucket(*baseImpl);
-            if (!bucket_) {
+
+            const auto* bucket_ = tile.getBucket(*baseImpl);
+            if (!bucket_ || !bucket_->hasData()) {
+                removeTile(renderPass, tileID);
                 continue;
             }
-            auto& bucket = static_cast<RasterBucket&>(*bucket_);
-            if (!bucket.hasData()) continue;
+
+            const auto& bucket = static_cast<const RasterBucket&>(*bucket_);
+
+            const auto prevBucketID = getRenderTileBucketID(tileID);
+            if (prevBucketID != util::SimpleIdentity::Empty && prevBucketID != bucket.getID()) {
+                // This tile was previously set up from a different bucket, drop and re-create any drawables for it.
+                removeTile(renderPass, tileID);
+            }
+            setRenderTileBucketID(tileID, bucket.getID());
 
             if (tileLayerGroup->getDrawableCount(renderPass, tileID) > 0) continue;
 

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -271,7 +271,8 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
         return builder;
     };
 
-    auto setTextures = [&context, &filter, this](std::unique_ptr<gfx::DrawableBuilder>& builder, const RasterBucket& bucket) {
+    auto setTextures = [&context, &filter, this](std::unique_ptr<gfx::DrawableBuilder>& builder,
+                                                 const RasterBucket& bucket) {
         // textures
         auto location0 = rasterShader->getSamplerLocation("u_image0");
         if (location0.has_value()) {
@@ -289,7 +290,8 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
         }
     };
 
-    auto buildTileDrawables = [&setTextures](std::unique_ptr<gfx::DrawableBuilder>& builder, const RasterBucket& bucket) {
+    auto buildTileDrawables = [&setTextures](std::unique_ptr<gfx::DrawableBuilder>& builder,
+                                             const RasterBucket& bucket) {
         auto buildRenderData = [](const TileMask& mask,
                                   std::vector<std::array<int16_t, 2>>& vertices,
                                   std::vector<std::array<int16_t, 2>>& attributes,

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -827,7 +827,6 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
         // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
         const auto& tileID = drawable.getTileID();
         if (drawable.getRenderPass() != passes || (tileID && !hasRenderTile(*tileID))) {
-            tileBucketInstances.erase(*tileID);
             return false;
         }
         return true;
@@ -864,19 +863,12 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
 
         // If we already have drawables for this tile, update them.
         if (tileLayerGroup->getDrawableCount(passes, tileID) > 0) {
-            // TODO: Is this redundant with the bucket ID check above?
-            const auto hit = tileBucketInstances.insert(std::make_pair(tileID, bucket.bucketInstanceId));
-            if (!hit.second && hit.first->second != bucket.bucketInstanceId) {
-                // The bucket has changed, reset the drawables for this tile.
-                tileLayerGroup->removeDrawables(passes, tileID);
-                hit.first->second = bucket.bucketInstanceId;
-            } else {
-                // Just update the drawables we already created
-                tileLayerGroup->observeDrawables(passes, tileID, [&](gfx::Drawable& drawable) {
-                    updateTileDrawable(drawable, context, bucket, bucketPaintProperties, state);
-                });
-                continue;
-            }
+            // Just update the drawables we already created
+            Log::Warning(Event::General, getID() + " updating " + util::toString(tileID));
+            tileLayerGroup->observeDrawables(passes, tileID, [&](gfx::Drawable& drawable) {
+                updateTileDrawable(drawable, context, bucket, bucketPaintProperties, state);
+            });
+            continue;
         }
 
         float serialKey = 1.0f;

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -748,14 +748,12 @@ constexpr auto fadeOpacityAttribName = "a_fade_opacity";
 constexpr auto texUniformName = "u_texture";
 constexpr auto iconTexUniformName = "u_texture_icon";
 
-std::vector<std::string> updateTileAttributes(
-        gfx::Context& context,
-        const SymbolBucket::Buffer& buffer,
-        const bool isText,
-        const SymbolBucket::PaintProperties& paintProps,
-        const SymbolPaintProperties::PossiblyEvaluated& evaluated,
-        gfx::VertexAttributeArray& attribs) {
-
+std::vector<std::string> updateTileAttributes(gfx::Context& context,
+                                              const SymbolBucket::Buffer& buffer,
+                                              const bool isText,
+                                              const SymbolBucket::PaintProperties& paintProps,
+                                              const SymbolPaintProperties::PossiblyEvaluated& evaluated,
+                                              gfx::VertexAttributeArray& attribs) {
     if (const auto& attr = attribs.getOrAdd(posOffsetAttribName)) {
         attr->setSharedRawData(buffer.sharedVertices,
                                offsetof(SymbolLayoutVertex, a1),
@@ -794,19 +792,14 @@ std::vector<std::string> updateTileAttributes(
                                sizeof(Vertex),
                                gfx::AttributeDataType::Float);
     }
-    
-    return isText ? attribs.readDataDrivenPaintProperties<TextOpacity,
-                                                          TextColor,
-                                                          TextHaloColor,
-                                                          TextHaloWidth,
-                                                          TextHaloBlur>(
-                          paintProps.textBinders, evaluated)
-                    : attribs.readDataDrivenPaintProperties<IconOpacity,
-                                                          IconColor,
-                                                          IconHaloColor,
-                                                          IconHaloWidth,
-                                                          IconHaloBlur>(
-                          paintProps.iconBinders, evaluated);
+
+    return isText
+               ? attribs
+                     .readDataDrivenPaintProperties<TextOpacity, TextColor, TextHaloColor, TextHaloWidth, TextHaloBlur>(
+                         paintProps.textBinders, evaluated)
+               : attribs
+                     .readDataDrivenPaintProperties<IconOpacity, IconColor, IconHaloColor, IconHaloWidth, IconHaloBlur>(
+                         paintProps.iconBinders, evaluated);
 }
 
 void updateTileDrawable(gfx::Drawable& drawable,
@@ -980,7 +973,8 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
         const auto vertexCount = buffer.vertices().elements();
 
         gfx::VertexAttributeArray attribs;
-        const auto uniformProps = updateTileAttributes(context, buffer, isText, bucketPaintProperties, evaluated, attribs);
+        const auto uniformProps = updateTileAttributes(
+            context, buffer, isText, bucketPaintProperties, evaluated, attribs);
 
         const auto textHalo = evaluated.get<style::TextHaloColor>().constantOr(Color::black()).a > 0.0f &&
                               evaluated.get<style::TextHaloWidth>().constantOr(1);

--- a/src/mbgl/renderer/layers/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.hpp
@@ -125,8 +125,6 @@ private:
     gfx::ShaderGroupPtr symbolSDFIconGroup;
     gfx::ShaderGroupPtr symbolSDFTextGroup;
     gfx::ShaderGroupPtr symbolTextAndIconGroup;
-
-    std::unordered_map<OverscaledTileID, uint32_t> tileBucketInstances;
 #endif // MLN_DRAWABLE_RENDERER
 };
 

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -10,7 +10,7 @@
 #include <mbgl/gfx/drawable.hpp>
 #include <mbgl/renderer/change_request.hpp>
 
-#include <unordered_set>
+#include <unordered_map>
 #endif // MLN_DRAWABLE_RENDERER
 
 #include <list>
@@ -205,8 +205,18 @@ protected:
     /// Remove all the drawables for tiles
     virtual void removeAllDrawables();
 
-    // Update `renderTileIDs` from `renderTiles`
+    /// Update `renderTileIDs` from `renderTiles`
     void updateRenderTileIDs();
+
+    /// Whether a given tile ID is present in the current cover set (`renderTiles`)
+    bool hasRenderTile(const OverscaledTileID&) const;
+
+    /// Get the bucket ID from which a given tile was built
+    util::SimpleIdentity getRenderTileBucketID(const OverscaledTileID&) const;
+
+    /// Set the bucket ID from which a given tile was built
+    /// @return true if updated, false if missing or unchanged
+    bool setRenderTileBucketID(const OverscaledTileID&, util::SimpleIdentity bucketID);
 #endif // MLN_DRAWABLE_RENDERER
 
 protected:
@@ -223,9 +233,11 @@ protected:
     // will need to be overriden to handle their activation.
     LayerGroupBasePtr layerGroup;
 
-    // The set of Tile IDs in `renderTiles`
-    std::unordered_set<OverscaledTileID> renderTileIDs;
+    // The set of Tile IDs in `renderTiles`, along with the
+    // identity of the bucket from which they were built.
+    std::unordered_map<OverscaledTileID, util::SimpleIdentity> renderTileIDs;
 #endif
+
     // Current layer index as specified by the layerIndexChanged event
     int32_t layerIndex{0};
 

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -133,8 +133,8 @@ void Renderer::Impl::render(const RenderTree& renderTree) {
 
     // Run layer tweakers to update any dynamic elements
     orchestrator.observeLayerGroups([&](LayerGroupBase& layerGroup) {
-        if (layerGroup.getLayerTweaker()) {
-            layerGroup.getLayerTweaker()->execute(layerGroup, renderTree, parameters);
+        if (const auto& tweaker = layerGroup.getLayerTweaker()) {
+            tweaker->execute(layerGroup, renderTree, parameters);
         }
     });
 


### PR DESCRIPTION
When the style changes, requests are initiated but not yet complete.  The buckets are re-created only when those requests complete, or after a layout pass, if they require layout.  If we drop the existing drawables immediately, they will just be re-created based on the old data on the next frame render.

So instead, we give each bucket instance a unique ID, and track that against the tile IDs.  This resolves the problem where things don't change when switching between styles with the same layer names, like the [FB light/dark example](https://osmus.slack.com/archives/C04SSR0S78B/p1689089320597589?thread_ts=1689089261.684019&cid=C04SSR0S78B).

This can be further improved by adding a mechanism to avoid updating the UBOs on the old drawables with the new style constants during this interval, which produces an intermediate between the old and new styles that isn't really valid. 