### PR TITLE
Linux CI: Retry failed XOpenDisplay calls and only log errors in coverage run

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -215,10 +215,11 @@ jobs:
           npm install --ignore-scripts
           node test/storage/server.js &
 
+      - run: echo coverage_report=$(bazel info output_path)/_coverage/_coverage_report.dat >> $GITHUB_ENV
+
       - name: Generate coverage report
         run: |
-          bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core //render-test:render-test --//:maplibre_platform=linux --run_under="xvfb-run -a"
-          echo coverage_report=$(bazel info output_path)/_coverage/_coverage_report.dat >> $GITHUB_ENV
+          bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core --//:maplibre_platform=linux --run_under="xvfb-run -a"
 
       - name: Upload coverage report
         if: '!cancelled()'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          xvfb-run -a bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core --//:maplibre_platform=linux --test-env=DISPLAY
+          xvfb-run -a bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core --//:maplibre_platform=linux --test_env=DISPLAY
 
       - name: Upload coverage report
         if: '!cancelled()'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          xvfb-run -a bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core --//:maplibre_platform=linux --test_env=DISPLAY
+          xvfb-run -a bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core --//:maplibre_platform=linux --test_env=DISPLAY --test_env=XAUTHORITY
 
       - name: Upload coverage report
         if: '!cancelled()'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Build MapLibre Native Core
         run: |
+          export CI=1
           cmake --version
           cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DMLN_WITH_CLANG_TIDY=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMLN_WITH_COVERAGE=ON
           cmake --build build --target mbgl-core mbgl-test-runner mbgl-render-test-runner mbgl-expression-test

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -162,7 +162,6 @@ jobs:
       - run: chmod +x ./mbgl-render-test-runner
 
       - name: Run render test
-        continue-on-error: true
         id: render_test
         run: xvfb-run -a ./mbgl-render-test-runner --manifestPath=metrics/linux-gcc8-release-style.json
 
@@ -221,7 +220,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          xvfb-run -a bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core //render-test:render-test --//:maplibre_platform=linux --test_env=DISPLAY --test_env=XAUTHORITY
+          xvfb-run -a bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core //render-test:render-test --//:maplibre_platform=linux --test_env=DISPLAY --test_env=XAUTHORITY  --define=CI_BUILD=1
 
       - name: Upload coverage report
         if: '!cancelled()'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
             libcurl4-openssl-dev \
             libuv1-dev \
             libjpeg-dev \
@@ -192,8 +192,8 @@ jobs:
             libwebp-dev \
             libglfw3-dev \
             libsqlite3-dev \
-            xserver-xorg-video-dummy \
-            xinit
+            xvfb \
+            x11-xserver-utils
 
       - name: Cache Bazel
         uses: actions/cache@v3
@@ -208,11 +208,9 @@ jobs:
           npm install --ignore-scripts
           node test/storage/server.js &
 
-      - run: echo coverage_report=$(bazel info output_path)/_coverage/_coverage_report.dat >> $GITHUB_ENV
-
       - name: Generate coverage report
         run: |
-          xvfb-run -a bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core //render-test:render-test --//:maplibre_platform=linux --test_env=DISPLAY --test_env=XAUTHORITY  --define=CI_BUILD=1
+          xvfb-run -a bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core --//:maplibre_platform=linux --test_env=DISPLAY --test_env=XAUTHORITY  --define=CI_BUILD=1
           echo coverage_report="$(bazel info output_path)"/_coverage/_coverage_report.dat >> "$GITHUB_ENV"
 
       - name: Upload coverage report

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -167,14 +167,14 @@ jobs:
         run: xvfb-run -a ./mbgl-render-test-runner --manifestPath=metrics/linux-gcc8-release-style.json
 
       - name: Save PR number
-        if: steps.render_test.outcome == 'failure'
+        if: always() && steps.render_test.outcome == 'failure'
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           echo $PR_NUMBER > ./pr_number
 
       - name: Upload render test result
-        if: steps.render_test.outcome == 'failure'
+        if: always() && steps.render_test.outcome == 'failure'
         uses: actions/upload-artifact@v3
         with:
           name: render-test-result

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -215,7 +215,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          bazel coverage --test_output=all --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core //render-test:render-test --//:maplibre_platform=linux --run_under=//platform/linux:startxwrapper
+          bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core //render-test:render-test --//:maplibre_platform=linux --run_under=//platform/linux:startxwrapper
           echo coverage_report=$(bazel info output_path)/_coverage/_coverage_report.dat >> $GITHUB_ENV
 
       - name: Upload coverage report

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -217,10 +217,11 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core //render-test:render-test --//:maplibre_platform=linux --run_under=//platform/linux:startxwrapper
+          bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core //render-test:render-test --//:maplibre_platform=linux --run_under="xvfb-run -a"
           echo coverage_report=$(bazel info output_path)/_coverage/_coverage_report.dat >> $GITHUB_ENV
 
       - name: Upload coverage report
