### PR TITLE
Install actionlint (GitHub Action workflow linter)

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -209,7 +209,7 @@ jobs:
     needs: build
 
     runs-on: ubuntu-latest
-    if: secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY
+    if: github.repository_owner == 'maplibre'
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -117,8 +117,8 @@ jobs:
         run: |
           RELEASE_NOTES_PATH="${PWD}/release_notes.txt"
           ./scripts/release-notes.js > ${RELEASE_NOTES_PATH}
-          echo ::set-output name=release_notes::${RELEASE_NOTES_PATH}
-          echo ::set-output name=version_tag::$( git describe --tags --match=android-v*.*.* --abbrev=0 )
+          echo release_notes=${RELEASE_NOTES_PATH} >> "$GITHUB_OUTPUT"
+          echo version_tag=$( git describe --tags --match=android-v*.*.* --abbrev=0 ) >> "$GITHUB_OUTPUT"
         shell: bash          
 
       - name: Create release

--- a/.github/workflows/gh-pages-ios-api.yml
+++ b/.github/workflows/gh-pages-ios-api.yml
@@ -22,48 +22,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Install macos dependencies
-        run: |
-          brew list cmake || brew install cmake
-          brew list ccache || brew install ccache
-          brew list pkg-config || brew install pkg-config
-          brew list glfw3 || brew install glfw3
-
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: /user/local/lib/node_modules
-          key: ${{ runner.macos }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.macos }}-build-${{ env.cache-name }}-
-            ${{ runner.macos }}-build-
-            ${{ runner.macos }}-
-
       - name: npm install
         run: npm install --ignore-scripts
 
       - name: Prepare ccache
         run: ccache --clear
-
-      - name: Cache ccache
-        uses: actions/cache@v3
-        env:
-          cache-name: ccache-v1
-        with:
-          path: ~/.ccache'
-          key: ${{ env.cache-name }}-${{ runner.macos }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}-${{ github.head_ref }}
-          restore-keys: |
-            ${{ env.cache-name }}-${{ runner.macos }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}
-            ${{ env.cache-name }}-${{ runner.macos }}-${{ github.job }}-${{ github.ref }}
-            ${{ env.cache-name }}-${{ runner.macos }}-${{ github.job }}
-
-      - name: Clear ccache statistics
-        run: |
-          ccache --zero-stats
-          ccache --max-size=2G
-          ccache --show-stats
 
       - name: Build docs
         run: make idocument

--- a/.github/workflows/ios-pre-release.yml
+++ b/.github/workflows/ios-pre-release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     #runs-on: macos-12
-    runs-on: [self-hosted, petr]
+    runs-on: [self-hosted]
     env:
       BUILDTYPE: Release
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/ios-render-test.yml
+++ b/.github/workflows/ios-render-test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ios-render-test:
     runs-on: ubuntu-22.04
-    if: secrets.MAPLIBRE_NATIVE_BOT_APP_ID
+    if: github.repository_owner == 'maplibre'
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -71,52 +71,12 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Install macos dependencies
-        run: |
-          brew list cmake || brew install cmake
-          brew list ccache || brew install ccache
-          brew list pkg-config || brew install pkg-config
-          brew list glfw || brew install glfw
-
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: /user/local/lib/node_modules
-          key: ${{ runner.macos }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.macos }}-build-${{ env.cache-name }}-
-            ${{ runner.macos }}-build-
-            ${{ runner.macos }}-
-
       - uses: actions/setup-node@v3
         with:
           node-version: 18
       
       - name: npm install
         run: npm ci --ignore-scripts
-
-      - name: Prepare ccache
-        run: ccache --clear
-
-      - name: Cache ccache
-        uses: actions/cache@v3
-        env:
-          cache-name: ccache-v1
-        with:
-          path: ~/.ccache'
-          key: ${{ env.cache-name }}-${{ runner.macos }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}-${{ github.head_ref }}
-          restore-keys: |
-            ${{ env.cache-name }}-${{ runner.macos }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}
-            ${{ env.cache-name }}-${{ runner.macos }}-${{ github.job }}-${{ github.ref }}
-            ${{ env.cache-name }}-${{ runner.macos }}-${{ github.job }}
-
-      - name: Clear ccache statistics
-        run: |
-          ccache --zero-stats
-          ccache --max-size=2G
-          ccache --show-stats
 
       - name: Run macOS Objective-C tests
         run: |

--- a/.github/workflows/node-ci-mac.yml
+++ b/.github/workflows/node-ci-mac.yml
@@ -73,8 +73,6 @@ jobs:
         include:
           - runs-on: macos-12
             arch: x86_64
-          - runs-on: macos-12-arm
-            arch: arm64
     continue-on-error: true
     env:
       BUILDTYPE: 'Release'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,10 @@ repos:
   rev: 6.1.0.2
   hooks:
     - id: buildifier
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.6.25
+  hooks:
+    - id: actionlint
 ci:
   # sometimes fails https://github.com/keith/pre-commit-buildifier/issues/13
   skip: [buildifier]


### PR DESCRIPTION
This PR adds [actionlint](https://github.com/rhysd/actionlint/tree/main) to the pre-commit hooks.

That is, type checking for the GitHub Actions workflows, detecting deprecated actions, that kind of thing. Very useful.

Had to fix up some workflows.

- I removed  ccache for iOS because we don't need it anymore with Bazel.
- I removed the `macos-12-arm` runner reference because it does not exist. https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.
- I removed caching of the global node_modules for the self-hosted runner.
- I removed installing the macOS dependencies with brew because we set up the self-hosted runner with https://github.com/maplibre/ci-runners
- I use `$GITHUB_OUTPUT` because the other syntax is deprecated.