### PR TITLE
Add documenation to did fail to load image

### DIFF
--- a/platform/ios/platform/ios/src/MLNMapViewDelegate.h
+++ b/platform/ios/platform/ios/src/MLNMapViewDelegate.h
@@ -276,6 +276,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)mapView:(MLNMapView *)mapView didFinishLoadingStyle:(MLNStyle *)style;
 
+/**
+ Tells the delegate that the `mapView`  is missing an image.The image should be added synchronously with addImage to be rendered on the current zoom level. When loading icons asynchronously, you can load a placeholder image and replace it when your image has loaded.
+
+ @param mapView The map view that is loading the image.
+ @param imageName The name of the image that is missing.
+ */
 - (nullable UIImage *)mapView:(MLNMapView *)mapView didFailToLoadImage:(NSString *)imageName;
 
 /**

--- a/platform/ios/platform/macos/src/MLNMapViewDelegate.h
+++ b/platform/ios/platform/macos/src/MLNMapViewDelegate.h
@@ -181,6 +181,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)mapView:(MLNMapView *)mapView didFinishLoadingStyle:(MLNStyle *)style;
 
+/**
+ Tells the delegate that the `mapView`  is missing an image.The image should be added synchronously with addImage to be rendered on the current zoom level. When loading icons asynchronously, you can load a placeholder image and replace it when your image has loaded.
+
+ @param mapView The map view that is loading the image.
+ @param imageName The name of the image that is missing.
+ */
 - (nullable NSImage *)mapView:(MLNMapView *)mapView didFailToLoadImage:(NSString *)imageName;
 
 /**


### PR DESCRIPTION
Up to now the documentation for the existing function on `MGLMapViewDelegate`/`MLNMapViewDelegate` ist missing. This PR adds it. The wording leans towards the [Android Documentation](https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.maps/-map-view/-on-style-image-missing-listener/on-style-image-missing.html?query=abstract%20fun%20onStyleImageMissing(id:%20String))