+        if: '!cancelled()'
         uses: codecov/codecov-action@v3
         with:
           files: ${{ env.coverage_report }}

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core --//:maplibre_platform=linux --run_under="xvfb-run -a"
+          xvfb-run -a bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core --//:maplibre_platform=linux --test-env=DISPLAY
 
       - name: Upload coverage report
         if: '!cancelled()'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -167,12 +167,14 @@ jobs:
         run: xvfb-run -a ./mbgl-render-test-runner --manifestPath=metrics/linux-gcc8-release-style.json
 
       - name: Save PR number
+        if: steps.render_test.outcome == 'failure'
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           echo $PR_NUMBER > ./pr_number
 
       - name: Upload render test result
+        if: steps.render_test.outcome == 'failure'
         uses: actions/upload-artifact@v3
         with:
           name: render-test-result

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -210,8 +210,11 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          xvfb-run -a bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core --//:maplibre_platform=linux --test_env=DISPLAY --test_env=XAUTHORITY  --define=CI_BUILD=1
-          echo coverage_report="$(bazel info output_path)"/_coverage/_coverage_report.dat >> "$GITHUB_ENV"
+          xvfb-run -a \
+            bazel coverage --combined_report=lcov  --instrumentation_filter="//:mbgl-core" --//:maplibre_platform=linux \
+            --test_output=errors --local_test_jobs=1 \
+            --test_env=DISPLAY --test_env=XAUTHORITY  --define=CI_BUILD=1 \
+            //test:core
 
       - name: Upload coverage report
         if: '!cancelled()'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          xvfb-run -a bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core --//:maplibre_platform=linux --test_env=DISPLAY --test_env=XAUTHORITY
+          xvfb-run -a bazel coverage --test_output=errors --combined_report=lcov --nobuild_runfile_links --local_test_jobs=1 --instrumentation_filter="//:mbgl-core" //test:core //render-test:render-test --//:maplibre_platform=linux --test_env=DISPLAY --test_env=XAUTHORITY
 
       - name: Upload coverage report
         if: '!cancelled()'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -72,8 +72,9 @@ jobs:
             libwebp-dev
 
       - name: Build MapLibre Native Core
+        env:
+          CI: 1
         run: |
-          export CI=1
           cmake --version
           cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DMLN_WITH_CLANG_TIDY=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMLN_WITH_COVERAGE=ON
           cmake --build build --target mbgl-core mbgl-test-runner mbgl-render-test-runner mbgl-expression-test

--- a/.github/workflows/pr-render-test-result.yml
+++ b/.github/workflows/pr-render-test-result.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: .github/actions/download-workflow-run-artifact
+      - uses: ./.github/actions/download-workflow-run-artifact
         with:
           artifact-name: render-test-result
           expect-files: "./pr_number, metrics/linux-gcc8-release-style.html"

