### PR TITLE
Fix Linux render test CI failure showing up as pass

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -164,14 +164,14 @@ jobs:
         run: xvfb-run -a ./mbgl-render-test-runner --manifestPath=metrics/linux-gcc8-release-style.json
 
       - name: Save PR number
-        if: steps.render_test.outcome != 'skipped'
+        if: steps.render_test.outcome != 'failure'
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           echo $PR_NUMBER > ./pr_number
 
       - name: Upload render test result
-        if: steps.render_test.outcome != 'skipped'
+        if: steps.render_test.outcome != 'failure'
         uses: actions/upload-artifact@v3
         with:
           name: render-test-result

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -164,14 +164,14 @@ jobs:
         run: xvfb-run -a ./mbgl-render-test-runner --manifestPath=metrics/linux-gcc8-release-style.json
 
       - name: Save PR number
-        if: steps.render_test.outcome != 'failure'
+        if: always() && steps.render_test.outcome != 'failure'
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           echo $PR_NUMBER > ./pr_number
 
       - name: Upload render test result
-        if: steps.render_test.outcome != 'failure'
+        if: always() && steps.render_test.outcome != 'failure'
         uses: actions/upload-artifact@v3
         with:
           name: render-test-result

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -160,17 +160,18 @@ jobs:
       - run: chmod +x ./mbgl-render-test-runner
 
       - name: Run render test
-        continue-on-error: true
         id: render_test
         run: xvfb-run -a ./mbgl-render-test-runner --manifestPath=metrics/linux-gcc8-release-style.json
 
       - name: Save PR number
+        if: steps.render_test.outcome != 'skipped'
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           echo $PR_NUMBER > ./pr_number
 
       - name: Upload render test result
+        if: steps.render_test.outcome != 'skipped'
         uses: actions/upload-artifact@v3
         with:
           name: render-test-result

--- a/.github/workflows/pr-render-test-result.yml
+++ b/.github/workflows/pr-render-test-result.yml
@@ -13,11 +13,11 @@ on:
 jobs:
   upload-render-test-result:
     runs-on: ubuntu-22.04
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
     steps:
       - uses: actions/checkout@v3
 
-      - uses: .github/actions/download-workflow-run-artifact
+      - uses: ./.github/actions/download-workflow-run-artifact
         with:
           artifact-name: render-test-result
           expect-files: "./pr_number, metrics/linux-gcc8-release-style.html"


### PR DESCRIPTION
- Don't show a failure as passed.
- Only create artifacts on failure & upload Linux render test results when the render test has failed.