### PR TITLE
Change upload creation iOS render test

### DIFF
--- a/.github/workflows/ios-render-test.yml
+++ b/.github/workflows/ios-render-test.yml
@@ -29,6 +29,7 @@ jobs:
         id: create_check
         with:
           token: ${{ steps.generate_token.outputs.token }}
+          details_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status: in_progress
           name: iOS Render Test
           sha: ${{ github.event.workflow_run.head_sha }}
@@ -43,37 +44,39 @@ jobs:
           role-duration-seconds: 1200
           role-session-name: MySessionName
 
-      - name: Create upload
-        uses: realm/aws-devicefarm/create-upload@master
-        id: upload-ios-app
-        with:
-          project_arn: ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }}
-          name: RenderTestApp.ipa
-          type: IOS_APP
+      - name: Create upload app
+        run: |
+          response=$(aws devicefarm create-upload --type IOS_APP --name RenderTestApp.ipa --project-arn ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }})
+          echo "$response"
+          arn="$(jq -r '.upload.arn' <<< "$response")"
+          url="$(jq -r '.upload.url' <<< "$response")"
+          echo "app_arn=$arn" >> "$GITHUB_ENV"
+          echo "app_url=$url" >> "$GITHUB_ENV"
 
-      - name: Create upload
-        uses: realm/aws-devicefarm/create-upload@master
-        id: upload-ios-test
-        with:
-          project_arn: ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }}
-          name: RenderTest.xctest.zip
-          type: XCTEST_TEST_PACKAGE
+      - name: Create upload test package
+        run: |
+          response=$(aws devicefarm create-upload --type XCTEST_TEST_PACKAGE --name RenderTest.xctest.zip --project-arn ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }})
+          echo "$response"
+          arn="$(jq -r '.upload.arn' <<< "$response")"
+          url="$(jq -r '.upload.url' <<< "$response")"
+          echo "test_package_arn=$arn" >> "$GITHUB_ENV"
+          echo "test_package_url=$url" >> "$GITHUB_ENV"
 
       - name: Upload iOS Render test
         run: |
-          curl -T RenderTestApp.ipa '${{ steps.upload-ios-app.outputs.url }}'
-          curl -T RenderTest.xctest.zip '${{ steps.upload-ios-test.outputs.url }}'
+          curl -T RenderTestApp.ipa "${{ env.app_url }}"
+          curl -T RenderTest.xctest.zip "${{ env.test_package_url }}"
 
       - name: Schedule test run
         uses: realm/aws-devicefarm/test-application@master
         with:
           name: MapLibre Native iOS Render Test
           project_arn: ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }}
-          device_pool_arn: "arn:aws:devicefarm:us-west-2:373521797162:devicepool:20687d72-0e46-403e-8f03-0941850665bc/d84a2883-0000-44b5-afc4-af22084caf85"
-          app_arn: ${{ steps.upload-ios-app.outputs.arn }}
+          device_pool_arn: ${{ vars.AWS_DEVICE_FARM_IPHONE_DEVICE_POOL_ARN }}
+          app_arn: ${{ env.app_arn }}
           app_type: IOS_APP
           test_type: XCTEST
-          test_package_arn: ${{ steps.upload-ios-test.outputs.arn }}
+          test_package_arn: ${{ env.test_package_arn }}
           timeout: 28800
 
       - uses: LouisBrunner/checks-action@v1.6.1


### PR DESCRIPTION
Use the AWS CLI to prepare uploads for the iOS render test. I think I am going to move away from the `realm/aws-devicefarm/create-upload` Action. It does not seem to be well maintained and it's an abstraction layer that makes debugging harder. 

In particular I am seeing:

> Error: ArgumentException: Missing or unprocessed resources

as can be seen here: https://github.com/maplibre/maplibre-native/actions/runs/5643456646/job/15285555942

When I use 

```
aws devicefarm list-uploads --no-paginate --arn  ...
```


I can see that the uploads are not set up even though the Action reports no failure.

Using

```
aws devicefarm create-upload
```

works fine.

I also created a new `AWS_DEVICE_FARM_IPHONE_DEVICE_POOL_ARN` variable tied to the repo which contains the ARN of the Device Pool that we are using (right now just one iPhone 14 Pro).