--- a/platform/linux/BUILD.bazel
+++ b/platform/linux/BUILD.bazel
@@ -16,7 +16,7 @@ cc_library(
     linkopts = [
         "-lGL",
         "-lglfw",
-        "-lEGL",
+        "-lX11",
         "-lsqlite3",
         "-luv",
         "-lz",

--- a/platform/linux/BUILD.bazel
+++ b/platform/linux/BUILD.bazel
@@ -10,7 +10,7 @@ cc_library(
     name = "impl",
     srcs = [
         "src/gl_functions.cpp",
-        "src/headless_backend_egl.cpp",
+        "src/headless_backend_glx.cpp.cpp",
     ],
     copts = CPP_FLAGS + MAPLIBRE_FLAGS,
     linkopts = [

--- a/platform/linux/BUILD.bazel
+++ b/platform/linux/BUILD.bazel
@@ -10,7 +10,7 @@ cc_library(
     name = "impl",
     srcs = [
         "src/gl_functions.cpp",
-        "src/headless_backend_glx.cpp.cpp",
+        "src/headless_backend_glx.cpp",
     ],
     copts = CPP_FLAGS + MAPLIBRE_FLAGS,
     linkopts = [

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -153,7 +153,9 @@ add_executable(
 
 target_compile_definitions(
     mbgl-test-runner
-    PRIVATE WORK_DIRECTORY=${PROJECT_SOURCE_DIR}
+    PRIVATE
+        WORK_DIRECTORY=${PROJECT_SOURCE_DIR}
+        $<DEFINED ENV{CI},CI_BUILD=1>
 )
 
 target_link_libraries(

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -155,8 +155,15 @@ target_compile_definitions(
     mbgl-test-runner
     PRIVATE
         WORK_DIRECTORY=${PROJECT_SOURCE_DIR}
-        $<DEFINED ENV{CI},CI_BUILD=1>
 )
+
+if (DEFINED ENV{CI})
+    target_compile_definitions(
+        mbgl-test-runner
+        PRIVATE
+            CI_BUILD=1
+    )
+endif()
 
 target_link_libraries(
     mbgl-test-runner

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -158,6 +158,7 @@ target_compile_definitions(
 )
 
 if (DEFINED ENV{CI})
+    message("Building for CI")
     target_compile_definitions(
         mbgl-test-runner
         PRIVATE

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -93,6 +93,15 @@ else()
     )
 endif()
 
+if (DEFINED ENV{CI})
+    message("Building for CI")
+    target_compile_definitions(
+        mbgl-core
+        PRIVATE
+            CI_BUILD=1
+    )
+endif()
+
 # FIXME: Should not be needed, but now needed by node because of the headless frontend.
 target_include_directories(
     mbgl-core

--- a/platform/linux/src/headless_backend_glx.cpp
+++ b/platform/linux/src/headless_backend_glx.cpp
@@ -39,7 +39,7 @@ public:
             if (xDisplay != nullptr) {
                 break;
             }
-            Log::Warning(Event::OpenGL, "[CI] Failed to open X display, retrying...");
+            Log::Debug(Event::OpenGL, "[CI] Failed to open X display, retrying...");
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
         }
 #endif

--- a/platform/linux/src/headless_backend_glx.cpp
+++ b/platform/linux/src/headless_backend_glx.cpp
@@ -31,7 +31,7 @@ public:
 
 #ifdef CI_BUILD
         // XOpenDisplay has proven very unreliable on CI, perform some retries if it fails
-        constexpr auto CI_RETRIES = 3;
+        constexpr auto CI_RETRIES = 10;
         for (int i = 0; i < CI_RETRIES; i++) {
 #endif
             xDisplay = XOpenDisplay(nullptr);

--- a/platform/linux/src/headless_backend_glx.cpp
+++ b/platform/linux/src/headless_backend_glx.cpp
@@ -40,7 +40,7 @@ public:
                 break;
             }
             Log::Warning(Event::OpenGL, "[CI] Failed to open X display, retrying...");
-            std::this_thread::sleep_for(std::chrono::milliseconds);
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
         }
 #endif
         if (xDisplay == nullptr) {

--- a/platform/linux/src/headless_backend_glx.cpp
+++ b/platform/linux/src/headless_backend_glx.cpp
@@ -34,7 +34,7 @@ public:
         constexpr auto CI_RETRIES = 3;
         for (int i = 0; i < CI_RETRIES; i++) {
 #endif
-        xDisplay = XOpenDisplay(nullptr);
+            xDisplay = XOpenDisplay(nullptr);
 #ifdef CI_BUILD
             if (xDisplay != nullptr) {
                 break;

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -42,7 +42,7 @@ cc_test(
         ],
     ),
     args = [
-        "--gtest_filter=-Map.StyleNetworkErrorRetry:Map.StyleNotFound",
+        "--gtest_filter=-Map.StyleNetworkErrorRetry:Map.StyleNotFound:MainResourceLoader.CachedResourceLowPriority",
     ],
     copts = CPP_FLAGS + MAPLIBRE_FLAGS,
     data = glob(["fixtures/**/*"]) + [

--- a/test/storage/main_resource_loader.test.cpp
+++ b/test/storage/main_resource_loader.test.cpp
@@ -715,9 +715,8 @@ TEST(MainResourceLoader, TEST_REQUIRES_SERVER(RespondToStaleMustRevalidate)) {
 }
 
 // Test that requests for expired resources have lower priority than requests for new resources
+// Flaky https://github.com/maplibre/maplibre-native/issues/1071
 TEST(MainResourceLoader, TEST_REQUIRES_SERVER(CachedResourceLowPriority)) {
-    GTEST_SKIP() << "Skipping MainResourceLoader.CachedResourceLowPriority. "
-                 << "See https://github.com/maplibre/maplibre-native/issues/1071";
     util::RunLoop loop;
     MainResourceLoader fs(ResourceOptions{}, ClientOptions{});
 


### PR DESCRIPTION
Linux CI is still being flaky when running rendering tests, attempt up to 3 retries of XOpenDisplay when built for a CI run. The coverage report is also difficult to read due to the amount of log noise, reduce coverage logging to only output errors.