### PR TITLE
Disable location-indicator query-test on iOS

### DIFF
--- a/metrics/ignores/platform-ios.json
+++ b/metrics/ignores/platform-ios.json
@@ -24,5 +24,6 @@
     "location_indicator/tilted_texture_shift_bottom_right": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
     "location_indicator/tilted_texture_shift_top_left": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
     "location_indicator/tilted_texture_shift_top_right": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
-    "location_indicator/two_textures": "https://github.com/mapbox/mapbox-gl-native/issues/16401"
+    "location_indicator/two_textures": "https://github.com/mapbox/mapbox-gl-native/issues/16401",
+    "location_indicator/query_test": "https://github.com/maplibre/maplibre-native/issues/1405"
 }

--- a/render-test/ios/iosTestRunner.mm
+++ b/render-test/ios/iosTestRunner.mm
@@ -69,13 +69,13 @@
 
         BOOL fileFound = [fileManager fileExistsAtPath: self.styleResultPath];
         if (fileFound == NO) {
-            NSLog(@"Style test result file '%@' doese not exit ", self.styleResultPath);
+            NSLog(@"Style test result file '%@' does not exit ", self.styleResultPath);
             self.testStatus = NO;
         }
 
         fileFound = [fileManager fileExistsAtPath: self.metricResultPath];
         if (fileFound == NO) {
-            NSLog(@"Metric test result file '%@' doese not exit ", self.metricResultPath);
+            NSLog(@"Metric test result file '%@' does not exit ", self.metricResultPath);
             self.testStatus = NO;
         }
 
@@ -96,7 +96,7 @@
             }
         }
         else {
-           NSLog(@"Metric path '%@' doese not exit ", rebaselinePath);
+           NSLog(@"Metric path '%@' does not exit ", rebaselinePath);
         }
 
         if (needArchiving) {
@@ -110,7 +110,7 @@
                     progressHandler:nil];
 
             if (success) {
-                NSLog(@"Successfully archive all of the metrics into metrics.zip");
+                NSLog(@"Successfully archived all of the metrics into metrics.zip");
                 self.metricPath =  archivePath;
             }
             else {

--- a/render-test/render_test.cpp
+++ b/render-test/render_test.cpp
@@ -168,7 +168,6 @@ int runRenderTests(int argc, char** argv, std::function<void()> testStatus) {
     TestStatistics stats;
 
     for (auto& testPath : testPaths) {
-        std::cout << "Running tests from " << testPath.stylePath << std::endl;
         TestMetadata metadata = parseTestMetadata(testPath);
 
         if (!recycleMap) {

--- a/render-test/render_test.cpp
+++ b/render-test/render_test.cpp
@@ -14,6 +14,7 @@
 #include "parser.hpp"
 #include "runner.hpp"
 
+#ifdef SHOW_ANSI_COLORS
 #define ANSI_COLOR_RED "\x1b[31m"
 #define ANSI_COLOR_GREEN "\x1b[32m"
 #define ANSI_COLOR_YELLOW "\x1b[33m"
@@ -23,6 +24,17 @@
 #define ANSI_COLOR_GRAY "\x1b[37m"
 #define ANSI_COLOR_LIGHT_GRAY "\x1b[90m"
 #define ANSI_COLOR_RESET "\x1b[0m"
+#else
+#define ANSI_COLOR_RED ""
+#define ANSI_COLOR_GREEN ""
+#define ANSI_COLOR_YELLOW ""
+#define ANSI_COLOR_BLUE ""
+#define ANSI_COLOR_MAGENTA ""
+#define ANSI_COLOR_CYAN ""
+#define ANSI_COLOR_GRAY ""
+#define ANSI_COLOR_LIGHT_GRAY ""
+#define ANSI_COLOR_RESET ""
+#endif
 
 #if !defined(SANITIZE)
 void* operator new(std::size_t sz) {
@@ -51,7 +63,7 @@ ArgumentsTuple parseArguments(int argc, char** argv) {
         {"metrics", TestRunner::UpdateResults::METRICS},
         {"rebaseline", TestRunner::UpdateResults::REBASELINE}};
 
-    args::ArgumentParser argumentParser("Mapbox GL Test Runner");
+    args::ArgumentParser argumentParser("MapLibre Native Test Runner");
 
     args::HelpFlag helpFlag(argumentParser, "help", "Display this help menu", {'h', "help"});
 
@@ -156,6 +168,7 @@ int runRenderTests(int argc, char** argv, std::function<void()> testStatus) {
     TestStatistics stats;
 
     for (auto& testPath : testPaths) {
+        std::cout << "Running tests from " << testPath.stylePath << std::endl;
         TestMetadata metadata = parseTestMetadata(testPath);
 
         if (!recycleMap) {


### PR DESCRIPTION
The instrumented render test has one failure. https://github.com/maplibre/maplibre-native/issues/1405

Adding to `metrics/ignores/platform-ios.json` until we get around to fixing it.