### PR TITLE
Workflows fixes and improvements

### DIFF
--- a/.github/actions/download-workflow-run-artifact/action.yml
+++ b/.github/actions/download-workflow-run-artifact/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
-    - name: 'Download render-test-result artifact'
+    - name: Download ${{ inputs.artifact-name }} artifact
       uses: actions/github-script@v6
       with:
         script: |
@@ -21,8 +21,9 @@ runs:
               run_id: context.payload.workflow_run.id,
           });
           let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-            return artifact.name == ${{ inputs.artifact-name }}
+            return artifact.name == "${{ inputs.artifact-name }}"
           })[0];
+          if (!matchArtifact) throw new Error("Could not find artifact ${{ inputs.artifact-name }}");
           let download = await github.rest.actions.downloadArtifact({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -123,14 +123,6 @@ jobs:
           ccache --max-size=2G
           ccache --show-stats
 
-      - name: Save PR number
-        if: github.event_name == 'pull_request'
-        working-directory: ./
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          echo $PR_NUMBER > ./pr_number
-
       - name: Check debug symbols
         run: make darwin-check-public-symbols
 
@@ -161,15 +153,7 @@ jobs:
           name: size-test-result
           path: |
             ./size
-            ./pr_number
 
-      - name: Upload PR number
-        uses: actions/upload-artifact@v3
-        with:
-          name: pr-number
-          path: |
-            ./pr_number
-      
       # render test
 
       - name: Build RenderTest .ipa and .xctest for AWS Device Farm

--- a/.github/workflows/ios-render-test.yml
+++ b/.github/workflows/ios-render-test.yml
@@ -17,7 +17,6 @@ jobs:
           artifact-name: ios-render-test
           expect-files: "RenderTest.xctest.zip, RenderTestApp.ipa"
 
-      - run: echo ${{ github.event.workflow_run }}
 
       - name: Generate token
         id: generate_token
@@ -32,7 +31,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
           status: in_progress
           name: iOS Render Test
-          sha: ${{ github.event.workflow_run.sha }}
+          sha: ${{ github.event.workflow_run.head_sha }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -163,21 +163,13 @@ jobs:
         id: render_test
         run: xvfb-run -a ./mbgl-render-test-runner --manifestPath=metrics/linux-gcc8-release-style.json
 
-      - name: Save PR number
-        if: always() && steps.render_test.outcome != 'failure'
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          echo $PR_NUMBER > ./pr_number
-
       - name: Upload render test result
-        if: always() && steps.render_test.outcome != 'failure'
+        if: always() && steps.render_test.outcome == 'failure'
         uses: actions/upload-artifact@v3
         with:
           name: render-test-result
           path: |
             metrics/linux-gcc8-release-style.html
-            ./pr_number
 
   coverage:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr-render-test-result.yml
+++ b/.github/workflows/pr-render-test-result.yml
@@ -13,14 +13,14 @@ on:
 jobs:
   upload-render-test-result:
     runs-on: ubuntu-22.04
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
+    if: github.event.workflow_run.event == 'pull_request'
     steps:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/download-workflow-run-artifact
         with:
           artifact-name: render-test-result
-          expect-files: "./pr_number, metrics/linux-gcc8-release-style.html"
+          expect-files: "metrics/linux-gcc8-release-style.html"
   
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -36,12 +36,10 @@ jobs:
             s3://maplibre-native-test-artifacts/${{ github.run_id	}}-linux-gcc8-release-style.html \
             --expires "$(date -d '+30 days' --utc +'%Y-%m-%dT%H:%M:%SZ')"
 
-      - run: echo pr_number="$(cat ./pr_number)" >> "$GITHUB_ENV"
-
       - name: 'Leave comment on PR with test results'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: render-test-result
-          number: ${{ env.pr_number }}
+          number: ${{ github.event.workflow_run.pull_requests[0].number }}
           message: |
             Render test results at https://maplibre-native-test-artifacts.s3.eu-central-1.amazonaws.com/${{ github.run_id }}-linux-gcc8-release-style.html

--- a/.github/workflows/pr-size-test-result.yml
+++ b/.github/workflows/pr-size-test-result.yml
@@ -15,10 +15,7 @@ jobs:
       - uses: ./.github/actions/download-workflow-run-artifact
         with:
           artifact-name: size-test-result
-          expect-files: "./pr_number, ./size"
-
-      - name: Show directory structure
-        run: ls -R
+          expect-files: "./size"
 
       # Move ./size artifact to ./size_main and store as cache
     
@@ -44,7 +41,6 @@ jobs:
           key: ios-size
 
       - run: |
-          echo pr_number="$(cat ./pr_number)" >> "$GITHUB_ENV"
           echo old_size="$(cat ./size_main)" >> "$GITHUB_ENV"
           echo new_size="$(cat ./size)" >> "$GITHUB_ENV"
           echo percentage_change=$(awk 'NR==FNR{a=$0;next}{printf "%+.2f%%\n", 100*($0-a)/a}' ./size ./size_main) >> "$GITHUB_ENV"
@@ -55,7 +51,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: size-test-result
-          number: ${{ env.pr_number }}
+          number: ${{ github.event.workflow_run.pull_requests[0].number }}
           message: |
             ### Size test result
 


### PR DESCRIPTION
- Use `github.event.workflow_run.head_sha` instead of `github.event.workflow_run.sha`
- Fix action that downloads artifacts from workflow that triggered a `workflow_run` workflow
- Use `github.event.workflow_run.pull_requests[0].number` instead of writing a PR number to a artifact (the latter is somehow recommended by the GitHub docs)