### PR TITLE
iOS render test on AWS Device Farm

### DIFF
--- a/.github/workflows/ios-render-test.yml
+++ b/.github/workflows/ios-render-test.yml
@@ -60,7 +60,7 @@ jobs:
           name: RenderTest.xctest.zip
           type: XCTEST_TEST_PACKAGE
 
-      - name: Upload Android UI test
+      - name: Upload iOS Render test
         run: |
           curl -T RenderTestApp.ipa '${{ steps.upload-ios-app.outputs.url }}'
           curl -T RenderTest.xctest.zip '${{ steps.upload-ios-test.outputs.url }}'
@@ -68,11 +68,11 @@ jobs:
       - name: Schedule test run
         uses: realm/aws-devicefarm/test-application@master
         with:
-          name: MapLibre Native Android Instrumentation Test
+          name: MapLibre Native iOS Render Test
           project_arn: ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }}
           device_pool_arn: "arn:aws:devicefarm:us-west-2:373521797162:devicepool:20687d72-0e46-403e-8f03-0941850665bc/d84a2883-0000-44b5-afc4-af22084caf85"
           app_arn: ${{ steps.upload-ios-app.outputs.arn }}
-          app_type: ANDROID_APP
+          app_type: IOS_APP
           test_type: INSTRUMENTATION
           test_package_arn: ${{ steps.upload-ios-test.outputs.arn }}
           timeout: 28800

--- a/.github/workflows/ios-render-test.yml
+++ b/.github/workflows/ios-render-test.yml
@@ -73,7 +73,7 @@ jobs:
           device_pool_arn: "arn:aws:devicefarm:us-west-2:373521797162:devicepool:20687d72-0e46-403e-8f03-0941850665bc/d84a2883-0000-44b5-afc4-af22084caf85"
           app_arn: ${{ steps.upload-ios-app.outputs.arn }}
           app_type: IOS_APP
-          test_type: INSTRUMENTATION
+          test_type: XCTEST
           test_package_arn: ${{ steps.upload-ios-test.outputs.arn }}
           timeout: 28800
 

--- a/.github/workflows/ios-render-test.yml
+++ b/.github/workflows/ios-render-test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: .github/actions/download-workflow-run-artifact
+      - uses: ./.github/actions/download-workflow-run-artifact
         with:
           artifact-name: ios-render-test
           expect-files: "RenderTest.xctest.zip, RenderTestApp.ipa"
@@ -21,3 +21,73 @@ jobs:
         with:
           artifact-name: pr-number
           expect-files: "pr_number"
+
+      - run: echo ${{ github.event.workflow_run }}
+
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.MAPLIBRE_NATIVE_BOT_APP_ID }}
+          private_key: ${{ secrets.MAPLIBRE_NATIVE_BOT_PRIVATE_KEY }}
+
+      - uses: LouisBrunner/checks-action@v1.6.1
+        id: create_check
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          status: in_progress
+          name: iOS Render Test
+          sha: ${{ github.event.workflow_run.sha }}
+
+      - name: Configure AWS Credentials
+        if: github.ref == 'refs/heads/main'
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1200
+          role-session-name: MySessionName
+
+      - name: Create upload
+        uses: realm/aws-devicefarm/create-upload@master
+        id: upload-ios-app
+        with:
+          project_arn: ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }}
+          name: RenderTestApp.ipa
+          type: IOS_APP
+
+      - name: Create upload
+        uses: realm/aws-devicefarm/create-upload@master
+        id: upload-ios-test
+        with:
+          project_arn: ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }}
+          name: RenderTest.xctest.zip
+          type: XCTEST_TEST_PACKAGE
+
+      - name: Upload Android UI test
+        if: github.ref == 'refs/heads/main'
+        run: |
+          curl -T RenderTestApp.ipa '${{ steps.upload-ios-app.outputs.url }}'
+          curl -T RenderTest.xctest.zip '${{ steps.upload-ios-test.outputs.url }}'
+
+      - name: Schedule test run
+        uses: realm/aws-devicefarm/test-application@master
+        with:
+          name: MapLibre Native Android Instrumentation Test
+          project_arn: ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }}
+          device_pool_arn: "arn:aws:devicefarm:us-west-2:373521797162:devicepool:20687d72-0e46-403e-8f03-0941850665bc/d84a2883-0000-44b5-afc4-af22084caf85"
+          app_arn: ${{ steps.upload-ios-app.outputs.arn }}
+          app_type: ANDROID_APP
+          test_type: INSTRUMENTATION
+          test_package_arn: ${{ steps.upload-ios-test.outputs.arn }}
+          timeout: 28800
+
+      - uses: LouisBrunner/checks-action@v1.6.1
+        if: always()
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          check_id: ${{ steps.create_check.outputs.check_id }}
+          conclusion: ${{ job.status }}
+          sha: ${{ github.event.workflow_run.sha }}

--- a/.github/workflows/ios-render-test.yml
+++ b/.github/workflows/ios-render-test.yml
@@ -17,11 +17,6 @@ jobs:
           artifact-name: ios-render-test
           expect-files: "RenderTest.xctest.zip, RenderTestApp.ipa"
 
-      - uses: .github/actions/download-workflow-run-artifact
-        with:
-          artifact-name: pr-number
-          expect-files: "pr_number"
-
       - run: echo ${{ github.event.workflow_run }}
 
       - name: Generate token

--- a/.github/workflows/ios-render-test.yml
+++ b/.github/workflows/ios-render-test.yml
@@ -35,7 +35,6 @@ jobs:
           sha: ${{ github.event.workflow_run.sha }}
 
       - name: Configure AWS Credentials
-        if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -62,7 +61,6 @@ jobs:
           type: XCTEST_TEST_PACKAGE
 
       - name: Upload Android UI test
-        if: github.ref == 'refs/heads/main'
         run: |
           curl -T RenderTestApp.ipa '${{ steps.upload-ios-app.outputs.url }}'
           curl -T RenderTest.xctest.zip '${{ steps.upload-ios-test.outputs.url }}'

--- a/.github/workflows/pr-render-test-result.yml
+++ b/.github/workflows/pr-render-test-result.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: .github/actions/download-workflow-run-artifact
+      - uses: ./.github/actions/download-workflow-run-artifact
         with:
           artifact-name: render-test-result
           expect-files: "./pr_number, metrics/linux-gcc8-release-style.html"

--- a/.github/workflows/pr-size-test-result.yml
+++ b/.github/workflows/pr-size-test-result.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: .github/actions/download-workflow-run-artifact
+      - uses: ./.github/actions/download-workflow-run-artifact
         with:
           artifact-name: size-test-result
           expect-files: "./pr_number, ./size"


### PR DESCRIPTION
Closes #942

When the `ios-ci` workflow ran it triggers `ios-render-test` with a `workflow_run`.

Then this workflow fetches a token from the MapLibre Native Bot so it can start a check on the PR.

It is in a separate workflow because we need to have access to the GitHub secrets to upload to AWS Device Farm.

I hope the SHA of the PR commit is available in `${{ github.event.workflow_run.sha }}`. I am printing `${{ github.event.workflow_run }}` for debugging purposes in case it is not. It's not very well documented it seems.  