### PR TITLE
Removed public texture resource from texture 2d class

### DIFF
--- a/include/mbgl/gfx/texture2d.hpp
+++ b/include/mbgl/gfx/texture2d.hpp
@@ -102,11 +102,6 @@ public:
     /// @see needsUpload
     virtual void upload() noexcept = 0;
 
-    /// @brief Get the underlying GL texture resource
-    /// @note: Compat with legacy textures, to be refactored
-    /// @return gfx::TextureResource
-    virtual gfx::TextureResource& getResource() const = 0;
-
     /// @brief Check whether the texture needs upload
     virtual bool needsUpload() const noexcept = 0;
 };

--- a/include/mbgl/gl/texture2d.hpp
+++ b/include/mbgl/gl/texture2d.hpp
@@ -40,11 +40,6 @@ public: // gfx::Texture2D
     void uploadSubRegion(const void* pixelData, const Size& size, uint16_t xOffset, uint16_t yOffset) noexcept override;
     void upload() noexcept override;
 
-    gfx::TextureResource& getResource() const override {
-        assert(textureResource);
-        return *textureResource;
-    }
-
     bool needsUpload() const noexcept override { return !!image; };
 
 public:

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -222,24 +222,17 @@ void DashPatternTexture::upload(gfx::UploadPass& uploadPass) {
 #endif
 }
 
+#if MLN_LEGACY_RENDERER
 gfx::TextureBinding DashPatternTexture::textureBinding() const {
     // The texture needs to have been uploaded already.
-#if MLN_DRAWABLE_RENDERER
-    assert(std::holds_alternative<gfx::Texture2DPtr>(texture));
-    return {std::get<gfx::Texture2DPtr>(texture)->getResource(),
-            gfx::TextureFilterType::Linear,
-            gfx::TextureMipMapType::No,
-            gfx::TextureWrapType::Repeat,
-            gfx::TextureWrapType::Clamp};
-#else
     assert(texture.is<gfx::Texture>());
     return {texture.get<gfx::Texture>().getResource(),
             gfx::TextureFilterType::Linear,
             gfx::TextureMipMapType::No,
             gfx::TextureWrapType::Repeat,
             gfx::TextureWrapType::Clamp};
-#endif
 }
+#endif
 
 #if MLN_DRAWABLE_RENDERER
 static const gfx::Texture2DPtr noTexture;

--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -51,9 +51,10 @@ public:
     void upload(gfx::UploadPass&);
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
-    gfx::TextureBinding textureBinding() const;
 #if MLN_DRAWABLE_RENDERER
     const std::shared_ptr<gfx::Texture2D>& getTexture() const;
+#else
+    gfx::TextureBinding textureBinding() const;
 #endif
 
     // Returns the size of the texture image.

--- a/src/mbgl/gfx/upload_pass.hpp
+++ b/src/mbgl/gfx/upload_pass.hpp
@@ -127,28 +127,6 @@ public:
         updateTextureResourceSub(texture.getResource(), offsetX, offsetY, image.size, image.data.get(), format, type);
     }
 
-#if MLN_DRAWABLE_RENDERER
-    template <typename Image>
-    void updateTexture(Texture2D& texture,
-                       const Image& image,
-                       TextureChannelDataType type = TextureChannelDataType::UnsignedByte) {
-        const auto format = image.channels == 4 ? TexturePixelType::RGBA : TexturePixelType::Alpha;
-        updateTexture2D(texture, image.size, image.data.get(), format, type);
-    }
-
-    template <typename Image>
-    void updateTextureSub(Texture2D& texture,
-                          const Image& image,
-                          const uint16_t offsetX,
-                          const uint16_t offsetY,
-                          TextureChannelDataType type = TextureChannelDataType::UnsignedByte) {
-        assert(image.size.width + offsetX <= texture.getSize().width);
-        assert(image.size.height + offsetY <= texture.getSize().height);
-        const auto format = image.channels == 4 ? TexturePixelType::RGBA : TexturePixelType::Alpha;
-        updateTextureResourceSub(texture.getResource(), offsetX, offsetY, image.size, image.data.get(), format, type);
-    }
-#endif
-
 public:
     virtual std::unique_ptr<TextureResource> createTextureResource(Size,
                                                                    const void* data,

--- a/src/mbgl/renderer/pattern_atlas.cpp
+++ b/src/mbgl/renderer/pattern_atlas.cpp
@@ -107,18 +107,14 @@ void PatternAtlas::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
     dirty = false;
 }
 
