### PR TITLE
Use Bazel to build XCFramework for release

### DIFF
--- a/platform/BUILD.bazel
+++ b/platform/BUILD.bazel
@@ -146,8 +146,8 @@ objc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//:objc-sdk",
-        "//:objcpp-sdk",
+        ":objc-sdk",
+        ":objcpp-sdk",
     ],
 )
 

--- a/platform/ios/scripts/swift_package_template.swift
+++ b/platform/ios/scripts/swift_package_template.swift
@@ -13,7 +13,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Mapbox",
-            url: "MAPBOX_PACKAGE_URL",
-            checksum: "MAPBOX_PACKAGE_CHECKSUM")
+            url: "MAPLIBRE_PACKAGE_URL",
+            checksum: "MAPLIBRE_PACKAGE_CHECKSUM")
     ]
 )


### PR DESCRIPTION
- Get rid of S3 distribution
- Use Bazel to create the XCFramework instead of the bespoke [xcpackage.sh](https://github.com/maplibre/maplibre-native/blob/main/platform/ios/scripts/xcpackage.sh)

I'll try making a pre-release once this is merged to test it.

Closes #1430