### PR TITLE
Windows: protect WGLDisplayConfig from being created multiple times by different threads

### DIFF
--- a/platform/windows/src/headless_backend_wgl.cpp
+++ b/platform/windows/src/headless_backend_wgl.cpp
@@ -196,15 +196,10 @@ public:
 
     ~WGLDisplayConfig() { UnregisterClassA(renderingWindowClass.lpszClassName, renderingWindowClass.hInstance); }
 
-    static std::shared_ptr<WGLDisplayConfig> create() {
-        static std::weak_ptr<WGLDisplayConfig> instance;
-        auto shared = instance.lock();
+    static WGLDisplayConfig& create() {
+        static WGLDisplayConfig instance = WGLDisplayConfig{Key{}};
 
-        if (!shared) {
-            instance = shared = std::make_shared<WGLDisplayConfig>(Key{});
-        }
-
-        return shared;
+        return instance;
     }
 
 public:
@@ -219,7 +214,7 @@ public:
 
 class WGLBackendImpl final : public HeadlessBackend::Impl {
 private:
-    std::shared_ptr<WGLDisplayConfig> wglDisplayConfig = WGLDisplayConfig::create();
+    WGLDisplayConfig& wglDisplayConfig = WGLDisplayConfig::create();
 
     HWND renderingWindowHandle = NULL;
     HDC renderingWindowDeviceContext = NULL;
@@ -230,7 +225,7 @@ private:
         MSG message;
 
         renderingWindowHandle = CreateWindowExA(0,
-                                                wglDisplayConfig->renderingWindowClass.lpszClassName,
+                                                wglDisplayConfig.renderingWindowClass.lpszClassName,
                                                 "WGL Render Window",
                                                 WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
                                                 0,
@@ -239,7 +234,7 @@ private:
                                                 1,
                                                 NULL,
                                                 NULL,
-                                                wglDisplayConfig->renderingWindowClass.hInstance,
+                                                wglDisplayConfig.renderingWindowClass.hInstance,
                                                 NULL);
 
         if (!renderingWindowHandle) {
@@ -330,7 +325,7 @@ private:
             throw std::runtime_error("Failed to set pixel format for context");
         }
 
-        if (wglDisplayConfig->ARB_create_context) {
+        if (wglDisplayConfig.ARB_create_context) {
             renderingWindowRenderingContext = mbgl::platform::wglCreateContextAttribsARB(
                 renderingWindowDeviceContext,
                 NULL,


### PR DESCRIPTION
Usually when using a single map instance, `WGLDisplayConfig` singleton is created only once when the rendering thread tries to access it. But when multiple rendering threads (each one with its own instance of map) try to access the singleton, it may be created multiple times. So this PR protects the creation of `WGLDisplayConfig` with a mutex, so it gets created only once, like it should.