+#if MLN_LEGACY_RENDERER
 // @note: Deprecated
 gfx::TextureBinding PatternAtlas::textureBinding() const {
-#if MLN_DRAWABLE_RENDERER
-    assert(atlasTexture2D);
-    assert(!dirty);
-    return {atlasTexture2D->getResource(), gfx::TextureFilterType::Linear};
-#else
     assert(atlasTexture);
     assert(!dirty);
     return {atlasTexture->getResource(), gfx::TextureFilterType::Linear};
-#endif
 }
+#endif
 
 #if MLN_DRAWABLE_RENDERER
 const std::shared_ptr<gfx::Texture2D>& PatternAtlas::texture() const {

--- a/src/mbgl/renderer/pattern_atlas.hpp
+++ b/src/mbgl/renderer/pattern_atlas.hpp
@@ -32,9 +32,10 @@ public:
     std::optional<ImagePosition> addPattern(const style::Image::Impl&);
     void removePattern(const std::string&);
 
-    gfx::TextureBinding textureBinding() const; // @TODO: Migrate
 #if MLN_DRAWABLE_RENDERER
     const std::shared_ptr<gfx::Texture2D>& texture() const;
+#else
+    gfx::TextureBinding textureBinding() const; // @TODO: Migrate
 #endif
 
     void upload(gfx::UploadPass&);

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -107,22 +107,12 @@ const gfx::Texture2DPtr& RenderTile::getGlyphAtlasTexture() const {
     return renderData ? renderData->getGlyphAtlasTexture() : noTexture;
 }
 
-gfx::TextureBinding RenderTile::getGlyphAtlasTextureBinding(gfx::TextureFilterType filter) const {
-    assert(renderData && renderData->getGlyphAtlasTexture());
-    return {getGlyphAtlasTexture()->getResource(), filter};
-}
-
 bool RenderTile::hasIconAtlasTexture() const {
     return renderData && renderData->getIconAtlasTexture();
 }
 
 const gfx::Texture2DPtr& RenderTile::getIconAtlasTexture() const {
     return renderData ? renderData->getIconAtlasTexture() : noTexture;
-}
-
-gfx::TextureBinding RenderTile::getIconAtlasTextureBinding(gfx::TextureFilterType filter) const {
-    assert(renderData && renderData->getIconAtlasTexture());
-    return {getIconAtlasTexture()->getResource(), filter};
 }
 
 static const std::shared_ptr<TileAtlasTextures> noAtlas;

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -65,11 +65,9 @@ public:
 #if MLN_DRAWABLE_RENDERER
     bool hasGlyphAtlasTexture() const;
     const gfx::Texture2DPtr& getGlyphAtlasTexture() const;
-    gfx::TextureBinding getGlyphAtlasTextureBinding(gfx::TextureFilterType) const;
 
     bool hasIconAtlasTexture() const;
     const gfx::Texture2DPtr& getIconAtlasTexture() const;
-    gfx::TextureBinding getIconAtlasTextureBinding(gfx::TextureFilterType) const;
 
     const std::shared_ptr<TileAtlasTextures>& getAtlasTextures() const;
 #else


### PR DESCRIPTION
I made this change on the metal branch, but I was thinking to add it now instead keeping it as a metal change.

Note: This change will break `flavor split`.
