### PR TITLE
Drawable PR 3 - Layers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,8 @@ load(
     "//bazel:core.bzl",
     "MLN_CORE_HEADERS",
     "MLN_CORE_SOURCE",
+    "MLN_DRAWABLES_SOURCE",
+    "MLN_DRAWABLES_HEADERS",
     "MLN_GENERATED_SHADER_HEADERS",
     "MLN_GENERATED_STYLE_SOURCE",
     "MLN_OPENGL_HEADERS",
@@ -78,11 +80,33 @@ cc_library(
     name = "mbgl-core",
     srcs = MLN_CORE_SOURCE +
            MLN_GENERATED_STYLE_SOURCE +
-           MLN_OPENGL_SOURCE,
+           MLN_OPENGL_SOURCE + select({
+            ":drawable_renderer": MLN_DRAWABLES_SOURCE,
+            ":split_renderer": MLN_DRAWABLES_SOURCE,
+            "//conditions:default": [],
+        }),
     hdrs = MLN_CORE_HEADERS +
-           MLN_OPENGL_HEADERS,
+           MLN_OPENGL_HEADERS + select({
+            ":drawable_renderer": MLN_DRAWABLES_HEADERS,
+            ":split_renderer": MLN_DRAWABLES_HEADERS,
+            "//conditions:default": []
+        }),
     copts = CPP_FLAGS + MAPLIBRE_FLAGS,
     defines = select({
+        ":legacy_renderer": [
+            "MLN_LEGACY_RENDERER=1",
+            "MLN_DRAWABLE_RENDERER=0"
+        ],
+        ":drawable_renderer": [
+            "MLN_LEGACY_RENDERER=0",
+            "MLN_DRAWABLE_RENDERER=1"
+        ],
+        ":split_renderer": [
+            "MLN_LEGACY_RENDERER=1",
+            "MLN_DRAWABLE_RENDERER=1",
+            "MLN_RENDERER_SPLIT_VIEW=1"
+        ],
+    }) + select({
         "//:ios": ["GLES_SILENCE_DEPRECATION=1"],
         "//conditions:default": [],
     }),
@@ -156,6 +180,35 @@ config_setting(
     flag_values = {
         ":maplibre_platform": "windows",
     },
+)
+
+# Selects the rendering implementation to utilize in the core
+
+string_flag(
+    name = "renderer",
+    build_setting_default = "legacy",
+    values=["legacy", "drawable", "split"]
+)
+
+config_setting(
+    name = "legacy_renderer",
+    flag_values = {
+        ":renderer": "legacy"
+    }
+)
+
+config_setting(
+    name = "drawable_renderer",
+        flag_values = {
+        ":renderer": "drawable"
+    }
+)
+
+config_setting(
+    name = "split_renderer",
+    flag_values = {
+        ":renderer": "split"
+    }
 )
 
 exports_files(

--- a/include/mbgl/gfx/drawable_atlases_tweaker.hpp
+++ b/include/mbgl/gfx/drawable_atlases_tweaker.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <mbgl/gfx/drawable_tweaker.hpp>
+
+#include <memory>
+#include <string>
+
+namespace mbgl {
+
+class TileAtlasTextures;
+using TileAtlasTexturesPtr = std::shared_ptr<TileAtlasTextures>;
+
+namespace gfx {
+
+class Drawable;
+
+/**
+ Tweaker that applies the latest values from a retained `TileAtlasTexturesPtr`
+ */
+class DrawableAtlasesTweaker : public gfx::DrawableTweaker {
+public:
+    DrawableAtlasesTweaker(TileAtlasTexturesPtr atlases_, std::string iconName_, std::string glyphName_, bool isText_)
+        : atlases(std::move(atlases_)),
+          iconName(std::move(iconName_)),
+          glyphName(std::move(glyphName_)),
+          isText(isText_) {}
+    ~DrawableAtlasesTweaker() override = default;
+
+    void init(Drawable&) override;
+
+    void execute(Drawable&, const PaintParameters&) override;
+
+protected:
+    void setupTextures(Drawable&);
+
+    TileAtlasTexturesPtr atlases;
+    std::string iconName;
+    std::string glyphName;
+    bool isText;
+};
+
+} // namespace gfx
+} // namespace mbgl

--- a/include/mbgl/gfx/drawable_builder.hpp
+++ b/include/mbgl/gfx/drawable_builder.hpp
@@ -148,7 +148,6 @@ public:
 
     /// Add a triangle
     void addTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2);
-
     /// Add another triangle based on the previous two points
     void appendTriangle(int16_t x0, int16_t y0);
 

--- a/include/mbgl/gfx/drawable_custom_layer_host_tweaker.hpp
+++ b/include/mbgl/gfx/drawable_custom_layer_host_tweaker.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <mbgl/gfx/drawable_tweaker.hpp>
+#include <mbgl/style/layers/custom_layer.hpp>
+
+#include <memory>
+#include <string>
+
+namespace mbgl {
+
+namespace gfx {
+
+class Drawable;
+
+/**
+ Tweaker that enables drawing a CustomLayer via their CustomLayerHost
+ */
+class DrawableCustomLayerHostTweaker : public gfx::DrawableTweaker {
+public:
+    DrawableCustomLayerHostTweaker(std::shared_ptr<style::CustomLayerHost> host_)
+        : host(host_) {}
+    ~DrawableCustomLayerHostTweaker() override = default;
+
+    void init(Drawable&) override{};
+
+    void execute(Drawable&, const PaintParameters&) override;
+
+protected:
+    std::shared_ptr<style::CustomLayerHost> host;
+};
+
+} // namespace gfx
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_background.hpp
+++ b/include/mbgl/shaders/gl/drawable_background.hpp
@@ -1,0 +1,35 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::BackgroundShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "BackgroundShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
+layout (std140) uniform BackgroundDrawableUBO {
+    highp mat4 u_matrix;
+};
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+}
+)";
+    static constexpr const char* fragment = R"(layout (std140) uniform BackgroundLayerUBO {
+    highp vec4 u_color;
+    highp vec4 u_opacity_pad3;
+};
+
+void main() {
+    fragColor = u_color * u_opacity_pad3.x;
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_background_pattern.hpp
+++ b/include/mbgl/shaders/gl/drawable_background_pattern.hpp
@@ -1,0 +1,85 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::BackgroundPatternShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "BackgroundPatternShader";
+    static constexpr const char* vertex = R"(layout (std140) uniform BackgroundDrawableUBO {
+    highp mat4 u_matrix;
+};
+layout (std140) uniform BackgroundLayerUBO {
+    highp vec2 u_pattern_tl_a;
+    highp vec2 u_pattern_br_a;
+    highp vec2 u_pattern_tl_b;
+    highp vec2 u_pattern_br_b;
+    highp vec2 u_texsize;
+    highp vec2 u_pattern_size_a;
+    highp vec2 u_pattern_size_b;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp float u_tile_units_to_pixels;
+    highp float u_scale_a;
+    highp float u_scale_b;
+    highp float u_mix;
+    highp float u_opacity;
+    highp float pad;
+};
+
+layout (location = 0) in vec2 a_pos;
+out mediump vec2 v_pos_a;
+out mediump vec2 v_pos_b;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+
+    v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, u_scale_a * u_pattern_size_a, u_tile_units_to_pixels, a_pos);
+    v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, u_scale_b * u_pattern_size_b, u_tile_units_to_pixels, a_pos);
+}
+)";
+    static constexpr const char* fragment = R"(layout (std140) uniform BackgroundLayerUBO {
+    highp vec2 u_pattern_tl_a;
+    highp vec2 u_pattern_br_a;
+    highp vec2 u_pattern_tl_b;
+    highp vec2 u_pattern_br_b;
+    highp vec2 u_texsize;
+    highp vec2 u_pattern_size_a;
+    highp vec2 u_pattern_size_b;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp float u_tile_units_to_pixels;
+    highp float u_scale_a;
+    highp float u_scale_b;
+    highp float u_mix;
+    highp float u_opacity;
+    highp float pad;
+};
+
+uniform sampler2D u_image;
+
+in mediump vec2 v_pos_a;
+in mediump vec2 v_pos_b;
+
+void main() {
+    vec2 imagecoord = mod(v_pos_a, 1.0);
+    vec2 pos = mix(u_pattern_tl_a / u_texsize, u_pattern_br_a / u_texsize, imagecoord);
+    vec4 color1 = texture(u_image, pos);
+
+    vec2 imagecoord_b = mod(v_pos_b, 1.0);
+    vec2 pos2 = mix(u_pattern_tl_b / u_texsize, u_pattern_br_b / u_texsize, imagecoord_b);
+    vec4 color2 = texture(u_image, pos2);
+
+    fragColor = mix(color1, color2, u_mix) * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_circle.hpp
+++ b/include/mbgl/shaders/gl/drawable_circle.hpp
@@ -1,0 +1,237 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::CircleShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "CircleShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
+out vec3 v_data;
+
+layout (std140) uniform CircleDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_extrude_scale;
+    lowp vec2 pad2_;
+};
+
+layout (std140) uniform CirclePaintParamsUBO {
+    highp float u_camera_to_center_distance;
+    lowp float u_device_pixel_ratio;
+    lowp vec2 pad3_;
+};
+
+layout (std140) uniform CircleEvaluatedPropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_stroke_color;
+    mediump float u_radius;
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_stroke_width;
+    lowp float u_stroke_opacity;
+    bool u_scale_with_map;
+    bool u_pitch_with_map;
+    lowp float pad0_;
+};
+
+layout (std140) uniform CircleInterpolateUBO {
+    lowp float u_color_t;
+    lowp float u_radius_t;
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_stroke_color_t;
+    lowp float u_stroke_width_t;
+    lowp float u_stroke_opacity_t;
+    lowp float pad1_;
+};
+
+#ifndef HAS_UNIFORM_u_color
+layout (location = 1) in highp vec4 a_color;
+out highp vec4 color;
+#endif
+#ifndef HAS_UNIFORM_u_radius
+layout (location = 2) in mediump vec2 a_radius;
+out mediump float radius;
+#endif
+#ifndef HAS_UNIFORM_u_blur
+layout (location = 3) in lowp vec2 a_blur;
+out lowp float blur;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 4) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_stroke_color
+layout (location = 5) in highp vec4 a_stroke_color;
+out highp vec4 stroke_color;
+#endif
+#ifndef HAS_UNIFORM_u_stroke_width
+layout (location = 6) in mediump vec2 a_stroke_width;
+out mediump float stroke_width;
+#endif
+#ifndef HAS_UNIFORM_u_stroke_opacity
+layout (location = 7) in lowp vec2 a_stroke_opacity;
+out lowp float stroke_opacity;
+#endif
+
+void main(void) {
+    #ifndef HAS_UNIFORM_u_color
+color = unpack_mix_color(a_color, u_color_t);
+#else
+highp vec4 color = u_color;
+#endif
+    #ifndef HAS_UNIFORM_u_radius
+radius = unpack_mix_vec2(a_radius, u_radius_t);
+#else
+mediump float radius = u_radius;
+#endif
+    #ifndef HAS_UNIFORM_u_blur
+blur = unpack_mix_vec2(a_blur, u_blur_t);
+#else
+lowp float blur = u_blur;
+#endif
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+    #ifndef HAS_UNIFORM_u_stroke_color
+stroke_color = unpack_mix_color(a_stroke_color, u_stroke_color_t);
+#else
+highp vec4 stroke_color = u_stroke_color;
+#endif
+    #ifndef HAS_UNIFORM_u_stroke_width
+stroke_width = unpack_mix_vec2(a_stroke_width, u_stroke_width_t);
+#else
+mediump float stroke_width = u_stroke_width;
+#endif
+    #ifndef HAS_UNIFORM_u_stroke_opacity
+stroke_opacity = unpack_mix_vec2(a_stroke_opacity, u_stroke_opacity_t);
+#else
+lowp float stroke_opacity = u_stroke_opacity;
+#endif
+
+    // unencode the extrusion vector that we snuck into the a_pos vector
+    vec2 extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);
+
+    // multiply a_pos by 0.5, since we had it * 2 in order to sneak
+    // in extrusion data
+    vec2 circle_center = floor(a_pos * 0.5);
+    if (u_pitch_with_map) {
+        vec2 corner_position = circle_center;
+        if (u_scale_with_map) {
+            corner_position += extrude * (radius + stroke_width) * u_extrude_scale;
+        } else {
+            // Pitching the circle with the map effectively scales it with the map
+            // To counteract the effect for pitch-scale: viewport, we rescale the
+            // whole circle based on the pitch scaling effect at its central point
+            vec4 projected_center = u_matrix * vec4(circle_center, 0, 1);
+            corner_position += extrude * (radius + stroke_width) * u_extrude_scale * (projected_center.w / u_camera_to_center_distance);
+        }
+
+        gl_Position = u_matrix * vec4(corner_position, 0, 1);
+    } else {
+        gl_Position = u_matrix * vec4(circle_center, 0, 1);
+
+        if (u_scale_with_map) {
+            gl_Position.xy += extrude * (radius + stroke_width) * u_extrude_scale * u_camera_to_center_distance;
+        } else {
+            gl_Position.xy += extrude * (radius + stroke_width) * u_extrude_scale * gl_Position.w;
+        }
+    }
+
+    // This is a minimum blur distance that serves as a faux-antialiasing for
+    // the circle. since blur is a ratio of the circle's size and the intent is
+    // to keep the blur at roughly 1px, the two are inversely related.
+    lowp float antialiasblur = 1.0 / u_device_pixel_ratio / (radius + stroke_width);
+
+    v_data = vec3(extrude.x, extrude.y, antialiasblur);
+}
+)";
+    static constexpr const char* fragment = R"(in vec3 v_data;
+
+layout (std140) uniform CircleEvaluatedPropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_stroke_color;
+    mediump float u_radius;
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_stroke_width;
+    lowp float u_stroke_opacity;
+    bool u_scale_with_map;
+    bool u_pitch_with_map;
+    lowp float pad0_;
+};
+
+#ifndef HAS_UNIFORM_u_color
+in highp vec4 color;
+#endif
+#ifndef HAS_UNIFORM_u_radius
+in mediump float radius;
+#endif
+#ifndef HAS_UNIFORM_u_blur
+in lowp float blur;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_stroke_color
+in highp vec4 stroke_color;
+#endif
+#ifndef HAS_UNIFORM_u_stroke_width
+in mediump float stroke_width;
+#endif
+#ifndef HAS_UNIFORM_u_stroke_opacity
+in lowp float stroke_opacity;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_color
+highp vec4 color = u_color;
+#endif
+    #ifdef HAS_UNIFORM_u_radius
+mediump float radius = u_radius;
+#endif
+    #ifdef HAS_UNIFORM_u_blur
+lowp float blur = u_blur;
+#endif
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+    #ifdef HAS_UNIFORM_u_stroke_color
+highp vec4 stroke_color = u_stroke_color;
+#endif
+    #ifdef HAS_UNIFORM_u_stroke_width
+mediump float stroke_width = u_stroke_width;
+#endif
+    #ifdef HAS_UNIFORM_u_stroke_opacity
+lowp float stroke_opacity = u_stroke_opacity;
+#endif
+
+    vec2 extrude = v_data.xy;
+    float extrude_length = length(extrude);
+
+    lowp float antialiasblur = v_data.z;
+    float antialiased_blur = -max(blur, antialiasblur);
+
+    float opacity_t = smoothstep(0.0, antialiased_blur, extrude_length - 1.0);
+
+    float color_t = stroke_width < 0.01 ? 0.0 : smoothstep(
+        antialiased_blur,
+        0.0,
+        extrude_length - radius / (radius + stroke_width)
+    );
+
+    fragColor = opacity_t * mix(color * opacity, stroke_color * stroke_opacity, color_t);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_fill.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill.hpp
@@ -1,0 +1,124 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::FillShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillShader";
+    static constexpr const char* vertex = R"(layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+layout (location = 0) in vec2 a_pos;
+
+#ifndef HAS_UNIFORM_u_color
+layout (location = 1) in highp vec4 a_color;
+out highp vec4 color;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 2) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_color
+color = unpack_mix_color(a_color, u_color_t);
+#else
+highp vec4 color = u_color;
+#endif
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+}
+)";
+    static constexpr const char* fragment = R"(layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+#ifndef HAS_UNIFORM_u_color
+in highp vec4 color;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_color
+highp vec4 color = u_color;
+#endif
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+
+    fragColor = color * opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_fill_extrusion.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill_extrusion.hpp
@@ -1,0 +1,135 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::FillExtrusionShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillExtrusionShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
+layout (location = 1) in vec4 a_normal_ed;
+out vec4 v_color;
+
+layout (std140) uniform FillExtrusionDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+layout (std140) uniform FillExtrusionInterpolateUBO {
+    highp float u_base_t;
+    highp float u_height_t;
+    highp float u_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_pad_interp1, u_pad_interp2, u_pad_interp3;
+};
+layout (std140) uniform FillExtrusionDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_texsize;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp float u_height_factor;
+    highp float u_pad_drawable;
+};
+layout (std140) uniform FillExtrusionDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec3 u_lightcolor;
+    highp float u_pad1;
+    highp vec3 u_lightpos;
+    highp float u_base;
+    highp float u_height;
+    highp float u_lightintensity;
+    highp float u_vertical_gradient;
+    highp float u_opacity;
+    highp float u_fade;
+    highp float u_pad_props2, u_pad_props3, u_pad_props4;
+};
+
+#ifndef HAS_UNIFORM_u_base
+layout (location = 2) in highp vec2 a_base;
+#endif
+#ifndef HAS_UNIFORM_u_height
+layout (location = 3) in highp vec2 a_height;
+#endif
+#ifndef HAS_UNIFORM_u_color
+layout (location = 4) in highp vec4 a_color;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_base
+highp float base = unpack_mix_vec2(a_base, u_base_t);
+#else
+highp float base = u_base;
+#endif
+    #ifndef HAS_UNIFORM_u_height
+highp float height = unpack_mix_vec2(a_height, u_height_t);
+#else
+highp float height = u_height;
+#endif
+    #ifndef HAS_UNIFORM_u_color
+highp vec4 color = unpack_mix_color(a_color, u_color_t);
+#else
+highp vec4 color = u_color;
+#endif
+
+    vec3 normal = a_normal_ed.xyz;
+
+    base = max(0.0, base);
+    height = max(0.0, height);
+
+    float t = mod(normal.x, 2.0);
+
+    gl_Position = u_matrix * vec4(a_pos, t > 0.0 ? height : base, 1);
+
+    // Relative luminance (how dark/bright is the surface color?)
+    float colorvalue = color.r * 0.2126 + color.g * 0.7152 + color.b * 0.0722;
+
+    v_color = vec4(0.0, 0.0, 0.0, 1.0);
+
+    // Add slight ambient lighting so no extrusions are totally black
+    vec4 ambientlight = vec4(0.03, 0.03, 0.03, 1.0);
+    color += ambientlight;
+
+    // Calculate cos(theta), where theta is the angle between surface normal and diffuse light ray
+    float directional = clamp(dot(normal / 16384.0, u_lightpos), 0.0, 1.0);
+
+    // Adjust directional so that
+    // the range of values for highlight/shading is narrower
+    // with lower light intensity
+    // and with lighter/brighter surface colors
+    directional = mix((1.0 - u_lightintensity), max((1.0 - colorvalue + u_lightintensity), 1.0), directional);
+
+    // Add gradient along z axis of side surfaces
+    if (normal.y != 0.0) {
+        // This avoids another branching statement, but multiplies by a constant of 0.84 if no vertical gradient,
+        // and otherwise calculates the gradient based on base + height
+        directional *= (
+            (1.0 - u_vertical_gradient) +
+            (u_vertical_gradient * clamp((t + base) * pow(height / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0)));
+    }
+
+    // Assign final color based on surface + ambient light color, diffuse light directional, and light color
+    // with lower bounds adjusted to hue of light
+    // so that shading is tinted with the complementary (opposite) color to the light color
+    v_color.r += clamp(color.r * directional * u_lightcolor.r, mix(0.0, 0.3, 1.0 - u_lightcolor.r), 1.0);
+    v_color.g += clamp(color.g * directional * u_lightcolor.g, mix(0.0, 0.3, 1.0 - u_lightcolor.g), 1.0);
+    v_color.b += clamp(color.b * directional * u_lightcolor.b, mix(0.0, 0.3, 1.0 - u_lightcolor.b), 1.0);
+    v_color *= u_opacity;
+}
+)";
+    static constexpr const char* fragment = R"(in vec4 v_color;
+
+void main() {
+    fragColor = v_color;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_fill_extrusion_pattern.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill_extrusion_pattern.hpp
@@ -1,0 +1,232 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::FillExtrusionPatternShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillExtrusionPatternShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
+layout (location = 1) in vec4 a_normal_ed;
+
+out vec2 v_pos_a;
+out vec2 v_pos_b;
+out vec4 v_lighting;
+
+layout (std140) uniform FillExtrusionDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+layout (std140) uniform FillExtrusionInterpolateUBO {
+    highp float u_base_t;
+    highp float u_height_t;
+    highp float u_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_pad_interp1, u_pad_interp2, u_pad_interp3;
+};
+layout (std140) uniform FillExtrusionDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_texsize;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp float u_height_factor;
+    highp float u_pad_drawable;
+};
+layout (std140) uniform FillExtrusionDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec3 u_lightcolor;
+    highp float u_pad1;
+    highp vec3 u_lightpos;
+    highp float u_base;
+    highp float u_height;
+    highp float u_lightintensity;
+    highp float u_vertical_gradient;
+    highp float u_opacity;
+    highp float u_fade;
+    highp float u_pad_props2, u_pad_props3, u_pad_props4;
+};
+
+#ifndef HAS_UNIFORM_u_base
+layout (location = 2) in lowp vec2 a_base;
+out lowp float base;
+#endif
+#ifndef HAS_UNIFORM_u_height
+layout (location = 3) in lowp vec2 a_height;
+out lowp float height;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_from
+layout (location = 4) in mediump vec4 a_pattern_from;
+out mediump vec4 pattern_from;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_to
+layout (location = 5) in mediump vec4 a_pattern_to;
+out mediump vec4 pattern_to;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_base
+base = unpack_mix_vec2(a_base, u_base_t);
+#else
+lowp float base = u_base;
+#endif
+    #ifndef HAS_UNIFORM_u_height
+height = unpack_mix_vec2(a_height, u_height_t);
+#else
+lowp float height = u_height;
+#endif
+    #ifndef HAS_UNIFORM_u_pattern_from
+pattern_from = a_pattern_from;
+#else
+mediump vec4 pattern_from = u_pattern_from;
+#endif
+    #ifndef HAS_UNIFORM_u_pattern_to
+pattern_to = a_pattern_to;
+#else
+mediump vec4 pattern_to = u_pattern_to;
+#endif
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    float pixelRatio = u_scale.x;
+    float tileRatio = u_scale.y;
+    float fromScale = u_scale.z;
+    float toScale = u_scale.w;
+
+    vec3 normal = a_normal_ed.xyz;
+    float edgedistance = a_normal_ed.w;
+
+    vec2 display_size_a = vec2((pattern_br_a.x - pattern_tl_a.x) / pixelRatio, (pattern_br_a.y - pattern_tl_a.y) / pixelRatio);
+    vec2 display_size_b = vec2((pattern_br_b.x - pattern_tl_b.x) / pixelRatio, (pattern_br_b.y - pattern_tl_b.y) / pixelRatio);
+
+    base = max(0.0, base);
+    height = max(0.0, height);
+
+    float t = mod(normal.x, 2.0);
+    float z = t > 0.0 ? height : base;
+
+    gl_Position = u_matrix * vec4(a_pos, z, 1);
+
+    vec2 pos = normal.x == 1.0 && normal.y == 0.0 && normal.z == 16384.0
+        ? a_pos // extrusion top
+        : vec2(edgedistance, z * u_height_factor); // extrusion side
+
+    v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, fromScale * display_size_a, tileRatio, pos);
+    v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, toScale * display_size_b, tileRatio, pos);
+
+    v_lighting = vec4(0.0, 0.0, 0.0, 1.0);
+    float directional = clamp(dot(normal / 16383.0, u_lightpos), 0.0, 1.0);
+    directional = mix((1.0 - u_lightintensity), max((0.5 + u_lightintensity), 1.0), directional);
+
+    if (normal.y != 0.0) {
+        // This avoids another branching statement, but multiplies by a constant of 0.84 if no vertical gradient,
+        // and otherwise calculates the gradient based on base + height
+        directional *= (
+            (1.0 - u_vertical_gradient) +
+            (u_vertical_gradient * clamp((t + base) * pow(height / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0)));
+    }
+
+    v_lighting.rgb += clamp(directional * u_lightcolor, mix(vec3(0.0), vec3(0.3), 1.0 - u_lightcolor), vec3(1.0));
+    v_lighting *= u_opacity;
+}
+)";
+    static constexpr const char* fragment = R"(in vec2 v_pos_a;
+in vec2 v_pos_b;
+in vec4 v_lighting;
+
+layout (std140) uniform FillExtrusionDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+layout (std140) uniform FillExtrusionInterpolateUBO {
+    highp float u_base_t;
+    highp float u_height_t;
+    highp float u_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_pad_interp1, u_pad_interp2, u_pad_interp3;
+};
+layout (std140) uniform FillExtrusionDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_texsize;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp float u_height_factor;
+    highp float u_pad_drawable;
+};
+layout (std140) uniform FillExtrusionDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec3 u_lightcolor;
+    highp float u_pad1;
+    highp vec3 u_lightpos;
+    highp float u_base;
+    highp float u_height;
+    highp float u_lightintensity;
+    highp float u_vertical_gradient;
+    highp float u_opacity;
+    highp float u_fade;
+    highp float u_pad_props2, u_pad_props3, u_pad_props4;
+};
+
+uniform sampler2D u_image;
+
+#ifndef HAS_UNIFORM_u_base
+in lowp float base;
+#endif
+#ifndef HAS_UNIFORM_u_height
+in lowp float height;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_from
+in mediump vec4 pattern_from;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_to
+in mediump vec4 pattern_to;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_base
+lowp float base = u_base;
+#endif
+    #ifdef HAS_UNIFORM_u_height
+lowp float height = u_height;
+#endif
+    #ifdef HAS_UNIFORM_u_pattern_from
+mediump vec4 pattern_from = u_pattern_from;
+#endif
+    #ifdef HAS_UNIFORM_u_pattern_to
+mediump vec4 pattern_to = u_pattern_to;
+#endif
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    vec2 imagecoord = mod(v_pos_a, 1.0);
+    vec2 pos = mix(pattern_tl_a / u_texsize, pattern_br_a / u_texsize, imagecoord);
+    vec4 color1 = texture(u_image, pos);
+
+    vec2 imagecoord_b = mod(v_pos_b, 1.0);
+    vec2 pos2 = mix(pattern_tl_b / u_texsize, pattern_br_b / u_texsize, imagecoord_b);
+    vec4 color2 = texture(u_image, pos2);
+
+    vec4 mixedColor = mix(color1, color2, u_fade);
+
+    fragColor = mixedColor * v_lighting;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_fill_outline.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill_outline.hpp
@@ -1,0 +1,131 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::FillOutlineShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillOutlineShader";
+    static constexpr const char* vertex = R"(layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+layout (location = 0) in vec2 a_pos;
+
+out vec2 v_pos;
+
+#ifndef HAS_UNIFORM_u_outline_color
+layout (location = 1) in highp vec4 a_outline_color;
+out highp vec4 outline_color;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 2) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_outline_color
+outline_color = unpack_mix_color(a_outline_color, u_outline_color_t);
+#else
+highp vec4 outline_color = u_outline_color;
+#endif
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+    v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
+}
+)";
+    static constexpr const char* fragment = R"(layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+in vec2 v_pos;
+
+#ifndef HAS_UNIFORM_u_outline_color
+in highp vec4 outline_color;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_outline_color
+highp vec4 outline_color = u_outline_color;
+#endif
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+
+    float dist = length(v_pos - gl_FragCoord.xy);
+    float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
+    fragColor = outline_color * (alpha * opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_fill_outline_pattern.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill_outline_pattern.hpp
@@ -1,0 +1,186 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::FillOutlinePatternShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillOutlinePatternShader";
+    static constexpr const char* vertex = R"(layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+layout (location = 0) in vec2 a_pos;
+
+out vec2 v_pos_a;
+out vec2 v_pos_b;
+out vec2 v_pos;
+
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 1) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_from
+layout (location = 2) in lowp vec4 a_pattern_from;
+out lowp vec4 pattern_from;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_to
+layout (location = 3) in lowp vec4 a_pattern_to;
+out lowp vec4 pattern_to;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+    #ifndef HAS_UNIFORM_u_pattern_from
+pattern_from = a_pattern_from;
+#else
+mediump vec4 pattern_from = u_pattern_from;
+#endif
+    #ifndef HAS_UNIFORM_u_pattern_to
+pattern_to = a_pattern_to;
+#else
+mediump vec4 pattern_to = u_pattern_to;
+#endif
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    float pixelRatio = u_scale.x;
+    float tileRatio = u_scale.y;
+    float fromScale = u_scale.z;
+    float toScale = u_scale.w;
+
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+
+    vec2 display_size_a = vec2((pattern_br_a.x - pattern_tl_a.x) / pixelRatio, (pattern_br_a.y - pattern_tl_a.y) / pixelRatio);
+    vec2 display_size_b = vec2((pattern_br_b.x - pattern_tl_b.x) / pixelRatio, (pattern_br_b.y - pattern_tl_b.y) / pixelRatio);
+
+    v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, fromScale * display_size_a, tileRatio, a_pos);
+    v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, toScale * display_size_b, tileRatio, a_pos);
+
+    v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
+}
+)";
+    static constexpr const char* fragment = R"(layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+uniform sampler2D u_image;
+
+in vec2 v_pos_a;
+in vec2 v_pos_b;
+in vec2 v_pos;
+
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_from
+in lowp vec4 pattern_from;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_to
+in lowp vec4 pattern_to;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+    #ifdef HAS_UNIFORM_u_pattern_from
+mediump vec4 pattern_from = u_pattern_from;
+#endif
+    #ifdef HAS_UNIFORM_u_pattern_to
+mediump vec4 pattern_to = u_pattern_to;
+#endif
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    vec2 imagecoord = mod(v_pos_a, 1.0);
+    vec2 pos = mix(pattern_tl_a / u_texsize, pattern_br_a / u_texsize, imagecoord);
+    vec4 color1 = texture(u_image, pos);
+
+    vec2 imagecoord_b = mod(v_pos_b, 1.0);
+    vec2 pos2 = mix(pattern_tl_b / u_texsize, pattern_br_b / u_texsize, imagecoord_b);
+    vec4 color2 = texture(u_image, pos2);
+
+    // find distance to outline for alpha interpolation
+
+    float dist = length(v_pos - gl_FragCoord.xy);
+    float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
+
+
+    fragColor = mix(color1, color2, u_fade) * alpha * opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_fill_pattern.hpp
+++ b/include/mbgl/shaders/gl/drawable_fill_pattern.hpp
@@ -1,0 +1,179 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::FillPatternShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "FillPatternShader";
+    static constexpr const char* vertex = R"(layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+layout (location = 0) in vec2 a_pos;
+
+out vec2 v_pos_a;
+out vec2 v_pos_b;
+
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 1) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_from
+layout (location = 2) in lowp vec4 a_pattern_from;
+out lowp vec4 pattern_from;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_to
+layout (location = 3) in lowp vec4 a_pattern_to;
+out lowp vec4 pattern_to;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+    #ifndef HAS_UNIFORM_u_pattern_from
+pattern_from = a_pattern_from;
+#else
+mediump vec4 pattern_from = u_pattern_from;
+#endif
+    #ifndef HAS_UNIFORM_u_pattern_to
+pattern_to = a_pattern_to;
+#else
+mediump vec4 pattern_to = u_pattern_to;
+#endif
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    float pixelRatio = u_scale.x;
+    float tileZoomRatio = u_scale.y;
+    float fromScale = u_scale.z;
+    float toScale = u_scale.w;
+
+    vec2 display_size_a = vec2((pattern_br_a.x - pattern_tl_a.x) / pixelRatio, (pattern_br_a.y - pattern_tl_a.y) / pixelRatio);
+    vec2 display_size_b = vec2((pattern_br_b.x - pattern_tl_b.x) / pixelRatio, (pattern_br_b.y - pattern_tl_b.y) / pixelRatio);
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+
+    v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, fromScale * display_size_a, tileZoomRatio, a_pos);
+    v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, toScale * display_size_b, tileZoomRatio, a_pos);
+}
+)";
+    static constexpr const char* fragment = R"(layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+uniform sampler2D u_image;
+
+in vec2 v_pos_a;
+in vec2 v_pos_b;
+
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_from
+in lowp vec4 pattern_from;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_to
+in lowp vec4 pattern_to;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+    #ifdef HAS_UNIFORM_u_pattern_from
+mediump vec4 pattern_from = u_pattern_from;
+#endif
+    #ifdef HAS_UNIFORM_u_pattern_to
+mediump vec4 pattern_to = u_pattern_to;
+#endif
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    if (u_texsize.x < 1.0 || u_texsize.y < 1.0) {
+        discard;
+    }
+
+    vec2 imagecoord = mod(v_pos_a, 1.0);
+    vec2 pos = mix(pattern_tl_a / u_texsize, pattern_br_a / u_texsize, imagecoord);
+    vec4 color1 = texture(u_image, pos);
+
+    vec2 imagecoord_b = mod(v_pos_b, 1.0);
+    vec2 pos2 = mix(pattern_tl_b / u_texsize, pattern_br_b / u_texsize, imagecoord_b);
+    vec4 color2 = texture(u_image, pos2);
+
+    fragColor = mix(color1, color2, u_fade) * opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_heatmap.hpp
+++ b/include/mbgl/shaders/gl/drawable_heatmap.hpp
@@ -1,0 +1,127 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::HeatmapShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "HeatmapShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
+out vec2 v_extrude;
+
+layout (std140) uniform HeatmapDrawableUBO {
+    highp mat4 u_matrix;
+    highp float u_extrude_scale;
+    lowp float pad1_;
+    lowp vec2 pad2_;
+};
+
+layout (std140) uniform HeatmapEvaluatedPropsUBO {
+    highp float u_weight;
+    highp float u_radius;
+    highp float u_intensity;
+    lowp float pad0_;
+};
+
+layout (std140) uniform HeatmapInterpolateUBO {
+    lowp float u_weight_t;
+    lowp float u_radius_t;
+    lowp vec2 pad3_;
+};
+
+#ifndef HAS_UNIFORM_u_weight
+layout (location = 1) in highp vec2 a_weight;
+out highp float weight;
+#endif
+#ifndef HAS_UNIFORM_u_radius
+layout (location = 2) in mediump vec2 a_radius;
+#endif
+
+// Effective "0" in the kernel density texture to adjust the kernel size to;
+// this empirically chosen number minimizes artifacts on overlapping kernels
+// for typical heatmap cases (assuming clustered source)
+const highp float ZERO = 1.0 / 255.0 / 16.0;
+
+// Gaussian kernel coefficient: 1 / sqrt(2 * PI)
+#define GAUSS_COEF 0.3989422804014327
+
+void main(void) {
+    #ifndef HAS_UNIFORM_u_weight
+weight = unpack_mix_vec2(a_weight, u_weight_t);
+#else
+highp float weight = u_weight;
+#endif
+    #ifndef HAS_UNIFORM_u_radius
+mediump float radius = unpack_mix_vec2(a_radius, u_radius_t);
+#else
+mediump float radius = u_radius;
+#endif
+
+    // unencode the extrusion vector that we snuck into the a_pos vector
+    vec2 unscaled_extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);
+
+    // This 'extrude' comes in ranging from [-1, -1], to [1, 1].  We'll use
+    // it to produce the vertices of a square mesh framing the point feature
+    // we're adding to the kernel density texture.  We'll also pass it as
+    // a varying, so that the fragment shader can determine the distance of
+    // each fragment from the point feature.
+    // Before we do so, we need to scale it up sufficiently so that the
+    // kernel falls effectively to zero at the edge of the mesh.
+    // That is, we want to know S such that
+    // weight * u_intensity * GAUSS_COEF * exp(-0.5 * 3.0^2 * S^2) == ZERO
+    // Which solves to:
+    // S = sqrt(-2.0 * log(ZERO / (weight * u_intensity * GAUSS_COEF))) / 3.0
+    float S = sqrt(-2.0 * log(ZERO / weight / u_intensity / GAUSS_COEF)) / 3.0;
+
+    // Pass the varying in units of radius
+    v_extrude = S * unscaled_extrude;
+
+    // Scale by radius and the zoom-based scale factor to produce actual
+    // mesh position
+    vec2 extrude = v_extrude * radius * u_extrude_scale;
+
+    // multiply a_pos by 0.5, since we had it * 2 in order to sneak
+    // in extrusion data
+    vec4 pos = vec4(floor(a_pos * 0.5) + extrude, 0, 1);
+
+    gl_Position = u_matrix * pos;
+}
+)";
+    static constexpr const char* fragment = R"(in vec2 v_extrude;
+
+layout (std140) uniform HeatmapEvaluatedPropsUBO {
+    highp float u_weight;
+    highp float u_radius;
+    highp float u_intensity;
+    lowp float pad0_;
+};
+
+#ifndef HAS_UNIFORM_u_weight
+in highp float weight;
+#endif
+
+// Gaussian kernel coefficient: 1 / sqrt(2 * PI)
+#define GAUSS_COEF 0.3989422804014327
+
+void main() {
+    #ifdef HAS_UNIFORM_u_weight
+highp float weight = u_weight;
+#endif
+
+    // Kernel density estimation with a Gaussian kernel of size 5x5
+    float d = -0.5 * 3.0 * 3.0 * dot(v_extrude, v_extrude);
+    float val = weight * u_intensity * GAUSS_COEF * exp(d);
+
+    fragColor = vec4(val, 1.0, 1.0, 1.0);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_heatmap_texture.hpp
+++ b/include/mbgl/shaders/gl/drawable_heatmap_texture.hpp
@@ -1,0 +1,52 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::HeatmapTextureShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "HeatmapTextureShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
+out vec2 v_pos;
+
+layout (std140) uniform HeatmapTextureDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_world;
+    highp float u_opacity;
+    lowp float pad0_;
+};
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos * u_world, 0, 1);
+
+    v_pos.x = a_pos.x;
+    v_pos.y = 1.0 - a_pos.y;
+}
+)";
+    static constexpr const char* fragment = R"(in vec2 v_pos;
+uniform sampler2D u_image;
+uniform sampler2D u_color_ramp;
+
+layout (std140) uniform HeatmapTextureDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_world;
+    highp float u_opacity;
+    lowp float pad0_;
+};
+
+void main() {
+    float t = texture(u_image, v_pos).r;
+    vec4 color = texture(u_color_ramp, vec2(t, 0.5));
+    fragColor = color * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(0.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_hillshade.hpp
+++ b/include/mbgl/shaders/gl/drawable_hillshade.hpp
@@ -1,0 +1,89 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::HillshadeShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "HillshadeShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
+layout (location = 1) in vec2 a_texture_pos;
+
+layout (std140) uniform HillshadeDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_latrange;
+    highp vec2 u_light;
+};
+
+out vec2 v_pos;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+    v_pos = a_texture_pos / 8192.0;
+}
+)";
+    static constexpr const char* fragment = R"(in vec2 v_pos;
+uniform sampler2D u_image;
+
+layout (std140) uniform HillshadeDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_latrange;
+    highp vec2 u_light;
+};
+
+layout (std140) uniform HillshadeEvaluatedPropsUBO {
+    highp vec4 u_highlight;
+    highp vec4 u_shadow;
+    highp vec4 u_accent;
+};
+
+#define PI 3.141592653589793
+
+void main() {
+    vec4 pixel = texture(u_image, v_pos);
+
+    vec2 deriv = ((pixel.rg * 2.0) - 1.0);
+
+    // We divide the slope by a scale factor based on the cosin of the pixel's approximate latitude
+    // to account for mercator projection distortion. see #4807 for details
+    float scaleFactor = cos(radians((u_latrange[0] - u_latrange[1]) * (1.0 - v_pos.y) + u_latrange[1]));
+    // We also multiply the slope by an arbitrary z-factor of 1.25
+    float slope = atan(1.25 * length(deriv) / scaleFactor);
+    float aspect = deriv.x != 0.0 ? atan(deriv.y, -deriv.x) : PI / 2.0 * (deriv.y > 0.0 ? 1.0 : -1.0);
+
+    float intensity = u_light.x;
+    // We add PI to make this property match the global light object, which adds PI/2 to the light's azimuthal
+    // position property to account for 0deg corresponding to north/the top of the viewport in the style spec
+    // and the original shader was written to accept (-illuminationDirection - 90) as the azimuthal.
+    float azimuth = u_light.y + PI;
+
+    // We scale the slope exponentially based on intensity, using a calculation similar to
+    // the exponential interpolation function in the style spec:
+    // https://github.com/mapbox/mapbox-gl-js/blob/master/src/style-spec/expression/definitions/interpolate.js#L217-L228
+    // so that higher intensity values create more opaque hillshading.
+    float base = 1.875 - intensity * 1.75;
+    float maxValue = 0.5 * PI;
+    float scaledSlope = intensity != 0.5 ? ((pow(base, slope) - 1.0) / (pow(base, maxValue) - 1.0)) * maxValue : slope;
+
+    // The accent color is calculated with the cosine of the slope while the shade color is calculated with the sine
+    // so that the accent color's rate of change eases in while the shade color's eases out.
+    float accent = cos(scaledSlope);
+    // We multiply both the accent and shade color by a clamped intensity value
+    // so that intensities >= 0.5 do not additionally affect the color values
+    // while intensity values < 0.5 make the overall color more transparent.
+    vec4 accent_color = (1.0 - accent) * u_accent * clamp(intensity * 2.0, 0.0, 1.0);
+    float shade = abs(mod((aspect + azimuth) / PI + 0.5, 2.0) - 1.0);
+    vec4 shade_color = mix(u_shadow, u_highlight, shade) * sin(scaledSlope) * clamp(intensity * 2.0, 0.0, 1.0);
+    fragColor = accent_color * (1.0 - shade_color.a) + shade_color;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_hillshade_prepare.hpp
+++ b/include/mbgl/shaders/gl/drawable_hillshade_prepare.hpp
@@ -1,0 +1,114 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::HillshadePrepareShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "HillshadePrepareShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec2 a_pos;
+layout (location = 1) in vec2 a_texture_pos;
+
+layout (std140) uniform HillshadePrepareDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_unpack;
+    highp vec2 u_dimension;
+    highp float u_zoom;
+    highp float u_maxzoom;
+};
+
+out vec2 v_pos;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+
+    highp vec2 epsilon = 1.0 / u_dimension;
+    float scale = (u_dimension.x - 2.0) / u_dimension.x;
+    v_pos = (a_texture_pos / 8192.0) * scale + epsilon;
+}
+)";
+    static constexpr const char* fragment = R"(#ifdef GL_ES
+precision highp float;
+#endif
+
+in vec2 v_pos;
+uniform sampler2D u_image;
+
+layout (std140) uniform HillshadePrepareDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_unpack;
+    highp vec2 u_dimension;
+    highp float u_zoom;
+    highp float u_maxzoom;
+};
+
+float getElevation(vec2 coord, float bias) {
+    // Convert encoded elevation value to meters
+    vec4 data = texture(u_image, coord) * 255.0;
+    data.a = -1.0;
+    return dot(data, u_unpack) / 4.0;
+}
+
+void main() {
+    vec2 epsilon = 1.0 / u_dimension;
+
+    // queried pixels:
+    // +-----------+
+    // |   |   |   |
+    // | a | b | c |
+    // |   |   |   |
+    // +-----------+
+    // |   |   |   |
+    // | d | e | f |
+    // |   |   |   |
+    // +-----------+
+    // |   |   |   |
+    // | g | h | i |
+    // |   |   |   |
+    // +-----------+
+
+    float a = getElevation(v_pos + vec2(-epsilon.x, -epsilon.y), 0.0);
+    float b = getElevation(v_pos + vec2(0, -epsilon.y), 0.0);
+    float c = getElevation(v_pos + vec2(epsilon.x, -epsilon.y), 0.0);
+    float d = getElevation(v_pos + vec2(-epsilon.x, 0), 0.0);
+    float e = getElevation(v_pos, 0.0);
+    float f = getElevation(v_pos + vec2(epsilon.x, 0), 0.0);
+    float g = getElevation(v_pos + vec2(-epsilon.x, epsilon.y), 0.0);
+    float h = getElevation(v_pos + vec2(0, epsilon.y), 0.0);
+    float i = getElevation(v_pos + vec2(epsilon.x, epsilon.y), 0.0);
+
+    // here we divide the x and y slopes by 8 * pixel size
+    // where pixel size (aka meters/pixel) is:
+    // circumference of the world / (pixels per tile * number of tiles)
+    // which is equivalent to: 8 * 40075016.6855785 / (512 * pow(2, u_zoom))
+    // which can be reduced to: pow(2, 19.25619978527 - u_zoom)
+    // we want to vertically exaggerate the hillshading though, because otherwise
+    // it is barely noticeable at low zooms. to do this, we multiply this by some
+    // scale factor pow(2, (u_zoom - u_maxzoom) * a) where a is an arbitrary value
+    // Here we use a=0.3 which works out to the expression below. see
+    // nickidlugash's awesome breakdown for more info
+    // https://github.com/mapbox/mapbox-gl-js/pull/5286#discussion_r148419556
+    float exaggeration = u_zoom < 2.0 ? 0.4 : u_zoom < 4.5 ? 0.35 : 0.3;
+
+    vec2 deriv = vec2(
+        (c + f + f + i) - (a + d + d + g),
+        (g + h + h + i) - (a + b + b + c)
+    ) /  pow(2.0, (u_zoom - u_maxzoom) * exaggeration + 19.2562 - u_zoom);
+
+    fragColor = clamp(vec4(
+        deriv.x / 2.0 + 0.5,
+        deriv.y / 2.0 + 0.5,
+        1.0,
+        1.0), 0.0, 1.0);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_line.hpp
+++ b/include/mbgl/shaders/gl/drawable_line.hpp
@@ -1,0 +1,235 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::LineShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "LineShader";
+    static constexpr const char* vertex = R"(// floor(127 / 2) == 63.0
+// the maximum allowed miter limit is 2.0 at the moment. the extrude normal is
+// stored in a byte (-128..127). we scale regular normals up to length 63, but
+// there are also "special" normals that have a bigger length (of up to 126 in
+// this case).
+// #define scale 63.0
+#define scale 0.015873016
+
+layout (location = 0) in vec2 a_pos_normal;
+layout (location = 1) in vec4 a_data;
+
+layout (std140) uniform LineUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_units_to_pixels;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+};
+
+layout (std140) uniform LinePropertiesUBO {
+    highp vec4 u_color;
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_gapwidth;
+    lowp float u_offset;
+    mediump float u_width;
+
+    highp float pad1;
+    highp vec2 pad2;
+};
+
+layout (std140) uniform LineInterpolationUBO {
+    lowp float u_color_t;
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_gapwidth_t;
+    lowp float u_offset_t;
+    lowp float u_width_t;
+
+    highp vec2 pad3;
+};
+
+out vec2 v_normal;
+out vec2 v_width2;
+out float v_gamma_scale;
+out highp float v_linesofar;
+
+#ifndef HAS_UNIFORM_u_color
+layout (location = 2) in highp vec4 a_color;
+out highp vec4 color;
+#endif
+#ifndef HAS_UNIFORM_u_blur
+layout (location = 3) in lowp vec2 a_blur;
+out lowp float blur;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 4) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_gapwidth
+layout (location = 5) in mediump vec2 a_gapwidth;
+#endif
+#ifndef HAS_UNIFORM_u_offset
+layout (location = 6) in lowp vec2 a_offset;
+#endif
+#ifndef HAS_UNIFORM_u_width
+layout (location = 7) in mediump vec2 a_width;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_color
+color = unpack_mix_color(a_color, u_color_t);
+#else
+highp vec4 color = u_color;
+#endif
+    #ifndef HAS_UNIFORM_u_blur
+blur = unpack_mix_vec2(a_blur, u_blur_t);
+#else
+lowp float blur = u_blur;
+#endif
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+    #ifndef HAS_UNIFORM_u_gapwidth
+mediump float gapwidth = unpack_mix_vec2(a_gapwidth, u_gapwidth_t);
+#else
+mediump float gapwidth = u_gapwidth;
+#endif
+    #ifndef HAS_UNIFORM_u_offset
+lowp float offset = unpack_mix_vec2(a_offset, u_offset_t);
+#else
+lowp float offset = u_offset;
+#endif
+    #ifndef HAS_UNIFORM_u_width
+mediump float width = unpack_mix_vec2(a_width, u_width_t);
+#else
+mediump float width = u_width;
+#endif
+
+    // the distance over which the line edge fades out.
+    // Retina devices need a smaller distance to avoid aliasing.
+    float ANTIALIASING = 1.0 / u_device_pixel_ratio / 2.0;
+
+    vec2 a_extrude = a_data.xy - 128.0;
+    float a_direction = mod(a_data.z, 4.0) - 1.0;
+
+    v_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * 2.0;
+
+    vec2 pos = floor(a_pos_normal * 0.5);
+
+    // x is 1 if it's a round cap, 0 otherwise
+    // y is 1 if the normal points up, and -1 if it points down
+    // We store these in the least significant bit of a_pos_normal
+    mediump vec2 normal = a_pos_normal - 2.0 * pos;
+    normal.y = normal.y * 2.0 - 1.0;
+    v_normal = normal;
+
+    // these transformations used to be applied in the JS and native code bases.
+    // moved them into the shader for clarity and simplicity.
+    gapwidth = gapwidth / 2.0;
+    float halfwidth = width / 2.0;
+    offset = -1.0 * offset;
+
+    float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
+    float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + (halfwidth == 0.0 ? 0.0 : ANTIALIASING);
+
+    // Scale the extrusion vector down to a normal and then up by the line width
+    // of this vertex.
+    mediump vec2 dist = outset * a_extrude * scale;
+
+    // Calculate the offset when drawing a line that is to the side of the actual line.
+    // We do this by creating a vector that points towards the extrude, but rotate
+    // it when we're drawing round end points (a_direction = -1 or 1) since their
+    // extrude vector points in another direction.
+    mediump float u = 0.5 * a_direction;
+    mediump float t = 1.0 - abs(u);
+    mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
+
+    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+
+    // calculate how much the perspective view squishes or stretches the extrude
+    float extrude_length_without_perspective = length(dist);
+    float extrude_length_with_perspective = length(projected_extrude.xy / gl_Position.w * u_units_to_pixels);
+    v_gamma_scale = extrude_length_without_perspective / extrude_length_with_perspective;
+
+    v_width2 = vec2(outset, inset);
+}
+)";
+    static constexpr const char* fragment = R"(layout (std140) uniform LineUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_units_to_pixels;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+};
+
+layout (std140) uniform LinePropertiesUBO {
+    highp vec4 u_color;
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_gapwidth;
+    lowp float u_offset;
+    mediump float u_width;
+
+    highp float pad1;
+    highp vec2 pad2;
+};
+
+layout (std140) uniform LineInterpolationUBO {
+    lowp float u_color_t;
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_gapwidth_t;
+    lowp float u_offset_t;
+    lowp float u_width_t;
+
+    highp vec2 pad3;
+};
+
+in vec2 v_width2;
+in vec2 v_normal;
+in float v_gamma_scale;
+
+#ifndef HAS_UNIFORM_u_color
+in highp vec4 color;
+#endif
+#ifndef HAS_UNIFORM_u_blur
+in lowp float blur;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_color
+highp vec4 color = u_color;
+#endif
+    #ifdef HAS_UNIFORM_u_blur
+lowp float blur = u_blur;
+#endif
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+
+    // Calculate the distance of the pixel from the line in pixels.
+    float dist = length(v_normal) * v_width2.s;
+
+    // Calculate the antialiasing fade factor. This is either when fading in
+    // the line in case of an offset line (v_width2.t) or when fading out
+    // (v_width2.s)
+    float blur2 = (blur + 1.0 / u_device_pixel_ratio) * v_gamma_scale;
+    float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
+
+    fragColor = color * (alpha * opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_line_gradient.hpp
+++ b/include/mbgl/shaders/gl/drawable_line_gradient.hpp
@@ -1,0 +1,229 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::LineGradientShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "LineGradientShader";
+    static constexpr const char* vertex = R"(
+// the attribute conveying progress along a line is scaled to [0, 2^15)
+#define MAX_LINE_DISTANCE 32767.0
+
+// floor(127 / 2) == 63.0
+// the maximum allowed miter limit is 2.0 at the moment. the extrude normal is
+// stored in a byte (-128..127). we scale regular normals up to length 63, but
+// there are also "special" normals that have a bigger length (of up to 126 in
+// this case).
+// #define scale 63.0
+#define scale 0.015873016
+
+layout (location = 0) in vec2 a_pos_normal;
+layout (location = 1) in vec4 a_data;
+
+layout (std140) uniform LineGradientUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_units_to_pixels;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+};
+
+layout (std140) uniform LineGradientPropertiesUBO {
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_gapwidth;
+    lowp float u_offset;
+    mediump float u_width;
+
+    highp float pad1;
+    highp vec2 pad2;
+};
+
+layout (std140) uniform LineGradientInterpolationUBO {
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_gapwidth_t;
+    lowp float u_offset_t;
+    lowp float u_width_t;
+
+    highp float pad3;
+    highp vec2 pad4;
+};
+
+out vec2 v_normal;
+out vec2 v_width2;
+out float v_gamma_scale;
+out highp float v_lineprogress;
+
+#ifndef HAS_UNIFORM_u_blur
+layout (location = 2) in lowp vec2 a_blur;
+out lowp float blur;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 3) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_gapwidth
+layout (location = 4) in mediump vec2 a_gapwidth;
+#endif
+#ifndef HAS_UNIFORM_u_offset
+layout (location = 5) in lowp vec2 a_offset;
+#endif
+#ifndef HAS_UNIFORM_u_width
+layout (location = 6) in mediump vec2 a_width;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_blur
+blur = unpack_mix_vec2(a_blur, u_blur_t);
+#else
+lowp float blur = u_blur;
+#endif
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+    #ifndef HAS_UNIFORM_u_gapwidth
+mediump float gapwidth = unpack_mix_vec2(a_gapwidth, u_gapwidth_t);
+#else
+mediump float gapwidth = u_gapwidth;
+#endif
+    #ifndef HAS_UNIFORM_u_offset
+lowp float offset = unpack_mix_vec2(a_offset, u_offset_t);
+#else
+lowp float offset = u_offset;
+#endif
+    #ifndef HAS_UNIFORM_u_width
+mediump float width = unpack_mix_vec2(a_width, u_width_t);
+#else
+mediump float width = u_width;
+#endif
+
+    // the distance over which the line edge fades out.
+    // Retina devices need a smaller distance to avoid aliasing.
+    float ANTIALIASING = 1.0 / u_device_pixel_ratio / 2.0;
+
+    vec2 a_extrude = a_data.xy - 128.0;
+    float a_direction = mod(a_data.z, 4.0) - 1.0;
+
+    v_lineprogress = (floor(a_data.z / 4.0) + a_data.w * 64.0) * 2.0 / MAX_LINE_DISTANCE;
+
+    vec2 pos = floor(a_pos_normal * 0.5);
+
+    // x is 1 if it's a round cap, 0 otherwise
+    // y is 1 if the normal points up, and -1 if it points down
+    // We store these in the least significant bit of a_pos_normal
+    mediump vec2 normal = a_pos_normal - 2.0 * pos;
+    normal.y = normal.y * 2.0 - 1.0;
+    v_normal = normal;
+
+    // these transformations used to be applied in the JS and native code bases.
+    // moved them into the shader for clarity and simplicity.
+    gapwidth = gapwidth / 2.0;
+    float halfwidth = width / 2.0;
+    offset = -1.0 * offset;
+
+    float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
+    float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + (halfwidth == 0.0 ? 0.0 : ANTIALIASING);
+
+    // Scale the extrusion vector down to a normal and then up by the line width
+    // of this vertex.
+    mediump vec2 dist = outset * a_extrude * scale;
+
+    // Calculate the offset when drawing a line that is to the side of the actual line.
+    // We do this by creating a vector that points towards the extrude, but rotate
+    // it when we're drawing round end points (a_direction = -1 or 1) since their
+    // extrude vector points in another direction.
+    mediump float u = 0.5 * a_direction;
+    mediump float t = 1.0 - abs(u);
+    mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
+
+    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+
+    // calculate how much the perspective view squishes or stretches the extrude
+    float extrude_length_without_perspective = length(dist);
+    float extrude_length_with_perspective = length(projected_extrude.xy / gl_Position.w * u_units_to_pixels);
+    v_gamma_scale = extrude_length_without_perspective / extrude_length_with_perspective;
+
+    v_width2 = vec2(outset, inset);
+}
+)";
+    static constexpr const char* fragment = R"(layout (std140) uniform LineGradientUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_units_to_pixels;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+};
+
+layout (std140) uniform LineGradientPropertiesUBO {
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_gapwidth;
+    lowp float u_offset;
+    mediump float u_width;
+
+    highp float pad1;
+    highp vec2 pad2;
+};
+
+layout (std140) uniform LineGradientInterpolationUBO {
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_gapwidth_t;
+    lowp float u_offset_t;
+    lowp float u_width_t;
+
+    highp float pad3;
+    highp vec2 pad4;
+};
+
+uniform sampler2D u_image;
+
+in vec2 v_width2;
+in vec2 v_normal;
+in float v_gamma_scale;
+in highp float v_lineprogress;
+
+#ifndef HAS_UNIFORM_u_blur
+in lowp float blur;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_blur
+lowp float blur = u_blur;
+#endif
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+
+    // Calculate the distance of the pixel from the line in pixels.
+    float dist = length(v_normal) * v_width2.s;
+
+    // Calculate the antialiasing fade factor. This is either when fading in
+    // the line in case of an offset line (v_width2.t) or when fading out
+    // (v_width2.s)
+    float blur2 = (blur + 1.0 / u_device_pixel_ratio) * v_gamma_scale;
+    float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
+
+    // For gradient lines, v_lineprogress is the ratio along the entire line,
+    // scaled to [0, 2^15), and the gradient ramp is stored in a texture.
+    vec4 color = texture(u_image, vec2(v_lineprogress, 0.5));
+
+    fragColor = color * (alpha * opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_line_pattern.hpp
+++ b/include/mbgl/shaders/gl/drawable_line_pattern.hpp
@@ -1,0 +1,309 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::LinePatternShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "LinePatternShader";
+    static constexpr const char* vertex = R"(// floor(127 / 2) == 63.0
+// the maximum allowed miter limit is 2.0 at the moment. the extrude normal is
+// stored in a byte (-128..127). we scale regular normals up to length 63, but
+// there are also "special" normals that have a bigger length (of up to 126 in
+// this case).
+// #define scale 63.0
+#define scale 0.015873016
+
+// We scale the distance before adding it to the buffers so that we can store
+// long distances for long segments. Use this value to unscale the distance.
+#define LINE_DISTANCE_SCALE 2.0
+
+layout (location = 0) in vec2 a_pos_normal;
+layout (location = 1) in vec4 a_data;
+
+layout (std140) uniform LinePatternUBO {
+    highp mat4 u_matrix;
+    mediump vec4 u_scale;
+    highp vec2 u_texsize;
+    highp vec2 u_units_to_pixels;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+    highp float u_fade;
+
+    highp float pad1;
+};
+
+layout (std140) uniform LinePatternPropertiesUBO {
+    lowp float u_blur;
+    lowp float u_opacity;
+    lowp float u_offset;
+    mediump float u_gapwidth;
+    mediump float u_width;
+
+    highp float pad2;
+    highp vec2 pad3;
+};
+
+layout (std140) uniform LinePatternTilePropertiesUBO {
+    lowp vec4 u_pattern_from;
+    lowp vec4 u_pattern_to;
+};
+
+layout (std140) uniform LinePatternInterpolationUBO {
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_offset_t;
+    lowp float u_gapwidth_t;
+    lowp float u_width_t;
+    lowp float u_pattern_from_t;
+    lowp float u_pattern_to_t;
+
+    highp float pad4;
+};
+
+out vec2 v_normal;
+out vec2 v_width2;
+out float v_linesofar;
+out float v_gamma_scale;
+
+#ifndef HAS_UNIFORM_u_blur
+layout (location = 2) in lowp vec2 a_blur;
+out lowp float blur;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 3) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_offset
+layout (location = 4) in lowp vec2 a_offset;
+#endif
+#ifndef HAS_UNIFORM_u_gapwidth
+layout (location = 5) in mediump vec2 a_gapwidth;
+#endif
+#ifndef HAS_UNIFORM_u_width
+layout (location = 6) in mediump vec2 a_width;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_from
+layout (location = 7) in lowp vec4 a_pattern_from;
+out lowp vec4 pattern_from;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_to
+layout (location = 8) in lowp vec4 a_pattern_to;
+out lowp vec4 pattern_to;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_blur
+blur = unpack_mix_vec2(a_blur, u_blur_t);
+#else
+lowp float blur = u_blur;
+#endif
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+    #ifndef HAS_UNIFORM_u_offset
+lowp float offset = unpack_mix_vec2(a_offset, u_offset_t);
+#else
+lowp float offset = u_offset;
+#endif
+    #ifndef HAS_UNIFORM_u_gapwidth
+mediump float gapwidth = unpack_mix_vec2(a_gapwidth, u_gapwidth_t);
+#else
+mediump float gapwidth = u_gapwidth;
+#endif
+    #ifndef HAS_UNIFORM_u_width
+mediump float width = unpack_mix_vec2(a_width, u_width_t);
+#else
+mediump float width = u_width;
+#endif
+    #ifndef HAS_UNIFORM_u_pattern_from
+pattern_from = a_pattern_from;
+#else
+mediump vec4 pattern_from = u_pattern_from;
+#endif
+    #ifndef HAS_UNIFORM_u_pattern_to
+pattern_to = a_pattern_to;
+#else
+mediump vec4 pattern_to = u_pattern_to;
+#endif
+
+    // the distance over which the line edge fades out.
+    // Retina devices need a smaller distance to avoid aliasing.
+    float ANTIALIASING = 1.0 / u_device_pixel_ratio / 2.0;
+
+    vec2 a_extrude = a_data.xy - 128.0;
+    float a_direction = mod(a_data.z, 4.0) - 1.0;
+    float a_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * LINE_DISTANCE_SCALE;
+    // float tileRatio = u_scale.y;
+    vec2 pos = floor(a_pos_normal * 0.5);
+
+    // x is 1 if it's a round cap, 0 otherwise
+    // y is 1 if the normal points up, and -1 if it points down
+    // We store these in the least significant bit of a_pos_normal
+    mediump vec2 normal = a_pos_normal - 2.0 * pos;
+    normal.y = normal.y * 2.0 - 1.0;
+    v_normal = normal;
+
+    // these transformations used to be applied in the JS and native code bases.
+    // moved them into the shader for clarity and simplicity.
+    gapwidth = gapwidth / 2.0;
+    float halfwidth = width / 2.0;
+    offset = -1.0 * offset;
+
+    float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
+    float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + (halfwidth == 0.0 ? 0.0 : ANTIALIASING);
+
+    // Scale the extrusion vector down to a normal and then up by the line width
+    // of this vertex.
+    mediump vec2 dist = outset * a_extrude * scale;
+
+    // Calculate the offset when drawing a line that is to the side of the actual line.
+    // We do this by creating a vector that points towards the extrude, but rotate
+    // it when we're drawing round end points (a_direction = -1 or 1) since their
+    // extrude vector points in another direction.
+    mediump float u = 0.5 * a_direction;
+    mediump float t = 1.0 - abs(u);
+    mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
+
+    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+
+    // calculate how much the perspective view squishes or stretches the extrude
+    float extrude_length_without_perspective = length(dist);
+    float extrude_length_with_perspective = length(projected_extrude.xy / gl_Position.w * u_units_to_pixels);
+    v_gamma_scale = extrude_length_without_perspective / extrude_length_with_perspective;
+
+    v_linesofar = a_linesofar;
+    v_width2 = vec2(outset, inset);
+}
+)";
+    static constexpr const char* fragment = R"(layout (std140) uniform LinePatternUBO {
+    highp mat4 u_matrix;
+    mediump vec4 u_scale;
+    highp vec2 u_texsize;
+    highp vec2 u_units_to_pixels;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+    highp float u_fade;
+
+    highp float pad1;
+};
+
+layout (std140) uniform LinePatternPropertiesUBO {
+    lowp float u_blur;
+    lowp float u_opacity;
+    lowp float u_offset;
+    mediump float u_gapwidth;
+    mediump float u_width;
+
+    highp float pad2;
+    highp vec2 pad3;
+};
+
+layout (std140) uniform LinePatternTilePropertiesUBO {
+    lowp vec4 u_pattern_from;
+    lowp vec4 u_pattern_to;
+};
+
+layout (std140) uniform LinePatternInterpolationUBO {
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_offset_t;
+    lowp float u_gapwidth_t;
+    lowp float u_width_t;
+    lowp float u_pattern_from_t;
+    lowp float u_pattern_to_t;
+
+    highp float pad4;
+};
+
+uniform sampler2D u_image;
+
+in vec2 v_normal;
+in vec2 v_width2;
+in float v_linesofar;
+in float v_gamma_scale;
+
+#ifndef HAS_UNIFORM_u_pattern_from
+in lowp vec4 pattern_from;
+#endif
+#ifndef HAS_UNIFORM_u_pattern_to
+in lowp vec4 pattern_to;
+#endif
+#ifndef HAS_UNIFORM_u_blur
+in lowp float blur;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_pattern_from
+mediump vec4 pattern_from = u_pattern_from;
+#endif
+    #ifdef HAS_UNIFORM_u_pattern_to
+mediump vec4 pattern_to = u_pattern_to;
+#endif
+
+    #ifdef HAS_UNIFORM_u_blur
+lowp float blur = u_blur;
+#endif
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    float pixelRatio = u_scale.x;
+    float tileZoomRatio = u_scale.y;
+    float fromScale = u_scale.z;
+    float toScale = u_scale.w;
+
+    vec2 display_size_a = vec2((pattern_br_a.x - pattern_tl_a.x) / pixelRatio, (pattern_br_a.y - pattern_tl_a.y) / pixelRatio);
+    vec2 display_size_b = vec2((pattern_br_b.x - pattern_tl_b.x) / pixelRatio, (pattern_br_b.y - pattern_tl_b.y) / pixelRatio);
+
+    vec2 pattern_size_a = vec2(display_size_a.x * fromScale / tileZoomRatio, display_size_a.y);
+    vec2 pattern_size_b = vec2(display_size_b.x * toScale / tileZoomRatio, display_size_b.y);
+
+    // Calculate the distance of the pixel from the line in pixels.
+    float dist = length(v_normal) * v_width2.s;
+
+    // Calculate the antialiasing fade factor. This is either when fading in
+    // the line in case of an offset line (v_width2.t) or when fading out
+    // (v_width2.s)
+    float blur2 = (blur + 1.0 / u_device_pixel_ratio) * v_gamma_scale;
+    float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
+
+    float x_a = mod(v_linesofar / pattern_size_a.x, 1.0);
+    float x_b = mod(v_linesofar / pattern_size_b.x, 1.0);
+
+    // v_normal.y is 0 at the midpoint of the line, -1 at the lower edge, 1 at the upper edge
+    // we clamp the line width outset to be between 0 and half the pattern height plus padding (2.0)
+    // to ensure we don't sample outside the designated symbol on the sprite sheet.
+    // 0.5 is added to shift the component to be bounded between 0 and 1 for interpolation of
+    // the texture coordinate
+    float y_a = 0.5 + (v_normal.y * clamp(v_width2.s, 0.0, (pattern_size_a.y + 2.0) / 2.0) / pattern_size_a.y);
+    float y_b = 0.5 + (v_normal.y * clamp(v_width2.s, 0.0, (pattern_size_b.y + 2.0) / 2.0) / pattern_size_b.y);
+    vec2 pos_a = mix(pattern_tl_a / u_texsize, pattern_br_a / u_texsize, vec2(x_a, y_a));
+    vec2 pos_b = mix(pattern_tl_b / u_texsize, pattern_br_b / u_texsize, vec2(x_b, y_b));
+
+    vec4 color = mix(texture(u_image, pos_a), texture(u_image, pos_b), u_fade);
+
+    fragColor = color * alpha * opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_line_sdf.hpp
+++ b/include/mbgl/shaders/gl/drawable_line_sdf.hpp
@@ -1,0 +1,288 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::LineSDFShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "LineSDFShader";
+    static constexpr const char* vertex = R"(// floor(127 / 2) == 63.0
+// the maximum allowed miter limit is 2.0 at the moment. the extrude normal is
+// stored in a byte (-128..127). we scale regular normals up to length 63, but
+// there are also "special" normals that have a bigger length (of up to 126 in
+// this case).
+// #define scale 63.0
+#define scale 0.015873016
+
+// We scale the distance before adding it to the buffers so that we can store
+// long distances for long segments. Use this value to unscale the distance.
+#define LINE_DISTANCE_SCALE 2.0
+
+layout (location = 0) in vec2 a_pos_normal;
+layout (location = 1) in vec4 a_data;
+
+layout (std140) uniform LineSDFUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_units_to_pixels;
+    highp vec2 u_patternscale_a;
+    highp vec2 u_patternscale_b;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+    highp float u_tex_y_a;
+    highp float u_tex_y_b;
+    highp float u_sdfgamma;
+    highp float u_mix;
+};
+
+layout (std140) uniform LineSDFPropertiesUBO {
+    highp vec4 u_color;
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_gapwidth;
+    lowp float u_offset;
+    mediump float u_width;
+    lowp float u_floorwidth;
+
+    highp vec2 pad1;
+};
+
+layout (std140) uniform LineSDFInterpolationUBO {
+    lowp float u_color_t;
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_gapwidth_t;
+    lowp float u_offset_t;
+    lowp float u_width_t;
+    lowp float u_floorwidth_t;
+
+    highp float pad2;
+};
+
+out vec2 v_normal;
+out vec2 v_width2;
+out vec2 v_tex_a;
+out vec2 v_tex_b;
+out float v_gamma_scale;
+
+#ifndef HAS_UNIFORM_u_color
+layout (location = 2) in highp vec4 a_color;
+out highp vec4 color;
+#endif
+#ifndef HAS_UNIFORM_u_blur
+layout (location = 3) in lowp vec2 a_blur;
+out lowp float blur;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 4) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_gapwidth
+layout (location = 5) in mediump vec2 a_gapwidth;
+#endif
+#ifndef HAS_UNIFORM_u_offset
+layout (location = 6) in lowp vec2 a_offset;
+#endif
+#ifndef HAS_UNIFORM_u_width
+layout (location = 7) in mediump vec2 a_width;
+out mediump float width;
+#endif
+#ifndef HAS_UNIFORM_u_floorwidth
+layout (location = 8) in lowp vec2 a_floorwidth;
+out lowp float floorwidth;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_color
+color = unpack_mix_color(a_color, u_color_t);
+#else
+highp vec4 color = u_color;
+#endif
+    #ifndef HAS_UNIFORM_u_blur
+blur = unpack_mix_vec2(a_blur, u_blur_t);
+#else
+lowp float blur = u_blur;
+#endif
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+    #ifndef HAS_UNIFORM_u_gapwidth
+mediump float gapwidth = unpack_mix_vec2(a_gapwidth, u_gapwidth_t);
+#else
+mediump float gapwidth = u_gapwidth;
+#endif
+    #ifndef HAS_UNIFORM_u_offset
+lowp float offset = unpack_mix_vec2(a_offset, u_offset_t);
+#else
+lowp float offset = u_offset;
+#endif
+    #ifndef HAS_UNIFORM_u_width
+width = unpack_mix_vec2(a_width, u_width_t);
+#else
+mediump float width = u_width;
+#endif
+    #ifndef HAS_UNIFORM_u_floorwidth
+floorwidth = unpack_mix_vec2(a_floorwidth, u_floorwidth_t);
+#else
+lowp float floorwidth = u_floorwidth;
+#endif
+
+    // the distance over which the line edge fades out.
+    // Retina devices need a smaller distance to avoid aliasing.
+    float ANTIALIASING = 1.0 / u_device_pixel_ratio / 2.0;
+
+    vec2 a_extrude = a_data.xy - 128.0;
+    float a_direction = mod(a_data.z, 4.0) - 1.0;
+    float a_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * LINE_DISTANCE_SCALE;
+
+    vec2 pos = floor(a_pos_normal * 0.5);
+
+    // x is 1 if it's a round cap, 0 otherwise
+    // y is 1 if the normal points up, and -1 if it points down
+    // We store these in the least significant bit of a_pos_normal
+    mediump vec2 normal = a_pos_normal - 2.0 * pos;
+    normal.y = normal.y * 2.0 - 1.0;
+    v_normal = normal;
+
+    // these transformations used to be applied in the JS and native code bases.
+    // moved them into the shader for clarity and simplicity.
+    gapwidth = gapwidth / 2.0;
+    float halfwidth = width / 2.0;
+    offset = -1.0 * offset;
+
+    float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
+    float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + (halfwidth == 0.0 ? 0.0 : ANTIALIASING);
+
+    // Scale the extrusion vector down to a normal and then up by the line width
+    // of this vertex.
+    mediump vec2 dist =outset * a_extrude * scale;
+
+    // Calculate the offset when drawing a line that is to the side of the actual line.
+    // We do this by creating a vector that points towards the extrude, but rotate
+    // it when we're drawing round end points (a_direction = -1 or 1) since their
+    // extrude vector points in another direction.
+    mediump float u = 0.5 * a_direction;
+    mediump float t = 1.0 - abs(u);
+    mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
+
+    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+
+    // calculate how much the perspective view squishes or stretches the extrude
+    float extrude_length_without_perspective = length(dist);
+    float extrude_length_with_perspective = length(projected_extrude.xy / gl_Position.w * u_units_to_pixels);
+    v_gamma_scale = extrude_length_without_perspective / extrude_length_with_perspective;
+
+    v_tex_a = vec2(a_linesofar * u_patternscale_a.x / floorwidth, normal.y * u_patternscale_a.y + u_tex_y_a);
+    v_tex_b = vec2(a_linesofar * u_patternscale_b.x / floorwidth, normal.y * u_patternscale_b.y + u_tex_y_b);
+
+    v_width2 = vec2(outset, inset);
+}
+)";
+    static constexpr const char* fragment = R"(
+layout (std140) uniform LineSDFUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_units_to_pixels;
+    highp vec2 u_patternscale_a;
+    highp vec2 u_patternscale_b;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+    highp float u_tex_y_a;
+    highp float u_tex_y_b;
+    highp float u_sdfgamma;
+    highp float u_mix;
+};
+
+layout (std140) uniform LineSDFPropertiesUBO {
+    highp vec4 u_color;
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_gapwidth;
+    lowp float u_offset;
+    mediump float u_width;
+    lowp float u_floorwidth;
+
+    highp vec2 pad1;
+};
+
+layout (std140) uniform LineSDFInterpolationUBO {
+    lowp float u_color_t;
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_gapwidth_t;
+    lowp float u_offset_t;
+    lowp float u_width_t;
+    lowp float u_floorwidth_t;
+
+    highp float pad2;
+};
+
+uniform sampler2D u_image;
+
+in vec2 v_normal;
+in vec2 v_width2;
+in vec2 v_tex_a;
+in vec2 v_tex_b;
+in float v_gamma_scale;
+
+#ifndef HAS_UNIFORM_u_color
+in highp vec4 color;
+#endif
+#ifndef HAS_UNIFORM_u_blur
+in lowp float blur;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_width
+in mediump float width;
+#endif
+#ifndef HAS_UNIFORM_u_floorwidth
+in lowp float floorwidth;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_color
+highp vec4 color = u_color;
+#endif
+    #ifdef HAS_UNIFORM_u_blur
+lowp float blur = u_blur;
+#endif
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+    #ifdef HAS_UNIFORM_u_width
+mediump float width = u_width;
+#endif
+    #ifdef HAS_UNIFORM_u_floorwidth
+lowp float floorwidth = u_floorwidth;
+#endif
+
+    // Calculate the distance of the pixel from the line in pixels.
+    float dist = length(v_normal) * v_width2.s;
+
+    // Calculate the antialiasing fade factor. This is either when fading in
+    // the line in case of an offset line (v_width2.t) or when fading out
+    // (v_width2.s)
+    float blur2 = (blur + 1.0 / u_device_pixel_ratio) * v_gamma_scale;
+    float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
+
+    float sdfdist_a = texture(u_image, v_tex_a).a;
+    float sdfdist_b = texture(u_image, v_tex_b).a;
+    float sdfdist = mix(sdfdist_a, sdfdist_b, u_mix);
+    alpha *= smoothstep(0.5 - u_sdfgamma / floorwidth, 0.5 + u_sdfgamma / floorwidth, sdfdist);
+
+    fragColor = color * (alpha * opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_raster.hpp
+++ b/include/mbgl/shaders/gl/drawable_raster.hpp
@@ -1,0 +1,107 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::RasterShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "RasterShader";
+    static constexpr const char* vertex = R"(layout (std140) uniform RasterDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec3 u_spin_weights;
+    highp vec2 u_tl_parent;
+    highp float u_scale_parent;
+    highp float u_buffer_scale;
+    highp float u_fade_t;
+    highp float u_opacity;
+    highp float u_brightness_low;
+    highp float u_brightness_high;
+    highp float u_saturation_factor;
+    highp float u_contrast_factor;
+    highp float pad1;
+    highp float pad2;
+};
+
+layout (location = 0) in vec2 a_pos;
+layout (location = 1) in vec2 a_texture_pos;
+
+out vec2 v_pos0;
+out vec2 v_pos1;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+    // We are using Int16 for texture position coordinates to give us enough precision for
+    // fractional coordinates. We use 8192 to scale the texture coordinates in the buffer
+    // as an arbitrarily high number to preserve adequate precision when rendering.
+    // This is also the same value as the EXTENT we are using for our tile buffer pos coordinates,
+    // so math for modifying either is consistent.
+    v_pos0 = (((a_texture_pos / 8192.0) - 0.5) / u_buffer_scale ) + 0.5;
+    v_pos1 = (v_pos0 * u_scale_parent) + u_tl_parent;
+}
+)";
+    static constexpr const char* fragment = R"(layout (std140) uniform RasterDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec3 u_spin_weights;
+    highp vec2 u_tl_parent;
+    highp float u_scale_parent;
+    highp float u_buffer_scale;
+    highp float u_fade_t;
+    highp float u_opacity;
+    highp float u_brightness_low;
+    highp float u_brightness_high;
+    highp float u_saturation_factor;
+    highp float u_contrast_factor;
+    highp float pad1;
+    highp float pad2;
+};
+uniform sampler2D u_image0;
+uniform sampler2D u_image1;
+
+in vec2 v_pos0;
+in vec2 v_pos1;
+
+void main() {
+
+    // read and cross-fade colors from the main and parent tiles
+    vec4 color0 = texture(u_image0, v_pos0);
+    vec4 color1 = texture(u_image1, v_pos1);
+    if (color0.a > 0.0) {
+        color0.rgb = color0.rgb / color0.a;
+    }
+    if (color1.a > 0.0) {
+        color1.rgb = color1.rgb / color1.a;
+    }
+    vec4 color = mix(color0, color1, u_fade_t);
+    color.a *= u_opacity;
+    vec3 rgb = color.rgb;
+
+    // spin
+    rgb = vec3(
+        dot(rgb, u_spin_weights.xyz),
+        dot(rgb, u_spin_weights.zxy),
+        dot(rgb, u_spin_weights.yzx));
+
+    // saturation
+    float average = (color.r + color.g + color.b) / 3.0;
+    rgb += (average - rgb) * u_saturation_factor;
+
+    // contrast
+    rgb = (rgb - 0.5) * u_contrast_factor + 0.5;
+
+    // brightness
+    vec3 u_high_vec = vec3(u_brightness_low, u_brightness_low, u_brightness_low);
+    vec3 u_low_vec = vec3(u_brightness_high, u_brightness_high, u_brightness_high);
+
+    fragColor = vec4(mix(u_high_vec, u_low_vec, rgb) * color.a, color.a);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_symbol_icon.hpp
+++ b/include/mbgl/shaders/gl/drawable_symbol_icon.hpp
@@ -1,0 +1,183 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::SymbolIconShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "SymbolIconShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec4 a_pos_offset;
+layout (location = 1) in vec4 a_data;
+layout (location = 2) in vec4 a_pixeloffset;
+layout (location = 3) in vec3 a_projected_pos;
+layout (location = 4) in float a_fade_opacity;
+
+layout (std140) uniform SymbolDrawableUBO {
+    highp mat4 u_matrix;
+    highp mat4 u_label_plane_matrix;
+    highp mat4 u_coord_matrix;
+
+    highp vec2 u_texsize;
+    highp vec2 u_texsize_icon;
+
+    highp float u_gamma_scale;
+    highp float u_device_pixel_ratio;
+
+    highp float u_camera_to_center_distance;
+    highp float u_pitch;
+    bool u_rotate_symbol;
+    highp float u_aspect_ratio;
+    highp float u_fade_change;
+    highp float u_pad2;
+};
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    bool u_pitch_with_map;
+    bool u_is_size_zoom_constant;
+    bool u_is_size_feature_constant;
+    highp float u_size_t; // used to interpolate between zoom stops when size is a composite function
+    highp float u_size; // used when size is both zoom and feature constant
+    bool u_pad3;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+out vec2 v_tex;
+out float v_fade_opacity;
+
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 5) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+
+    vec2 a_pos = a_pos_offset.xy;
+    vec2 a_offset = a_pos_offset.zw;
+
+    vec2 a_tex = a_data.xy;
+    vec2 a_size = a_data.zw;
+
+    float a_size_min = floor(a_size[0] * 0.5);
+    vec2 a_pxoffset = a_pixeloffset.xy;
+    vec2 a_minFontScale = a_pixeloffset.zw / 256.0;
+
+    highp float segment_angle = -a_projected_pos[2];
+    float size;
+
+    if (!u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = mix(a_size_min, a_size[1], u_size_t) / 128.0;
+    } else if (u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = a_size_min / 128.0;
+    } else {
+        size = u_size;
+    }
+
+    vec4 projectedPoint = u_matrix * vec4(a_pos, 0, 1);
+    highp float camera_to_anchor_distance = projectedPoint.w;
+    // See comments in symbol_sdf.vertex
+    highp float distance_ratio = u_pitch_with_map ?
+        camera_to_anchor_distance / u_camera_to_center_distance :
+        u_camera_to_center_distance / camera_to_anchor_distance;
+    highp float perspective_ratio = clamp(
+            0.5 + 0.5 * distance_ratio,
+            0.0, // Prevents oversized near-field symbols in pitched/overzoomed tiles
+            4.0);
+
+    size *= perspective_ratio;
+
+    float fontScale = u_is_text ? size / 24.0 : size;
+
+    highp float symbol_rotation = 0.0;
+    if (u_rotate_symbol) {
+        // See comments in symbol_sdf.vertex
+        vec4 offsetProjectedPoint = u_matrix * vec4(a_pos + vec2(1, 0), 0, 1);
+
+        vec2 a = projectedPoint.xy / projectedPoint.w;
+        vec2 b = offsetProjectedPoint.xy / offsetProjectedPoint.w;
+
+        symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
+    }
+
+    highp float angle_sin = sin(segment_angle + symbol_rotation);
+    highp float angle_cos = cos(segment_angle + symbol_rotation);
+    mat2 rotation_matrix = mat2(angle_cos, -1.0 * angle_sin, angle_sin, angle_cos);
+
+    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
+    gl_Position = u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + rotation_matrix * (a_offset / 32.0 * max(a_minFontScale, fontScale) + a_pxoffset / 16.0), 0.0, 1.0);
+
+    v_tex = a_tex / u_texsize;
+    vec2 fade_opacity = unpack_opacity(a_fade_opacity);
+    float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
+    v_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
+}
+)";
+    static constexpr const char* fragment = R"(uniform sampler2D u_texture;
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+in vec2 v_tex;
+in float v_fade_opacity;
+
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+
+    lowp float alpha = opacity * v_fade_opacity;
+    fragColor = texture(u_texture, v_tex) * alpha;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_symbol_sdf_icon.hpp
+++ b/include/mbgl/shaders/gl/drawable_symbol_sdf_icon.hpp
@@ -1,0 +1,313 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::SymbolSDFIconShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "SymbolSDFIconShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec4 a_pos_offset;
+layout (location = 1) in vec4 a_data;
+layout (location = 2) in vec4 a_pixeloffset;
+layout (location = 3) in vec3 a_projected_pos;
+layout (location = 4) in float a_fade_opacity;
+
+// contents of a_size vary based on the type of property value
+// used for {text,icon}-size.
+// For constants, a_size is disabled.
+// For source functions, we bind only one value per vertex: the value of {text,icon}-size evaluated for the current feature.
+// For composite functions:
+// [ text-size(lowerZoomStop, feature),
+//   text-size(upperZoomStop, feature) ]
+
+layout (std140) uniform SymbolDrawableUBO {
+    highp mat4 u_matrix;
+    highp mat4 u_label_plane_matrix;
+    highp mat4 u_coord_matrix;
+
+    highp vec2 u_texsize;
+    highp vec2 u_texsize_icon;
+
+    highp float u_gamma_scale;
+    highp float u_device_pixel_ratio;
+
+    highp float u_camera_to_center_distance;
+    highp float u_pitch;
+    bool u_rotate_symbol;
+    highp float u_aspect_ratio;
+    highp float u_fade_change;
+    highp float u_pad2;
+};
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    bool u_pitch_with_map;
+    bool u_is_size_zoom_constant;
+    bool u_is_size_feature_constant;
+    highp float u_size_t; // used to interpolate between zoom stops when size is a composite function
+    highp float u_size; // used when size is both zoom and feature constant
+    bool u_pad3;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+out vec2 v_data0;
+out vec3 v_data1;
+
+#ifndef HAS_UNIFORM_u_fill_color
+layout (location = 5) in highp vec4 a_fill_color;
+out highp vec4 fill_color;
+#endif
+#ifndef HAS_UNIFORM_u_halo_color
+layout (location = 6) in highp vec4 a_halo_color;
+out highp vec4 halo_color;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 7) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_halo_width
+layout (location = 8) in lowp vec2 a_halo_width;
+out lowp float halo_width;
+#endif
+#ifndef HAS_UNIFORM_u_halo_blur
+layout (location = 9) in lowp vec2 a_halo_blur;
+out lowp float halo_blur;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_fill_color
+fill_color = unpack_mix_color(a_fill_color, u_fill_color_t);
+#else
+highp vec4 fill_color = u_fill_color;
+#endif
+    #ifndef HAS_UNIFORM_u_halo_color
+halo_color = unpack_mix_color(a_halo_color, u_halo_color_t);
+#else
+highp vec4 halo_color = u_halo_color;
+#endif
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+    #ifndef HAS_UNIFORM_u_halo_width
+halo_width = unpack_mix_vec2(a_halo_width, u_halo_width_t);
+#else
+lowp float halo_width = u_halo_width;
+#endif
+    #ifndef HAS_UNIFORM_u_halo_blur
+halo_blur = unpack_mix_vec2(a_halo_blur, u_halo_blur_t);
+#else
+lowp float halo_blur = u_halo_blur;
+#endif
+
+    vec2 a_pos = a_pos_offset.xy;
+    vec2 a_offset = a_pos_offset.zw;
+
+    vec2 a_tex = a_data.xy;
+    vec2 a_size = a_data.zw;
+
+    float a_size_min = floor(a_size[0] * 0.5);
+    vec2 a_pxoffset = a_pixeloffset.xy;
+
+    highp float segment_angle = -a_projected_pos[2];
+    float size;
+
+    if (!u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = mix(a_size_min, a_size[1], u_size_t) / 128.0;
+    } else if (u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = a_size_min / 128.0;
+    } else {
+        size = u_size;
+    }
+
+    vec4 projectedPoint = u_matrix * vec4(a_pos, 0, 1);
+    highp float camera_to_anchor_distance = projectedPoint.w;
+    // If the label is pitched with the map, layout is done in pitched space,
+    // which makes labels in the distance smaller relative to viewport space.
+    // We counteract part of that effect by multiplying by the perspective ratio.
+    // If the label isn't pitched with the map, we do layout in viewport space,
+    // which makes labels in the distance larger relative to the features around
+    // them. We counteract part of that effect by dividing by the perspective ratio.
+    highp float distance_ratio = u_pitch_with_map ?
+        camera_to_anchor_distance / u_camera_to_center_distance :
+        u_camera_to_center_distance / camera_to_anchor_distance;
+    highp float perspective_ratio = clamp(
+        0.5 + 0.5 * distance_ratio,
+        0.0, // Prevents oversized near-field symbols in pitched/overzoomed tiles
+        4.0);
+
+    size *= perspective_ratio;
+
+    float fontScale = u_is_text ? size / 24.0 : size;
+
+    highp float symbol_rotation = 0.0;
+    if (u_rotate_symbol) {
+        // Point labels with 'rotation-alignment: map' are horizontal with respect to tile units
+        // To figure out that angle in projected space, we draw a short horizontal line in tile
+        // space, project it, and measure its angle in projected space.
+        vec4 offsetProjectedPoint = u_matrix * vec4(a_pos + vec2(1, 0), 0, 1);
+
+        vec2 a = projectedPoint.xy / projectedPoint.w;
+        vec2 b = offsetProjectedPoint.xy / offsetProjectedPoint.w;
+
+        symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
+    }
+
+    highp float angle_sin = sin(segment_angle + symbol_rotation);
+    highp float angle_cos = cos(segment_angle + symbol_rotation);
+    mat2 rotation_matrix = mat2(angle_cos, -1.0 * angle_sin, angle_sin, angle_cos);
+
+    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
+    gl_Position = u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + rotation_matrix * (a_offset / 32.0 * fontScale + a_pxoffset), 0.0, 1.0);
+    float gamma_scale = gl_Position.w;
+
+    vec2 fade_opacity = unpack_opacity(a_fade_opacity);
+    float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
+    float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
+
+    v_data0 = a_tex / u_texsize;
+    v_data1 = vec3(gamma_scale, size, interpolated_fade_opacity);
+}
+)";
+    static constexpr const char* fragment = R"(#define SDF_PX 8.0
+
+layout (std140) uniform SymbolDrawableUBO {
+    highp mat4 u_matrix;
+    highp mat4 u_label_plane_matrix;
+    highp mat4 u_coord_matrix;
+
+    highp vec2 u_texsize;
+    highp vec2 u_texsize_icon;
+
+    highp float u_gamma_scale;
+    highp float u_device_pixel_ratio;
+
+    highp float u_camera_to_center_distance;
+    highp float u_pitch;
+    bool u_rotate_symbol;
+    highp float u_aspect_ratio;
+    highp float u_fade_change;
+    highp float u_pad2;
+};
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    bool u_pitch_with_map;
+    bool u_is_size_zoom_constant;
+    bool u_is_size_feature_constant;
+    highp float u_size_t; // used to interpolate between zoom stops when size is a composite function
+    highp float u_size; // used when size is both zoom and feature constant
+    bool u_pad3;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+uniform sampler2D u_texture;
+
+in vec2 v_data0;
+in vec3 v_data1;
+
+#ifndef HAS_UNIFORM_u_fill_color
+in highp vec4 fill_color;
+#endif
+#ifndef HAS_UNIFORM_u_halo_color
+in highp vec4 halo_color;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_halo_width
+in lowp float halo_width;
+#endif
+#ifndef HAS_UNIFORM_u_halo_blur
+in lowp float halo_blur;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_fill_color
+highp vec4 fill_color = u_fill_color;
+#endif
+    #ifdef HAS_UNIFORM_u_halo_color
+highp vec4 halo_color = u_halo_color;
+#endif
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+    #ifdef HAS_UNIFORM_u_halo_width
+lowp float halo_width = u_halo_width;
+#endif
+    #ifdef HAS_UNIFORM_u_halo_blur
+lowp float halo_blur = u_halo_blur;
+#endif
+
+    float EDGE_GAMMA = 0.105 / u_device_pixel_ratio;
+
+    vec2 tex = v_data0.xy;
+    float gamma_scale = v_data1.x;
+    float size = v_data1.y;
+    float fade_opacity = v_data1[2];
+
+    float fontScale = u_is_text ? size / 24.0 : size;
+
+    lowp vec4 color = fill_color;
+    highp float gamma = EDGE_GAMMA / (fontScale * u_gamma_scale);
+    lowp float buff = (256.0 - 64.0) / 256.0;
+    if (u_is_halo) {
+        color = halo_color;
+        gamma = (halo_blur * 1.19 / SDF_PX + EDGE_GAMMA) / (fontScale * u_gamma_scale);
+        buff = (6.0 - halo_width / fontScale) / SDF_PX;
+    }
+
+    lowp float dist = texture(u_texture, tex).a;
+    highp float gamma_scaled = gamma * gamma_scale;
+    highp float alpha = smoothstep(buff - gamma_scaled, buff + gamma_scaled, dist);
+
+    fragColor = color * (alpha * opacity * fade_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_symbol_sdf_text.hpp
+++ b/include/mbgl/shaders/gl/drawable_symbol_sdf_text.hpp
@@ -1,0 +1,313 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::SymbolSDFTextShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "SymbolSDFTextShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec4 a_pos_offset;
+layout (location = 1) in vec4 a_data;
+layout (location = 2) in vec4 a_pixeloffset;
+layout (location = 3) in vec3 a_projected_pos;
+layout (location = 4) in float a_fade_opacity;
+
+// contents of a_size vary based on the type of property value
+// used for {text,icon}-size.
+// For constants, a_size is disabled.
+// For source functions, we bind only one value per vertex: the value of {text,icon}-size evaluated for the current feature.
+// For composite functions:
+// [ text-size(lowerZoomStop, feature),
+//   text-size(upperZoomStop, feature) ]
+
+layout (std140) uniform SymbolDrawableUBO {
+    highp mat4 u_matrix;
+    highp mat4 u_label_plane_matrix;
+    highp mat4 u_coord_matrix;
+
+    highp vec2 u_texsize;
+    highp vec2 u_texsize_icon;
+
+    highp float u_gamma_scale;
+    highp float u_device_pixel_ratio;
+
+    highp float u_camera_to_center_distance;
+    highp float u_pitch;
+    bool u_rotate_symbol;
+    highp float u_aspect_ratio;
+    highp float u_fade_change;
+    highp float u_pad2;
+};
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    bool u_pitch_with_map;
+    bool u_is_size_zoom_constant;
+    bool u_is_size_feature_constant;
+    highp float u_size_t; // used to interpolate between zoom stops when size is a composite function
+    highp float u_size; // used when size is both zoom and feature constant
+    bool u_pad3;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+out vec2 v_data0;
+out vec3 v_data1;
+
+#ifndef HAS_UNIFORM_u_fill_color
+layout (location = 5) in highp vec4 a_fill_color;
+out highp vec4 fill_color;
+#endif
+#ifndef HAS_UNIFORM_u_halo_color
+layout (location = 6) in highp vec4 a_halo_color;
+out highp vec4 halo_color;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 7) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_halo_width
+layout (location = 8) in lowp vec2 a_halo_width;
+out lowp float halo_width;
+#endif
+#ifndef HAS_UNIFORM_u_halo_blur
+layout (location = 9) in lowp vec2 a_halo_blur;
+out lowp float halo_blur;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_fill_color
+fill_color = unpack_mix_color(a_fill_color, u_fill_color_t);
+#else
+highp vec4 fill_color = u_fill_color;
+#endif
+    #ifndef HAS_UNIFORM_u_halo_color
+halo_color = unpack_mix_color(a_halo_color, u_halo_color_t);
+#else
+highp vec4 halo_color = u_halo_color;
+#endif
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+    #ifndef HAS_UNIFORM_u_halo_width
+halo_width = unpack_mix_vec2(a_halo_width, u_halo_width_t);
+#else
+lowp float halo_width = u_halo_width;
+#endif
+    #ifndef HAS_UNIFORM_u_halo_blur
+halo_blur = unpack_mix_vec2(a_halo_blur, u_halo_blur_t);
+#else
+lowp float halo_blur = u_halo_blur;
+#endif
+
+    vec2 a_pos = a_pos_offset.xy;
+    vec2 a_offset = a_pos_offset.zw;
+
+    vec2 a_tex = a_data.xy;
+    vec2 a_size = a_data.zw;
+
+    float a_size_min = floor(a_size[0] * 0.5);
+    vec2 a_pxoffset = a_pixeloffset.xy;
+
+    highp float segment_angle = -a_projected_pos[2];
+    float size;
+
+    if (!u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = mix(a_size_min, a_size[1], u_size_t) / 128.0;
+    } else if (u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = a_size_min / 128.0;
+    } else {
+        size = u_size;
+    }
+
+    vec4 projectedPoint = u_matrix * vec4(a_pos, 0, 1);
+    highp float camera_to_anchor_distance = projectedPoint.w;
+    // If the label is pitched with the map, layout is done in pitched space,
+    // which makes labels in the distance smaller relative to viewport space.
+    // We counteract part of that effect by multiplying by the perspective ratio.
+    // If the label isn't pitched with the map, we do layout in viewport space,
+    // which makes labels in the distance larger relative to the features around
+    // them. We counteract part of that effect by dividing by the perspective ratio.
+    highp float distance_ratio = u_pitch_with_map ?
+        camera_to_anchor_distance / u_camera_to_center_distance :
+        u_camera_to_center_distance / camera_to_anchor_distance;
+    highp float perspective_ratio = clamp(
+        0.5 + 0.5 * distance_ratio,
+        0.0, // Prevents oversized near-field symbols in pitched/overzoomed tiles
+        4.0);
+
+    size *= perspective_ratio;
+
+    float fontScale = u_is_text ? size / 24.0 : size;
+
+    highp float symbol_rotation = 0.0;
+    if (u_rotate_symbol) {
+        // Point labels with 'rotation-alignment: map' are horizontal with respect to tile units
+        // To figure out that angle in projected space, we draw a short horizontal line in tile
+        // space, project it, and measure its angle in projected space.
+        vec4 offsetProjectedPoint = u_matrix * vec4(a_pos + vec2(1, 0), 0, 1);
+
+        vec2 a = projectedPoint.xy / projectedPoint.w;
+        vec2 b = offsetProjectedPoint.xy / offsetProjectedPoint.w;
+
+        symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
+    }
+
+    highp float angle_sin = sin(segment_angle + symbol_rotation);
+    highp float angle_cos = cos(segment_angle + symbol_rotation);
+    mat2 rotation_matrix = mat2(angle_cos, -1.0 * angle_sin, angle_sin, angle_cos);
+
+    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
+    gl_Position = u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + rotation_matrix * (a_offset / 32.0 * fontScale + a_pxoffset), 0.0, 1.0);
+    float gamma_scale = gl_Position.w;
+
+    vec2 fade_opacity = unpack_opacity(a_fade_opacity);
+    float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
+    float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
+
+    v_data0 = a_tex / u_texsize;
+    v_data1 = vec3(gamma_scale, size, interpolated_fade_opacity);
+}
+)";
+    static constexpr const char* fragment = R"(#define SDF_PX 8.0
+
+layout (std140) uniform SymbolDrawableUBO {
+    highp mat4 u_matrix;
+    highp mat4 u_label_plane_matrix;
+    highp mat4 u_coord_matrix;
+
+    highp vec2 u_texsize;
+    highp vec2 u_texsize_icon;
+
+    highp float u_gamma_scale;
+    highp float u_device_pixel_ratio;
+
+    highp float u_camera_to_center_distance;
+    highp float u_pitch;
+    bool u_rotate_symbol;
+    highp float u_aspect_ratio;
+    highp float u_fade_change;
+    highp float u_pad2;
+};
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    bool u_pitch_with_map;
+    bool u_is_size_zoom_constant;
+    bool u_is_size_feature_constant;
+    highp float u_size_t; // used to interpolate between zoom stops when size is a composite function
+    highp float u_size; // used when size is both zoom and feature constant
+    bool u_pad3;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+uniform sampler2D u_texture;
+
+in vec2 v_data0;
+in vec3 v_data1;
+
+#ifndef HAS_UNIFORM_u_fill_color
+in highp vec4 fill_color;
+#endif
+#ifndef HAS_UNIFORM_u_halo_color
+in highp vec4 halo_color;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_halo_width
+in lowp float halo_width;
+#endif
+#ifndef HAS_UNIFORM_u_halo_blur
+in lowp float halo_blur;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_fill_color
+highp vec4 fill_color = u_fill_color;
+#endif
+    #ifdef HAS_UNIFORM_u_halo_color
+highp vec4 halo_color = u_halo_color;
+#endif
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+    #ifdef HAS_UNIFORM_u_halo_width
+lowp float halo_width = u_halo_width;
+#endif
+    #ifdef HAS_UNIFORM_u_halo_blur
+lowp float halo_blur = u_halo_blur;
+#endif
+
+    float EDGE_GAMMA = 0.105 / u_device_pixel_ratio;
+
+    vec2 tex = v_data0.xy;
+    float gamma_scale = v_data1.x;
+    float size = v_data1.y;
+    float fade_opacity = v_data1[2];
+
+    float fontScale = u_is_text ? size / 24.0 : size;
+
+    lowp vec4 color = fill_color;
+    highp float gamma = EDGE_GAMMA / (fontScale * u_gamma_scale);
+    lowp float buff = (256.0 - 64.0) / 256.0;
+    if (u_is_halo) {
+        color = halo_color;
+        gamma = (halo_blur * 1.19 / SDF_PX + EDGE_GAMMA) / (fontScale * u_gamma_scale);
+        buff = (6.0 - halo_width / fontScale) / SDF_PX;
+    }
+
+    lowp float dist = texture(u_texture, tex).a;
+    highp float gamma_scaled = gamma * gamma_scale;
+    highp float alpha = smoothstep(buff - gamma_scaled, buff + gamma_scaled, dist);
+
+    fragColor = color * (alpha * opacity * fade_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/gl/drawable_symbol_text_and_icon.hpp
+++ b/include/mbgl/shaders/gl/drawable_symbol_text_and_icon.hpp
@@ -1,0 +1,330 @@
+// Generated code, do not modify this file!
+#pragma once
+#include <mbgl/shaders/shader_source.hpp>
+
+namespace mbgl {
+namespace shaders {
+
+template <>
+struct ShaderSource<BuiltIn::SymbolTextAndIconShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "SymbolTextAndIconShader";
+    static constexpr const char* vertex = R"(layout (location = 0) in vec4 a_pos_offset;
+layout (location = 1) in vec4 a_data;
+layout (location = 2) in vec3 a_projected_pos;
+layout (location = 3) in float a_fade_opacity;
+
+// contents of a_size vary based on the type of property value
+// used for {text,icon}-size.
+// For constants, a_size is disabled.
+// For source functions, we bind only one value per vertex: the value of {text,icon}-size evaluated for the current feature.
+// For composite functions:
+// [ text-size(lowerZoomStop, feature),
+//   text-size(upperZoomStop, feature) ]
+
+layout (std140) uniform SymbolDrawableUBO {
+    highp mat4 u_matrix;
+    highp mat4 u_label_plane_matrix;
+    highp mat4 u_coord_matrix;
+
+    highp vec2 u_texsize;
+    highp vec2 u_texsize_icon;
+
+    highp float u_gamma_scale;
+    highp float u_device_pixel_ratio;
+
+    highp float u_camera_to_center_distance;
+    highp float u_pitch;
+    bool u_rotate_symbol;
+    highp float u_aspect_ratio;
+    highp float u_fade_change;
+    highp float u_pad2;
+};
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    bool u_pitch_with_map;
+    bool u_is_size_zoom_constant;
+    bool u_is_size_feature_constant;
+    highp float u_size_t; // used to interpolate between zoom stops when size is a composite function
+    highp float u_size; // used when size is both zoom and feature constant
+    bool u_pad3;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+out vec4 v_data0;
+out vec4 v_data1;
+
+#ifndef HAS_UNIFORM_u_fill_color
+layout (location = 4) in highp vec4 a_fill_color;
+out highp vec4 fill_color;
+#endif
+#ifndef HAS_UNIFORM_u_halo_color
+layout (location = 5) in highp vec4 a_halo_color;
+out highp vec4 halo_color;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+layout (location = 6) in lowp vec2 a_opacity;
+out lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_halo_width
+layout (location = 7) in lowp vec2 a_halo_width;
+out lowp float halo_width;
+#endif
+#ifndef HAS_UNIFORM_u_halo_blur
+layout (location = 8) in lowp vec2 a_halo_blur;
+out lowp float halo_blur;
+#endif
+
+void main() {
+    #ifndef HAS_UNIFORM_u_fill_color
+fill_color = unpack_mix_color(a_fill_color, u_fill_color_t);
+#else
+highp vec4 fill_color = u_fill_color;
+#endif
+    #ifndef HAS_UNIFORM_u_halo_color
+halo_color = unpack_mix_color(a_halo_color, u_halo_color_t);
+#else
+highp vec4 halo_color = u_halo_color;
+#endif
+    #ifndef HAS_UNIFORM_u_opacity
+opacity = unpack_mix_vec2(a_opacity, u_opacity_t);
+#else
+lowp float opacity = u_opacity;
+#endif
+    #ifndef HAS_UNIFORM_u_halo_width
+halo_width = unpack_mix_vec2(a_halo_width, u_halo_width_t);
+#else
+lowp float halo_width = u_halo_width;
+#endif
+    #ifndef HAS_UNIFORM_u_halo_blur
+halo_blur = unpack_mix_vec2(a_halo_blur, u_halo_blur_t);
+#else
+lowp float halo_blur = u_halo_blur;
+#endif
+
+    vec2 a_pos = a_pos_offset.xy;
+    vec2 a_offset = a_pos_offset.zw;
+
+    vec2 a_tex = a_data.xy;
+    vec2 a_size = a_data.zw;
+
+    float a_size_min = floor(a_size[0] * 0.5);
+    float is_sdf = a_size[0] - 2.0 * a_size_min;
+
+    highp float segment_angle = -a_projected_pos[2];
+    float size;
+
+    if (!u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = mix(a_size_min, a_size[1], u_size_t) / 128.0;
+    } else if (u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = a_size_min / 128.0;
+    } else {
+        size = u_size;
+    }
+
+    vec4 projectedPoint = u_matrix * vec4(a_pos, 0, 1);
+    highp float camera_to_anchor_distance = projectedPoint.w;
+    // If the label is pitched with the map, layout is done in pitched space,
+    // which makes labels in the distance smaller relative to viewport space.
+    // We counteract part of that effect by multiplying by the perspective ratio.
+    // If the label isn't pitched with the map, we do layout in viewport space,
+    // which makes labels in the distance larger relative to the features around
+    // them. We counteract part of that effect by dividing by the perspective ratio.
+    highp float distance_ratio = u_pitch_with_map ?
+        camera_to_anchor_distance / u_camera_to_center_distance :
+        u_camera_to_center_distance / camera_to_anchor_distance;
+    highp float perspective_ratio = clamp(
+        0.5 + 0.5 * distance_ratio,
+        0.0, // Prevents oversized near-field symbols in pitched/overzoomed tiles
+        4.0);
+
+    size *= perspective_ratio;
+
+    float fontScale = size / 24.0;
+
+    highp float symbol_rotation = 0.0;
+    if (u_rotate_symbol) {
+        // Point labels with 'rotation-alignment: map' are horizontal with respect to tile units
+        // To figure out that angle in projected space, we draw a short horizontal line in tile
+        // space, project it, and measure its angle in projected space.
+        vec4 offsetProjectedPoint = u_matrix * vec4(a_pos + vec2(1, 0), 0, 1);
+
+        vec2 a = projectedPoint.xy / projectedPoint.w;
+        vec2 b = offsetProjectedPoint.xy / offsetProjectedPoint.w;
+
+        symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
+    }
+
+    highp float angle_sin = sin(segment_angle + symbol_rotation);
+    highp float angle_cos = cos(segment_angle + symbol_rotation);
+    mat2 rotation_matrix = mat2(angle_cos, -1.0 * angle_sin, angle_sin, angle_cos);
+
+    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
+    gl_Position = u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + rotation_matrix * (a_offset / 32.0 * fontScale), 0.0, 1.0);
+    float gamma_scale = gl_Position.w;
+
+    vec2 fade_opacity = unpack_opacity(a_fade_opacity);
+    float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
+    float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
+
+    v_data0.xy = a_tex / u_texsize;
+    v_data0.zw = a_tex / u_texsize_icon;
+    v_data1 = vec4(gamma_scale, size, interpolated_fade_opacity, is_sdf);
+}
+)";
+    static constexpr const char* fragment = R"(#define SDF_PX 8.0
+
+#define SDF 1.0
+#define ICON 0.0
+
+layout (std140) uniform SymbolDrawableUBO {
+    highp mat4 u_matrix;
+    highp mat4 u_label_plane_matrix;
+    highp mat4 u_coord_matrix;
+
+    highp vec2 u_texsize;
+    highp vec2 u_texsize_icon;
+
+    highp float u_gamma_scale;
+    highp float u_device_pixel_ratio;
+
+    highp float u_camera_to_center_distance;
+    highp float u_pitch;
+    bool u_rotate_symbol;
+    highp float u_aspect_ratio;
+    highp float u_fade_change;
+    highp float u_pad2;
+};
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    bool u_pitch_with_map;
+    bool u_is_size_zoom_constant;
+    bool u_is_size_feature_constant;
+    highp float u_size_t; // used to interpolate between zoom stops when size is a composite function
+    highp float u_size; // used when size is both zoom and feature constant
+    bool u_pad3;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+uniform sampler2D u_texture;
+uniform sampler2D u_texture_icon;
+
+in vec4 v_data0;
+in vec4 v_data1;
+
+#ifndef HAS_UNIFORM_u_fill_color
+in highp vec4 fill_color;
+#endif
+#ifndef HAS_UNIFORM_u_halo_color
+in highp vec4 halo_color;
+#endif
+#ifndef HAS_UNIFORM_u_opacity
+in lowp float opacity;
+#endif
+#ifndef HAS_UNIFORM_u_halo_width
+in lowp float halo_width;
+#endif
+#ifndef HAS_UNIFORM_u_halo_blur
+in lowp float halo_blur;
+#endif
+
+void main() {
+    #ifdef HAS_UNIFORM_u_fill_color
+highp vec4 fill_color = u_fill_color;
+#endif
+    #ifdef HAS_UNIFORM_u_halo_color
+highp vec4 halo_color = u_halo_color;
+#endif
+    #ifdef HAS_UNIFORM_u_opacity
+lowp float opacity = u_opacity;
+#endif
+    #ifdef HAS_UNIFORM_u_halo_width
+lowp float halo_width = u_halo_width;
+#endif
+    #ifdef HAS_UNIFORM_u_halo_blur
+lowp float halo_blur = u_halo_blur;
+#endif
+
+    float fade_opacity = v_data1[2];
+
+    if (v_data1.w == ICON) {
+        vec2 tex_icon = v_data0.zw;
+        lowp float alpha = opacity * fade_opacity;
+        fragColor = texture(u_texture_icon, tex_icon) * alpha;
+
+#ifdef OVERDRAW_INSPECTOR
+        fragColor = vec4(1.0);
+#endif
+        return;
+    }
+
+    vec2 tex = v_data0.xy;
+
+    float EDGE_GAMMA = 0.105 / u_device_pixel_ratio;
+
+    float gamma_scale = v_data1.x;
+    float size = v_data1.y;
+
+    float fontScale = size / 24.0;
+
+    lowp vec4 color = fill_color;
+    highp float gamma = EDGE_GAMMA / (fontScale * u_gamma_scale);
+    lowp float buff = (256.0 - 64.0) / 256.0;
+    if (u_is_halo) {
+        color = halo_color;
+        gamma = (halo_blur * 1.19 / SDF_PX + EDGE_GAMMA) / (fontScale * u_gamma_scale);
+        buff = (6.0 - halo_width / fontScale) / SDF_PX;
+    }
+
+    lowp float dist = texture(u_texture, tex).a;
+    highp float gamma_scaled = gamma * gamma_scale;
+    highp float alpha = smoothstep(buff - gamma_scaled, buff + gamma_scaled, dist);
+
+    fragColor = color * (alpha * opacity * fade_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}
+)";
+};
+
+} // namespace shaders
+} // namespace mbgl

--- a/include/mbgl/shaders/shader_manifest.hpp
+++ b/include/mbgl/shaders/shader_manifest.hpp
@@ -1,10 +1,30 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 
 #ifdef MBGL_RENDER_BACKEND_OPENGL
+#include <mbgl/shaders/gl/drawable_background.hpp>
+#include <mbgl/shaders/gl/drawable_background_pattern.hpp>
+#include <mbgl/shaders/gl/drawable_circle.hpp>
+#include <mbgl/shaders/gl/drawable_fill.hpp>
+#include <mbgl/shaders/gl/drawable_fill_outline.hpp>
+#include <mbgl/shaders/gl/drawable_line_gradient.hpp>
+#include <mbgl/shaders/gl/drawable_line_pattern.hpp>
+#include <mbgl/shaders/gl/drawable_line_sdf.hpp>
+#include <mbgl/shaders/gl/drawable_line.hpp>
+#include <mbgl/shaders/gl/drawable_fill_pattern.hpp>
+#include <mbgl/shaders/gl/drawable_fill_outline_pattern.hpp>
+#include <mbgl/shaders/gl/drawable_fill_extrusion.hpp>
+#include <mbgl/shaders/gl/drawable_fill_extrusion_pattern.hpp>
+#include <mbgl/shaders/gl/drawable_heatmap.hpp>
+#include <mbgl/shaders/gl/drawable_heatmap_texture.hpp>
+#include <mbgl/shaders/gl/drawable_hillshade_prepare.hpp>
+#include <mbgl/shaders/gl/drawable_hillshade.hpp>
+#include <mbgl/shaders/gl/drawable_raster.hpp>
+#include <mbgl/shaders/gl/drawable_symbol_icon.hpp>
+#include <mbgl/shaders/gl/drawable_symbol_sdf_text.hpp>
+#include <mbgl/shaders/gl/drawable_symbol_sdf_icon.hpp>
+#include <mbgl/shaders/gl/drawable_symbol_text_and_icon.hpp>
 #include <mbgl/shaders/gl/prelude.hpp>
 #include <mbgl/shaders/gl/background.hpp>
 #include <mbgl/shaders/gl/background_pattern.hpp>

--- a/include/mbgl/shaders/shader_source.hpp
+++ b/include/mbgl/shaders/shader_source.hpp
@@ -1,6 +1,4 @@
 // Generated code, do not modify this file!
-// Generated on 2023-04-05T16:25:15.886Z by mwilsnd using shaders/generate_shader_code.js
-
 #pragma once
 #include <mbgl/gfx/backend.hpp>
 
@@ -11,6 +9,29 @@ namespace shaders {
 /// source code for the desired program and graphics back-end.
 enum class BuiltIn {
     None,
+    BackgroundShader,
+    BackgroundPatternShader,
+    CircleShader,
+    FillShader,
+    FillOutlineShader,
+    LineGradientShader,
+    LinePatternShader,
+    LineSDFShader,
+    LineShader,
+    FillPatternShader,
+    FillOutlinePatternShader,
+    FillExtrusionShader,
+    FillExtrusionPatternShader,
+    HeatmapShader,
+    HeatmapTextureShader,
+    HillshadePrepareShader,
+    HillshadeShader,
+    RasterShader,
+    SymbolIconShader,
+    SymbolSDFTextShader,
+    SymbolSDFIconShader,
+    SymbolTextAndIconShader,
+
     Prelude,
     BackgroundProgram,
     BackgroundPatternProgram,
@@ -51,6 +72,7 @@ struct ShaderSource;
 /// @brief A specialization of the ShaderSource template for no shader code.
 template <>
 struct ShaderSource<BuiltIn::None, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "";
     static constexpr const char* vertex = "";
     static constexpr const char* fragment = "";
 };

--- a/shaders/drawable.background.fragment.glsl
+++ b/shaders/drawable.background.fragment.glsl
@@ -1,0 +1,11 @@
+layout (std140) uniform BackgroundLayerUBO {
+    highp vec4 u_color;
+    highp vec4 u_opacity_pad3;
+};
+
+void main() {
+    fragColor = u_color * u_opacity_pad3.x;
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.background.vertex.glsl
+++ b/shaders/drawable.background.vertex.glsl
@@ -1,0 +1,8 @@
+layout (location = 0) in vec2 a_pos;
+layout (std140) uniform BackgroundDrawableUBO {
+    highp mat4 u_matrix;
+};
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+}

--- a/shaders/drawable.background_pattern.fragment.glsl
+++ b/shaders/drawable.background_pattern.fragment.glsl
@@ -1,0 +1,38 @@
+layout (std140) uniform BackgroundLayerUBO {
+    highp vec2 u_pattern_tl_a;
+    highp vec2 u_pattern_br_a;
+    highp vec2 u_pattern_tl_b;
+    highp vec2 u_pattern_br_b;
+    highp vec2 u_texsize;
+    highp vec2 u_pattern_size_a;
+    highp vec2 u_pattern_size_b;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp float u_tile_units_to_pixels;
+    highp float u_scale_a;
+    highp float u_scale_b;
+    highp float u_mix;
+    highp float u_opacity;
+    highp float pad;
+};
+
+uniform sampler2D u_image;
+
+in mediump vec2 v_pos_a;
+in mediump vec2 v_pos_b;
+
+void main() {
+    vec2 imagecoord = mod(v_pos_a, 1.0);
+    vec2 pos = mix(u_pattern_tl_a / u_texsize, u_pattern_br_a / u_texsize, imagecoord);
+    vec4 color1 = texture(u_image, pos);
+
+    vec2 imagecoord_b = mod(v_pos_b, 1.0);
+    vec2 pos2 = mix(u_pattern_tl_b / u_texsize, u_pattern_br_b / u_texsize, imagecoord_b);
+    vec4 color2 = texture(u_image, pos2);
+
+    fragColor = mix(color1, color2, u_mix) * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.background_pattern.vertex.glsl
+++ b/shaders/drawable.background_pattern.vertex.glsl
@@ -1,0 +1,31 @@
+layout (std140) uniform BackgroundDrawableUBO {
+    highp mat4 u_matrix;
+};
+layout (std140) uniform BackgroundLayerUBO {
+    highp vec2 u_pattern_tl_a;
+    highp vec2 u_pattern_br_a;
+    highp vec2 u_pattern_tl_b;
+    highp vec2 u_pattern_br_b;
+    highp vec2 u_texsize;
+    highp vec2 u_pattern_size_a;
+    highp vec2 u_pattern_size_b;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp float u_tile_units_to_pixels;
+    highp float u_scale_a;
+    highp float u_scale_b;
+    highp float u_mix;
+    highp float u_opacity;
+    highp float pad;
+};
+
+layout (location = 0) in vec2 a_pos;
+out mediump vec2 v_pos_a;
+out mediump vec2 v_pos_b;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+
+    v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, u_scale_a * u_pattern_size_a, u_tile_units_to_pixels, a_pos);
+    v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, u_scale_b * u_pattern_size_b, u_tile_units_to_pixels, a_pos);
+}

--- a/shaders/drawable.circle.fragment.glsl
+++ b/shaders/drawable.circle.fragment.glsl
@@ -1,0 +1,52 @@
+in vec3 v_data;
+
+layout (std140) uniform CircleEvaluatedPropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_stroke_color;
+    mediump float u_radius;
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_stroke_width;
+    lowp float u_stroke_opacity;
+    bool u_scale_with_map;
+    bool u_pitch_with_map;
+    lowp float pad0_;
+};
+
+#pragma mapbox: define highp vec4 color
+#pragma mapbox: define mediump float radius
+#pragma mapbox: define lowp float blur
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define highp vec4 stroke_color
+#pragma mapbox: define mediump float stroke_width
+#pragma mapbox: define lowp float stroke_opacity
+
+void main() {
+    #pragma mapbox: initialize highp vec4 color
+    #pragma mapbox: initialize mediump float radius
+    #pragma mapbox: initialize lowp float blur
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize highp vec4 stroke_color
+    #pragma mapbox: initialize mediump float stroke_width
+    #pragma mapbox: initialize lowp float stroke_opacity
+
+    vec2 extrude = v_data.xy;
+    float extrude_length = length(extrude);
+
+    lowp float antialiasblur = v_data.z;
+    float antialiased_blur = -max(blur, antialiasblur);
+
+    float opacity_t = smoothstep(0.0, antialiased_blur, extrude_length - 1.0);
+
+    float color_t = stroke_width < 0.01 ? 0.0 : smoothstep(
+        antialiased_blur,
+        0.0,
+        extrude_length - radius / (radius + stroke_width)
+    );
+
+    fragColor = opacity_t * mix(color * opacity, stroke_color * stroke_opacity, color_t);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.circle.vertex.glsl
+++ b/shaders/drawable.circle.vertex.glsl
@@ -1,0 +1,92 @@
+layout (location = 0) in vec2 a_pos;
+out vec3 v_data;
+
+layout (std140) uniform CircleDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_extrude_scale;
+    lowp vec2 pad2_;
+};
+
+layout (std140) uniform CirclePaintParamsUBO {
+    highp float u_camera_to_center_distance;
+    lowp float u_device_pixel_ratio;
+    lowp vec2 pad3_;
+};
+
+layout (std140) uniform CircleEvaluatedPropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_stroke_color;
+    mediump float u_radius;
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_stroke_width;
+    lowp float u_stroke_opacity;
+    bool u_scale_with_map;
+    bool u_pitch_with_map;
+    lowp float pad0_;
+};
+
+layout (std140) uniform CircleInterpolateUBO {
+    lowp float u_color_t;
+    lowp float u_radius_t;
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_stroke_color_t;
+    lowp float u_stroke_width_t;
+    lowp float u_stroke_opacity_t;
+    lowp float pad1_;
+};
+
+#pragma mapbox: define highp vec4 color
+#pragma mapbox: define mediump float radius
+#pragma mapbox: define lowp float blur
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define highp vec4 stroke_color
+#pragma mapbox: define mediump float stroke_width
+#pragma mapbox: define lowp float stroke_opacity
+
+void main(void) {
+    #pragma mapbox: initialize highp vec4 color
+    #pragma mapbox: initialize mediump float radius
+    #pragma mapbox: initialize lowp float blur
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize highp vec4 stroke_color
+    #pragma mapbox: initialize mediump float stroke_width
+    #pragma mapbox: initialize lowp float stroke_opacity
+
+    // unencode the extrusion vector that we snuck into the a_pos vector
+    vec2 extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);
+
+    // multiply a_pos by 0.5, since we had it * 2 in order to sneak
+    // in extrusion data
+    vec2 circle_center = floor(a_pos * 0.5);
+    if (u_pitch_with_map) {
+        vec2 corner_position = circle_center;
+        if (u_scale_with_map) {
+            corner_position += extrude * (radius + stroke_width) * u_extrude_scale;
+        } else {
+            // Pitching the circle with the map effectively scales it with the map
+            // To counteract the effect for pitch-scale: viewport, we rescale the
+            // whole circle based on the pitch scaling effect at its central point
+            vec4 projected_center = u_matrix * vec4(circle_center, 0, 1);
+            corner_position += extrude * (radius + stroke_width) * u_extrude_scale * (projected_center.w / u_camera_to_center_distance);
+        }
+
+        gl_Position = u_matrix * vec4(corner_position, 0, 1);
+    } else {
+        gl_Position = u_matrix * vec4(circle_center, 0, 1);
+
+        if (u_scale_with_map) {
+            gl_Position.xy += extrude * (radius + stroke_width) * u_extrude_scale * u_camera_to_center_distance;
+        } else {
+            gl_Position.xy += extrude * (radius + stroke_width) * u_extrude_scale * gl_Position.w;
+        }
+    }
+
+    // This is a minimum blur distance that serves as a faux-antialiasing for
+    // the circle. since blur is a ratio of the circle's size and the intent is
+    // to keep the blur at roughly 1px, the two are inversely related.
+    lowp float antialiasblur = 1.0 / u_device_pixel_ratio / (radius + stroke_width);
+
+    v_data = vec3(extrude.x, extrude.y, antialiasblur);
+}

--- a/shaders/drawable.fill.fragment.glsl
+++ b/shaders/drawable.fill.fragment.glsl
@@ -1,0 +1,44 @@
+layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+#pragma mapbox: define highp vec4 color
+#pragma mapbox: define lowp float opacity
+
+void main() {
+    #pragma mapbox: initialize highp vec4 color
+    #pragma mapbox: initialize lowp float opacity
+
+    fragColor = color * opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.fill.vertex.glsl
+++ b/shaders/drawable.fill.vertex.glsl
@@ -1,0 +1,42 @@
+layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+layout (location = 0) in vec2 a_pos;
+
+#pragma mapbox: define highp vec4 color
+#pragma mapbox: define lowp float opacity
+
+void main() {
+    #pragma mapbox: initialize highp vec4 color
+    #pragma mapbox: initialize lowp float opacity
+
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+}

--- a/shaders/drawable.fill_extrusion.fragment.glsl
+++ b/shaders/drawable.fill_extrusion.fragment.glsl
@@ -1,0 +1,9 @@
+in vec4 v_color;
+
+void main() {
+    fragColor = v_color;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.fill_extrusion.vertex.glsl
+++ b/shaders/drawable.fill_extrusion.vertex.glsl
@@ -1,0 +1,92 @@
+layout (location = 0) in vec2 a_pos;
+layout (location = 1) in vec4 a_normal_ed;
+out vec4 v_color;
+
+layout (std140) uniform FillExtrusionDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+layout (std140) uniform FillExtrusionInterpolateUBO {
+    highp float u_base_t;
+    highp float u_height_t;
+    highp float u_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_pad_interp1, u_pad_interp2, u_pad_interp3;
+};
+layout (std140) uniform FillExtrusionDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_texsize;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp float u_height_factor;
+    highp float u_pad_drawable;
+};
+layout (std140) uniform FillExtrusionDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec3 u_lightcolor;
+    highp float u_pad1;
+    highp vec3 u_lightpos;
+    highp float u_base;
+    highp float u_height;
+    highp float u_lightintensity;
+    highp float u_vertical_gradient;
+    highp float u_opacity;
+    highp float u_fade;
+    highp float u_pad_props2, u_pad_props3, u_pad_props4;
+};
+
+#pragma mapbox: define highp float base
+#pragma mapbox: define highp float height
+#pragma mapbox: define highp vec4 color
+
+void main() {
+    #pragma mapbox: initialize highp float base
+    #pragma mapbox: initialize highp float height
+    #pragma mapbox: initialize highp vec4 color
+
+    vec3 normal = a_normal_ed.xyz;
+
+    base = max(0.0, base);
+    height = max(0.0, height);
+
+    float t = mod(normal.x, 2.0);
+
+    gl_Position = u_matrix * vec4(a_pos, t > 0.0 ? height : base, 1);
+
+    // Relative luminance (how dark/bright is the surface color?)
+    float colorvalue = color.r * 0.2126 + color.g * 0.7152 + color.b * 0.0722;
+
+    v_color = vec4(0.0, 0.0, 0.0, 1.0);
+
+    // Add slight ambient lighting so no extrusions are totally black
+    vec4 ambientlight = vec4(0.03, 0.03, 0.03, 1.0);
+    color += ambientlight;
+
+    // Calculate cos(theta), where theta is the angle between surface normal and diffuse light ray
+    float directional = clamp(dot(normal / 16384.0, u_lightpos), 0.0, 1.0);
+
+    // Adjust directional so that
+    // the range of values for highlight/shading is narrower
+    // with lower light intensity
+    // and with lighter/brighter surface colors
+    directional = mix((1.0 - u_lightintensity), max((1.0 - colorvalue + u_lightintensity), 1.0), directional);
+
+    // Add gradient along z axis of side surfaces
+    if (normal.y != 0.0) {
+        // This avoids another branching statement, but multiplies by a constant of 0.84 if no vertical gradient,
+        // and otherwise calculates the gradient based on base + height
+        directional *= (
+            (1.0 - u_vertical_gradient) +
+            (u_vertical_gradient * clamp((t + base) * pow(height / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0)));
+    }
+
+    // Assign final color based on surface + ambient light color, diffuse light directional, and light color
+    // with lower bounds adjusted to hue of light
+    // so that shading is tinted with the complementary (opposite) color to the light color
+    v_color.r += clamp(color.r * directional * u_lightcolor.r, mix(0.0, 0.3, 1.0 - u_lightcolor.r), 1.0);
+    v_color.g += clamp(color.g * directional * u_lightcolor.g, mix(0.0, 0.3, 1.0 - u_lightcolor.g), 1.0);
+    v_color.b += clamp(color.b * directional * u_lightcolor.b, mix(0.0, 0.3, 1.0 - u_lightcolor.b), 1.0);
+    v_color *= u_opacity;
+}

--- a/shaders/drawable.fill_extrusion_pattern.fragment.glsl
+++ b/shaders/drawable.fill_extrusion_pattern.fragment.glsl
@@ -1,0 +1,73 @@
+in vec2 v_pos_a;
+in vec2 v_pos_b;
+in vec4 v_lighting;
+
+layout (std140) uniform FillExtrusionDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+layout (std140) uniform FillExtrusionInterpolateUBO {
+    highp float u_base_t;
+    highp float u_height_t;
+    highp float u_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_pad_interp1, u_pad_interp2, u_pad_interp3;
+};
+layout (std140) uniform FillExtrusionDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_texsize;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp float u_height_factor;
+    highp float u_pad_drawable;
+};
+layout (std140) uniform FillExtrusionDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec3 u_lightcolor;
+    highp float u_pad1;
+    highp vec3 u_lightpos;
+    highp float u_base;
+    highp float u_height;
+    highp float u_lightintensity;
+    highp float u_vertical_gradient;
+    highp float u_opacity;
+    highp float u_fade;
+    highp float u_pad_props2, u_pad_props3, u_pad_props4;
+};
+
+uniform sampler2D u_image;
+
+#pragma mapbox: define lowp float base
+#pragma mapbox: define lowp float height
+#pragma mapbox: define mediump vec4 pattern_from
+#pragma mapbox: define mediump vec4 pattern_to
+
+void main() {
+    #pragma mapbox: initialize lowp float base
+    #pragma mapbox: initialize lowp float height
+    #pragma mapbox: initialize mediump vec4 pattern_from
+    #pragma mapbox: initialize mediump vec4 pattern_to
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    vec2 imagecoord = mod(v_pos_a, 1.0);
+    vec2 pos = mix(pattern_tl_a / u_texsize, pattern_br_a / u_texsize, imagecoord);
+    vec4 color1 = texture(u_image, pos);
+
+    vec2 imagecoord_b = mod(v_pos_b, 1.0);
+    vec2 pos2 = mix(pattern_tl_b / u_texsize, pattern_br_b / u_texsize, imagecoord_b);
+    vec4 color2 = texture(u_image, pos2);
+
+    vec4 mixedColor = mix(color1, color2, u_fade);
+
+    fragColor = mixedColor * v_lighting;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.fill_extrusion_pattern.vertex.glsl
+++ b/shaders/drawable.fill_extrusion_pattern.vertex.glsl
@@ -1,0 +1,99 @@
+layout (location = 0) in vec2 a_pos;
+layout (location = 1) in vec4 a_normal_ed;
+
+out vec2 v_pos_a;
+out vec2 v_pos_b;
+out vec4 v_lighting;
+
+layout (std140) uniform FillExtrusionDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+layout (std140) uniform FillExtrusionInterpolateUBO {
+    highp float u_base_t;
+    highp float u_height_t;
+    highp float u_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_pad_interp1, u_pad_interp2, u_pad_interp3;
+};
+layout (std140) uniform FillExtrusionDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_texsize;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp float u_height_factor;
+    highp float u_pad_drawable;
+};
+layout (std140) uniform FillExtrusionDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec3 u_lightcolor;
+    highp float u_pad1;
+    highp vec3 u_lightpos;
+    highp float u_base;
+    highp float u_height;
+    highp float u_lightintensity;
+    highp float u_vertical_gradient;
+    highp float u_opacity;
+    highp float u_fade;
+    highp float u_pad_props2, u_pad_props3, u_pad_props4;
+};
+
+#pragma mapbox: define lowp float base
+#pragma mapbox: define lowp float height
+#pragma mapbox: define mediump vec4 pattern_from
+#pragma mapbox: define mediump vec4 pattern_to
+
+void main() {
+    #pragma mapbox: initialize lowp float base
+    #pragma mapbox: initialize lowp float height
+    #pragma mapbox: initialize mediump vec4 pattern_from
+    #pragma mapbox: initialize mediump vec4 pattern_to
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    float pixelRatio = u_scale.x;
+    float tileRatio = u_scale.y;
+    float fromScale = u_scale.z;
+    float toScale = u_scale.w;
+
+    vec3 normal = a_normal_ed.xyz;
+    float edgedistance = a_normal_ed.w;
+
+    vec2 display_size_a = vec2((pattern_br_a.x - pattern_tl_a.x) / pixelRatio, (pattern_br_a.y - pattern_tl_a.y) / pixelRatio);
+    vec2 display_size_b = vec2((pattern_br_b.x - pattern_tl_b.x) / pixelRatio, (pattern_br_b.y - pattern_tl_b.y) / pixelRatio);
+
+    base = max(0.0, base);
+    height = max(0.0, height);
+
+    float t = mod(normal.x, 2.0);
+    float z = t > 0.0 ? height : base;
+
+    gl_Position = u_matrix * vec4(a_pos, z, 1);
+
+    vec2 pos = normal.x == 1.0 && normal.y == 0.0 && normal.z == 16384.0
+        ? a_pos // extrusion top
+        : vec2(edgedistance, z * u_height_factor); // extrusion side
+
+    v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, fromScale * display_size_a, tileRatio, pos);
+    v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, toScale * display_size_b, tileRatio, pos);
+
+    v_lighting = vec4(0.0, 0.0, 0.0, 1.0);
+    float directional = clamp(dot(normal / 16383.0, u_lightpos), 0.0, 1.0);
+    directional = mix((1.0 - u_lightintensity), max((0.5 + u_lightintensity), 1.0), directional);
+
+    if (normal.y != 0.0) {
+        // This avoids another branching statement, but multiplies by a constant of 0.84 if no vertical gradient,
+        // and otherwise calculates the gradient based on base + height
+        directional *= (
+            (1.0 - u_vertical_gradient) +
+            (u_vertical_gradient * clamp((t + base) * pow(height / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0)));
+    }
+
+    v_lighting.rgb += clamp(directional * u_lightcolor, mix(vec3(0.0), vec3(0.3), 1.0 - u_lightcolor), vec3(1.0));
+    v_lighting *= u_opacity;
+}

--- a/shaders/drawable.fill_outline.fragment.glsl
+++ b/shaders/drawable.fill_outline.fragment.glsl
@@ -1,0 +1,48 @@
+layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+in vec2 v_pos;
+
+#pragma mapbox: define highp vec4 outline_color
+#pragma mapbox: define lowp float opacity
+
+void main() {
+    #pragma mapbox: initialize highp vec4 outline_color
+    #pragma mapbox: initialize lowp float opacity
+
+    float dist = length(v_pos - gl_FragCoord.xy);
+    float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
+    fragColor = outline_color * (alpha * opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.fill_outline.vertex.glsl
+++ b/shaders/drawable.fill_outline.vertex.glsl
@@ -1,0 +1,45 @@
+layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+layout (location = 0) in vec2 a_pos;
+
+out vec2 v_pos;
+
+#pragma mapbox: define highp vec4 outline_color
+#pragma mapbox: define lowp float opacity
+
+void main() {
+    #pragma mapbox: initialize highp vec4 outline_color
+    #pragma mapbox: initialize lowp float opacity
+
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+    v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
+}

--- a/shaders/drawable.fill_outline_pattern.fragment.glsl
+++ b/shaders/drawable.fill_outline_pattern.fragment.glsl
@@ -1,0 +1,71 @@
+layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+uniform sampler2D u_image;
+
+in vec2 v_pos_a;
+in vec2 v_pos_b;
+in vec2 v_pos;
+
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define lowp vec4 pattern_from
+#pragma mapbox: define lowp vec4 pattern_to
+
+void main() {
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize mediump vec4 pattern_from
+    #pragma mapbox: initialize mediump vec4 pattern_to
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    vec2 imagecoord = mod(v_pos_a, 1.0);
+    vec2 pos = mix(pattern_tl_a / u_texsize, pattern_br_a / u_texsize, imagecoord);
+    vec4 color1 = texture(u_image, pos);
+
+    vec2 imagecoord_b = mod(v_pos_b, 1.0);
+    vec2 pos2 = mix(pattern_tl_b / u_texsize, pattern_br_b / u_texsize, imagecoord_b);
+    vec4 color2 = texture(u_image, pos2);
+
+    // find distance to outline for alpha interpolation
+
+    float dist = length(v_pos - gl_FragCoord.xy);
+    float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
+
+
+    fragColor = mix(color1, color2, u_fade) * alpha * opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.fill_outline_pattern.vertex.glsl
+++ b/shaders/drawable.fill_outline_pattern.vertex.glsl
@@ -1,0 +1,66 @@
+layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+layout (location = 0) in vec2 a_pos;
+
+out vec2 v_pos_a;
+out vec2 v_pos_b;
+out vec2 v_pos;
+
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define lowp vec4 pattern_from
+#pragma mapbox: define lowp vec4 pattern_to
+
+void main() {
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize mediump vec4 pattern_from
+    #pragma mapbox: initialize mediump vec4 pattern_to
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    float pixelRatio = u_scale.x;
+    float tileRatio = u_scale.y;
+    float fromScale = u_scale.z;
+    float toScale = u_scale.w;
+
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+
+    vec2 display_size_a = vec2((pattern_br_a.x - pattern_tl_a.x) / pixelRatio, (pattern_br_a.y - pattern_tl_a.y) / pixelRatio);
+    vec2 display_size_b = vec2((pattern_br_b.x - pattern_tl_b.x) / pixelRatio, (pattern_br_b.y - pattern_tl_b.y) / pixelRatio);
+
+    v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, fromScale * display_size_a, tileRatio, a_pos);
+    v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, toScale * display_size_b, tileRatio, a_pos);
+
+    v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
+}

--- a/shaders/drawable.fill_pattern.fragment.glsl
+++ b/shaders/drawable.fill_pattern.fragment.glsl
@@ -1,0 +1,68 @@
+layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+uniform sampler2D u_image;
+
+in vec2 v_pos_a;
+in vec2 v_pos_b;
+
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define lowp vec4 pattern_from
+#pragma mapbox: define lowp vec4 pattern_to
+
+void main() {
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize mediump vec4 pattern_from
+    #pragma mapbox: initialize mediump vec4 pattern_to
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    if (u_texsize.x < 1.0 || u_texsize.y < 1.0) {
+        discard;
+    }
+
+    vec2 imagecoord = mod(v_pos_a, 1.0);
+    vec2 pos = mix(pattern_tl_a / u_texsize, pattern_br_a / u_texsize, imagecoord);
+    vec4 color1 = texture(u_image, pos);
+
+    vec2 imagecoord_b = mod(v_pos_b, 1.0);
+    vec2 pos2 = mix(pattern_tl_b / u_texsize, pattern_br_b / u_texsize, imagecoord_b);
+    vec4 color2 = texture(u_image, pos2);
+
+    fragColor = mix(color1, color2, u_fade) * opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.fill_pattern.vertex.glsl
+++ b/shaders/drawable.fill_pattern.vertex.glsl
@@ -1,0 +1,62 @@
+layout (std140) uniform FillInterpolateUBO {
+    highp float u_color_t;
+    highp float u_opacity_t;
+    highp float u_outline_color_t;
+    highp float u_pattern_from_t;
+    highp float u_pattern_to_t;
+    highp float u_fade;
+    highp float u_padding_interp1;
+    highp float u_padding_interp2;
+};
+layout (std140) uniform FillDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_scale;
+    highp vec2 u_world;
+    highp vec2 u_pixel_coord_upper;
+    highp vec2 u_pixel_coord_lower;
+    highp vec2 u_texsize;
+};
+layout (std140) uniform FillDrawablePropsUBO {
+    highp vec4 u_color;
+    highp vec4 u_outline_color;
+    highp float u_opacity;
+    highp float padding_props1;
+    highp float padding_props2;
+    highp float padding_props3;
+};
+layout (std140) uniform FillDrawableTilePropsUBO {
+    highp vec4 u_pattern_from;
+    highp vec4 u_pattern_to;
+};
+
+layout (location = 0) in vec2 a_pos;
+
+out vec2 v_pos_a;
+out vec2 v_pos_b;
+
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define lowp vec4 pattern_from
+#pragma mapbox: define lowp vec4 pattern_to
+
+void main() {
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize mediump vec4 pattern_from
+    #pragma mapbox: initialize mediump vec4 pattern_to
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    float pixelRatio = u_scale.x;
+    float tileZoomRatio = u_scale.y;
+    float fromScale = u_scale.z;
+    float toScale = u_scale.w;
+
+    vec2 display_size_a = vec2((pattern_br_a.x - pattern_tl_a.x) / pixelRatio, (pattern_br_a.y - pattern_tl_a.y) / pixelRatio);
+    vec2 display_size_b = vec2((pattern_br_b.x - pattern_tl_b.x) / pixelRatio, (pattern_br_b.y - pattern_tl_b.y) / pixelRatio);
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+
+    v_pos_a = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, fromScale * display_size_a, tileZoomRatio, a_pos);
+    v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, toScale * display_size_b, tileZoomRatio, a_pos);
+}

--- a/shaders/drawable.heatmap.fragment.glsl
+++ b/shaders/drawable.heatmap.fragment.glsl
@@ -1,0 +1,27 @@
+in vec2 v_extrude;
+
+layout (std140) uniform HeatmapEvaluatedPropsUBO {
+    highp float u_weight;
+    highp float u_radius;
+    highp float u_intensity;
+    lowp float pad0_;
+};
+
+#pragma mapbox: define highp float weight
+
+// Gaussian kernel coefficient: 1 / sqrt(2 * PI)
+#define GAUSS_COEF 0.3989422804014327
+
+void main() {
+    #pragma mapbox: initialize highp float weight
+
+    // Kernel density estimation with a Gaussian kernel of size 5x5
+    float d = -0.5 * 3.0 * 3.0 * dot(v_extrude, v_extrude);
+    float val = weight * u_intensity * GAUSS_COEF * exp(d);
+
+    fragColor = vec4(val, 1.0, 1.0, 1.0);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.heatmap.vertex.glsl
+++ b/shaders/drawable.heatmap.vertex.glsl
@@ -1,0 +1,67 @@
+layout (location = 0) in vec2 a_pos;
+out vec2 v_extrude;
+
+layout (std140) uniform HeatmapDrawableUBO {
+    highp mat4 u_matrix;
+    highp float u_extrude_scale;
+    lowp float pad1_;
+    lowp vec2 pad2_;
+};
+
+layout (std140) uniform HeatmapEvaluatedPropsUBO {
+    highp float u_weight;
+    highp float u_radius;
+    highp float u_intensity;
+    lowp float pad0_;
+};
+
+layout (std140) uniform HeatmapInterpolateUBO {
+    lowp float u_weight_t;
+    lowp float u_radius_t;
+    lowp vec2 pad3_;
+};
+
+#pragma mapbox: define highp float weight
+#pragma mapbox: define mediump float radius
+
+// Effective "0" in the kernel density texture to adjust the kernel size to;
+// this empirically chosen number minimizes artifacts on overlapping kernels
+// for typical heatmap cases (assuming clustered source)
+const highp float ZERO = 1.0 / 255.0 / 16.0;
+
+// Gaussian kernel coefficient: 1 / sqrt(2 * PI)
+#define GAUSS_COEF 0.3989422804014327
+
+void main(void) {
+    #pragma mapbox: initialize highp float weight
+    #pragma mapbox: initialize mediump float radius
+
+    // unencode the extrusion vector that we snuck into the a_pos vector
+    vec2 unscaled_extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);
+
+    // This 'extrude' comes in ranging from [-1, -1], to [1, 1].  We'll use
+    // it to produce the vertices of a square mesh framing the point feature
+    // we're adding to the kernel density texture.  We'll also pass it as
+    // a varying, so that the fragment shader can determine the distance of
+    // each fragment from the point feature.
+    // Before we do so, we need to scale it up sufficiently so that the
+    // kernel falls effectively to zero at the edge of the mesh.
+    // That is, we want to know S such that
+    // weight * u_intensity * GAUSS_COEF * exp(-0.5 * 3.0^2 * S^2) == ZERO
+    // Which solves to:
+    // S = sqrt(-2.0 * log(ZERO / (weight * u_intensity * GAUSS_COEF))) / 3.0
+    float S = sqrt(-2.0 * log(ZERO / weight / u_intensity / GAUSS_COEF)) / 3.0;
+
+    // Pass the varying in units of radius
+    v_extrude = S * unscaled_extrude;
+
+    // Scale by radius and the zoom-based scale factor to produce actual
+    // mesh position
+    vec2 extrude = v_extrude * radius * u_extrude_scale;
+
+    // multiply a_pos by 0.5, since we had it * 2 in order to sneak
+    // in extrusion data
+    vec4 pos = vec4(floor(a_pos * 0.5) + extrude, 0, 1);
+
+    gl_Position = u_matrix * pos;
+}

--- a/shaders/drawable.heatmap_texture.fragment.glsl
+++ b/shaders/drawable.heatmap_texture.fragment.glsl
@@ -1,0 +1,20 @@
+in vec2 v_pos;
+uniform sampler2D u_image;
+uniform sampler2D u_color_ramp;
+
+layout (std140) uniform HeatmapTextureDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_world;
+    highp float u_opacity;
+    lowp float pad0_;
+};
+
+void main() {
+    float t = texture(u_image, v_pos).r;
+    vec4 color = texture(u_color_ramp, vec2(t, 0.5));
+    fragColor = color * u_opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(0.0);
+#endif
+}

--- a/shaders/drawable.heatmap_texture.vertex.glsl
+++ b/shaders/drawable.heatmap_texture.vertex.glsl
@@ -1,0 +1,16 @@
+layout (location = 0) in vec2 a_pos;
+out vec2 v_pos;
+
+layout (std140) uniform HeatmapTextureDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_world;
+    highp float u_opacity;
+    lowp float pad0_;
+};
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos * u_world, 0, 1);
+
+    v_pos.x = a_pos.x;
+    v_pos.y = 1.0 - a_pos.y;
+}

--- a/shaders/drawable.hillshade.fragment.glsl
+++ b/shaders/drawable.hillshade.fragment.glsl
@@ -1,0 +1,58 @@
+in vec2 v_pos;
+uniform sampler2D u_image;
+
+layout (std140) uniform HillshadeDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_latrange;
+    highp vec2 u_light;
+};
+
+layout (std140) uniform HillshadeEvaluatedPropsUBO {
+    highp vec4 u_highlight;
+    highp vec4 u_shadow;
+    highp vec4 u_accent;
+};
+
+#define PI 3.141592653589793
+
+void main() {
+    vec4 pixel = texture(u_image, v_pos);
+
+    vec2 deriv = ((pixel.rg * 2.0) - 1.0);
+
+    // We divide the slope by a scale factor based on the cosin of the pixel's approximate latitude
+    // to account for mercator projection distortion. see #4807 for details
+    float scaleFactor = cos(radians((u_latrange[0] - u_latrange[1]) * (1.0 - v_pos.y) + u_latrange[1]));
+    // We also multiply the slope by an arbitrary z-factor of 1.25
+    float slope = atan(1.25 * length(deriv) / scaleFactor);
+    float aspect = deriv.x != 0.0 ? atan(deriv.y, -deriv.x) : PI / 2.0 * (deriv.y > 0.0 ? 1.0 : -1.0);
+
+    float intensity = u_light.x;
+    // We add PI to make this property match the global light object, which adds PI/2 to the light's azimuthal
+    // position property to account for 0deg corresponding to north/the top of the viewport in the style spec
+    // and the original shader was written to accept (-illuminationDirection - 90) as the azimuthal.
+    float azimuth = u_light.y + PI;
+
+    // We scale the slope exponentially based on intensity, using a calculation similar to
+    // the exponential interpolation function in the style spec:
+    // https://github.com/mapbox/mapbox-gl-js/blob/master/src/style-spec/expression/definitions/interpolate.js#L217-L228
+    // so that higher intensity values create more opaque hillshading.
+    float base = 1.875 - intensity * 1.75;
+    float maxValue = 0.5 * PI;
+    float scaledSlope = intensity != 0.5 ? ((pow(base, slope) - 1.0) / (pow(base, maxValue) - 1.0)) * maxValue : slope;
+
+    // The accent color is calculated with the cosine of the slope while the shade color is calculated with the sine
+    // so that the accent color's rate of change eases in while the shade color's eases out.
+    float accent = cos(scaledSlope);
+    // We multiply both the accent and shade color by a clamped intensity value
+    // so that intensities >= 0.5 do not additionally affect the color values
+    // while intensity values < 0.5 make the overall color more transparent.
+    vec4 accent_color = (1.0 - accent) * u_accent * clamp(intensity * 2.0, 0.0, 1.0);
+    float shade = abs(mod((aspect + azimuth) / PI + 0.5, 2.0) - 1.0);
+    vec4 shade_color = mix(u_shadow, u_highlight, shade) * sin(scaledSlope) * clamp(intensity * 2.0, 0.0, 1.0);
+    fragColor = accent_color * (1.0 - shade_color.a) + shade_color;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.hillshade.vertex.glsl
+++ b/shaders/drawable.hillshade.vertex.glsl
@@ -1,0 +1,15 @@
+layout (location = 0) in vec2 a_pos;
+layout (location = 1) in vec2 a_texture_pos;
+
+layout (std140) uniform HillshadeDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_latrange;
+    highp vec2 u_light;
+};
+
+out vec2 v_pos;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+    v_pos = a_texture_pos / 8192.0;
+}

--- a/shaders/drawable.hillshade_prepare.fragment.glsl
+++ b/shaders/drawable.hillshade_prepare.fragment.glsl
@@ -1,0 +1,78 @@
+#ifdef GL_ES
+precision highp float;
+#endif
+
+in vec2 v_pos;
+uniform sampler2D u_image;
+
+layout (std140) uniform HillshadePrepareDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_unpack;
+    highp vec2 u_dimension;
+    highp float u_zoom;
+    highp float u_maxzoom;
+};
+
+float getElevation(vec2 coord, float bias) {
+    // Convert encoded elevation value to meters
+    vec4 data = texture(u_image, coord) * 255.0;
+    data.a = -1.0;
+    return dot(data, u_unpack) / 4.0;
+}
+
+void main() {
+    vec2 epsilon = 1.0 / u_dimension;
+
+    // queried pixels:
+    // +-----------+
+    // |   |   |   |
+    // | a | b | c |
+    // |   |   |   |
+    // +-----------+
+    // |   |   |   |
+    // | d | e | f |
+    // |   |   |   |
+    // +-----------+
+    // |   |   |   |
+    // | g | h | i |
+    // |   |   |   |
+    // +-----------+
+
+    float a = getElevation(v_pos + vec2(-epsilon.x, -epsilon.y), 0.0);
+    float b = getElevation(v_pos + vec2(0, -epsilon.y), 0.0);
+    float c = getElevation(v_pos + vec2(epsilon.x, -epsilon.y), 0.0);
+    float d = getElevation(v_pos + vec2(-epsilon.x, 0), 0.0);
+    float e = getElevation(v_pos, 0.0);
+    float f = getElevation(v_pos + vec2(epsilon.x, 0), 0.0);
+    float g = getElevation(v_pos + vec2(-epsilon.x, epsilon.y), 0.0);
+    float h = getElevation(v_pos + vec2(0, epsilon.y), 0.0);
+    float i = getElevation(v_pos + vec2(epsilon.x, epsilon.y), 0.0);
+
+    // here we divide the x and y slopes by 8 * pixel size
+    // where pixel size (aka meters/pixel) is:
+    // circumference of the world / (pixels per tile * number of tiles)
+    // which is equivalent to: 8 * 40075016.6855785 / (512 * pow(2, u_zoom))
+    // which can be reduced to: pow(2, 19.25619978527 - u_zoom)
+    // we want to vertically exaggerate the hillshading though, because otherwise
+    // it is barely noticeable at low zooms. to do this, we multiply this by some
+    // scale factor pow(2, (u_zoom - u_maxzoom) * a) where a is an arbitrary value
+    // Here we use a=0.3 which works out to the expression below. see
+    // nickidlugash's awesome breakdown for more info
+    // https://github.com/mapbox/mapbox-gl-js/pull/5286#discussion_r148419556
+    float exaggeration = u_zoom < 2.0 ? 0.4 : u_zoom < 4.5 ? 0.35 : 0.3;
+
+    vec2 deriv = vec2(
+        (c + f + f + i) - (a + d + d + g),
+        (g + h + h + i) - (a + b + b + c)
+    ) /  pow(2.0, (u_zoom - u_maxzoom) * exaggeration + 19.2562 - u_zoom);
+
+    fragColor = clamp(vec4(
+        deriv.x / 2.0 + 0.5,
+        deriv.y / 2.0 + 0.5,
+        1.0,
+        1.0), 0.0, 1.0);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.hillshade_prepare.vertex.glsl
+++ b/shaders/drawable.hillshade_prepare.vertex.glsl
@@ -1,0 +1,20 @@
+layout (location = 0) in vec2 a_pos;
+layout (location = 1) in vec2 a_texture_pos;
+
+layout (std140) uniform HillshadePrepareDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec4 u_unpack;
+    highp vec2 u_dimension;
+    highp float u_zoom;
+    highp float u_maxzoom;
+};
+
+out vec2 v_pos;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+
+    highp vec2 epsilon = 1.0 / u_dimension;
+    float scale = (u_dimension.x - 2.0) / u_dimension.x;
+    v_pos = (a_texture_pos / 8192.0) * scale + epsilon;
+}

--- a/shaders/drawable.line.fragment.glsl
+++ b/shaders/drawable.line.fragment.glsl
@@ -1,0 +1,58 @@
+layout (std140) uniform LineUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_units_to_pixels;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+};
+
+layout (std140) uniform LinePropertiesUBO {
+    highp vec4 u_color;
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_gapwidth;
+    lowp float u_offset;
+    mediump float u_width;
+
+    highp float pad1;
+    highp vec2 pad2;
+};
+
+layout (std140) uniform LineInterpolationUBO {
+    lowp float u_color_t;
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_gapwidth_t;
+    lowp float u_offset_t;
+    lowp float u_width_t;
+
+    highp vec2 pad3;
+};
+
+in vec2 v_width2;
+in vec2 v_normal;
+in float v_gamma_scale;
+
+#pragma mapbox: define highp vec4 color
+#pragma mapbox: define lowp float blur
+#pragma mapbox: define lowp float opacity
+
+void main() {
+    #pragma mapbox: initialize highp vec4 color
+    #pragma mapbox: initialize lowp float blur
+    #pragma mapbox: initialize lowp float opacity
+
+    // Calculate the distance of the pixel from the line in pixels.
+    float dist = length(v_normal) * v_width2.s;
+
+    // Calculate the antialiasing fade factor. This is either when fading in
+    // the line in case of an offset line (v_width2.t) or when fading out
+    // (v_width2.s)
+    float blur2 = (blur + 1.0 / u_device_pixel_ratio) * v_gamma_scale;
+    float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
+
+    fragColor = color * (alpha * opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.line.vertex.glsl
+++ b/shaders/drawable.line.vertex.glsl
@@ -1,0 +1,110 @@
+// floor(127 / 2) == 63.0
+// the maximum allowed miter limit is 2.0 at the moment. the extrude normal is
+// stored in a byte (-128..127). we scale regular normals up to length 63, but
+// there are also "special" normals that have a bigger length (of up to 126 in
+// this case).
+// #define scale 63.0
+#define scale 0.015873016
+
+layout (location = 0) in vec2 a_pos_normal;
+layout (location = 1) in vec4 a_data;
+
+layout (std140) uniform LineUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_units_to_pixels;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+};
+
+layout (std140) uniform LinePropertiesUBO {
+    highp vec4 u_color;
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_gapwidth;
+    lowp float u_offset;
+    mediump float u_width;
+
+    highp float pad1;
+    highp vec2 pad2;
+};
+
+layout (std140) uniform LineInterpolationUBO {
+    lowp float u_color_t;
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_gapwidth_t;
+    lowp float u_offset_t;
+    lowp float u_width_t;
+
+    highp vec2 pad3;
+};
+
+out vec2 v_normal;
+out vec2 v_width2;
+out float v_gamma_scale;
+out highp float v_linesofar;
+
+#pragma mapbox: define highp vec4 color
+#pragma mapbox: define lowp float blur
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define mediump float gapwidth
+#pragma mapbox: define lowp float offset
+#pragma mapbox: define mediump float width
+
+void main() {
+    #pragma mapbox: initialize highp vec4 color
+    #pragma mapbox: initialize lowp float blur
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize mediump float gapwidth
+    #pragma mapbox: initialize lowp float offset
+    #pragma mapbox: initialize mediump float width
+
+    // the distance over which the line edge fades out.
+    // Retina devices need a smaller distance to avoid aliasing.
+    float ANTIALIASING = 1.0 / u_device_pixel_ratio / 2.0;
+
+    vec2 a_extrude = a_data.xy - 128.0;
+    float a_direction = mod(a_data.z, 4.0) - 1.0;
+
+    v_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * 2.0;
+
+    vec2 pos = floor(a_pos_normal * 0.5);
+
+    // x is 1 if it's a round cap, 0 otherwise
+    // y is 1 if the normal points up, and -1 if it points down
+    // We store these in the least significant bit of a_pos_normal
+    mediump vec2 normal = a_pos_normal - 2.0 * pos;
+    normal.y = normal.y * 2.0 - 1.0;
+    v_normal = normal;
+
+    // these transformations used to be applied in the JS and native code bases.
+    // moved them into the shader for clarity and simplicity.
+    gapwidth = gapwidth / 2.0;
+    float halfwidth = width / 2.0;
+    offset = -1.0 * offset;
+
+    float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
+    float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + (halfwidth == 0.0 ? 0.0 : ANTIALIASING);
+
+    // Scale the extrusion vector down to a normal and then up by the line width
+    // of this vertex.
+    mediump vec2 dist = outset * a_extrude * scale;
+
+    // Calculate the offset when drawing a line that is to the side of the actual line.
+    // We do this by creating a vector that points towards the extrude, but rotate
+    // it when we're drawing round end points (a_direction = -1 or 1) since their
+    // extrude vector points in another direction.
+    mediump float u = 0.5 * a_direction;
+    mediump float t = 1.0 - abs(u);
+    mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
+
+    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+
+    // calculate how much the perspective view squishes or stretches the extrude
+    float extrude_length_without_perspective = length(dist);
+    float extrude_length_with_perspective = length(projected_extrude.xy / gl_Position.w * u_units_to_pixels);
+    v_gamma_scale = extrude_length_without_perspective / extrude_length_with_perspective;
+
+    v_width2 = vec2(outset, inset);
+}

--- a/shaders/drawable.line_gradient.fragment.glsl
+++ b/shaders/drawable.line_gradient.fragment.glsl
@@ -1,0 +1,62 @@
+layout (std140) uniform LineGradientUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_units_to_pixels;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+};
+
+layout (std140) uniform LineGradientPropertiesUBO {
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_gapwidth;
+    lowp float u_offset;
+    mediump float u_width;
+
+    highp float pad1;
+    highp vec2 pad2;
+};
+
+layout (std140) uniform LineGradientInterpolationUBO {
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_gapwidth_t;
+    lowp float u_offset_t;
+    lowp float u_width_t;
+
+    highp float pad3;
+    highp vec2 pad4;
+};
+
+uniform sampler2D u_image;
+
+in vec2 v_width2;
+in vec2 v_normal;
+in float v_gamma_scale;
+in highp float v_lineprogress;
+
+#pragma mapbox: define lowp float blur
+#pragma mapbox: define lowp float opacity
+
+void main() {
+    #pragma mapbox: initialize lowp float blur
+    #pragma mapbox: initialize lowp float opacity
+
+    // Calculate the distance of the pixel from the line in pixels.
+    float dist = length(v_normal) * v_width2.s;
+
+    // Calculate the antialiasing fade factor. This is either when fading in
+    // the line in case of an offset line (v_width2.t) or when fading out
+    // (v_width2.s)
+    float blur2 = (blur + 1.0 / u_device_pixel_ratio) * v_gamma_scale;
+    float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
+
+    // For gradient lines, v_lineprogress is the ratio along the entire line,
+    // scaled to [0, 2^15), and the gradient ramp is stored in a texture.
+    vec4 color = texture(u_image, vec2(v_lineprogress, 0.5));
+
+    fragColor = color * (alpha * opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.line_gradient.vertex.glsl
+++ b/shaders/drawable.line_gradient.vertex.glsl
@@ -1,0 +1,111 @@
+
+// the attribute conveying progress along a line is scaled to [0, 2^15)
+#define MAX_LINE_DISTANCE 32767.0
+
+// floor(127 / 2) == 63.0
+// the maximum allowed miter limit is 2.0 at the moment. the extrude normal is
+// stored in a byte (-128..127). we scale regular normals up to length 63, but
+// there are also "special" normals that have a bigger length (of up to 126 in
+// this case).
+// #define scale 63.0
+#define scale 0.015873016
+
+layout (location = 0) in vec2 a_pos_normal;
+layout (location = 1) in vec4 a_data;
+
+layout (std140) uniform LineGradientUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_units_to_pixels;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+};
+
+layout (std140) uniform LineGradientPropertiesUBO {
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_gapwidth;
+    lowp float u_offset;
+    mediump float u_width;
+
+    highp float pad1;
+    highp vec2 pad2;
+};
+
+layout (std140) uniform LineGradientInterpolationUBO {
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_gapwidth_t;
+    lowp float u_offset_t;
+    lowp float u_width_t;
+
+    highp float pad3;
+    highp vec2 pad4;
+};
+
+out vec2 v_normal;
+out vec2 v_width2;
+out float v_gamma_scale;
+out highp float v_lineprogress;
+
+#pragma mapbox: define lowp float blur
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define mediump float gapwidth
+#pragma mapbox: define lowp float offset
+#pragma mapbox: define mediump float width
+
+void main() {
+    #pragma mapbox: initialize lowp float blur
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize mediump float gapwidth
+    #pragma mapbox: initialize lowp float offset
+    #pragma mapbox: initialize mediump float width
+
+    // the distance over which the line edge fades out.
+    // Retina devices need a smaller distance to avoid aliasing.
+    float ANTIALIASING = 1.0 / u_device_pixel_ratio / 2.0;
+
+    vec2 a_extrude = a_data.xy - 128.0;
+    float a_direction = mod(a_data.z, 4.0) - 1.0;
+
+    v_lineprogress = (floor(a_data.z / 4.0) + a_data.w * 64.0) * 2.0 / MAX_LINE_DISTANCE;
+
+    vec2 pos = floor(a_pos_normal * 0.5);
+
+    // x is 1 if it's a round cap, 0 otherwise
+    // y is 1 if the normal points up, and -1 if it points down
+    // We store these in the least significant bit of a_pos_normal
+    mediump vec2 normal = a_pos_normal - 2.0 * pos;
+    normal.y = normal.y * 2.0 - 1.0;
+    v_normal = normal;
+
+    // these transformations used to be applied in the JS and native code bases.
+    // moved them into the shader for clarity and simplicity.
+    gapwidth = gapwidth / 2.0;
+    float halfwidth = width / 2.0;
+    offset = -1.0 * offset;
+
+    float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
+    float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + (halfwidth == 0.0 ? 0.0 : ANTIALIASING);
+
+    // Scale the extrusion vector down to a normal and then up by the line width
+    // of this vertex.
+    mediump vec2 dist = outset * a_extrude * scale;
+
+    // Calculate the offset when drawing a line that is to the side of the actual line.
+    // We do this by creating a vector that points towards the extrude, but rotate
+    // it when we're drawing round end points (a_direction = -1 or 1) since their
+    // extrude vector points in another direction.
+    mediump float u = 0.5 * a_direction;
+    mediump float t = 1.0 - abs(u);
+    mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
+
+    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+
+    // calculate how much the perspective view squishes or stretches the extrude
+    float extrude_length_without_perspective = length(dist);
+    float extrude_length_with_perspective = length(projected_extrude.xy / gl_Position.w * u_units_to_pixels);
+    v_gamma_scale = extrude_length_without_perspective / extrude_length_with_perspective;
+
+    v_width2 = vec2(outset, inset);
+}

--- a/shaders/drawable.line_pattern.fragment.glsl
+++ b/shaders/drawable.line_pattern.fragment.glsl
@@ -1,0 +1,105 @@
+layout (std140) uniform LinePatternUBO {
+    highp mat4 u_matrix;
+    mediump vec4 u_scale;
+    highp vec2 u_texsize;
+    highp vec2 u_units_to_pixels;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+    highp float u_fade;
+
+    highp float pad1;
+};
+
+layout (std140) uniform LinePatternPropertiesUBO {
+    lowp float u_blur;
+    lowp float u_opacity;
+    lowp float u_offset;
+    mediump float u_gapwidth;
+    mediump float u_width;
+
+    highp float pad2;
+    highp vec2 pad3;
+};
+
+layout (std140) uniform LinePatternTilePropertiesUBO {
+    lowp vec4 u_pattern_from;
+    lowp vec4 u_pattern_to;
+};
+
+layout (std140) uniform LinePatternInterpolationUBO {
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_offset_t;
+    lowp float u_gapwidth_t;
+    lowp float u_width_t;
+    lowp float u_pattern_from_t;
+    lowp float u_pattern_to_t;
+
+    highp float pad4;
+};
+
+uniform sampler2D u_image;
+
+in vec2 v_normal;
+in vec2 v_width2;
+in float v_linesofar;
+in float v_gamma_scale;
+
+#pragma mapbox: define lowp vec4 pattern_from
+#pragma mapbox: define lowp vec4 pattern_to
+#pragma mapbox: define lowp float blur
+#pragma mapbox: define lowp float opacity
+
+void main() {
+    #pragma mapbox: initialize mediump vec4 pattern_from
+    #pragma mapbox: initialize mediump vec4 pattern_to
+
+    #pragma mapbox: initialize lowp float blur
+    #pragma mapbox: initialize lowp float opacity
+
+    vec2 pattern_tl_a = pattern_from.xy;
+    vec2 pattern_br_a = pattern_from.zw;
+    vec2 pattern_tl_b = pattern_to.xy;
+    vec2 pattern_br_b = pattern_to.zw;
+
+    float pixelRatio = u_scale.x;
+    float tileZoomRatio = u_scale.y;
+    float fromScale = u_scale.z;
+    float toScale = u_scale.w;
+
+    vec2 display_size_a = vec2((pattern_br_a.x - pattern_tl_a.x) / pixelRatio, (pattern_br_a.y - pattern_tl_a.y) / pixelRatio);
+    vec2 display_size_b = vec2((pattern_br_b.x - pattern_tl_b.x) / pixelRatio, (pattern_br_b.y - pattern_tl_b.y) / pixelRatio);
+
+    vec2 pattern_size_a = vec2(display_size_a.x * fromScale / tileZoomRatio, display_size_a.y);
+    vec2 pattern_size_b = vec2(display_size_b.x * toScale / tileZoomRatio, display_size_b.y);
+
+    // Calculate the distance of the pixel from the line in pixels.
+    float dist = length(v_normal) * v_width2.s;
+
+    // Calculate the antialiasing fade factor. This is either when fading in
+    // the line in case of an offset line (v_width2.t) or when fading out
+    // (v_width2.s)
+    float blur2 = (blur + 1.0 / u_device_pixel_ratio) * v_gamma_scale;
+    float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
+
+    float x_a = mod(v_linesofar / pattern_size_a.x, 1.0);
+    float x_b = mod(v_linesofar / pattern_size_b.x, 1.0);
+
+    // v_normal.y is 0 at the midpoint of the line, -1 at the lower edge, 1 at the upper edge
+    // we clamp the line width outset to be between 0 and half the pattern height plus padding (2.0)
+    // to ensure we don't sample outside the designated symbol on the sprite sheet.
+    // 0.5 is added to shift the component to be bounded between 0 and 1 for interpolation of
+    // the texture coordinate
+    float y_a = 0.5 + (v_normal.y * clamp(v_width2.s, 0.0, (pattern_size_a.y + 2.0) / 2.0) / pattern_size_a.y);
+    float y_b = 0.5 + (v_normal.y * clamp(v_width2.s, 0.0, (pattern_size_b.y + 2.0) / 2.0) / pattern_size_b.y);
+    vec2 pos_a = mix(pattern_tl_a / u_texsize, pattern_br_a / u_texsize, vec2(x_a, y_a));
+    vec2 pos_b = mix(pattern_tl_b / u_texsize, pattern_br_b / u_texsize, vec2(x_b, y_b));
+
+    vec4 color = mix(texture(u_image, pos_a), texture(u_image, pos_b), u_fade);
+
+    fragColor = color * alpha * opacity;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.line_pattern.vertex.glsl
+++ b/shaders/drawable.line_pattern.vertex.glsl
@@ -1,0 +1,126 @@
+// floor(127 / 2) == 63.0
+// the maximum allowed miter limit is 2.0 at the moment. the extrude normal is
+// stored in a byte (-128..127). we scale regular normals up to length 63, but
+// there are also "special" normals that have a bigger length (of up to 126 in
+// this case).
+// #define scale 63.0
+#define scale 0.015873016
+
+// We scale the distance before adding it to the buffers so that we can store
+// long distances for long segments. Use this value to unscale the distance.
+#define LINE_DISTANCE_SCALE 2.0
+
+layout (location = 0) in vec2 a_pos_normal;
+layout (location = 1) in vec4 a_data;
+
+layout (std140) uniform LinePatternUBO {
+    highp mat4 u_matrix;
+    mediump vec4 u_scale;
+    highp vec2 u_texsize;
+    highp vec2 u_units_to_pixels;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+    highp float u_fade;
+
+    highp float pad1;
+};
+
+layout (std140) uniform LinePatternPropertiesUBO {
+    lowp float u_blur;
+    lowp float u_opacity;
+    lowp float u_offset;
+    mediump float u_gapwidth;
+    mediump float u_width;
+
+    highp float pad2;
+    highp vec2 pad3;
+};
+
+layout (std140) uniform LinePatternTilePropertiesUBO {
+    lowp vec4 u_pattern_from;
+    lowp vec4 u_pattern_to;
+};
+
+layout (std140) uniform LinePatternInterpolationUBO {
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_offset_t;
+    lowp float u_gapwidth_t;
+    lowp float u_width_t;
+    lowp float u_pattern_from_t;
+    lowp float u_pattern_to_t;
+
+    highp float pad4;
+};
+
+out vec2 v_normal;
+out vec2 v_width2;
+out float v_linesofar;
+out float v_gamma_scale;
+
+#pragma mapbox: define lowp float blur
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define lowp float offset
+#pragma mapbox: define mediump float gapwidth
+#pragma mapbox: define mediump float width
+#pragma mapbox: define lowp vec4 pattern_from
+#pragma mapbox: define lowp vec4 pattern_to
+
+void main() {
+    #pragma mapbox: initialize lowp float blur
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize lowp float offset
+    #pragma mapbox: initialize mediump float gapwidth
+    #pragma mapbox: initialize mediump float width
+    #pragma mapbox: initialize mediump vec4 pattern_from
+    #pragma mapbox: initialize mediump vec4 pattern_to
+
+    // the distance over which the line edge fades out.
+    // Retina devices need a smaller distance to avoid aliasing.
+    float ANTIALIASING = 1.0 / u_device_pixel_ratio / 2.0;
+
+    vec2 a_extrude = a_data.xy - 128.0;
+    float a_direction = mod(a_data.z, 4.0) - 1.0;
+    float a_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * LINE_DISTANCE_SCALE;
+    // float tileRatio = u_scale.y;
+    vec2 pos = floor(a_pos_normal * 0.5);
+
+    // x is 1 if it's a round cap, 0 otherwise
+    // y is 1 if the normal points up, and -1 if it points down
+    // We store these in the least significant bit of a_pos_normal
+    mediump vec2 normal = a_pos_normal - 2.0 * pos;
+    normal.y = normal.y * 2.0 - 1.0;
+    v_normal = normal;
+
+    // these transformations used to be applied in the JS and native code bases.
+    // moved them into the shader for clarity and simplicity.
+    gapwidth = gapwidth / 2.0;
+    float halfwidth = width / 2.0;
+    offset = -1.0 * offset;
+
+    float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
+    float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + (halfwidth == 0.0 ? 0.0 : ANTIALIASING);
+
+    // Scale the extrusion vector down to a normal and then up by the line width
+    // of this vertex.
+    mediump vec2 dist = outset * a_extrude * scale;
+
+    // Calculate the offset when drawing a line that is to the side of the actual line.
+    // We do this by creating a vector that points towards the extrude, but rotate
+    // it when we're drawing round end points (a_direction = -1 or 1) since their
+    // extrude vector points in another direction.
+    mediump float u = 0.5 * a_direction;
+    mediump float t = 1.0 - abs(u);
+    mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
+
+    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+
+    // calculate how much the perspective view squishes or stretches the extrude
+    float extrude_length_without_perspective = length(dist);
+    float extrude_length_with_perspective = length(projected_extrude.xy / gl_Position.w * u_units_to_pixels);
+    v_gamma_scale = extrude_length_without_perspective / extrude_length_with_perspective;
+
+    v_linesofar = a_linesofar;
+    v_width2 = vec2(outset, inset);
+}

--- a/shaders/drawable.line_sdf.fragment.glsl
+++ b/shaders/drawable.line_sdf.fragment.glsl
@@ -1,0 +1,79 @@
+
+layout (std140) uniform LineSDFUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_units_to_pixels;
+    highp vec2 u_patternscale_a;
+    highp vec2 u_patternscale_b;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+    highp float u_tex_y_a;
+    highp float u_tex_y_b;
+    highp float u_sdfgamma;
+    highp float u_mix;
+};
+
+layout (std140) uniform LineSDFPropertiesUBO {
+    highp vec4 u_color;
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_gapwidth;
+    lowp float u_offset;
+    mediump float u_width;
+    lowp float u_floorwidth;
+
+    highp vec2 pad1;
+};
+
+layout (std140) uniform LineSDFInterpolationUBO {
+    lowp float u_color_t;
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_gapwidth_t;
+    lowp float u_offset_t;
+    lowp float u_width_t;
+    lowp float u_floorwidth_t;
+
+    highp float pad2;
+};
+
+uniform sampler2D u_image;
+
+in vec2 v_normal;
+in vec2 v_width2;
+in vec2 v_tex_a;
+in vec2 v_tex_b;
+in float v_gamma_scale;
+
+#pragma mapbox: define highp vec4 color
+#pragma mapbox: define lowp float blur
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define mediump float width
+#pragma mapbox: define lowp float floorwidth
+
+void main() {
+    #pragma mapbox: initialize highp vec4 color
+    #pragma mapbox: initialize lowp float blur
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize mediump float width
+    #pragma mapbox: initialize lowp float floorwidth
+
+    // Calculate the distance of the pixel from the line in pixels.
+    float dist = length(v_normal) * v_width2.s;
+
+    // Calculate the antialiasing fade factor. This is either when fading in
+    // the line in case of an offset line (v_width2.t) or when fading out
+    // (v_width2.s)
+    float blur2 = (blur + 1.0 / u_device_pixel_ratio) * v_gamma_scale;
+    float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
+
+    float sdfdist_a = texture(u_image, v_tex_a).a;
+    float sdfdist_b = texture(u_image, v_tex_b).a;
+    float sdfdist = mix(sdfdist_a, sdfdist_b, u_mix);
+    alpha *= smoothstep(0.5 - u_sdfgamma / floorwidth, 0.5 + u_sdfgamma / floorwidth, sdfdist);
+
+    fragColor = color * (alpha * opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.line_sdf.vertex.glsl
+++ b/shaders/drawable.line_sdf.vertex.glsl
@@ -1,0 +1,126 @@
+// floor(127 / 2) == 63.0
+// the maximum allowed miter limit is 2.0 at the moment. the extrude normal is
+// stored in a byte (-128..127). we scale regular normals up to length 63, but
+// there are also "special" normals that have a bigger length (of up to 126 in
+// this case).
+// #define scale 63.0
+#define scale 0.015873016
+
+// We scale the distance before adding it to the buffers so that we can store
+// long distances for long segments. Use this value to unscale the distance.
+#define LINE_DISTANCE_SCALE 2.0
+
+layout (location = 0) in vec2 a_pos_normal;
+layout (location = 1) in vec4 a_data;
+
+layout (std140) uniform LineSDFUBO {
+    highp mat4 u_matrix;
+    highp vec2 u_units_to_pixels;
+    highp vec2 u_patternscale_a;
+    highp vec2 u_patternscale_b;
+    mediump float u_ratio;
+    lowp float u_device_pixel_ratio;
+    highp float u_tex_y_a;
+    highp float u_tex_y_b;
+    highp float u_sdfgamma;
+    highp float u_mix;
+};
+
+layout (std140) uniform LineSDFPropertiesUBO {
+    highp vec4 u_color;
+    lowp float u_blur;
+    lowp float u_opacity;
+    mediump float u_gapwidth;
+    lowp float u_offset;
+    mediump float u_width;
+    lowp float u_floorwidth;
+
+    highp vec2 pad1;
+};
+
+layout (std140) uniform LineSDFInterpolationUBO {
+    lowp float u_color_t;
+    lowp float u_blur_t;
+    lowp float u_opacity_t;
+    lowp float u_gapwidth_t;
+    lowp float u_offset_t;
+    lowp float u_width_t;
+    lowp float u_floorwidth_t;
+
+    highp float pad2;
+};
+
+out vec2 v_normal;
+out vec2 v_width2;
+out vec2 v_tex_a;
+out vec2 v_tex_b;
+out float v_gamma_scale;
+
+#pragma mapbox: define highp vec4 color
+#pragma mapbox: define lowp float blur
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define mediump float gapwidth
+#pragma mapbox: define lowp float offset
+#pragma mapbox: define mediump float width
+#pragma mapbox: define lowp float floorwidth
+
+void main() {
+    #pragma mapbox: initialize highp vec4 color
+    #pragma mapbox: initialize lowp float blur
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize mediump float gapwidth
+    #pragma mapbox: initialize lowp float offset
+    #pragma mapbox: initialize mediump float width
+    #pragma mapbox: initialize lowp float floorwidth
+
+    // the distance over which the line edge fades out.
+    // Retina devices need a smaller distance to avoid aliasing.
+    float ANTIALIASING = 1.0 / u_device_pixel_ratio / 2.0;
+
+    vec2 a_extrude = a_data.xy - 128.0;
+    float a_direction = mod(a_data.z, 4.0) - 1.0;
+    float a_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * LINE_DISTANCE_SCALE;
+
+    vec2 pos = floor(a_pos_normal * 0.5);
+
+    // x is 1 if it's a round cap, 0 otherwise
+    // y is 1 if the normal points up, and -1 if it points down
+    // We store these in the least significant bit of a_pos_normal
+    mediump vec2 normal = a_pos_normal - 2.0 * pos;
+    normal.y = normal.y * 2.0 - 1.0;
+    v_normal = normal;
+
+    // these transformations used to be applied in the JS and native code bases.
+    // moved them into the shader for clarity and simplicity.
+    gapwidth = gapwidth / 2.0;
+    float halfwidth = width / 2.0;
+    offset = -1.0 * offset;
+
+    float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
+    float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) + (halfwidth == 0.0 ? 0.0 : ANTIALIASING);
+
+    // Scale the extrusion vector down to a normal and then up by the line width
+    // of this vertex.
+    mediump vec2 dist =outset * a_extrude * scale;
+
+    // Calculate the offset when drawing a line that is to the side of the actual line.
+    // We do this by creating a vector that points towards the extrude, but rotate
+    // it when we're drawing round end points (a_direction = -1 or 1) since their
+    // extrude vector points in another direction.
+    mediump float u = 0.5 * a_direction;
+    mediump float t = 1.0 - abs(u);
+    mediump vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
+
+    vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
+    gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
+
+    // calculate how much the perspective view squishes or stretches the extrude
+    float extrude_length_without_perspective = length(dist);
+    float extrude_length_with_perspective = length(projected_extrude.xy / gl_Position.w * u_units_to_pixels);
+    v_gamma_scale = extrude_length_without_perspective / extrude_length_with_perspective;
+
+    v_tex_a = vec2(a_linesofar * u_patternscale_a.x / floorwidth, normal.y * u_patternscale_a.y + u_tex_y_a);
+    v_tex_b = vec2(a_linesofar * u_patternscale_b.x / floorwidth, normal.y * u_patternscale_b.y + u_tex_y_b);
+
+    v_width2 = vec2(outset, inset);
+}

--- a/shaders/drawable.raster.fragment.glsl
+++ b/shaders/drawable.raster.fragment.glsl
@@ -1,0 +1,59 @@
+layout (std140) uniform RasterDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec3 u_spin_weights;
+    highp vec2 u_tl_parent;
+    highp float u_scale_parent;
+    highp float u_buffer_scale;
+    highp float u_fade_t;
+    highp float u_opacity;
+    highp float u_brightness_low;
+    highp float u_brightness_high;
+    highp float u_saturation_factor;
+    highp float u_contrast_factor;
+    highp float pad1;
+    highp float pad2;
+};
+uniform sampler2D u_image0;
+uniform sampler2D u_image1;
+
+in vec2 v_pos0;
+in vec2 v_pos1;
+
+void main() {
+
+    // read and cross-fade colors from the main and parent tiles
+    vec4 color0 = texture(u_image0, v_pos0);
+    vec4 color1 = texture(u_image1, v_pos1);
+    if (color0.a > 0.0) {
+        color0.rgb = color0.rgb / color0.a;
+    }
+    if (color1.a > 0.0) {
+        color1.rgb = color1.rgb / color1.a;
+    }
+    vec4 color = mix(color0, color1, u_fade_t);
+    color.a *= u_opacity;
+    vec3 rgb = color.rgb;
+
+    // spin
+    rgb = vec3(
+        dot(rgb, u_spin_weights.xyz),
+        dot(rgb, u_spin_weights.zxy),
+        dot(rgb, u_spin_weights.yzx));
+
+    // saturation
+    float average = (color.r + color.g + color.b) / 3.0;
+    rgb += (average - rgb) * u_saturation_factor;
+
+    // contrast
+    rgb = (rgb - 0.5) * u_contrast_factor + 0.5;
+
+    // brightness
+    vec3 u_high_vec = vec3(u_brightness_low, u_brightness_low, u_brightness_low);
+    vec3 u_low_vec = vec3(u_brightness_high, u_brightness_high, u_brightness_high);
+
+    fragColor = vec4(mix(u_high_vec, u_low_vec, rgb) * color.a, color.a);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.raster.vertex.glsl
+++ b/shaders/drawable.raster.vertex.glsl
@@ -1,0 +1,32 @@
+layout (std140) uniform RasterDrawableUBO {
+    highp mat4 u_matrix;
+    highp vec3 u_spin_weights;
+    highp vec2 u_tl_parent;
+    highp float u_scale_parent;
+    highp float u_buffer_scale;
+    highp float u_fade_t;
+    highp float u_opacity;
+    highp float u_brightness_low;
+    highp float u_brightness_high;
+    highp float u_saturation_factor;
+    highp float u_contrast_factor;
+    highp float pad1;
+    highp float pad2;
+};
+
+layout (location = 0) in vec2 a_pos;
+layout (location = 1) in vec2 a_texture_pos;
+
+out vec2 v_pos0;
+out vec2 v_pos1;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+    // We are using Int16 for texture position coordinates to give us enough precision for
+    // fractional coordinates. We use 8192 to scale the texture coordinates in the buffer
+    // as an arbitrarily high number to preserve adequate precision when rendering.
+    // This is also the same value as the EXTENT we are using for our tile buffer pos coordinates,
+    // so math for modifying either is consistent.
+    v_pos0 = (((a_texture_pos / 8192.0) - 0.5) / u_buffer_scale ) + 0.5;
+    v_pos1 = (v_pos0 * u_scale_parent) + u_tl_parent;
+}

--- a/shaders/drawable.symbol_icon.fragment.glsl
+++ b/shaders/drawable.symbol_icon.fragment.glsl
@@ -1,0 +1,35 @@
+uniform sampler2D u_texture;
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+in vec2 v_tex;
+in float v_fade_opacity;
+
+#pragma mapbox: define lowp float opacity
+
+void main() {
+    #pragma mapbox: initialize lowp float opacity
+
+    lowp float alpha = opacity * v_fade_opacity;
+    fragColor = texture(u_texture, v_tex) * alpha;
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.symbol_icon.vertex.glsl
+++ b/shaders/drawable.symbol_icon.vertex.glsl
@@ -1,0 +1,121 @@
+layout (location = 0) in vec4 a_pos_offset;
+layout (location = 1) in vec4 a_data;
+layout (location = 2) in vec4 a_pixeloffset;
+layout (location = 3) in vec3 a_projected_pos;
+layout (location = 4) in float a_fade_opacity;
+
+layout (std140) uniform SymbolDrawableUBO {
+    highp mat4 u_matrix;
+    highp mat4 u_label_plane_matrix;
+    highp mat4 u_coord_matrix;
+
+    highp vec2 u_texsize;
+    highp vec2 u_texsize_icon;
+
+    highp float u_gamma_scale;
+    highp float u_device_pixel_ratio;
+
+    highp float u_camera_to_center_distance;
+    highp float u_pitch;
+    bool u_rotate_symbol;
+    highp float u_aspect_ratio;
+    highp float u_fade_change;
+    highp float u_pad2;
+};
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    bool u_pitch_with_map;
+    bool u_is_size_zoom_constant;
+    bool u_is_size_feature_constant;
+    highp float u_size_t; // used to interpolate between zoom stops when size is a composite function
+    highp float u_size; // used when size is both zoom and feature constant
+    bool u_pad3;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+out vec2 v_tex;
+out float v_fade_opacity;
+
+#pragma mapbox: define lowp float opacity
+
+void main() {
+    #pragma mapbox: initialize lowp float opacity
+
+    vec2 a_pos = a_pos_offset.xy;
+    vec2 a_offset = a_pos_offset.zw;
+
+    vec2 a_tex = a_data.xy;
+    vec2 a_size = a_data.zw;
+
+    float a_size_min = floor(a_size[0] * 0.5);
+    vec2 a_pxoffset = a_pixeloffset.xy;
+    vec2 a_minFontScale = a_pixeloffset.zw / 256.0;
+
+    highp float segment_angle = -a_projected_pos[2];
+    float size;
+
+    if (!u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = mix(a_size_min, a_size[1], u_size_t) / 128.0;
+    } else if (u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = a_size_min / 128.0;
+    } else {
+        size = u_size;
+    }
+
+    vec4 projectedPoint = u_matrix * vec4(a_pos, 0, 1);
+    highp float camera_to_anchor_distance = projectedPoint.w;
+    // See comments in symbol_sdf.vertex
+    highp float distance_ratio = u_pitch_with_map ?
+        camera_to_anchor_distance / u_camera_to_center_distance :
+        u_camera_to_center_distance / camera_to_anchor_distance;
+    highp float perspective_ratio = clamp(
+            0.5 + 0.5 * distance_ratio,
+            0.0, // Prevents oversized near-field symbols in pitched/overzoomed tiles
+            4.0);
+
+    size *= perspective_ratio;
+
+    float fontScale = u_is_text ? size / 24.0 : size;
+
+    highp float symbol_rotation = 0.0;
+    if (u_rotate_symbol) {
+        // See comments in symbol_sdf.vertex
+        vec4 offsetProjectedPoint = u_matrix * vec4(a_pos + vec2(1, 0), 0, 1);
+
+        vec2 a = projectedPoint.xy / projectedPoint.w;
+        vec2 b = offsetProjectedPoint.xy / offsetProjectedPoint.w;
+
+        symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
+    }
+
+    highp float angle_sin = sin(segment_angle + symbol_rotation);
+    highp float angle_cos = cos(segment_angle + symbol_rotation);
+    mat2 rotation_matrix = mat2(angle_cos, -1.0 * angle_sin, angle_sin, angle_cos);
+
+    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
+    gl_Position = u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + rotation_matrix * (a_offset / 32.0 * max(a_minFontScale, fontScale) + a_pxoffset / 16.0), 0.0, 1.0);
+
+    v_tex = a_tex / u_texsize;
+    vec2 fade_opacity = unpack_opacity(a_fade_opacity);
+    float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
+    v_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
+}

--- a/shaders/drawable.symbol_sdf.fragment.glsl
+++ b/shaders/drawable.symbol_sdf.fragment.glsl
@@ -1,0 +1,96 @@
+#define SDF_PX 8.0
+
+layout (std140) uniform SymbolDrawableUBO {
+    highp mat4 u_matrix;
+    highp mat4 u_label_plane_matrix;
+    highp mat4 u_coord_matrix;
+
+    highp vec2 u_texsize;
+    highp vec2 u_texsize_icon;
+
+    highp float u_gamma_scale;
+    highp float u_device_pixel_ratio;
+
+    highp float u_camera_to_center_distance;
+    highp float u_pitch;
+    bool u_rotate_symbol;
+    highp float u_aspect_ratio;
+    highp float u_fade_change;
+    highp float u_pad2;
+};
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    bool u_pitch_with_map;
+    bool u_is_size_zoom_constant;
+    bool u_is_size_feature_constant;
+    highp float u_size_t; // used to interpolate between zoom stops when size is a composite function
+    highp float u_size; // used when size is both zoom and feature constant
+    bool u_pad3;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+uniform sampler2D u_texture;
+
+in vec2 v_data0;
+in vec3 v_data1;
+
+#pragma mapbox: define highp vec4 fill_color
+#pragma mapbox: define highp vec4 halo_color
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define lowp float halo_width
+#pragma mapbox: define lowp float halo_blur
+
+void main() {
+    #pragma mapbox: initialize highp vec4 fill_color
+    #pragma mapbox: initialize highp vec4 halo_color
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize lowp float halo_width
+    #pragma mapbox: initialize lowp float halo_blur
+
+    float EDGE_GAMMA = 0.105 / u_device_pixel_ratio;
+
+    vec2 tex = v_data0.xy;
+    float gamma_scale = v_data1.x;
+    float size = v_data1.y;
+    float fade_opacity = v_data1[2];
+
+    float fontScale = u_is_text ? size / 24.0 : size;
+
+    lowp vec4 color = fill_color;
+    highp float gamma = EDGE_GAMMA / (fontScale * u_gamma_scale);
+    lowp float buff = (256.0 - 64.0) / 256.0;
+    if (u_is_halo) {
+        color = halo_color;
+        gamma = (halo_blur * 1.19 / SDF_PX + EDGE_GAMMA) / (fontScale * u_gamma_scale);
+        buff = (6.0 - halo_width / fontScale) / SDF_PX;
+    }
+
+    lowp float dist = texture(u_texture, tex).a;
+    highp float gamma_scaled = gamma * gamma_scale;
+    highp float alpha = smoothstep(buff - gamma_scaled, buff + gamma_scaled, dist);
+
+    fragColor = color * (alpha * opacity * fade_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.symbol_sdf.vertex.glsl
+++ b/shaders/drawable.symbol_sdf.vertex.glsl
@@ -1,0 +1,146 @@
+layout (location = 0) in vec4 a_pos_offset;
+layout (location = 1) in vec4 a_data;
+layout (location = 2) in vec4 a_pixeloffset;
+layout (location = 3) in vec3 a_projected_pos;
+layout (location = 4) in float a_fade_opacity;
+
+// contents of a_size vary based on the type of property value
+// used for {text,icon}-size.
+// For constants, a_size is disabled.
+// For source functions, we bind only one value per vertex: the value of {text,icon}-size evaluated for the current feature.
+// For composite functions:
+// [ text-size(lowerZoomStop, feature),
+//   text-size(upperZoomStop, feature) ]
+
+layout (std140) uniform SymbolDrawableUBO {
+    highp mat4 u_matrix;
+    highp mat4 u_label_plane_matrix;
+    highp mat4 u_coord_matrix;
+
+    highp vec2 u_texsize;
+    highp vec2 u_texsize_icon;
+
+    highp float u_gamma_scale;
+    highp float u_device_pixel_ratio;
+
+    highp float u_camera_to_center_distance;
+    highp float u_pitch;
+    bool u_rotate_symbol;
+    highp float u_aspect_ratio;
+    highp float u_fade_change;
+    highp float u_pad2;
+};
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    bool u_pitch_with_map;
+    bool u_is_size_zoom_constant;
+    bool u_is_size_feature_constant;
+    highp float u_size_t; // used to interpolate between zoom stops when size is a composite function
+    highp float u_size; // used when size is both zoom and feature constant
+    bool u_pad3;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+out vec2 v_data0;
+out vec3 v_data1;
+
+#pragma mapbox: define highp vec4 fill_color
+#pragma mapbox: define highp vec4 halo_color
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define lowp float halo_width
+#pragma mapbox: define lowp float halo_blur
+
+void main() {
+    #pragma mapbox: initialize highp vec4 fill_color
+    #pragma mapbox: initialize highp vec4 halo_color
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize lowp float halo_width
+    #pragma mapbox: initialize lowp float halo_blur
+
+    vec2 a_pos = a_pos_offset.xy;
+    vec2 a_offset = a_pos_offset.zw;
+
+    vec2 a_tex = a_data.xy;
+    vec2 a_size = a_data.zw;
+
+    float a_size_min = floor(a_size[0] * 0.5);
+    vec2 a_pxoffset = a_pixeloffset.xy;
+
+    highp float segment_angle = -a_projected_pos[2];
+    float size;
+
+    if (!u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = mix(a_size_min, a_size[1], u_size_t) / 128.0;
+    } else if (u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = a_size_min / 128.0;
+    } else {
+        size = u_size;
+    }
+
+    vec4 projectedPoint = u_matrix * vec4(a_pos, 0, 1);
+    highp float camera_to_anchor_distance = projectedPoint.w;
+    // If the label is pitched with the map, layout is done in pitched space,
+    // which makes labels in the distance smaller relative to viewport space.
+    // We counteract part of that effect by multiplying by the perspective ratio.
+    // If the label isn't pitched with the map, we do layout in viewport space,
+    // which makes labels in the distance larger relative to the features around
+    // them. We counteract part of that effect by dividing by the perspective ratio.
+    highp float distance_ratio = u_pitch_with_map ?
+        camera_to_anchor_distance / u_camera_to_center_distance :
+        u_camera_to_center_distance / camera_to_anchor_distance;
+    highp float perspective_ratio = clamp(
+        0.5 + 0.5 * distance_ratio,
+        0.0, // Prevents oversized near-field symbols in pitched/overzoomed tiles
+        4.0);
+
+    size *= perspective_ratio;
+
+    float fontScale = u_is_text ? size / 24.0 : size;
+
+    highp float symbol_rotation = 0.0;
+    if (u_rotate_symbol) {
+        // Point labels with 'rotation-alignment: map' are horizontal with respect to tile units
+        // To figure out that angle in projected space, we draw a short horizontal line in tile
+        // space, project it, and measure its angle in projected space.
+        vec4 offsetProjectedPoint = u_matrix * vec4(a_pos + vec2(1, 0), 0, 1);
+
+        vec2 a = projectedPoint.xy / projectedPoint.w;
+        vec2 b = offsetProjectedPoint.xy / offsetProjectedPoint.w;
+
+        symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
+    }
+
+    highp float angle_sin = sin(segment_angle + symbol_rotation);
+    highp float angle_cos = cos(segment_angle + symbol_rotation);
+    mat2 rotation_matrix = mat2(angle_cos, -1.0 * angle_sin, angle_sin, angle_cos);
+
+    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
+    gl_Position = u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + rotation_matrix * (a_offset / 32.0 * fontScale + a_pxoffset), 0.0, 1.0);
+    float gamma_scale = gl_Position.w;
+
+    vec2 fade_opacity = unpack_opacity(a_fade_opacity);
+    float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
+    float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
+
+    v_data0 = a_tex / u_texsize;
+    v_data1 = vec3(gamma_scale, size, interpolated_fade_opacity);
+}

--- a/shaders/drawable.symbol_text_and_icon.fragment.glsl
+++ b/shaders/drawable.symbol_text_and_icon.fragment.glsl
@@ -1,0 +1,113 @@
+#define SDF_PX 8.0
+
+#define SDF 1.0
+#define ICON 0.0
+
+layout (std140) uniform SymbolDrawableUBO {
+    highp mat4 u_matrix;
+    highp mat4 u_label_plane_matrix;
+    highp mat4 u_coord_matrix;
+
+    highp vec2 u_texsize;
+    highp vec2 u_texsize_icon;
+
+    highp float u_gamma_scale;
+    highp float u_device_pixel_ratio;
+
+    highp float u_camera_to_center_distance;
+    highp float u_pitch;
+    bool u_rotate_symbol;
+    highp float u_aspect_ratio;
+    highp float u_fade_change;
+    highp float u_pad2;
+};
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    bool u_pitch_with_map;
+    bool u_is_size_zoom_constant;
+    bool u_is_size_feature_constant;
+    highp float u_size_t; // used to interpolate between zoom stops when size is a composite function
+    highp float u_size; // used when size is both zoom and feature constant
+    bool u_pad3;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+uniform sampler2D u_texture;
+uniform sampler2D u_texture_icon;
+
+in vec4 v_data0;
+in vec4 v_data1;
+
+#pragma mapbox: define highp vec4 fill_color
+#pragma mapbox: define highp vec4 halo_color
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define lowp float halo_width
+#pragma mapbox: define lowp float halo_blur
+
+void main() {
+    #pragma mapbox: initialize highp vec4 fill_color
+    #pragma mapbox: initialize highp vec4 halo_color
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize lowp float halo_width
+    #pragma mapbox: initialize lowp float halo_blur
+
+    float fade_opacity = v_data1[2];
+
+    if (v_data1.w == ICON) {
+        vec2 tex_icon = v_data0.zw;
+        lowp float alpha = opacity * fade_opacity;
+        fragColor = texture(u_texture_icon, tex_icon) * alpha;
+
+#ifdef OVERDRAW_INSPECTOR
+        fragColor = vec4(1.0);
+#endif
+        return;
+    }
+
+    vec2 tex = v_data0.xy;
+
+    float EDGE_GAMMA = 0.105 / u_device_pixel_ratio;
+
+    float gamma_scale = v_data1.x;
+    float size = v_data1.y;
+
+    float fontScale = size / 24.0;
+
+    lowp vec4 color = fill_color;
+    highp float gamma = EDGE_GAMMA / (fontScale * u_gamma_scale);
+    lowp float buff = (256.0 - 64.0) / 256.0;
+    if (u_is_halo) {
+        color = halo_color;
+        gamma = (halo_blur * 1.19 / SDF_PX + EDGE_GAMMA) / (fontScale * u_gamma_scale);
+        buff = (6.0 - halo_width / fontScale) / SDF_PX;
+    }
+
+    lowp float dist = texture(u_texture, tex).a;
+    highp float gamma_scaled = gamma * gamma_scale;
+    highp float alpha = smoothstep(buff - gamma_scaled, buff + gamma_scaled, dist);
+
+    fragColor = color * (alpha * opacity * fade_opacity);
+
+#ifdef OVERDRAW_INSPECTOR
+    fragColor = vec4(1.0);
+#endif
+}

--- a/shaders/drawable.symbol_text_and_icon.vertex.glsl
+++ b/shaders/drawable.symbol_text_and_icon.vertex.glsl
@@ -1,0 +1,146 @@
+layout (location = 0) in vec4 a_pos_offset;
+layout (location = 1) in vec4 a_data;
+layout (location = 2) in vec3 a_projected_pos;
+layout (location = 3) in float a_fade_opacity;
+
+// contents of a_size vary based on the type of property value
+// used for {text,icon}-size.
+// For constants, a_size is disabled.
+// For source functions, we bind only one value per vertex: the value of {text,icon}-size evaluated for the current feature.
+// For composite functions:
+// [ text-size(lowerZoomStop, feature),
+//   text-size(upperZoomStop, feature) ]
+
+layout (std140) uniform SymbolDrawableUBO {
+    highp mat4 u_matrix;
+    highp mat4 u_label_plane_matrix;
+    highp mat4 u_coord_matrix;
+
+    highp vec2 u_texsize;
+    highp vec2 u_texsize_icon;
+
+    highp float u_gamma_scale;
+    highp float u_device_pixel_ratio;
+
+    highp float u_camera_to_center_distance;
+    highp float u_pitch;
+    bool u_rotate_symbol;
+    highp float u_aspect_ratio;
+    highp float u_fade_change;
+    highp float u_pad2;
+};
+
+layout (std140) uniform SymbolDrawablePaintUBO {
+    highp vec4 u_fill_color;
+    highp vec4 u_halo_color;
+    highp float u_opacity;
+    highp float u_halo_width;
+    highp float u_halo_blur;
+    highp float u_padding;
+};
+
+layout (std140) uniform SymbolDrawableTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    bool u_pitch_with_map;
+    bool u_is_size_zoom_constant;
+    bool u_is_size_feature_constant;
+    highp float u_size_t; // used to interpolate between zoom stops when size is a composite function
+    highp float u_size; // used when size is both zoom and feature constant
+    bool u_pad3;
+};
+
+layout (std140) uniform SymbolDrawableInterpolateUBO {
+    highp float u_fill_color_t;
+    highp float u_halo_color_t;
+    highp float u_opacity_t;
+    highp float u_halo_width_t;
+    highp float u_halo_blur_t;
+    highp float u_pad4,u_pad5,u_pad6;
+};
+
+out vec4 v_data0;
+out vec4 v_data1;
+
+#pragma mapbox: define highp vec4 fill_color
+#pragma mapbox: define highp vec4 halo_color
+#pragma mapbox: define lowp float opacity
+#pragma mapbox: define lowp float halo_width
+#pragma mapbox: define lowp float halo_blur
+
+void main() {
+    #pragma mapbox: initialize highp vec4 fill_color
+    #pragma mapbox: initialize highp vec4 halo_color
+    #pragma mapbox: initialize lowp float opacity
+    #pragma mapbox: initialize lowp float halo_width
+    #pragma mapbox: initialize lowp float halo_blur
+
+    vec2 a_pos = a_pos_offset.xy;
+    vec2 a_offset = a_pos_offset.zw;
+
+    vec2 a_tex = a_data.xy;
+    vec2 a_size = a_data.zw;
+
+    float a_size_min = floor(a_size[0] * 0.5);
+    float is_sdf = a_size[0] - 2.0 * a_size_min;
+
+    highp float segment_angle = -a_projected_pos[2];
+    float size;
+
+    if (!u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = mix(a_size_min, a_size[1], u_size_t) / 128.0;
+    } else if (u_is_size_zoom_constant && !u_is_size_feature_constant) {
+        size = a_size_min / 128.0;
+    } else {
+        size = u_size;
+    }
+
+    vec4 projectedPoint = u_matrix * vec4(a_pos, 0, 1);
+    highp float camera_to_anchor_distance = projectedPoint.w;
+    // If the label is pitched with the map, layout is done in pitched space,
+    // which makes labels in the distance smaller relative to viewport space.
+    // We counteract part of that effect by multiplying by the perspective ratio.
+    // If the label isn't pitched with the map, we do layout in viewport space,
+    // which makes labels in the distance larger relative to the features around
+    // them. We counteract part of that effect by dividing by the perspective ratio.
+    highp float distance_ratio = u_pitch_with_map ?
+        camera_to_anchor_distance / u_camera_to_center_distance :
+        u_camera_to_center_distance / camera_to_anchor_distance;
+    highp float perspective_ratio = clamp(
+        0.5 + 0.5 * distance_ratio,
+        0.0, // Prevents oversized near-field symbols in pitched/overzoomed tiles
+        4.0);
+
+    size *= perspective_ratio;
+
+    float fontScale = size / 24.0;
+
+    highp float symbol_rotation = 0.0;
+    if (u_rotate_symbol) {
+        // Point labels with 'rotation-alignment: map' are horizontal with respect to tile units
+        // To figure out that angle in projected space, we draw a short horizontal line in tile
+        // space, project it, and measure its angle in projected space.
+        vec4 offsetProjectedPoint = u_matrix * vec4(a_pos + vec2(1, 0), 0, 1);
+
+        vec2 a = projectedPoint.xy / projectedPoint.w;
+        vec2 b = offsetProjectedPoint.xy / offsetProjectedPoint.w;
+
+        symbol_rotation = atan((b.y - a.y) / u_aspect_ratio, b.x - a.x);
+    }
+
+    highp float angle_sin = sin(segment_angle + symbol_rotation);
+    highp float angle_cos = cos(segment_angle + symbol_rotation);
+    mat2 rotation_matrix = mat2(angle_cos, -1.0 * angle_sin, angle_sin, angle_cos);
+
+    vec4 projected_pos = u_label_plane_matrix * vec4(a_projected_pos.xy, 0.0, 1.0);
+    gl_Position = u_coord_matrix * vec4(projected_pos.xy / projected_pos.w + rotation_matrix * (a_offset / 32.0 * fontScale), 0.0, 1.0);
+    float gamma_scale = gl_Position.w;
+
+    vec2 fade_opacity = unpack_opacity(a_fade_opacity);
+    float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
+    float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
+
+    v_data0.xy = a_tex / u_texsize;
+    v_data0.zw = a_tex / u_texsize_icon;
+    v_data1 = vec4(gamma_scale, size, interpolated_fade_opacity, is_sdf);
+}

--- a/src/mbgl/geometry/dem_data.hpp
+++ b/src/mbgl/geometry/dem_data.hpp
@@ -19,14 +19,15 @@ public:
     int32_t get(int32_t x, int32_t y) const;
     const std::array<float, 4>& getUnpackVector() const;
 
-    const PremultipliedImage* getImage() const { return &image; }
+    const PremultipliedImage* getImage() const { return &*image; }
+    const std::shared_ptr<PremultipliedImage>& getImagePtr() const { return image; }
 
     const int32_t dim;
     const int32_t stride;
+    const Tileset::DEMEncoding encoding;
 
 private:
-    Tileset::DEMEncoding encoding;
-    PremultipliedImage image;
+    std::shared_ptr<PremultipliedImage> image;
 
     size_t idx(const int32_t x, const int32_t y) const {
         assert(x >= -1);

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <mbgl/geometry/line_atlas.hpp>
 #include <mbgl/gfx/upload_pass.hpp>
+#include <mbgl/gfx/context.hpp>
 #include <mbgl/math/log2.hpp>
 #include <mbgl/math/minmax.hpp>
 #include <mbgl/util/hash.hpp>
@@ -206,23 +207,56 @@ DashPatternTexture::DashPatternTexture(const std::vector<float>& from_,
 }
 
 void DashPatternTexture::upload(gfx::UploadPass& uploadPass) {
+#if MLN_DRAWABLE_RENDERER
+    if (std::holds_alternative<AlphaImage>(texture)) {
+        auto tempTexture = uploadPass.getContext().createTexture2D();
+        tempTexture->upload(std::get<AlphaImage>(texture));
+        tempTexture->setSamplerConfiguration(
+            {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Repeat, gfx::TextureWrapType::Clamp});
+        texture = std::move(tempTexture);
+    }
+#else
     if (texture.is<AlphaImage>()) {
         texture = uploadPass.createTexture(texture.get<AlphaImage>());
     }
+#endif
 }
 
 gfx::TextureBinding DashPatternTexture::textureBinding() const {
     // The texture needs to have been uploaded already.
+#if MLN_DRAWABLE_RENDERER
+    assert(std::holds_alternative<gfx::Texture2DPtr>(texture));
+    return {std::get<gfx::Texture2DPtr>(texture)->getResource(),
+            gfx::TextureFilterType::Linear,
+            gfx::TextureMipMapType::No,
+            gfx::TextureWrapType::Repeat,
+            gfx::TextureWrapType::Clamp};
+#else
     assert(texture.is<gfx::Texture>());
     return {texture.get<gfx::Texture>().getResource(),
             gfx::TextureFilterType::Linear,
             gfx::TextureMipMapType::No,
             gfx::TextureWrapType::Repeat,
             gfx::TextureWrapType::Clamp};
+#endif
 }
 
+#if MLN_DRAWABLE_RENDERER
+static const gfx::Texture2DPtr noTexture;
+const std::shared_ptr<gfx::Texture2D>& DashPatternTexture::getTexture() const {
+    return (std::holds_alternative<gfx::Texture2DPtr>(texture)) ? std::get<gfx::Texture2DPtr>(texture) : noTexture;
+}
+#endif
+
 Size DashPatternTexture::getSize() const {
+#if MLN_DRAWABLE_RENDERER
+    if (std::holds_alternative<AlphaImage>(texture)) {
+        return std::get<AlphaImage>(texture).size;
+    }
+    return std::get<gfx::Texture2DPtr>(texture)->getSize();
+#else
     return texture.match([](const auto& obj) { return obj.size; });
+#endif
 }
 
 LineAtlas::LineAtlas() = default;

--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -1,13 +1,20 @@
 #pragma once
 
 #include <mbgl/gfx/texture.hpp>
+#include <mbgl/gfx/context.hpp>
 #include <mbgl/util/image.hpp>
+
+#if MLN_DRAWABLE_RENDERER
+#include <mbgl/gfx/texture2d.hpp>
+#include <variant>
+#else
 #include <mbgl/util/variant.hpp>
+#include <optional>
+#endif
 
 #include <map>
 #include <memory>
 #include <vector>
-#include <optional>
 
 namespace mbgl {
 
@@ -45,6 +52,9 @@ public:
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
     gfx::TextureBinding textureBinding() const;
+#if MLN_DRAWABLE_RENDERER
+    const std::shared_ptr<gfx::Texture2D>& getTexture() const;
+#endif
 
     // Returns the size of the texture image.
     Size getSize() const;
@@ -54,7 +64,12 @@ public:
 
 private:
     LinePatternPos from, to;
+
+#if MLN_DRAWABLE_RENDERER
+    std::variant<AlphaImage, gfx::Texture2DPtr> texture;
+#else
     variant<AlphaImage, gfx::Texture> texture;
+#endif
 };
 
 class LineAtlas {
@@ -75,7 +90,7 @@ public:
 private:
     std::map<size_t, DashPatternTexture> textures;
 
-    // Stores a list of hashes of texture objcts that need uploading.
+    // Stores a list of hashes of texture objects that need uploading.
     std::vector<size_t> needsUpload;
 };
 

--- a/src/mbgl/gfx/drawable_atlases_tweaker.cpp
+++ b/src/mbgl/gfx/drawable_atlases_tweaker.cpp
@@ -1,0 +1,33 @@
+#include <mbgl/gfx/drawable_atlases_tweaker.hpp>
+
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/renderer/tile_render_data.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+
+namespace mbgl {
+namespace gfx {
+
+void DrawableAtlasesTweaker::setupTextures(gfx::Drawable& drawable) {
+    if (const auto& shader = drawable.getShader()) {
+        if (const auto samplerLocation = shader->getSamplerLocation(glyphName)) {
+            if (const auto iconSamplerLocation = shader->getSamplerLocation(iconName)) {
+                assert(*samplerLocation != *iconSamplerLocation);
+                drawable.setTexture(atlases ? atlases->glyph : nullptr, *samplerLocation);
+                drawable.setTexture(atlases ? atlases->icon : nullptr, *iconSamplerLocation);
+            } else {
+                drawable.setTexture(atlases ? (isText ? atlases->glyph : atlases->icon) : nullptr, *samplerLocation);
+            }
+        }
+    }
+}
+
+void DrawableAtlasesTweaker::init(gfx::Drawable& drawable) {
+    setupTextures(drawable);
+}
+
+void DrawableAtlasesTweaker::execute(gfx::Drawable& drawable, const PaintParameters&) {
+    setupTextures(drawable);
+}
+
+} // namespace gfx
+} // namespace mbgl

--- a/src/mbgl/gfx/drawable_custom_layer_host_tweaker.cpp
+++ b/src/mbgl/gfx/drawable_custom_layer_host_tweaker.cpp
@@ -1,0 +1,46 @@
+#include <mbgl/gfx/drawable_custom_layer_host_tweaker.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/gfx/renderer_backend.hpp>
+#include <mbgl/gfx/renderable.hpp>
+
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/gfx/context.hpp>
+
+#include <mbgl/gfx/renderable.hpp>
+
+namespace mbgl {
+namespace gfx {
+
+void DrawableCustomLayerHostTweaker::execute([[maybe_unused]] gfx::Drawable& drawable,
+                                             const PaintParameters& paintParameters) {
+    // custom drawing
+    auto& context = paintParameters.context;
+    const TransformState& state = paintParameters.state;
+    context.resetState(paintParameters.depthModeForSublayer(0, gfx::DepthMaskType::ReadOnly),
+                       paintParameters.colorModeForRenderPass());
+
+    style::CustomLayerRenderParameters parameters;
+
+    parameters.width = state.getSize().width;
+    parameters.height = state.getSize().height;
+    parameters.latitude = state.getLatLng().latitude();
+    parameters.longitude = state.getLatLng().longitude();
+    parameters.zoom = state.getZoom();
+    parameters.bearing = util::rad2deg(-state.getBearing());
+    parameters.pitch = state.getPitch();
+    parameters.fieldOfView = state.getFieldOfView();
+    mat4 projMatrix;
+    state.getProjMatrix(projMatrix);
+    parameters.projectionMatrix = projMatrix;
+
+    host->render(parameters);
+
+    // Reset the view back to our original one, just in case the CustomLayer
+    // changed the viewport or Framebuffer.
+    paintParameters.backend.getDefaultRenderable().getResource<gfx::RenderableResource>().bind();
+
+    context.setDirtyState();
+}
+
+} // namespace gfx
+} // namespace mbgl

--- a/src/mbgl/gfx/hillshade_prepare_drawable_data.hpp
+++ b/src/mbgl/gfx/hillshade_prepare_drawable_data.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <mbgl/gfx/drawable_data.hpp>
+#include <mbgl/util/tileset.hpp>
+
+#include <memory>
+
+namespace mbgl {
+
+namespace gfx {
+
+class HillshadePrepareDrawableData : public DrawableData {
+public:
+    HillshadePrepareDrawableData(int32_t stride_, Tileset::DEMEncoding encoding_, uint8_t maxzoom_)
+        : stride(stride_),
+          encoding(encoding_),
+          maxzoom(maxzoom_) {}
+
+    int32_t stride;
+    Tileset::DEMEncoding encoding;
+    uint8_t maxzoom;
+};
+
+using UniqueHillshadePrepareDrawableData = std::unique_ptr<HillshadePrepareDrawableData>;
+
+} // namespace gfx
+} // namespace mbgl

--- a/src/mbgl/gfx/image_drawable_data.hpp
+++ b/src/mbgl/gfx/image_drawable_data.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <mbgl/gfx/drawable_data.hpp>
+#include <mbgl/util/mat4.hpp>
+
+#include <memory>
+
+namespace mbgl {
+
+namespace gfx {
+
+class ImageDrawableData : public DrawableData {
+public:
+    ImageDrawableData(mat4 matrix_)
+        : matrix(matrix_) {}
+
+    mat4 matrix;
+};
+
+using UniqueImageDrawableData = std::unique_ptr<ImageDrawableData>;
+
+} // namespace gfx
+} // namespace mbgl

--- a/src/mbgl/gfx/line_drawable_data.hpp
+++ b/src/mbgl/gfx/line_drawable_data.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <mbgl/gfx/drawable_data.hpp>
+#include <mbgl/geometry/line_atlas.hpp>
+
+#include <memory>
+
+namespace mbgl {
+
+namespace gfx {
+
+class LineDrawableData : public DrawableData {
+public:
+    LineDrawableData(LinePatternCap linePatternCap_)
+        : linePatternCap(linePatternCap_) {}
+
+    LinePatternCap linePatternCap;
+};
+
+using UniqueLineDrawableData = std::unique_ptr<LineDrawableData>;
+
+} // namespace gfx
+} // namespace mbgl

--- a/src/mbgl/gfx/symbol_drawable_data.hpp
+++ b/src/mbgl/gfx/symbol_drawable_data.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <mbgl/gfx/drawable_data.hpp>
+#include <mbgl/style/types.hpp>
+
+#include <memory>
+
+namespace mbgl {
+namespace style {
+enum class SymbolType : uint8_t;
+} // namespace style
+namespace gfx {
+
+struct SymbolDrawableData : public DrawableData {
+    SymbolDrawableData(const bool isHalo_,
+                       const bool bucketVariablePlacement_,
+                       const style::SymbolType symbolType_,
+                       const style::AlignmentType pitchAlignment_,
+                       const style::AlignmentType rotationAlignment_,
+                       const style::SymbolPlacementType placement_,
+                       const style::IconTextFitType textFit_)
+        : isHalo(isHalo_),
+          bucketVariablePlacement(bucketVariablePlacement_),
+          symbolType(symbolType_),
+          pitchAlignment(pitchAlignment_),
+          rotationAlignment(rotationAlignment_),
+          placement(placement_),
+          textFit(textFit_) {}
+    ~SymbolDrawableData() override = default;
+
+    const bool isHalo;
+    bool bucketVariablePlacement;
+    const style::SymbolType symbolType;
+    const style::AlignmentType pitchAlignment;
+    const style::AlignmentType rotationAlignment;
+    const style::SymbolPlacementType placement;
+    const style::IconTextFitType textFit;
+};
+
+using UniqueSymbolDrawableData = std::unique_ptr<SymbolDrawableData>;
+
+} // namespace gfx
+} // namespace mbgl

--- a/src/mbgl/layermanager/fill_layer_factory.cpp
+++ b/src/mbgl/layermanager/fill_layer_factory.cpp
@@ -13,12 +13,8 @@ const style::LayerTypeInfo* FillLayerFactory::getTypeInfo() const noexcept {
 
 std::unique_ptr<style::Layer> FillLayerFactory::createLayer(const std::string& id,
                                                             const style::conversion::Convertible& value) noexcept {
-    std::optional<std::string> source = getSource(value);
-    if (!source) {
-        return nullptr;
-    }
-
-    return std::unique_ptr<style::Layer>(new style::FillLayer(id, *source));
+    const auto source = getSource(value);
+    return std::unique_ptr<style::Layer>(source ? new (std::nothrow) style::FillLayer(id, *source) : nullptr);
 }
 
 std::unique_ptr<Layout> FillLayerFactory::createLayout(

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -844,7 +844,7 @@ void SymbolLayout::createBucket(const ImagePositions&,
 
             for (auto& pair : bucket->paintProperties) {
                 pair.second.iconBinders.populateVertexVectors(
-                    feature, iconBuffer.vertices.elements(), symbolInstance.dataFeatureIndex, {}, {}, canonical);
+                    feature, iconBuffer.vertices().elements(), symbolInstance.dataFeatureIndex, {}, {}, canonical);
             }
         }
 
@@ -932,7 +932,7 @@ void SymbolLayout::updatePaintPropertiesForSection(SymbolBucket& bucket,
     const auto& formattedSection = sectionOptionsToValue((*feature.formattedText).sectionAt(sectionIndex));
     for (auto& pair : bucket.paintProperties) {
         pair.second.textBinders.populateVertexVectors(
-            feature, bucket.text.vertices.elements(), feature.index, {}, {}, canonical, formattedSection);
+            feature, bucket.text.vertices().elements(), feature.index, {}, {}, canonical, formattedSection);
     }
 }
 
@@ -1002,7 +1002,7 @@ size_t SymbolLayout::addSymbol(SymbolBucket::Buffer& buffer,
     if (buffer.segments.empty() ||
         buffer.segments.back().vertexLength + vertexLength > std::numeric_limits<uint16_t>::max() ||
         std::fabs(buffer.segments.back().sortKey - sortKey) > std::numeric_limits<float>::epsilon()) {
-        buffer.segments.emplace_back(buffer.vertices.elements(), buffer.triangles.elements(), 0ul, 0ul, sortKey);
+        buffer.segments.emplace_back(buffer.vertices().elements(), buffer.triangles.elements(), 0ul, 0ul, sortKey);
     }
 
     // We're generating triangle fans, so we always start with the first
@@ -1012,57 +1012,58 @@ size_t SymbolLayout::addSymbol(SymbolBucket::Buffer& buffer,
     auto index = static_cast<uint16_t>(segment.vertexLength);
 
     // coordinates (2 triangles)
-    buffer.vertices.emplace_back(SymbolSDFIconProgram::layoutVertex(labelAnchor.point,
-                                                                    tl,
-                                                                    symbol.glyphOffset.y,
-                                                                    tex.x,
-                                                                    tex.y,
-                                                                    sizeData,
-                                                                    symbol.isSDF,
-                                                                    pixelOffsetTL,
-                                                                    minFontScale));
-    buffer.vertices.emplace_back(SymbolSDFIconProgram::layoutVertex(labelAnchor.point,
-                                                                    tr,
-                                                                    symbol.glyphOffset.y,
-                                                                    tex.x + tex.w,
-                                                                    tex.y,
-                                                                    sizeData,
-                                                                    symbol.isSDF,
-                                                                    {pixelOffsetBR.x, pixelOffsetTL.y},
-                                                                    minFontScale));
-    buffer.vertices.emplace_back(SymbolSDFIconProgram::layoutVertex(labelAnchor.point,
-                                                                    bl,
-                                                                    symbol.glyphOffset.y,
-                                                                    tex.x,
-                                                                    tex.y + tex.h,
-                                                                    sizeData,
-                                                                    symbol.isSDF,
-                                                                    {pixelOffsetTL.x, pixelOffsetBR.y},
-                                                                    minFontScale));
-    buffer.vertices.emplace_back(SymbolSDFIconProgram::layoutVertex(labelAnchor.point,
-                                                                    br,
-                                                                    symbol.glyphOffset.y,
-                                                                    tex.x + tex.w,
-                                                                    tex.y + tex.h,
-                                                                    sizeData,
-                                                                    symbol.isSDF,
-                                                                    pixelOffsetBR,
-                                                                    minFontScale));
+    auto& vertices = buffer.vertices();
+    vertices.emplace_back(SymbolSDFIconProgram::layoutVertex(labelAnchor.point,
+                                                             tl,
+                                                             symbol.glyphOffset.y,
+                                                             tex.x,
+                                                             tex.y,
+                                                             sizeData,
+                                                             symbol.isSDF,
+                                                             pixelOffsetTL,
+                                                             minFontScale));
+    vertices.emplace_back(SymbolSDFIconProgram::layoutVertex(labelAnchor.point,
+                                                             tr,
+                                                             symbol.glyphOffset.y,
+                                                             tex.x + tex.w,
+                                                             tex.y,
+                                                             sizeData,
+                                                             symbol.isSDF,
+                                                             {pixelOffsetBR.x, pixelOffsetTL.y},
+                                                             minFontScale));
+    vertices.emplace_back(SymbolSDFIconProgram::layoutVertex(labelAnchor.point,
+                                                             bl,
+                                                             symbol.glyphOffset.y,
+                                                             tex.x,
+                                                             tex.y + tex.h,
+                                                             sizeData,
+                                                             symbol.isSDF,
+                                                             {pixelOffsetTL.x, pixelOffsetBR.y},
+                                                             minFontScale));
+    vertices.emplace_back(SymbolSDFIconProgram::layoutVertex(labelAnchor.point,
+                                                             br,
+                                                             symbol.glyphOffset.y,
+                                                             tex.x + tex.w,
+                                                             tex.y + tex.h,
+                                                             sizeData,
+                                                             symbol.isSDF,
+                                                             pixelOffsetBR,
+                                                             minFontScale));
 
     // Dynamic/Opacity vertices are initialized so that the vertex count always
     // agrees with the layout vertex buffer, but they will always be updated
     // before rendering happens
     auto dynamicVertex = SymbolSDFIconProgram::dynamicLayoutVertex(labelAnchor.point, 0);
-    buffer.dynamicVertices.emplace_back(dynamicVertex);
-    buffer.dynamicVertices.emplace_back(dynamicVertex);
-    buffer.dynamicVertices.emplace_back(dynamicVertex);
-    buffer.dynamicVertices.emplace_back(dynamicVertex);
+    buffer.dynamicVertices().emplace_back(dynamicVertex);
+    buffer.dynamicVertices().emplace_back(dynamicVertex);
+    buffer.dynamicVertices().emplace_back(dynamicVertex);
+    buffer.dynamicVertices().emplace_back(dynamicVertex);
 
     auto opacityVertex = SymbolSDFIconProgram::opacityVertex(1.0, 1.0);
-    buffer.opacityVertices.emplace_back(opacityVertex);
-    buffer.opacityVertices.emplace_back(opacityVertex);
-    buffer.opacityVertices.emplace_back(opacityVertex);
-    buffer.opacityVertices.emplace_back(opacityVertex);
+    buffer.opacityVertices().emplace_back(opacityVertex);
+    buffer.opacityVertices().emplace_back(opacityVertex);
+    buffer.opacityVertices().emplace_back(opacityVertex);
+    buffer.opacityVertices().emplace_back(opacityVertex);
 
     // add the two triangles, referencing the four coordinates we just inserted.
     buffer.triangles.emplace_back(index + 0, index + 1, index + 2);

--- a/src/mbgl/programs/fill_extrusion_program.cpp
+++ b/src/mbgl/programs/fill_extrusion_program.cpp
@@ -11,12 +11,12 @@ using namespace style;
 
 static_assert(sizeof(FillExtrusionLayoutVertex) == 12, "expected FillExtrusionLayoutVertex size");
 
-std::array<float, 3> lightColor(const EvaluatedLight& light) {
+std::array<float, 3> FillExtrusionProgram::lightColor(const EvaluatedLight& light) {
     const auto color = light.get<LightColor>();
     return {{color.r, color.g, color.b}};
 }
 
-std::array<float, 3> lightPosition(const EvaluatedLight& light, const TransformState& state) {
+std::array<float, 3> FillExtrusionProgram::lightPosition(const EvaluatedLight& light, const TransformState& state) {
     auto lightPos = light.get<LightPosition>().getCartesian();
     mat3 lightMat;
     matrix::identity(lightMat);
@@ -27,26 +27,26 @@ std::array<float, 3> lightPosition(const EvaluatedLight& light, const TransformS
     return lightPos;
 }
 
-float lightIntensity(const EvaluatedLight& light) {
+float FillExtrusionProgram::lightIntensity(const EvaluatedLight& light) {
     return light.get<LightIntensity>();
 }
 
-FillExtrusionProgram::LayoutUniformValues FillExtrusionProgram::layoutUniformValues(mat4 matrix,
+FillExtrusionProgram::LayoutUniformValues FillExtrusionProgram::layoutUniformValues(const mat4& matrix,
                                                                                     const TransformState& state,
                                                                                     const float opacity,
                                                                                     const EvaluatedLight& light,
                                                                                     const float verticalGradient) {
     return {uniforms::matrix::Value(matrix),
             uniforms::opacity::Value(opacity),
-            uniforms::lightcolor::Value(lightColor(light)),
-            uniforms::lightpos::Value(lightPosition(light, state)),
-            uniforms::lightintensity::Value(lightIntensity(light)),
+            uniforms::lightcolor::Value(FillExtrusionProgram::lightColor(light)),
+            uniforms::lightpos::Value(FillExtrusionProgram::lightPosition(light, state)),
+            uniforms::lightintensity::Value(FillExtrusionProgram::lightIntensity(light)),
             uniforms::vertical_gradient::Value(verticalGradient)};
 }
 
 FillExtrusionPatternProgram::LayoutUniformValues FillExtrusionPatternProgram::layoutUniformValues(
-    mat4 matrix,
-    Size atlasSize,
+    const mat4& matrix,
+    const Size atlasSize,
     const CrossfadeParameters& crossfade,
     const UnwrappedTileID& tileID,
     const TransformState& state,
@@ -56,11 +56,11 @@ FillExtrusionPatternProgram::LayoutUniformValues FillExtrusionPatternProgram::la
     const EvaluatedLight& light,
     const float verticalGradient) {
     const auto tileRatio = 1 / tileID.pixelsToTileUnits(1, state.getIntegerZoom());
-    int32_t tileSizeAtNearestZoom = static_cast<int32_t>(util::tileSize_D *
-                                                         state.zoomScale(state.getIntegerZoom() - tileID.canonical.z));
-    int32_t pixelX = static_cast<int32_t>(tileSizeAtNearestZoom *
-                                          (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z)));
-    int32_t pixelY = tileSizeAtNearestZoom * tileID.canonical.y;
+    const int32_t tileSizeAtNearestZoom = static_cast<int32_t>(
+        util::tileSize_D * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z));
+    const int32_t pixelX = static_cast<int32_t>(
+        tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z)));
+    const int32_t pixelY = tileSizeAtNearestZoom * tileID.canonical.y;
 
     return {uniforms::matrix::Value(matrix),
             uniforms::opacity::Value(opacity),
@@ -72,9 +72,9 @@ FillExtrusionPatternProgram::LayoutUniformValues FillExtrusionPatternProgram::la
             uniforms::pixel_coord_lower::Value(
                 std::array<float, 2>{{static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)}}),
             uniforms::height_factor::Value(heightFactor),
-            uniforms::lightcolor::Value(lightColor(light)),
-            uniforms::lightpos::Value(lightPosition(light, state)),
-            uniforms::lightintensity::Value(lightIntensity(light)),
+            uniforms::lightcolor::Value(FillExtrusionProgram::lightColor(light)),
+            uniforms::lightpos::Value(FillExtrusionProgram::lightPosition(light, state)),
+            uniforms::lightintensity::Value(FillExtrusionProgram::lightIntensity(light)),
             uniforms::vertical_gradient::Value(verticalGradient)};
 }
 

--- a/src/mbgl/programs/fill_extrusion_program.hpp
+++ b/src/mbgl/programs/fill_extrusion_program.hpp
@@ -11,6 +11,7 @@
 #include <mbgl/style/style.hpp>
 #include <mbgl/renderer/render_light.hpp>
 
+#include <array>
 #include <string>
 
 namespace mbgl {
@@ -78,8 +79,12 @@ public:
                               static_cast<int16_t>(e)}}};
     }
 
+    static std::array<float, 3> lightColor(const EvaluatedLight&);
+    static std::array<float, 3> lightPosition(const EvaluatedLight&, const TransformState&);
+    static float lightIntensity(const EvaluatedLight&);
+
     static LayoutUniformValues layoutUniformValues(
-        mat4, const TransformState&, float opacity, const EvaluatedLight&, float verticalGradient);
+        const mat4&, const TransformState&, float opacity, const EvaluatedLight&, float verticalGradient);
 };
 
 class FillExtrusionPatternProgram final : public Program<FillExtrusionPatternProgram,
@@ -95,7 +100,7 @@ public:
 
     using Program::Program;
 
-    static LayoutUniformValues layoutUniformValues(mat4,
+    static LayoutUniformValues layoutUniformValues(const mat4&,
                                                    Size atlasSize,
                                                    const CrossfadeParameters&,
                                                    const UnwrappedTileID&,

--- a/src/mbgl/renderer/buckets/circle_bucket.cpp
+++ b/src/mbgl/renderer/buckets/circle_bucket.cpp
@@ -21,9 +21,12 @@ CircleBucket::CircleBucket(const std::map<std::string, Immutable<LayerProperties
     }
 }
 
-CircleBucket::~CircleBucket() = default;
+CircleBucket::~CircleBucket() {
+    sharedVertices->release();
+}
 
-void CircleBucket::upload(gfx::UploadPass& uploadPass) {
+void CircleBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
+#if MLN_LEGACY_RENDERER
     if (!uploaded) {
         vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
         indexBuffer = uploadPass.createIndexBuffer(std::move(triangles));
@@ -32,6 +35,7 @@ void CircleBucket::upload(gfx::UploadPass& uploadPass) {
     for (auto& pair : paintPropertyBinders) {
         pair.second.upload(uploadPass);
     }
+#endif // MLN_LEGACY_RENDERER
 
     uploaded = true;
 }

--- a/src/mbgl/renderer/buckets/circle_bucket.hpp
+++ b/src/mbgl/renderer/buckets/circle_bucket.hpp
@@ -30,12 +30,20 @@ public:
 
     void update(const FeatureStates&, const GeometryTileLayer&, const std::string&, const ImagePositions&) override;
 
-    gfx::VertexVector<CircleLayoutVertex> vertices;
-    gfx::IndexVector<gfx::Triangles> triangles;
+    using VertexVector = gfx::VertexVector<CircleLayoutVertex>;
+    const std::shared_ptr<VertexVector> sharedVertices = std::make_shared<VertexVector>();
+    VertexVector& vertices = *sharedVertices;
+
+    using TriangleIndexVector = gfx::IndexVector<gfx::Triangles>;
+    const std::shared_ptr<TriangleIndexVector> sharedTriangles = std::make_shared<TriangleIndexVector>();
+    TriangleIndexVector& triangles = *sharedTriangles;
+
     SegmentVector<CircleAttributes> segments;
 
+#if MLN_LEGACY_RENDERER
     std::optional<gfx::VertexBuffer<CircleLayoutVertex>> vertexBuffer;
     std::optional<gfx::IndexBuffer> indexBuffer;
+#endif // MLN_LEGACY_RENDERER
 
     std::map<std::string, CircleProgram::Binders> paintPropertyBinders;
 

--- a/src/mbgl/renderer/buckets/debug_bucket.cpp
+++ b/src/mbgl/renderer/buckets/debug_bucket.cpp
@@ -70,7 +70,8 @@ DebugBucket::DebugBucket(const OverscaledTileID& id,
     segments.emplace_back(0, 0, vertices.elements(), indices.elements());
 }
 
-void DebugBucket::upload(gfx::UploadPass& uploadPass) {
+void DebugBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
+#if MLN_LEGACY_RENDERER
     if (!vertices.empty()) {
         vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
         indexBuffer = uploadPass.createIndexBuffer(std::move(indices));
@@ -80,6 +81,7 @@ void DebugBucket::upload(gfx::UploadPass& uploadPass) {
         static const PremultipliedImage emptyImage{Size(1, 1), data.data(), data.size()};
         texture = uploadPass.createTexture(emptyImage);
     }
+#endif // MLN_LEGACY_RENDERER
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/buckets/fill_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_bucket.cpp
@@ -49,7 +49,9 @@ FillBucket::FillBucket(const FillBucket::PossiblyEvaluatedLayoutProperties&,
     }
 }
 
-FillBucket::~FillBucket() = default;
+FillBucket::~FillBucket() {
+    sharedVertices->release();
+}
 
 void FillBucket::addFeature(const GeometryTileFeature& feature,
                             const GeometryCollection& geometry,
@@ -130,7 +132,8 @@ void FillBucket::addFeature(const GeometryTileFeature& feature,
     }
 }
 
-void FillBucket::upload(gfx::UploadPass& uploadPass) {
+void FillBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
+#if MLN_LEGACY_RENDERER
     if (!uploaded) {
         vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
         lineIndexBuffer = uploadPass.createIndexBuffer(std::move(lines));
@@ -141,6 +144,7 @@ void FillBucket::upload(gfx::UploadPass& uploadPass) {
     for (auto& pair : paintPropertyBinders) {
         pair.second.upload(uploadPass);
     }
+#endif // MLN_LEGACY_RENDERER
 
     uploaded = true;
 }

--- a/src/mbgl/renderer/buckets/fill_bucket.hpp
+++ b/src/mbgl/renderer/buckets/fill_bucket.hpp
@@ -40,15 +40,26 @@ public:
 
     void update(const FeatureStates&, const GeometryTileLayer&, const std::string&, const ImagePositions&) override;
 
-    gfx::VertexVector<FillLayoutVertex> vertices;
-    gfx::IndexVector<gfx::Lines> lines;
-    gfx::IndexVector<gfx::Triangles> triangles;
+    using VertexVector = gfx::VertexVector<FillLayoutVertex>;
+    const std::shared_ptr<VertexVector> sharedVertices = std::make_shared<VertexVector>();
+    VertexVector& vertices = *sharedVertices;
+
+    using LineIndexVector = gfx::IndexVector<gfx::Lines>;
+    const std::shared_ptr<LineIndexVector> sharedLines = std::make_shared<LineIndexVector>();
+    LineIndexVector& lines = *sharedLines;
+
+    using TriangleIndexVector = gfx::IndexVector<gfx::Triangles>;
+    const std::shared_ptr<TriangleIndexVector> sharedTriangles = std::make_shared<TriangleIndexVector>();
+    TriangleIndexVector& triangles = *sharedTriangles;
+
     SegmentVector<FillAttributes> lineSegments;
     SegmentVector<FillAttributes> triangleSegments;
 
+#if MLN_LEGACY_RENDERER
     std::optional<gfx::VertexBuffer<FillLayoutVertex>> vertexBuffer;
     std::optional<gfx::IndexBuffer> lineIndexBuffer;
     std::optional<gfx::IndexBuffer> triangleIndexBuffer;
+#endif // MLN_LEGACY_RENDERER
 
     std::map<std::string, FillProgram::Binders> paintPropertyBinders;
 };

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
@@ -52,7 +52,9 @@ FillExtrusionBucket::FillExtrusionBucket(
     }
 }
 
-FillExtrusionBucket::~FillExtrusionBucket() = default;
+FillExtrusionBucket::~FillExtrusionBucket() {
+    sharedVertices->release();
+}
 
 void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature,
                                      const GeometryCollection& geometry,
@@ -167,7 +169,8 @@ void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature,
     }
 }
 
-void FillExtrusionBucket::upload(gfx::UploadPass& uploadPass) {
+void FillExtrusionBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
+#if MLN_LEGACY_RENDERER
     if (!uploaded) {
         vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
         indexBuffer = uploadPass.createIndexBuffer(std::move(triangles));
@@ -176,6 +179,7 @@ void FillExtrusionBucket::upload(gfx::UploadPass& uploadPass) {
     for (auto& pair : paintPropertyBinders) {
         pair.second.upload(uploadPass);
     }
+#endif // MLN_LEGACY_RENDERER
 
     uploaded = true;
 }

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.hpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.hpp
@@ -39,12 +39,20 @@ public:
 
     void update(const FeatureStates&, const GeometryTileLayer&, const std::string&, const ImagePositions&) override;
 
-    gfx::VertexVector<FillExtrusionLayoutVertex> vertices;
-    gfx::IndexVector<gfx::Triangles> triangles;
+    using VertexVector = gfx::VertexVector<FillExtrusionLayoutVertex>;
+    const std::shared_ptr<VertexVector> sharedVertices = std::make_shared<VertexVector>();
+    VertexVector& vertices = *sharedVertices;
+
+    using TriangleIndexVector = gfx::IndexVector<gfx::Triangles>;
+    const std::shared_ptr<TriangleIndexVector> sharedTriangles = std::make_shared<TriangleIndexVector>();
+    TriangleIndexVector& triangles = *sharedTriangles;
+
     SegmentVector<FillExtrusionAttributes> triangleSegments;
 
+#if MLN_LEGACY_RENDERER
     std::optional<gfx::VertexBuffer<FillExtrusionLayoutVertex>> vertexBuffer;
     std::optional<gfx::IndexBuffer> indexBuffer;
+#endif // MLN_LEGACY_RENDERER
 
     std::unordered_map<std::string, FillExtrusionProgram::Binders> paintPropertyBinders;
 };

--- a/src/mbgl/renderer/buckets/heatmap_bucket.cpp
+++ b/src/mbgl/renderer/buckets/heatmap_bucket.cpp
@@ -21,15 +21,19 @@ HeatmapBucket::HeatmapBucket(const BucketParameters& parameters,
     }
 }
 
-HeatmapBucket::~HeatmapBucket() = default;
+HeatmapBucket::~HeatmapBucket() {
+    sharedVertices->release();
+}
 
-void HeatmapBucket::upload(gfx::UploadPass& uploadPass) {
+void HeatmapBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
+#if MLN_LEGACY_RENDERER
     vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
     indexBuffer = uploadPass.createIndexBuffer(std::move(triangles));
 
     for (auto& pair : paintPropertyBinders) {
         pair.second.upload(uploadPass);
     }
+#endif // MLN_LEGACY_RENDERER
 
     uploaded = true;
 }

--- a/src/mbgl/renderer/buckets/heatmap_bucket.hpp
+++ b/src/mbgl/renderer/buckets/heatmap_bucket.hpp
@@ -30,12 +30,20 @@ public:
 
     float getQueryRadius(const RenderLayer&) const override;
 
-    gfx::VertexVector<HeatmapLayoutVertex> vertices;
-    gfx::IndexVector<gfx::Triangles> triangles;
+    using VertexVector = gfx::VertexVector<HeatmapLayoutVertex>;
+    const std::shared_ptr<VertexVector> sharedVertices = std::make_shared<VertexVector>();
+    VertexVector& vertices = *sharedVertices;
+
+    using TriangleIndexVector = gfx::IndexVector<gfx::Triangles>;
+    const std::shared_ptr<TriangleIndexVector> sharedTriangles = std::make_shared<TriangleIndexVector>();
+    TriangleIndexVector& triangles = *sharedTriangles;
+
     SegmentVector<HeatmapAttributes> segments;
 
+#if MLN_LEGACY_RENDERER
     std::optional<gfx::VertexBuffer<HeatmapLayoutVertex>> vertexBuffer;
     std::optional<gfx::IndexBuffer> indexBuffer;
+#endif // MLN_LEGACY_RENDERER
 
     std::map<std::string, HeatmapProgram::Binders> paintPropertyBinders;
 

--- a/src/mbgl/renderer/buckets/hillshade_bucket.cpp
+++ b/src/mbgl/renderer/buckets/hillshade_bucket.cpp
@@ -14,7 +14,9 @@ HillshadeBucket::HillshadeBucket(PremultipliedImage&& image_, Tileset::DEMEncodi
 HillshadeBucket::HillshadeBucket(DEMData&& demdata_)
     : demdata(std::move(demdata_)) {}
 
-HillshadeBucket::~HillshadeBucket() = default;
+HillshadeBucket::~HillshadeBucket() {
+    sharedVertices->release();
+}
 
 const DEMData& HillshadeBucket::getDEMData() const {
     return demdata;
@@ -24,11 +26,12 @@ DEMData& HillshadeBucket::getDEMData() {
     return demdata;
 }
 
-void HillshadeBucket::upload(gfx::UploadPass& uploadPass) {
+void HillshadeBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
     if (!hasData()) {
         return;
     }
 
+#if MLN_LEGACY_RENDERER
     const PremultipliedImage* image = demdata.getImage();
     dem = uploadPass.createTexture(*image);
 
@@ -38,13 +41,17 @@ void HillshadeBucket::upload(gfx::UploadPass& uploadPass) {
     if (!indices.empty()) {
         indexBuffer = uploadPass.createIndexBuffer(std::move(indices));
     }
+#endif // MLN_LEGACY_RENDERER
 
     uploaded = true;
 }
 
 void HillshadeBucket::clear() {
+#if MLN_LEGACY_RENDERER
     vertexBuffer = {};
     indexBuffer = {};
+#endif // MLN_LEGACY_RENDERER
+
     segments.clear();
     vertices.clear();
     indices.clear();

--- a/src/mbgl/renderer/buckets/hillshade_bucket.hpp
+++ b/src/mbgl/renderer/buckets/hillshade_bucket.hpp
@@ -30,6 +30,11 @@ public:
     std::optional<gfx::Texture> dem;
     std::optional<gfx::Texture> texture;
 
+#if MLN_DRAWABLE_RENDERER
+    RenderTargetPtr renderTarget;
+    bool renderTargetPrepared = false;
+#endif
+
     TileMask mask{{0, 0, 0}};
 
     const DEMData& getDEMData() const;
@@ -40,12 +45,17 @@ public:
     void setPrepared(bool preparedState) { prepared = preparedState; }
 
     // Raster-DEM Tile Sources use the default buffers from Painter
-    gfx::VertexVector<HillshadeLayoutVertex> vertices;
+    using VertexVector = gfx::VertexVector<HillshadeLayoutVertex>;
+    std::shared_ptr<VertexVector> sharedVertices = std::make_shared<VertexVector>();
+    VertexVector& vertices = *sharedVertices;
+
     gfx::IndexVector<gfx::Triangles> indices;
     SegmentVector<HillshadeAttributes> segments;
 
+#if MLN_LEGACY_RENDERER
     std::optional<gfx::VertexBuffer<HillshadeLayoutVertex>> vertexBuffer;
     std::optional<gfx::IndexBuffer> indexBuffer;
+#endif // MLN_LEGACY_RENDERER
 
 private:
     DEMData demdata;

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -25,7 +25,9 @@ LineBucket::LineBucket(LineBucket::PossiblyEvaluatedLayoutProperties layout_,
     }
 }
 
-LineBucket::~LineBucket() = default;
+LineBucket::~LineBucket() {
+    sharedVertices->release();
+}
 
 void LineBucket::addFeature(const GeometryTileFeature& feature,
                             const GeometryCollection& geometryCollection,
@@ -574,7 +576,8 @@ void LineBucket::addPieSliceVertex(const GeometryCoordinate& currentVertex,
     }
 }
 
-void LineBucket::upload(gfx::UploadPass& uploadPass) {
+void LineBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
+#if MLN_LEGACY_RENDERER
     if (!uploaded) {
         vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
         indexBuffer = uploadPass.createIndexBuffer(std::move(triangles));
@@ -583,6 +586,7 @@ void LineBucket::upload(gfx::UploadPass& uploadPass) {
     for (auto& pair : paintPropertyBinders) {
         pair.second.upload(uploadPass);
     }
+#endif // MLN_LEGACY_RENDERER
 
     uploaded = true;
 }

--- a/src/mbgl/renderer/buckets/line_bucket.hpp
+++ b/src/mbgl/renderer/buckets/line_bucket.hpp
@@ -42,12 +42,20 @@ public:
 
     PossiblyEvaluatedLayoutProperties layout;
 
-    gfx::VertexVector<LineLayoutVertex> vertices;
-    gfx::IndexVector<gfx::Triangles> triangles;
+    using VertexVector = gfx::VertexVector<LineLayoutVertex>;
+    const std::shared_ptr<VertexVector> sharedVertices = std::make_shared<VertexVector>();
+    VertexVector& vertices = *sharedVertices;
+
+    using TriangleIndexVector = gfx::IndexVector<gfx::Triangles>;
+    const std::shared_ptr<TriangleIndexVector> sharedTriangles = std::make_shared<TriangleIndexVector>();
+    TriangleIndexVector& triangles = *sharedTriangles;
+
     SegmentVector<LineAttributes> segments;
 
+#if MLN_LEGACY_RENDERER
     std::optional<gfx::VertexBuffer<LineLayoutVertex>> vertexBuffer;
     std::optional<gfx::IndexBuffer> indexBuffer;
+#endif // MLN_LEGACY_RENDERER
 
     std::map<std::string, LineProgram::Binders> paintPropertyBinders;
 

--- a/src/mbgl/renderer/buckets/raster_bucket.cpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.cpp
@@ -15,10 +15,11 @@ RasterBucket::RasterBucket(std::shared_ptr<PremultipliedImage> image_)
 
 RasterBucket::~RasterBucket() = default;
 
-void RasterBucket::upload(gfx::UploadPass& uploadPass) {
+void RasterBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
     if (!hasData()) {
         return;
     }
+#if MLN_LEGACY_RENDERER
     if (!texture) {
         texture = uploadPass.createTexture(*image);
     }
@@ -28,12 +29,16 @@ void RasterBucket::upload(gfx::UploadPass& uploadPass) {
     if (!indices.empty()) {
         indexBuffer = uploadPass.createIndexBuffer(std::move(indices));
     }
+#endif // MLN_LEGACY_RENDERER
     uploaded = true;
 }
 
 void RasterBucket::clear() {
+#if MLN_LEGACY_RENDERER
     vertexBuffer = {};
     indexBuffer = {};
+#endif // MLN_LEGACY_RENDERER
+
     segments.clear();
     vertices.clear();
     indices.clear();

--- a/src/mbgl/renderer/buckets/raster_bucket.hpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.hpp
@@ -32,12 +32,20 @@ public:
 
     // Bucket specific vertices are used for Image Sources only
     // Raster Tile Sources use the default buffers from Painter
-    gfx::VertexVector<RasterLayoutVertex> vertices;
-    gfx::IndexVector<gfx::Triangles> indices;
+    using VertexVector = gfx::VertexVector<RasterLayoutVertex>;
+    const std::shared_ptr<VertexVector> sharedVertices = std::make_shared<VertexVector>();
+    VertexVector& vertices = *sharedVertices;
+
+    using TriangleIndexVector = gfx::IndexVector<gfx::Triangles>;
+    const std::shared_ptr<TriangleIndexVector> sharedTriangles = std::make_shared<TriangleIndexVector>();
+    TriangleIndexVector& indices = *sharedTriangles;
+
     SegmentVector<RasterAttributes> segments;
 
+#if MLN_LEGACY_RENDERER
     std::optional<gfx::VertexBuffer<RasterLayoutVertex>> vertexBuffer;
     std::optional<gfx::IndexBuffer> indexBuffer;
+#endif // MLN_LEGACY_RENDERER
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -62,13 +62,14 @@ SymbolBucket::SymbolBucket(Immutable<style::SymbolLayoutProperties::PossiblyEval
 
 SymbolBucket::~SymbolBucket() = default;
 
-void SymbolBucket::upload(gfx::UploadPass& uploadPass) {
+void SymbolBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
+#if MLN_LEGACY_RENDERER
     if (hasTextData()) {
         if (!staticUploaded) {
             text.indexBuffer = uploadPass.createIndexBuffer(
                 std::move(text.triangles),
                 sortFeaturesByY ? gfx::BufferUsageType::StreamDraw : gfx::BufferUsageType::StaticDraw);
-            text.vertexBuffer = uploadPass.createVertexBuffer(std::move(text.vertices));
+            text.vertexBuffer = uploadPass.createVertexBuffer(text.vertices());
             for (auto& pair : paintProperties) {
                 pair.second.textBinders.upload(uploadPass);
             }
@@ -78,18 +79,18 @@ void SymbolBucket::upload(gfx::UploadPass& uploadPass) {
 
         if (!dynamicUploaded) {
             if (!text.dynamicVertexBuffer) {
-                text.dynamicVertexBuffer = uploadPass.createVertexBuffer(std::move(text.dynamicVertices),
+                text.dynamicVertexBuffer = uploadPass.createVertexBuffer(text.dynamicVertices(),
                                                                          gfx::BufferUsageType::StreamDraw);
             } else {
-                uploadPass.updateVertexBuffer(*text.dynamicVertexBuffer, std::move(text.dynamicVertices));
+                uploadPass.updateVertexBuffer(*text.dynamicVertexBuffer, text.dynamicVertices());
             }
         }
         if (!placementChangesUploaded) {
             if (!text.opacityVertexBuffer) {
-                text.opacityVertexBuffer = uploadPass.createVertexBuffer(std::move(text.opacityVertices),
+                text.opacityVertexBuffer = uploadPass.createVertexBuffer(text.opacityVertices(),
                                                                          gfx::BufferUsageType::StreamDraw);
             } else {
-                uploadPass.updateVertexBuffer(*text.opacityVertexBuffer, std::move(text.opacityVertices));
+                uploadPass.updateVertexBuffer(*text.opacityVertexBuffer, text.opacityVertices());
             }
         }
     }
@@ -99,7 +100,7 @@ void SymbolBucket::upload(gfx::UploadPass& uploadPass) {
             iconBuffer.indexBuffer = uploadPass.createIndexBuffer(
                 std::move(iconBuffer.triangles),
                 sortFeaturesByY ? gfx::BufferUsageType::StreamDraw : gfx::BufferUsageType::StaticDraw);
-            iconBuffer.vertexBuffer = uploadPass.createVertexBuffer(std::move(iconBuffer.vertices));
+            iconBuffer.vertexBuffer = uploadPass.createVertexBuffer(iconBuffer.vertices());
             for (auto& pair : paintProperties) {
                 pair.second.iconBinders.upload(uploadPass);
             }
@@ -108,18 +109,18 @@ void SymbolBucket::upload(gfx::UploadPass& uploadPass) {
         }
         if (!dynamicUploaded) {
             if (!iconBuffer.dynamicVertexBuffer) {
-                iconBuffer.dynamicVertexBuffer = uploadPass.createVertexBuffer(std::move(iconBuffer.dynamicVertices),
+                iconBuffer.dynamicVertexBuffer = uploadPass.createVertexBuffer(iconBuffer.dynamicVertices(),
                                                                                gfx::BufferUsageType::StreamDraw);
             } else {
-                uploadPass.updateVertexBuffer(*iconBuffer.dynamicVertexBuffer, std::move(iconBuffer.dynamicVertices));
+                uploadPass.updateVertexBuffer(*iconBuffer.dynamicVertexBuffer, iconBuffer.dynamicVertices());
             }
         }
         if (!placementChangesUploaded) {
             if (!iconBuffer.opacityVertexBuffer) {
-                iconBuffer.opacityVertexBuffer = uploadPass.createVertexBuffer(std::move(iconBuffer.opacityVertices),
+                iconBuffer.opacityVertexBuffer = uploadPass.createVertexBuffer(iconBuffer.opacityVertices(),
                                                                                gfx::BufferUsageType::StreamDraw);
             } else {
-                uploadPass.updateVertexBuffer(*iconBuffer.opacityVertexBuffer, std::move(iconBuffer.opacityVertices));
+                uploadPass.updateVertexBuffer(*iconBuffer.opacityVertexBuffer, iconBuffer.opacityVertices());
             }
         }
     };
@@ -175,6 +176,7 @@ void SymbolBucket::upload(gfx::UploadPass& uploadPass) {
     if (hasTextCollisionCircleData()) {
         updateCollisionCircle(*textCollisionCircle);
     }
+#endif // MLN_LEGACY_RENDERER
 
     uploaded = true;
     staticUploaded = true;

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -13,6 +13,7 @@
 #include <mbgl/text/glyph_range.hpp>
 #include <mbgl/text/placement.hpp>
 
+#include <memory>
 #include <vector>
 
 namespace mbgl {
@@ -132,18 +133,44 @@ public:
 
     std::unique_ptr<SymbolSizeBinder> textSizeBinder;
 
-    struct Buffer {
-        gfx::VertexVector<SymbolLayoutVertex> vertices;
-        gfx::VertexVector<gfx::Vertex<SymbolDynamicLayoutAttributes>> dynamicVertices;
-        gfx::VertexVector<gfx::Vertex<SymbolOpacityAttributes>> opacityVertices;
-        gfx::IndexVector<gfx::Triangles> triangles;
+    using VertexVector = gfx::VertexVector<SymbolLayoutVertex>;
+    using VertexBuffer = gfx::VertexBuffer<SymbolLayoutVertex>;
+    using DynamicVertexVector = gfx::VertexVector<gfx::Vertex<SymbolDynamicLayoutAttributes>>;
+    using DynamicVertexBuffer = gfx::VertexBuffer<gfx::Vertex<SymbolDynamicLayoutAttributes>>;
+    using OpacityVertexVector = gfx::VertexVector<gfx::Vertex<SymbolOpacityAttributes>>;
+    using OpacityVertexBuffer = gfx::VertexBuffer<gfx::Vertex<SymbolOpacityAttributes>>;
+
+    struct Buffer final {
+        ~Buffer() {
+            sharedVertices->release();
+            sharedDynamicVertices->release();
+            sharedOpacityVertices->release();
+        }
+        std::shared_ptr<VertexVector> sharedVertices = std::make_shared<VertexVector>();
+        VertexVector& vertices() { return *sharedVertices; }
+        const VertexVector& vertices() const { return *sharedVertices; }
+
+        std::shared_ptr<DynamicVertexVector> sharedDynamicVertices = std::make_shared<DynamicVertexVector>();
+        DynamicVertexVector& dynamicVertices() { return *sharedDynamicVertices; }
+        const DynamicVertexVector& dynamicVertices() const { return *sharedDynamicVertices; }
+
+        std::shared_ptr<OpacityVertexVector> sharedOpacityVertices = std::make_shared<OpacityVertexVector>();
+        OpacityVertexVector& opacityVertices() { return *sharedOpacityVertices; }
+        const OpacityVertexVector& opacityVertices() const { return *sharedOpacityVertices; }
+
+        using TriangleIndexVector = gfx::IndexVector<gfx::Triangles>;
+        const std::shared_ptr<TriangleIndexVector> sharedTriangles = std::make_shared<TriangleIndexVector>();
+        TriangleIndexVector& triangles = *sharedTriangles;
+
         SegmentVector<SymbolTextAttributes> segments;
         std::vector<PlacedSymbol> placedSymbols;
 
-        std::optional<gfx::VertexBuffer<SymbolLayoutVertex>> vertexBuffer;
-        std::optional<gfx::VertexBuffer<gfx::Vertex<SymbolDynamicLayoutAttributes>>> dynamicVertexBuffer;
-        std::optional<gfx::VertexBuffer<gfx::Vertex<SymbolOpacityAttributes>>> opacityVertexBuffer;
+#if MLN_LEGACY_RENDERER
+        std::optional<VertexBuffer> vertexBuffer;
+        std::optional<DynamicVertexBuffer> dynamicVertexBuffer;
+        std::optional<OpacityVertexBuffer> opacityVertexBuffer;
         std::optional<gfx::IndexBuffer> indexBuffer;
+#endif // MLN_LEGACY_RENDERER
     } text;
 
     std::unique_ptr<SymbolSizeBinder> iconSizeBinder;

--- a/src/mbgl/renderer/layers/background_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/background_layer_tweaker.cpp
@@ -1,0 +1,155 @@
+#include <mbgl/renderer/layers/background_layer_tweaker.hpp>
+
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/renderer/pattern_atlas.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#include <mbgl/style/layers/background_layer_properties.hpp>
+#include <mbgl/util/convert.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+struct alignas(16) BackgroundDrawableUBO {
+    std::array<float, 4 * 4> matrix;
+};
+static_assert(sizeof(BackgroundDrawableUBO) % 16 == 0);
+
+struct alignas(16) BackgroundLayerUBO {
+    /*  0 */ Color color;
+    /* 16 */ float opacity;
+    /* 20 */ float pad1, pad2, pad3;
+    /* 32 */
+};
+static_assert(sizeof(BackgroundLayerUBO) == 32);
+
+struct alignas(16) BackgroundPatternLayerUBO {
+    /*  0 */ std::array<float, 2> pattern_tl_a;
+    /*  8 */ std::array<float, 2> pattern_br_a;
+    /* 16 */ std::array<float, 2> pattern_tl_b;
+    /* 24 */ std::array<float, 2> pattern_br_b;
+    /* 32 */ std::array<float, 2> texsize;
+    /* 40 */ std::array<float, 2> pattern_size_a;
+    /* 48 */ std::array<float, 2> pattern_size_b;
+    /* 56 */ std::array<float, 2> pixel_coord_upper;
+    /* 64 */ std::array<float, 2> pixel_coord_lower;
+    /* 72 */ float tile_units_to_pixels;
+    /* 76 */ float scale_a;
+    /* 80 */ float scale_b;
+    /* 84 */ float mix;
+    /* 88 */ float opacity;
+    /* 92 */ float pad;
+    /* 96 */
+};
+static_assert(sizeof(BackgroundPatternLayerUBO) == 96);
+
+#if !defined(NDEBUG)
+static constexpr auto BackgroundPatternShaderName = "BackgroundPatternShader";
+#endif
+static constexpr auto BackgroundDrawableUBOName = "BackgroundDrawableUBO";
+static constexpr auto BackgroundLayerUBOName = "BackgroundLayerUBO";
+static constexpr auto texUniformName = "u_image";
+
+void BackgroundLayerTweaker::execute(LayerGroupBase& layerGroup, const RenderTree&, const PaintParameters& parameters) {
+    const auto& state = parameters.state;
+    auto& context = parameters.context;
+
+    if (layerGroup.empty()) {
+        return;
+    }
+
+#if defined(DEBUG)
+    const auto label = layerGroup.getName() + "-update-uniforms";
+    const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
+#endif
+
+    const auto& evaluated = static_cast<const BackgroundLayerProperties&>(*evaluatedProperties).evaluated;
+    const auto& crossfade = static_cast<const BackgroundLayerProperties&>(*evaluatedProperties).crossfade;
+    const bool hasPattern = !evaluated.get<BackgroundPattern>().to.empty();
+    const auto imagePosA = hasPattern ? parameters.patternAtlas.getPattern(evaluated.get<BackgroundPattern>().from.id())
+                                      : std::nullopt;
+    const auto imagePosB = hasPattern ? parameters.patternAtlas.getPattern(evaluated.get<BackgroundPattern>().to.id())
+                                      : std::nullopt;
+
+    if (hasPattern && (!imagePosA || !imagePosB)) {
+        // The pattern isn't valid, disable the whole thing.
+        layerGroup.setEnabled(false);
+        return;
+    }
+    layerGroup.setEnabled(true);
+
+    int32_t samplerLocation = -1;
+    layerGroup.visitDrawables([&](gfx::Drawable& drawable) {
+        assert(drawable.getTileID());
+
+        // We assume that drawables don't change between pattern and non-pattern.
+        const auto& shader = drawable.getShader();
+        assert(hasPattern ==
+               (shader == context.getGenericShader(parameters.shaders, std::string(BackgroundPatternShaderName))));
+
+        const UnwrappedTileID tileID = drawable.getTileID()->toUnwrapped();
+        const auto matrix = parameters.matrixForTile(tileID);
+
+        const BackgroundDrawableUBO drawableUBO = {/* .matrix = */ util::cast<float>(matrix)};
+
+        auto& uniforms = drawable.mutableUniformBuffers();
+        uniforms.createOrUpdate(BackgroundDrawableUBOName, &drawableUBO, context);
+
+        if (hasPattern) {
+            if (samplerLocation < 0) {
+                if (const auto index = shader->getSamplerLocation(texUniformName)) {
+                    samplerLocation = *index;
+                }
+            }
+            if (0 <= samplerLocation) {
+                if (const auto& tex = parameters.patternAtlas.texture()) {
+                    drawable.setTexture(tex, samplerLocation);
+                }
+            }
+
+            // from BackgroundPatternProgram::layoutUniformValues
+            const int32_t tileSizeAtNearestZoom = static_cast<int32_t>(
+                util::tileSize_D * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z));
+            const int32_t pixelX = static_cast<int32_t>(
+                tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z)));
+            const int32_t pixelY = tileSizeAtNearestZoom * tileID.canonical.y;
+            const Size atlasSize = parameters.patternAtlas.getPixelSize();
+            const auto pixToTile = tileID.pixelsToTileUnits(1.0f, state.getIntegerZoom());
+
+            const BackgroundPatternLayerUBO layerUBO = {
+                /* .pattern_tl_a = */ util::cast<float>(imagePosA->tl()),
+                /* .pattern_br_a = */ util::cast<float>(imagePosA->br()),
+                /* .pattern_tl_b = */ util::cast<float>(imagePosB->tl()),
+                /* .pattern_br_b = */ util::cast<float>(imagePosB->br()),
+                /* .texsize = */ {static_cast<float>(atlasSize.width), static_cast<float>(atlasSize.height)},
+                /* .pattern_size_a = */ imagePosA->displaySize(),
+                /* .pattern_size_b = */ imagePosB->displaySize(),
+                /* .pixel_coord_upper = */ {static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16)},
+                /* .pixel_coord_lower = */ {static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)},
+                /* .tile_units_to_pixels = */ (pixToTile != 0) ? 1.0f / pixToTile : 0.0f,
+                /* .scale_a = */ crossfade.fromScale,
+                /* .scale_b = */ crossfade.toScale,
+                /* .mix = */ crossfade.t,
+                /* .opacity = */ evaluated.get<BackgroundOpacity>(),
+                /* .pad = */ 0,
+            };
+            uniforms.createOrUpdate(BackgroundLayerUBOName, &layerUBO, context);
+        } else {
+            // UBOs can be shared
+            if (!backgroundLayerBuffer) {
+                const BackgroundLayerUBO layerUBO = {/* .color = */ evaluated.get<BackgroundColor>(),
+                                                     /* .opacity = */ evaluated.get<BackgroundOpacity>(),
+                                                     /* .pad = */ 0,
+                                                     0,
+                                                     0};
+                backgroundLayerBuffer = context.createUniformBuffer(&layerUBO, sizeof(layerUBO));
+            }
+            uniforms.addOrReplace(BackgroundLayerUBOName, backgroundLayerBuffer);
+        }
+    });
+}
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/background_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/background_layer_tweaker.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <mbgl/renderer/layer_tweaker.hpp>
+
+#include <memory>
+
+namespace mbgl {
+
+namespace gfx {
+class ShaderProgramBase;
+class UniformBuffer;
+
+using ShaderProgramBasePtr = std::shared_ptr<ShaderProgramBase>;
+using UniformBufferPtr = std::shared_ptr<UniformBuffer>;
+} // namespace gfx
+
+/**
+    Background layer specific tweaker
+ */
+class BackgroundLayerTweaker : public LayerTweaker {
+public:
+    BackgroundLayerTweaker(Immutable<style::LayerProperties> properties)
+        : LayerTweaker(properties){};
+
+public:
+    ~BackgroundLayerTweaker() override = default;
+
+    void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
+
+protected:
+    gfx::UniformBufferPtr backgroundLayerBuffer;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
@@ -1,0 +1,123 @@
+#include <mbgl/renderer/layers/circle_layer_tweaker.hpp>
+
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/renderer/render_tree.hpp>
+#include <mbgl/style/layers/circle_layer_properties.hpp>
+#include <mbgl/util/convert.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+struct alignas(16) CircleDrawableUBO {
+    std::array<float, 4 * 4> matrix;
+    std::array<float, 2> extrude_scale;
+    std::array<float, 2> padding;
+};
+static_assert(sizeof(CircleDrawableUBO) % 16 == 0);
+
+struct alignas(16) CirclePaintParamsUBO {
+    float camera_to_center_distance;
+    float device_pixel_ratio;
+    std::array<float, 2> padding;
+};
+static_assert(sizeof(CirclePaintParamsUBO) % 16 == 0);
+
+struct alignas(16) CircleEvaluatedPropsUBO {
+    Color color;
+    Color stroke_color;
+    float radius;
+    float blur;
+    float opacity;
+    float stroke_width;
+    float stroke_opacity;
+    int scale_with_map;
+    int pitch_with_map;
+    float padding;
+};
+static_assert(sizeof(CircleEvaluatedPropsUBO) % 16 == 0);
+
+static constexpr std::string_view CircleDrawableUBOName = "CircleDrawableUBO";
+static constexpr std::string_view CirclePaintParamsUBOName = "CirclePaintParamsUBO";
+static constexpr std::string_view CircleEvaluatedPropsUBOName = "CircleEvaluatedPropsUBO";
+
+void CircleLayerTweaker::execute(LayerGroupBase& layerGroup,
+                                 const RenderTree& renderTree,
+                                 const PaintParameters& parameters) {
+    auto& context = parameters.context;
+    const auto& evaluated = static_cast<const CircleLayerProperties&>(*evaluatedProperties).evaluated;
+
+    if (layerGroup.empty()) {
+        return;
+    }
+
+#if !defined(NDEBUG)
+    const auto label = layerGroup.getName() + "-update-uniforms";
+    const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
+#endif
+
+    // Updated every frame, but shared across drawables
+    const CirclePaintParamsUBO paintParamsUBO = {
+        /* .camera_to_center_distance = */ parameters.state.getCameraToCenterDistance(),
+        /* .device_pixel_ratio = */ parameters.pixelRatio,
+        /* .padding = */ {0}};
+
+    if (!paintParamsUniformBuffer) {
+        paintParamsUniformBuffer = context.createUniformBuffer(&paintParamsUBO, sizeof(paintParamsUBO));
+    } else {
+        paintParamsUniformBuffer->update(&paintParamsUBO, sizeof(CirclePaintParamsUBO));
+    }
+
+    const bool pitchWithMap = evaluated.get<CirclePitchAlignment>() == AlignmentType::Map;
+
+    // Updated only with evaluated properties
+    if (!evaluatedPropsUniformBuffer) {
+        const CircleEvaluatedPropsUBO evaluatedPropsUBO = {
+            /* .color = */ evaluated.get<CircleColor>().constantOr(CircleColor::defaultValue()),
+            /* .stroke_color = */ evaluated.get<CircleStrokeColor>().constantOr(CircleStrokeColor::defaultValue()),
+            /* .radius = */ evaluated.get<CircleRadius>().constantOr(CircleRadius::defaultValue()),
+            /* .blur = */ evaluated.get<CircleBlur>().constantOr(CircleBlur::defaultValue()),
+            /* .opacity = */ evaluated.get<CircleOpacity>().constantOr(CircleOpacity::defaultValue()),
+            /* .stroke_width = */ evaluated.get<CircleStrokeWidth>().constantOr(CircleStrokeWidth::defaultValue()),
+            /* .stroke_opacity = */
+            evaluated.get<CircleStrokeOpacity>().constantOr(CircleStrokeOpacity::defaultValue()),
+            /* .scale_with_map = */ evaluated.get<CirclePitchScale>() == CirclePitchScaleType::Map,
+            /* .pitch_with_map = */ pitchWithMap,
+            /* .padding = */ 0};
+        evaluatedPropsUniformBuffer = context.createUniformBuffer(&evaluatedPropsUBO, sizeof(evaluatedPropsUBO));
+    }
+
+    layerGroup.visitDrawables([&](gfx::Drawable& drawable) {
+        auto& uniforms = drawable.mutableUniformBuffers();
+        uniforms.addOrReplace(CirclePaintParamsUBOName, paintParamsUniformBuffer);
+        uniforms.addOrReplace(CircleEvaluatedPropsUBOName, evaluatedPropsUniformBuffer);
+
+        if (!drawable.getTileID()) {
+            return;
+        }
+        const UnwrappedTileID tileID = drawable.getTileID()->toUnwrapped();
+
+        const auto& translation = evaluated.get<CircleTranslate>();
+        const auto anchor = evaluated.get<CircleTranslateAnchor>();
+        constexpr bool inViewportPixelUnits = false; // from RenderTile::translatedMatrix
+        constexpr bool nearClipped = false;
+        const auto matrix = getTileMatrix(
+            tileID, renderTree, parameters.state, translation, anchor, nearClipped, inViewportPixelUnits);
+
+        const auto pixelsToTileUnits = tileID.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom()));
+
+        // Updated for each drawable on each frame
+        const CircleDrawableUBO drawableUBO = {
+            /* .matrix = */ util::cast<float>(matrix),
+            /* .extrude_scale = */
+            pitchWithMap ? std::array<float, 2>{{pixelsToTileUnits}} : parameters.pixelsToGLUnits,
+            /* .padding = */ {0}};
+
+        uniforms.createOrUpdate(CircleDrawableUBOName, &drawableUBO, context);
+    });
+}
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/circle_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/circle_layer_tweaker.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <mbgl/renderer/layer_tweaker.hpp>
+
+namespace mbgl {
+
+/**
+    Circle layer specific tweaker
+ */
+class CircleLayerTweaker : public LayerTweaker {
+public:
+    CircleLayerTweaker(Immutable<style::LayerProperties> properties)
+        : LayerTweaker(properties){};
+
+public:
+    ~CircleLayerTweaker() override = default;
+
+    void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
+
+protected:
+    gfx::UniformBufferPtr paintParamsUniformBuffer;
+    gfx::UniformBufferPtr evaluatedPropsUniformBuffer;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.cpp
@@ -1,0 +1,154 @@
+#include <mbgl/renderer/layers/fill_extrusion_layer_tweaker.hpp>
+
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/gfx/renderable.hpp>
+#include <mbgl/gfx/renderer_backend.hpp>
+#include <mbgl/programs/fill_extrusion_program.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/render_tree.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/renderer/paint_property_binder.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#include <mbgl/style/layers/fill_extrusion_layer_properties.hpp>
+#include <mbgl/util/convert.hpp>
+#include <mbgl/util/std.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+namespace {
+
+struct alignas(16) FillExtrusionDrawableUBO {
+    /*   0 */ std::array<float, 4 * 4> matrix;
+    /*  64 */ std::array<float, 4> scale;
+    /*  80 */ std::array<float, 2> texsize;
+    /*  88 */ std::array<float, 2> pixel_coord_upper;
+    /*  96 */ std::array<float, 2> pixel_coord_lower;
+    /* 104 */ float height_factor;
+    /* 108 */ float pad;
+    /* 112 */
+};
+static_assert(sizeof(FillExtrusionDrawableUBO) == 7 * 16);
+
+/// Evaluated properties that do not depend on the tile
+struct alignas(16) FillExtrusionDrawablePropsUBO {
+    /*  0 */ std::array<float, 4> color;
+    /* 16 */ std::array<float, 3> light_color;
+    /* 28 */ float pad1;
+    /* 32 */ std::array<float, 3> light_position;
+    /* 44 */ float base;
+    /* 48 */ float height;
+    /* 52 */ float light_intensity;
+    /* 56 */ float vertical_gradient;
+    /* 60 */ float opacity;
+    /* 64 */ float fade;
+    /* 68 */ float pad2, pad3, pad4;
+    /* 80 */
+};
+static_assert(sizeof(FillExtrusionDrawablePropsUBO) == 5 * 16);
+
+constexpr auto FillExtrusionDrawableUBOName = "FillExtrusionDrawableUBO";
+constexpr auto FillExtrusionDrawablePropsUBOName = "FillExtrusionDrawablePropsUBO";
+
+constexpr auto texUniformName = "u_image";
+
+template <typename T, class... Is, class... Ts>
+auto constOrDefault(const IndexedTuple<TypeList<Is...>, TypeList<Ts...>>& evaluated) {
+    return evaluated.template get<T>().constantOr(T::defaultValue());
+}
+
+} // namespace
+
+void FillExtrusionLayerTweaker::execute(LayerGroupBase& layerGroup,
+                                        const RenderTree& renderTree,
+                                        const PaintParameters& parameters) {
+    auto& context = parameters.context;
+    const auto& props = static_cast<const FillExtrusionLayerProperties&>(*evaluatedProperties);
+    const auto& evaluated = props.evaluated;
+    const auto& crossfade = props.crossfade;
+    const auto& state = parameters.state;
+
+    if (layerGroup.empty()) {
+        return;
+    }
+
+#if !defined(NDEBUG)
+    const auto label = layerGroup.getName() + "-update-uniforms";
+    const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
+#endif
+
+    // UBO depends on more than just evaluated properties, so we need to update every time,
+    // but the resulting buffer can be shared across all the drawables from the layer.
+    const FillExtrusionDrawablePropsUBO paramsUBO = {
+        /* .color = */ gfx::VertexAttribute::colorAttrRGBA(constOrDefault<FillExtrusionColor>(evaluated)),
+        /* .light_color = */ FillExtrusionProgram::lightColor(parameters.evaluatedLight),
+        /* .pad = */ 0,
+        /* .light_position = */ FillExtrusionProgram::lightPosition(parameters.evaluatedLight, state),
+        /* .base = */ constOrDefault<FillExtrusionBase>(evaluated),
+        /* .height = */ constOrDefault<FillExtrusionHeight>(evaluated),
+        /* .light_intensity = */ FillExtrusionProgram::lightIntensity(parameters.evaluatedLight),
+        /* .vertical_gradient = */ evaluated.get<FillExtrusionVerticalGradient>() ? 1.0f : 0.0f,
+        /* .opacity = */ evaluated.get<FillExtrusionOpacity>(),
+        /* .fade = */ crossfade.t,
+        /* .pad = */ 0,
+        0,
+        0};
+    if (!propsBuffer) {
+        propsBuffer = context.createUniformBuffer(&paramsUBO, sizeof(paramsUBO));
+    } else {
+        propsBuffer->update(&paramsUBO, sizeof(paramsUBO));
+    }
+
+    layerGroup.visitDrawables([&](gfx::Drawable& drawable) {
+        auto& uniforms = drawable.mutableUniformBuffers();
+        uniforms.addOrReplace(FillExtrusionDrawablePropsUBOName, propsBuffer);
+
+        if (!drawable.getTileID()) {
+            return;
+        }
+
+        const UnwrappedTileID tileID = drawable.getTileID()->toUnwrapped();
+
+        const auto& translation = evaluated.get<FillExtrusionTranslate>();
+        const auto anchor = evaluated.get<FillExtrusionTranslateAnchor>();
+        constexpr bool inViewportPixelUnits = false; // from RenderTile::translatedMatrix
+        constexpr bool nearClipped = true;
+        const auto matrix = getTileMatrix(
+            tileID, renderTree, parameters.state, translation, anchor, nearClipped, inViewportPixelUnits);
+
+        const auto tileRatio = 1 / tileID.pixelsToTileUnits(1, state.getIntegerZoom());
+        const auto zoomScale = state.zoomScale(tileID.canonical.z);
+        const auto nearestZoomScale = state.zoomScale(state.getIntegerZoom() - tileID.canonical.z);
+        const auto tileSizeAtNearestZoom = std::floor(util::tileSize_D * nearestZoomScale);
+        const auto pixelX = static_cast<int32_t>(tileSizeAtNearestZoom *
+                                                 (tileID.canonical.x + tileID.wrap * zoomScale));
+        const auto pixelY = static_cast<int32_t>(tileSizeAtNearestZoom * tileID.canonical.y);
+        const auto pixelRatio = parameters.pixelRatio;
+        const auto numTiles = std::pow(2, tileID.canonical.z);
+        const auto heightFactor = static_cast<float>(-numTiles / util::tileSize_D / 8.0);
+
+        Size textureSize = {0, 0};
+        if (const auto shader = drawable.getShader()) {
+            if (const auto index = shader->getSamplerLocation(texUniformName)) {
+                if (const auto& tex = drawable.getTexture(*index)) {
+                    textureSize = tex->getSize();
+                }
+            }
+        }
+
+        const FillExtrusionDrawableUBO drawableUBO = {
+            /* .matrix = */ util::cast<float>(matrix),
+            /* .scale = */ {pixelRatio, tileRatio, crossfade.fromScale, crossfade.toScale},
+            /* .texsize = */ {static_cast<float>(textureSize.width), static_cast<float>(textureSize.height)},
+            /* .pixel_coord_upper = */ {static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16)},
+            /* .pixel_coord_lower = */ {static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)},
+            /* .height_factor = */ heightFactor,
+            /* .pad = */ 0};
+
+        uniforms.createOrUpdate(FillExtrusionDrawableUBOName, &drawableUBO, context);
+    });
+}
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <mbgl/renderer/layer_tweaker.hpp>
+
+#include <string>
+
+namespace mbgl {
+
+/**
+    Fill extrusion layer specific tweaker
+ */
+class FillExtrusionLayerTweaker : public LayerTweaker {
+public:
+    FillExtrusionLayerTweaker(Immutable<style::LayerProperties> properties)
+        : LayerTweaker(properties){};
+
+public:
+    ~FillExtrusionLayerTweaker() override = default;
+
+    void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
+
+    static constexpr std::string_view FillExtrusionTilePropsUBOName = "FillExtrusionDrawableTilePropsUBO";
+    static constexpr std::string_view FillExtrusionInterpolateUBOName = "FillExtrusionInterpolateUBO";
+
+private:
+    gfx::UniformBufferPtr propsBuffer;
+};
+
+/// Evaluated properties that depend on the tile
+struct alignas(16) FillExtrusionDrawableTilePropsUBO {
+    /*  0 */ std::array<float, 4> pattern_from;
+    /* 16 */ std::array<float, 4> pattern_to;
+    /* 32 */
+};
+static_assert(sizeof(FillExtrusionDrawableTilePropsUBO) == 2 * 16);
+
+/// Attribute interpolations
+struct alignas(16) FillExtrusionInterpolateUBO {
+    /*  0 */ float base_t;
+    /*  4 */ float height_t;
+    /*  8 */ float color_t;
+    /* 12 */ float pattern_from_t;
+    /* 16 */ float pattern_to_t;
+    /* 20 */ float pad1, pad2, pad3;
+    /* 32 */
+};
+static_assert(sizeof(FillExtrusionInterpolateUBO) == 2 * 16);
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
@@ -1,0 +1,123 @@
+#include <mbgl/renderer/layers/fill_layer_tweaker.hpp>
+
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/gfx/renderable.hpp>
+#include <mbgl/gfx/renderer_backend.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/render_tree.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/renderer/paint_property_binder.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#include <mbgl/style/layers/fill_layer_properties.hpp>
+#include <mbgl/util/convert.hpp>
+#include <mbgl/util/std.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+struct alignas(16) FillDrawableUBO {
+    /*   0 */ std::array<float, 4 * 4> matrix;
+    /*  64 */ std::array<float, 4> scale;
+    /*  80 */ std::array<float, 2> world;
+    /*  88 */ std::array<float, 2> pixel_coord_upper;
+    /*  96 */ std::array<float, 2> pixel_coord_lower;
+    /* 104 */ std::array<float, 2> texsize;
+    /* 112 */
+};
+static_assert(sizeof(FillDrawableUBO) == 112);
+
+/// Evaluated properties that do not depend on the tile
+struct alignas(16) FillDrawablePropsUBO {
+    /*  0 */ Color color;
+    /* 16 */ Color outline_color;
+    /* 32 */ float opacity;
+    /* 36 */ float pad1, pad2, pad3;
+    /* 48 */
+};
+static_assert(sizeof(FillDrawablePropsUBO) == 48);
+
+static constexpr std::string_view FillDrawableUBOName = "FillDrawableUBO";
+static constexpr std::string_view FillDrawablePropsUBOName = "FillDrawablePropsUBO";
+
+void FillLayerTweaker::execute(LayerGroupBase& layerGroup,
+                               const RenderTree& renderTree,
+                               const PaintParameters& parameters) {
+    auto& context = parameters.context;
+    const auto& props = static_cast<const FillLayerProperties&>(*evaluatedProperties);
+    const auto& evaluated = props.evaluated;
+    const auto& crossfade = props.crossfade;
+
+    if (layerGroup.empty()) {
+        return;
+    }
+
+#if !defined(NDEBUG)
+    const auto label = layerGroup.getName() + "-update-uniforms";
+    const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
+#endif
+
+    if (!propsBuffer) {
+        const FillDrawablePropsUBO paramsUBO = {
+            /* .color = */ evaluated.get<FillColor>().constantOr(FillColor::defaultValue()),
+            /* .outline_color = */ evaluated.get<FillOutlineColor>().constantOr(FillOutlineColor::defaultValue()),
+            /* .opacity = */ evaluated.get<FillOpacity>().constantOr(FillOpacity::defaultValue()),
+            /* .padding = */ 0,
+            0,
+            0};
+        propsBuffer = context.createUniformBuffer(&paramsUBO, sizeof(paramsUBO));
+    }
+
+    layerGroup.visitDrawables([&](gfx::Drawable& drawable) {
+        auto& uniforms = drawable.mutableUniformBuffers();
+        uniforms.addOrReplace(FillDrawablePropsUBOName, propsBuffer);
+
+        if (!drawable.getTileID()) {
+            return;
+        }
+
+        const UnwrappedTileID tileID = drawable.getTileID()->toUnwrapped();
+
+        const auto& translation = evaluated.get<FillTranslate>();
+        const auto anchor = evaluated.get<FillTranslateAnchor>();
+        constexpr bool inViewportPixelUnits = false; // from RenderTile::translatedMatrix
+        constexpr bool nearClipped = false;
+        const auto matrix = getTileMatrix(
+            tileID, renderTree, parameters.state, translation, anchor, nearClipped, inViewportPixelUnits);
+
+        // from FillPatternProgram::layoutUniformValues
+        const auto renderableSize = parameters.backend.getDefaultRenderable().getSize();
+        const auto intZoom = parameters.state.getIntegerZoom();
+        const auto tileRatio = 1.0f / tileID.pixelsToTileUnits(1.0f, intZoom);
+        const int32_t tileSizeAtNearestZoom = static_cast<int32_t>(
+            util::tileSize_D * parameters.state.zoomScale(intZoom - tileID.canonical.z));
+        const int32_t pixelX = static_cast<int32_t>(
+            tileSizeAtNearestZoom *
+            (tileID.canonical.x + tileID.wrap * parameters.state.zoomScale(tileID.canonical.z)));
+        const int32_t pixelY = tileSizeAtNearestZoom * tileID.canonical.y;
+        const auto pixelRatio = parameters.pixelRatio;
+
+        Size textureSize = {0, 0};
+        if (const auto shader = drawable.getShader()) {
+            if (const auto index = shader->getSamplerLocation("u_image")) {
+                if (const auto& tex = drawable.getTexture(*index)) {
+                    textureSize = tex->getSize();
+                }
+            }
+        }
+
+        const FillDrawableUBO drawableUBO = {
+            /*.matrix=*/util::cast<float>(matrix),
+            /*.scale=*/{pixelRatio, tileRatio, crossfade.fromScale, crossfade.toScale},
+            /*.world=*/{(float)renderableSize.width, (float)renderableSize.height},
+            /*.pixel_coord_upper=*/{static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16)},
+            /*.pixel_coord_lower=*/{static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)},
+            /*.texsize=*/{static_cast<float>(textureSize.width), static_cast<float>(textureSize.height)},
+        };
+
+        uniforms.createOrUpdate(FillDrawableUBOName, &drawableUBO, context);
+    });
+}
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/fill_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/fill_layer_tweaker.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <mbgl/renderer/layer_tweaker.hpp>
+
+#include <string>
+
+namespace mbgl {
+
+/**
+    Fill layer specific tweaker
+ */
+class FillLayerTweaker : public LayerTweaker {
+public:
+    FillLayerTweaker(Immutable<style::LayerProperties> properties)
+        : LayerTweaker(properties){};
+
+public:
+    ~FillLayerTweaker() override = default;
+
+    void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
+
+    static constexpr std::string_view FillTilePropsUBOName = "FillDrawableTilePropsUBO";
+    static constexpr std::string_view FillInterpolateUBOName = "FillInterpolateUBO";
+
+private:
+    gfx::UniformBufferPtr propsBuffer;
+};
+
+/// Evaluated properties that depend on the tile
+struct alignas(16) FillDrawableTilePropsUBO {
+    /*  0 */ std::array<float, 4> pattern_from;
+    /* 16 */ std::array<float, 4> pattern_to;
+    /* 32 */
+};
+static_assert(sizeof(FillDrawableTilePropsUBO) == 32);
+
+/// Attribute interpolations
+struct alignas(16) FillInterpolateUBO {
+    /*  0 */ float color_t;
+    /*  4 */ float opacity_t;
+    /*  8 */ float outline_color_t;
+    /* 12 */ float pattern_from_t;
+    /* 16 */ float pattern_to_t;
+    /* 20 */ float fade;
+    /* 24 */ float pad1, pad2;
+    /* 32 */
+};
+static_assert(sizeof(FillInterpolateUBO) == 32);
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
@@ -1,0 +1,85 @@
+#include <mbgl/renderer/layers/heatmap_layer_tweaker.hpp>
+
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/renderer/render_static_data.hpp>
+#include <mbgl/renderer/render_tree.hpp>
+#include <mbgl/style/layers/heatmap_layer_properties.hpp>
+#include <mbgl/util/convert.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+struct alignas(16) HeatmapDrawableUBO {
+    std::array<float, 4 * 4> matrix;
+    float extrude_scale;
+    std::array<float, 3> padding;
+};
+static_assert(sizeof(HeatmapDrawableUBO) % 16 == 0);
+
+struct alignas(16) HeatmapEvaluatedPropsUBO {
+    float weight;
+    float radius;
+    float intensity;
+    float padding;
+};
+static_assert(sizeof(HeatmapEvaluatedPropsUBO) % 16 == 0);
+
+static constexpr std::string_view HeatmapDrawableUBOName = "HeatmapDrawableUBO";
+static constexpr std::string_view HeatmapEvaluatedPropsUBOName = "HeatmapEvaluatedPropsUBO";
+
+void HeatmapLayerTweaker::execute(LayerGroupBase& layerGroup,
+                                  const RenderTree& renderTree,
+                                  const PaintParameters& parameters) {
+    auto& context = parameters.context;
+    const auto& evaluated = static_cast<const HeatmapLayerProperties&>(*evaluatedProperties).evaluated;
+
+    if (layerGroup.empty()) {
+        return;
+    }
+
+#if !defined(NDEBUG)
+    const auto label = layerGroup.getName() + "-update-uniforms";
+    const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
+#endif
+
+    if (!evaluatedPropsUniformBuffer) {
+        const HeatmapEvaluatedPropsUBO evaluatedPropsUBO = {
+            /* .weight = */ evaluated.get<HeatmapWeight>().constantOr(HeatmapWeight::defaultValue()),
+            /* .radius = */ evaluated.get<HeatmapRadius>().constantOr(HeatmapRadius::defaultValue()),
+            /* .intensity = */ evaluated.get<HeatmapIntensity>(),
+            /* .padding = */ 0};
+        evaluatedPropsUniformBuffer = parameters.context.createUniformBuffer(&evaluatedPropsUBO,
+                                                                             sizeof(evaluatedPropsUBO));
+    }
+
+    layerGroup.visitDrawables([&](gfx::Drawable& drawable) {
+        auto& uniforms = drawable.mutableUniformBuffers();
+        uniforms.addOrReplace(HeatmapEvaluatedPropsUBOName, evaluatedPropsUniformBuffer);
+
+        if (!drawable.getTileID()) {
+            return;
+        }
+        const UnwrappedTileID tileID = drawable.getTileID()->toUnwrapped();
+        constexpr bool nearClipped = false;
+        constexpr bool inViewportPixelUnits = false;
+        const auto matrix = getTileMatrix(tileID,
+                                          renderTree,
+                                          parameters.state,
+                                          {0.f, 0.f},
+                                          TranslateAnchorType::Viewport,
+                                          nearClipped,
+                                          inViewportPixelUnits);
+        const HeatmapDrawableUBO drawableUBO = {
+            /* .matrix = */ util::cast<float>(matrix),
+            /* .extrude_scale = */ tileID.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom())),
+            /* .padding = */ {0}};
+
+        uniforms.createOrUpdate(HeatmapDrawableUBOName, &drawableUBO, context);
+    });
+}
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/heatmap_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/heatmap_layer_tweaker.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <mbgl/renderer/layer_tweaker.hpp>
+
+namespace mbgl {
+
+/**
+    Heatmap layer specific tweaker
+ */
+class HeatmapLayerTweaker : public LayerTweaker {
+public:
+    HeatmapLayerTweaker(Immutable<style::LayerProperties> properties)
+        : LayerTweaker(properties){};
+
+public:
+    ~HeatmapLayerTweaker() override = default;
+
+    void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
+
+protected:
+    gfx::UniformBufferPtr evaluatedPropsUniformBuffer;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.cpp
@@ -1,0 +1,55 @@
+#include <mbgl/renderer/layers/heatmap_texture_layer_tweaker.hpp>
+
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/renderer/render_static_data.hpp>
+#include <mbgl/renderer/render_tree.hpp>
+#include <mbgl/style/layers/heatmap_layer_properties.hpp>
+#include <mbgl/util/convert.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+struct alignas(16) HeatmapTextureDrawableUBO {
+    std::array<float, 4 * 4> matrix;
+    std::array<float, 2> world;
+    float opacity;
+    float padding;
+};
+static_assert(sizeof(HeatmapTextureDrawableUBO) % 16 == 0);
+
+static constexpr std::string_view HeatmapTextureDrawableUBOName = "HeatmapTextureDrawableUBO";
+
+void HeatmapTextureLayerTweaker::execute(LayerGroupBase& layerGroup,
+                                         [[maybe_unused]] const RenderTree& renderTree,
+                                         const PaintParameters& parameters) {
+    const auto& evaluated = static_cast<const HeatmapLayerProperties&>(*evaluatedProperties).evaluated;
+
+    if (layerGroup.empty()) {
+        return;
+    }
+
+#if !defined(NDEBUG)
+    const auto label = layerGroup.getName() + "-update-uniforms";
+    const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
+#endif
+
+    layerGroup.visitDrawables([&](gfx::Drawable& drawable) {
+        const auto& size = parameters.staticData.backendSize;
+        mat4 viewportMat;
+        matrix::ortho(viewportMat, 0, size.width, size.height, 0, 0, 1);
+        const HeatmapTextureDrawableUBO drawableUBO = {
+            /* .matrix = */ util::cast<float>(viewportMat),
+            /* .world = */ {static_cast<float>(size.width), static_cast<float>(size.height)},
+            /* .opacity = */ evaluated.get<HeatmapOpacity>(),
+            /* .padding = */ 0};
+
+        drawable.mutableUniformBuffers().createOrUpdate(
+            HeatmapTextureDrawableUBOName, &drawableUBO, parameters.context);
+    });
+}
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <mbgl/renderer/layer_tweaker.hpp>
+
+namespace mbgl {
+
+/**
+    Heatmap texture layer specific tweaker
+ */
+class HeatmapTextureLayerTweaker : public LayerTweaker {
+public:
+    HeatmapTextureLayerTweaker(Immutable<style::LayerProperties> properties)
+        : LayerTweaker(properties){};
+
+public:
+    ~HeatmapTextureLayerTweaker() override = default;
+
+    void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
+
+protected:
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/hillshade_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/hillshade_layer_tweaker.cpp
@@ -1,0 +1,85 @@
+#include <mbgl/renderer/layers/hillshade_layer_tweaker.hpp>
+
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/renderer/render_tree.hpp>
+#include <mbgl/style/layers/hillshade_layer_properties.hpp>
+#include <mbgl/util/convert.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+struct alignas(16) HillshadeDrawableUBO {
+    std::array<float, 4 * 4> matrix;
+    std::array<float, 2> latrange;
+    std::array<float, 2> light;
+};
+static_assert(sizeof(HillshadeDrawableUBO) % 16 == 0);
+
+struct alignas(16) HillshadeEvaluatedPropsUBO {
+    Color highlight;
+    Color shadow;
+    Color accent;
+};
+static_assert(sizeof(HillshadeEvaluatedPropsUBO) % 16 == 0);
+
+static constexpr std::string_view HillshadeDrawableUBOName = "HillshadeDrawableUBO";
+static constexpr std::string_view HillshadeEvaluatedPropsUBOName = "HillshadeEvaluatedPropsUBO";
+
+std::array<float, 2> getLatRange(const UnwrappedTileID& id) {
+    const LatLng latlng0 = LatLng(id);
+    const LatLng latlng1 = LatLng(UnwrappedTileID(id.canonical.z, id.canonical.x, id.canonical.y + 1));
+    return {{static_cast<float>(latlng0.latitude()), static_cast<float>(latlng1.latitude())}};
+}
+
+std::array<float, 2> getLight(const PaintParameters& parameters,
+                              const HillshadePaintProperties::PossiblyEvaluated& evaluated) {
+    float azimuthal = util::deg2radf(evaluated.get<HillshadeIlluminationDirection>());
+    if (evaluated.get<HillshadeIlluminationAnchor>() == HillshadeIlluminationAnchorType::Viewport)
+        azimuthal = azimuthal - static_cast<float>(parameters.state.getBearing());
+    return {{evaluated.get<HillshadeExaggeration>(), azimuthal}};
+}
+
+void HillshadeLayerTweaker::execute(LayerGroupBase& layerGroup,
+                                    const RenderTree& renderTree,
+                                    const PaintParameters& parameters) {
+    const auto& evaluated = static_cast<const HillshadeLayerProperties&>(*evaluatedProperties).evaluated;
+
+    if (layerGroup.empty()) {
+        return;
+    }
+
+#if !defined(NDEBUG)
+    const auto label = layerGroup.getName() + "-update-uniforms";
+    const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
+#endif
+
+    if (!evaluatedPropsUniformBuffer) {
+        HillshadeEvaluatedPropsUBO evaluatedPropsUBO = {/* .highlight = */ evaluated.get<HillshadeHighlightColor>(),
+                                                        /* .shadow = */ evaluated.get<HillshadeShadowColor>(),
+                                                        /* .accent = */ evaluated.get<HillshadeAccentColor>()};
+        evaluatedPropsUniformBuffer = parameters.context.createUniformBuffer(&evaluatedPropsUBO,
+                                                                             sizeof(evaluatedPropsUBO));
+    }
+
+    layerGroup.visitDrawables([&](gfx::Drawable& drawable) {
+        drawable.mutableUniformBuffers().addOrReplace(HillshadeEvaluatedPropsUBOName, evaluatedPropsUniformBuffer);
+
+        if (!drawable.getTileID()) {
+            return;
+        }
+        const UnwrappedTileID tileID = drawable.getTileID()->toUnwrapped();
+        const auto matrix = getTileMatrix(
+            tileID, renderTree, parameters.state, {0.f, 0.f}, TranslateAnchorType::Viewport, false, false, true);
+        HillshadeDrawableUBO drawableUBO = {/* .matrix = */ util::cast<float>(matrix),
+                                            /* .latrange = */ getLatRange(tileID),
+                                            /* .light = */ getLight(parameters, evaluated)};
+
+        drawable.mutableUniformBuffers().createOrUpdate(HillshadeDrawableUBOName, &drawableUBO, parameters.context);
+    });
+}
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/hillshade_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/hillshade_layer_tweaker.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <mbgl/renderer/layer_tweaker.hpp>
+
+namespace mbgl {
+
+/**
+    Hillshade layer specific tweaker
+ */
+class HillshadeLayerTweaker : public LayerTweaker {
+public:
+    HillshadeLayerTweaker(Immutable<style::LayerProperties> properties)
+        : LayerTweaker(properties){};
+
+public:
+    ~HillshadeLayerTweaker() override = default;
+
+    void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
+
+protected:
+    gfx::UniformBufferPtr evaluatedPropsUniformBuffer;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.cpp
@@ -1,0 +1,73 @@
+#include <mbgl/renderer/layers/hillshade_prepare_layer_tweaker.hpp>
+
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/gfx/hillshade_prepare_drawable_data.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/renderer/render_tree.hpp>
+#include <mbgl/style/layers/hillshade_layer_properties.hpp>
+#include <mbgl/util/convert.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+struct alignas(16) HillshadePrepareDrawableUBO {
+    std::array<float, 4 * 4> matrix;
+    std::array<float, 4> unpack;
+    std::array<float, 2> dimension;
+    float zoom;
+    float maxzoom;
+};
+static_assert(sizeof(HillshadePrepareDrawableUBO) % 16 == 0);
+
+static constexpr std::string_view HillshadePrepareDrawableUBOName = "HillshadePrepareDrawableUBO";
+
+const std::array<float, 4>& getUnpackVector(Tileset::DEMEncoding encoding) {
+    // https://www.mapbox.com/help/access-elevation-data/#mapbox-terrain-rgb
+    static const std::array<float, 4> unpackMapbox = {{6553.6f, 25.6f, 0.1f, 10000.0f}};
+    // https://aws.amazon.com/public-datasets/terrain/
+    static const std::array<float, 4> unpackTerrarium = {{256.0f, 1.0f, 1.0f / 256.0f, 32768.0f}};
+
+    return encoding == Tileset::DEMEncoding::Terrarium ? unpackTerrarium : unpackMapbox;
+}
+
+void HillshadePrepareLayerTweaker::execute(LayerGroupBase& layerGroup,
+                                           [[maybe_unused]] const RenderTree& renderTree,
+                                           const PaintParameters& parameters) {
+    // const auto& evaluated = static_cast<const HillshadeLayerProperties&>(*evaluatedProperties).evaluated;
+
+    if (layerGroup.empty()) {
+        return;
+    }
+
+#if !defined(NDEBUG)
+    const auto label = layerGroup.getName() + "-update-uniforms";
+    const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
+#endif
+
+    layerGroup.visitDrawables([&](gfx::Drawable& drawable) {
+        if (!drawable.getTileID() || !drawable.getData()) {
+            return;
+        }
+        const UnwrappedTileID tileID = drawable.getTileID()->toUnwrapped();
+        const auto& drawableData = static_cast<const gfx::HillshadePrepareDrawableData&>(*drawable.getData());
+
+        mat4 matrix;
+        matrix::ortho(matrix, 0, util::EXTENT, -util::EXTENT, 0, 0, 1);
+        matrix::translate(matrix, matrix, 0, -util::EXTENT, 0);
+
+        HillshadePrepareDrawableUBO drawableUBO = {
+            /* .matrix = */ util::cast<float>(matrix),
+            /* .unpack = */ getUnpackVector(drawableData.encoding),
+            /* .dimension = */ {static_cast<float>(drawableData.stride), static_cast<float>(drawableData.stride)},
+            /* .zoom = */ static_cast<float>(tileID.canonical.z),
+            /* .maxzoom = */ static_cast<float>(drawableData.maxzoom)};
+
+        drawable.mutableUniformBuffers().createOrUpdate(
+            HillshadePrepareDrawableUBOName, &drawableUBO, parameters.context);
+    });
+}
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <mbgl/renderer/layer_tweaker.hpp>
+
+namespace mbgl {
+
+/**
+    Hillshade prepare layer specific tweaker
+ */
+class HillshadePrepareLayerTweaker : public LayerTweaker {
+public:
+    HillshadePrepareLayerTweaker(Immutable<style::LayerProperties> properties)
+        : LayerTweaker(properties){};
+
+public:
+    ~HillshadePrepareLayerTweaker() override = default;
+
+    void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
+
+protected:
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/line_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.cpp
@@ -1,0 +1,298 @@
+#include <mbgl/renderer/layers/line_layer_tweaker.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/style/layers/line_layer_properties.hpp>
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/util/convert.hpp>
+#include <mbgl/util/math.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#include <mbgl/renderer/image_atlas.hpp>
+#include <mbgl/util/logging.hpp>
+#include <mbgl/geometry/line_atlas.hpp>
+#include <mbgl/gfx/line_drawable_data.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+struct alignas(16) LineUBO {
+    std::array<float, 4 * 4> matrix;
+    std::array<float, 2> units_to_pixels;
+    float ratio;
+    float device_pixel_ratio;
+};
+static_assert(sizeof(LineUBO) % 16 == 0);
+static constexpr std::string_view LineUBOName = "LineUBO";
+
+struct alignas(16) LinePropertiesUBO {
+    Color color;
+    float blur;
+    float opacity;
+    float gapwidth;
+    float offset;
+    float width;
+
+    float pad1;
+    std::array<float, 2> pad2;
+};
+static_assert(sizeof(LinePropertiesUBO) % 16 == 0);
+static constexpr std::string_view LinePropertiesUBOName = "LinePropertiesUBO";
+
+struct alignas(16) LineGradientUBO {
+    std::array<float, 4 * 4> matrix;
+    std::array<float, 2> units_to_pixels;
+    float ratio;
+    float device_pixel_ratio;
+};
+static_assert(sizeof(LineGradientUBO) % 16 == 0);
+static constexpr std::string_view LineGradientUBOName = "LineGradientUBO";
+
+struct alignas(16) LineGradientPropertiesUBO {
+    float blur;
+    float opacity;
+    float gapwidth;
+    float offset;
+    float width;
+
+    float pad1;
+    std::array<float, 2> pad2;
+};
+static_assert(sizeof(LineGradientPropertiesUBO) % 16 == 0);
+static constexpr std::string_view LineGradientPropertiesUBOName = "LineGradientPropertiesUBO";
+
+struct alignas(16) LinePatternUBO {
+    std::array<float, 4 * 4> matrix;
+    std::array<float, 4> scale;
+    std::array<float, 2> texsize;
+    std::array<float, 2> units_to_pixels;
+    float ratio;
+    float device_pixel_ratio;
+    float fade;
+
+    float pad1;
+};
+static_assert(sizeof(LinePatternUBO) % 16 == 0);
+static constexpr std::string_view LinePatternUBOName = "LinePatternUBO";
+
+struct alignas(16) LinePatternPropertiesUBO {
+    float blur;
+    float opacity;
+    float offset;
+    float gapwidth;
+    float width;
+
+    float pad1;
+    std::array<float, 2> pad2;
+};
+static_assert(sizeof(LinePatternPropertiesUBO) % 16 == 0);
+static constexpr std::string_view LinePatternPropertiesUBOName = "LinePatternPropertiesUBO";
+
+struct alignas(16) LineSDFUBO {
+    std::array<float, 4 * 4> matrix;
+    std::array<float, 2> units_to_pixels;
+    std::array<float, 2> patternscale_a;
+    std::array<float, 2> patternscale_b;
+    float ratio;
+    float device_pixel_ratio;
+    float tex_y_a;
+    float tex_y_b;
+    float sdfgamma;
+    float mix;
+};
+static_assert(sizeof(LineSDFUBO) % 16 == 0);
+static constexpr std::string_view LineSDFUBOName = "LineSDFUBO";
+
+struct alignas(16) LineSDFPropertiesUBO {
+    Color color;
+    float blur;
+    float opacity;
+    float gapwidth;
+    float offset;
+    float width;
+    float floorwidth;
+
+    std::array<float, 2> pad1;
+};
+static_assert(sizeof(LineSDFPropertiesUBO) % 16 == 0);
+static constexpr std::string_view LineSDFPropertiesUBOName = "LineSDFPropertiesUBO";
+
+void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
+                               const RenderTree& renderTree,
+                               const PaintParameters& parameters) {
+    auto& context = parameters.context;
+    const auto& evaluated = static_cast<const LineLayerProperties&>(*evaluatedProperties).evaluated;
+    const auto& crossfade = static_cast<const LineLayerProperties&>(*evaluatedProperties).crossfade;
+
+    const auto getLinePropsBuffer = [&]() {
+        if (!linePropertiesBuffer) {
+            const LinePropertiesUBO linePropertiesUBO{
+                /*color =*/evaluated.get<LineColor>().constantOr(LineColor::defaultValue()),
+                /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
+                /*opacity =*/evaluated.get<LineOpacity>().constantOr(LineOpacity::defaultValue()),
+                /*gapwidth =*/evaluated.get<LineGapWidth>().constantOr(LineGapWidth::defaultValue()),
+                /*offset =*/evaluated.get<LineOffset>().constantOr(LineOffset::defaultValue()),
+                /*width =*/evaluated.get<LineWidth>().constantOr(LineWidth::defaultValue()),
+                0,
+                {0, 0}};
+            linePropertiesBuffer = context.createUniformBuffer(&linePropertiesUBO, sizeof(linePropertiesUBO));
+        }
+        return linePropertiesBuffer;
+    };
+    const auto getLineGradientPropsBuffer = [&]() {
+        if (!lineGradientPropertiesBuffer) {
+            const LineGradientPropertiesUBO lineGradientPropertiesUBO{
+                /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
+                /*opacity =*/evaluated.get<LineOpacity>().constantOr(LineOpacity::defaultValue()),
+                /*gapwidth =*/evaluated.get<LineGapWidth>().constantOr(LineGapWidth::defaultValue()),
+                /*offset =*/evaluated.get<LineOffset>().constantOr(LineOffset::defaultValue()),
+                /*width =*/evaluated.get<LineWidth>().constantOr(LineWidth::defaultValue()),
+                0,
+                {0, 0}};
+            lineGradientPropertiesBuffer = context.createUniformBuffer(&lineGradientPropertiesUBO,
+                                                                       sizeof(lineGradientPropertiesUBO));
+        }
+        return lineGradientPropertiesBuffer;
+    };
+    const auto getLineSDFPropsBuffer = [&]() {
+        if (!lineSDFPropertiesBuffer) {
+            const LineSDFPropertiesUBO lineSDFPropertiesUBO{
+                /*color =*/evaluated.get<LineColor>().constantOr(LineColor::defaultValue()),
+                /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
+                /*opacity =*/evaluated.get<LineOpacity>().constantOr(LineOpacity::defaultValue()),
+                /*gapwidth =*/evaluated.get<LineGapWidth>().constantOr(LineGapWidth::defaultValue()),
+                /*offset =*/evaluated.get<LineOffset>().constantOr(LineOffset::defaultValue()),
+                /*width =*/evaluated.get<LineWidth>().constantOr(LineWidth::defaultValue()),
+                /*floorwidth =*/evaluated.get<LineFloorWidth>().constantOr(LineFloorWidth::defaultValue()),
+                {0, 0}};
+            lineSDFPropertiesBuffer = context.createUniformBuffer(&lineSDFPropertiesUBO, sizeof(lineSDFPropertiesUBO));
+        }
+        return lineSDFPropertiesBuffer;
+    };
+
+    layerGroup.visitDrawables([&](gfx::Drawable& drawable) {
+        const auto shader = drawable.getShader();
+        if (!drawable.getTileID() || !shader) {
+            return;
+        }
+
+        const UnwrappedTileID tileID = drawable.getTileID()->toUnwrapped();
+        const auto& translation = evaluated.get<LineTranslate>();
+        const auto anchor = evaluated.get<LineTranslateAnchor>();
+        constexpr bool nearClipped = false;
+        constexpr bool inViewportPixelUnits = false; // from RenderTile::translatedMatrix
+        auto& uniforms = drawable.mutableUniformBuffers();
+        const auto& shaderUniforms = shader->getUniformBlocks();
+
+        const auto matrix = getTileMatrix(
+            tileID, renderTree, parameters.state, translation, anchor, nearClipped, inViewportPixelUnits);
+
+        // simple line
+        if (shaderUniforms.get(std::string(LineUBOName))) {
+            // main UBO
+            const LineUBO lineUBO{
+                /*matrix = */ util::cast<float>(matrix),
+                /*units_to_pixels = */ {1.0f / parameters.pixelsToGLUnits[0], 1.0f / parameters.pixelsToGLUnits[1]},
+                /*ratio = */ 1.0f / tileID.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom())),
+                /*device_pixel_ratio = */ parameters.pixelRatio};
+            uniforms.createOrUpdate(LineUBOName, &lineUBO, context);
+
+            // properties UBO
+            uniforms.addOrReplace(LinePropertiesUBOName, getLinePropsBuffer());
+        }
+        // gradient line
+        else if (shaderUniforms.get(std::string(LineGradientUBOName))) {
+            // main UBO
+            const LineGradientUBO lineGradientUBO{
+                /*matrix = */ util::cast<float>(matrix),
+                /*units_to_pixels = */ {1.0f / parameters.pixelsToGLUnits[0], 1.0f / parameters.pixelsToGLUnits[1]},
+                /*ratio = */ 1.0f / tileID.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom())),
+                /*device_pixel_ratio = */ parameters.pixelRatio};
+            uniforms.createOrUpdate(LineGradientUBOName, &lineGradientUBO, context);
+
+            // properties UBO
+            uniforms.addOrReplace(LineGradientPropertiesUBOName, getLineGradientPropsBuffer());
+        }
+        // pattern line
+        else if (shaderUniforms.get(std::string(LinePatternUBOName))) {
+            // main UBO
+            Size textureSize{0, 0};
+            if (const auto index = shader->getSamplerLocation("u_image")) {
+                if (const auto& texture = drawable.getTexture(index.value())) {
+                    textureSize = texture->getSize();
+                }
+            }
+            const LinePatternUBO linePatternUBO{
+                /*matrix =*/util::cast<float>(matrix),
+                /*scale =*/
+                {parameters.pixelRatio,
+                 1 / tileID.pixelsToTileUnits(1, parameters.state.getIntegerZoom()),
+                 crossfade.fromScale,
+                 crossfade.toScale},
+                /*texsize =*/{static_cast<float>(textureSize.width), static_cast<float>(textureSize.height)},
+                /*units_to_pixels =*/{1.0f / parameters.pixelsToGLUnits[0], 1.0f / parameters.pixelsToGLUnits[1]},
+                /*ratio =*/1.0f / tileID.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom())),
+                /*device_pixel_ratio =*/parameters.pixelRatio,
+                /*fade =*/crossfade.t,
+                0};
+            uniforms.createOrUpdate(LinePatternUBOName, &linePatternUBO, context);
+
+            // properties UBO
+            const LinePatternPropertiesUBO linePatternPropertiesUBO{
+                /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
+                /*opacity =*/evaluated.get<LineOpacity>().constantOr(LineOpacity::defaultValue()),
+                /*offset =*/evaluated.get<LineOffset>().constantOr(LineOffset::defaultValue()),
+                /*gapwidth =*/evaluated.get<LineGapWidth>().constantOr(LineGapWidth::defaultValue()),
+                /*width =*/evaluated.get<LineWidth>().constantOr(LineWidth::defaultValue()),
+                0,
+                {0, 0}};
+            uniforms.createOrUpdate(LinePatternPropertiesUBOName, &linePatternPropertiesUBO, context);
+        }
+        // SDF line
+        else if (shaderUniforms.get(std::string(LineSDFUBOName))) {
+            if (const auto& data = drawable.getData()) {
+                const gfx::LineDrawableData& lineData = static_cast<const gfx::LineDrawableData&>(*data);
+                const auto& dashPatternTexture = parameters.lineAtlas.getDashPatternTexture(
+                    evaluated.get<LineDasharray>().from, evaluated.get<LineDasharray>().to, lineData.linePatternCap);
+
+                // texture
+                if (const auto index = shader->getSamplerLocation("u_image")) {
+                    if (!drawable.getTexture(index.value())) {
+                        const auto& texture = dashPatternTexture.getTexture();
+                        drawable.setEnabled(!!texture);
+                        if (texture) {
+                            drawable.setTexture(texture, index.value());
+                        }
+                    }
+                }
+
+                // main UBO
+                const LinePatternPos& posA = dashPatternTexture.getFrom();
+                const LinePatternPos& posB = dashPatternTexture.getTo();
+                const float widthA = posA.width * crossfade.fromScale;
+                const float widthB = posB.width * crossfade.toScale;
+                const LineSDFUBO lineSDFUBO{
+                    /* matrix = */ util::cast<float>(matrix),
+                    /* units_to_pixels = */
+                    {1.0f / parameters.pixelsToGLUnits[0], 1.0f / parameters.pixelsToGLUnits[1]},
+                    /* patternscale_a = */
+                    {1.0f / tileID.pixelsToTileUnits(widthA, parameters.state.getIntegerZoom()), -posA.height / 2.0f},
+                    /* patternscale_b = */
+                    {1.0f / tileID.pixelsToTileUnits(widthB, parameters.state.getIntegerZoom()), -posB.height / 2.0f},
+                    /* ratio = */ 1.0f / tileID.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom())),
+                    /* device_pixel_ratio = */ parameters.pixelRatio,
+                    /* tex_y_a = */ posA.y,
+                    /* tex_y_b = */ posB.y,
+                    /* sdfgamma = */ static_cast<float>(dashPatternTexture.getSize().width) /
+                        (std::min(widthA, widthB) * 256.0f * parameters.pixelRatio) / 2.0f,
+                    /* mix = */ crossfade.t};
+                uniforms.createOrUpdate(LineSDFUBOName, &lineSDFUBO, context);
+
+                // properties UBO
+                uniforms.addOrReplace(LineSDFPropertiesUBOName, getLineSDFPropsBuffer());
+            }
+        }
+    });
+}
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/line_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <mbgl/renderer/layer_tweaker.hpp>
+
+#include <string_view>
+
+namespace mbgl {
+
+namespace gfx {
+class UniformBuffer;
+using UniformBufferPtr = std::shared_ptr<UniformBuffer>;
+} // namespace gfx
+
+/**
+    Line layer specific tweaker
+ */
+class LineLayerTweaker : public LayerTweaker {
+public:
+    LineLayerTweaker(Immutable<style::LayerProperties> properties)
+        : LayerTweaker(properties){};
+
+    ~LineLayerTweaker() override = default;
+
+    void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
+
+protected:
+    gfx::UniformBufferPtr linePropertiesBuffer;
+    gfx::UniformBufferPtr lineGradientPropertiesBuffer;
+    gfx::UniformBufferPtr lineSDFPropertiesBuffer;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/raster_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/raster_layer_tweaker.cpp
@@ -1,0 +1,100 @@
+#include <mbgl/renderer/layers/raster_layer_tweaker.hpp>
+
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/renderer/render_tree.hpp>
+#include <mbgl/style/layers/raster_layer_properties.hpp>
+#include <mbgl/util/convert.hpp>
+#include <mbgl/gfx/image_drawable_data.hpp>
+#include <mbgl/util/logging.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+struct alignas(16) RasterDrawableUBO {
+    std::array<float, 4 * 4> matrix;
+    std::array<float, 4> spin_weights;
+    std::array<float, 2> tl_parent;
+    float scale_parent;
+    float buffer_scale;
+    float fade_t;
+    float opacity;
+    float brightness_low;
+    float brightness_high;
+    float saturation_factor;
+    float contrast_factor;
+    float pad1;
+    float pad2;
+};
+static_assert(sizeof(RasterDrawableUBO) == 128);
+static_assert(sizeof(RasterDrawableUBO) % 16 == 0);
+
+void RasterLayerTweaker::execute([[maybe_unused]] LayerGroupBase& layerGroup,
+                                 [[maybe_unused]] const RenderTree& renderTree,
+                                 [[maybe_unused]] const PaintParameters& parameters) {
+    const auto& evaluated = static_cast<const RasterLayerProperties&>(*evaluatedProperties).evaluated;
+
+    layerGroup.visitDrawables([&](gfx::Drawable& drawable) {
+        const auto spinWeights = [](float spin) -> std::array<float, 4> {
+            spin = util::deg2radf(spin);
+            const float s = std::sin(spin);
+            const float c = std::cos(spin);
+            std::array<float, 4> spin_weights = {
+                {(2 * c + 1) / 3, (-std::sqrt(3.0f) * s - c + 1) / 3, (std::sqrt(3.0f) * s - c + 1) / 3, 0}};
+            return spin_weights;
+        };
+        const auto saturationFactor = [](float saturation) -> float {
+            if (saturation > 0) {
+                return 1.f - 1.f / (1.001f - saturation);
+            } else {
+                return -saturation;
+            }
+        };
+        const auto contrastFactor = [](float contrast) -> float {
+            if (contrast > 0) {
+                return 1 / (1 - contrast);
+            } else {
+                return 1 + contrast;
+            }
+        };
+
+        mat4 matrix;
+        if (!drawable.getTileID()) {
+            // this is an image drawable
+            if (const auto& data = drawable.getData()) {
+                const gfx::ImageDrawableData& imageData = static_cast<const gfx::ImageDrawableData&>(*data);
+
+                matrix = imageData.matrix;
+            } else {
+                Log::Error(Event::General, "Invalid raster layer drawable: neither tile id nor image data is set.");
+                return;
+            }
+        } else {
+            // this is a tile drawable
+            const UnwrappedTileID tileID = drawable.getTileID()->toUnwrapped();
+            matrix = parameters.matrixForTile(tileID, !parameters.state.isChanging());
+        }
+
+        const RasterDrawableUBO drawableUBO{
+            /*.matrix = */ util::cast<float>(matrix),
+            /*.spin_weigths = */ spinWeights(evaluated.get<RasterHueRotate>()),
+            /*.tl_parent = */ {{0.0f, 0.0f}},
+            /*.scale_parent = */ 1.0f,
+            /*.buffer_scale = */ 1.0f,
+            /*.fade_t = */ 1.0f,
+            /*.opacity = */ evaluated.get<RasterOpacity>(),
+            /*.brightness_low = */ evaluated.get<RasterBrightnessMin>(),
+            /*.brightness_high = */ evaluated.get<RasterBrightnessMax>(),
+            /*.saturation_factor = */ saturationFactor(evaluated.get<RasterSaturation>()),
+            /*.contrast_factor = */ contrastFactor(evaluated.get<RasterContrast>()),
+            0,
+            0};
+        auto& uniforms = drawable.mutableUniformBuffers();
+        uniforms.createOrUpdate("RasterDrawableUBO", &drawableUBO, parameters.context);
+    });
+}
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/raster_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/raster_layer_tweaker.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <mbgl/renderer/layer_tweaker.hpp>
+
+namespace mbgl {
+
+namespace gfx {
+class UniformBuffer;
+using UniformBufferPtr = std::shared_ptr<UniformBuffer>;
+} // namespace gfx
+
+/**
+    Raster layer tweaker
+ */
+class RasterLayerTweaker : public LayerTweaker {
+public:
+    RasterLayerTweaker(Immutable<style::LayerProperties> properties)
+        : LayerTweaker(properties){};
+
+public:
+    ~RasterLayerTweaker() override = default;
+
+    void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
+
+protected:
+    gfx::UniformBufferPtr evaluatedPropsUniformBuffer = nullptr;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -1,16 +1,30 @@
 #include <mbgl/renderer/layers/render_background_layer.hpp>
-#include <mbgl/style/layers/background_layer_impl.hpp>
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/gfx/cull_face_mode.hpp>
+#include <mbgl/map/transform_state.hpp>
+#include <mbgl/programs/programs.hpp>
 #include <mbgl/renderer/bucket.hpp>
-#include <mbgl/renderer/upload_parameters.hpp>
+#include <mbgl/renderer/image_manager.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/renderer/pattern_atlas.hpp>
-#include <mbgl/renderer/image_manager.hpp>
+#include <mbgl/renderer/render_pass.hpp>
 #include <mbgl/renderer/render_static_data.hpp>
-#include <mbgl/programs/programs.hpp>
+#include <mbgl/renderer/upload_parameters.hpp>
+#include <mbgl/style/layers/background_layer_impl.hpp>
+#include <mbgl/style/layer_properties.hpp>
 #include <mbgl/util/tile_cover.hpp>
-#include <mbgl/map/transform_state.hpp>
-#include <mbgl/gfx/cull_face_mode.hpp>
-#include <mbgl/gfx/shader_registry.hpp>
+#include <mbgl/util/convert.hpp>
+#include <mbgl/util/logging.hpp>
+
+#if MLN_DRAWABLE_RENDERER
+#include <mbgl/renderer/layers/background_layer_tweaker.hpp>
+#include <mbgl/gfx/drawable_builder.hpp>
+#include <mbgl/renderer/change_request.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#endif
+
+#include <unordered_set>
 
 namespace mbgl {
 
@@ -36,9 +50,9 @@ void RenderBackgroundLayer::transition(const TransitionParameters& parameters) {
 }
 
 void RenderBackgroundLayer::evaluate(const PropertyEvaluationParameters& parameters) {
-    auto properties = makeMutable<BackgroundLayerProperties>(staticImmutableCast<BackgroundLayer::Impl>(baseImpl),
-                                                             parameters.getCrossfadeParameters(),
-                                                             unevaluated.evaluate(parameters));
+    auto evaluated = unevaluated.evaluate(parameters);
+    auto properties = makeMutable<BackgroundLayerProperties>(
+        staticImmutableCast<BackgroundLayer::Impl>(baseImpl), parameters.getCrossfadeParameters(), evaluated);
 
     passes = properties->evaluated.get<style::BackgroundOpacity>() == 0.0f ? RenderPass::None
              : (!unevaluated.get<style::BackgroundPattern>().isUndefined() ||
@@ -48,7 +62,14 @@ void RenderBackgroundLayer::evaluate(const PropertyEvaluationParameters& paramet
                  // Supply both - evaluated based on opaquePassCutoff in render().
                  : RenderPass::Opaque | RenderPass::Translucent;
     properties->renderPasses = mbgl::underlying_type(passes);
+
     evaluatedProperties = std::move(properties);
+
+#if MLN_DRAWABLE_RENDERER
+    if (layerGroup) {
+        layerGroup->setLayerTweaker(std::make_shared<BackgroundLayerTweaker>(evaluatedProperties));
+    }
+#endif
 }
 
 bool RenderBackgroundLayer::hasTransition() const {
@@ -59,13 +80,14 @@ bool RenderBackgroundLayer::hasCrossfade() const {
     return getCrossfade<BackgroundLayerProperties>(evaluatedProperties).t != 1;
 }
 
+#if MLN_LEGACY_RENDERER
 void RenderBackgroundLayer::render(PaintParameters& parameters) {
     // Note that for bottommost layers without a pattern, the background color
     // is drawn with glClear rather than this method.
 
     // Ensure programs are available
-    if (!parameters.shaders.populate(backgroundProgram)) return;
-    if (!parameters.shaders.populate(backgroundPatternProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(backgroundProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(backgroundPatternProgram)) return;
 
     const Properties<>::PossiblyEvaluated properties;
     const BackgroundProgram::Binders paintAttributeData(properties, 0);
@@ -152,6 +174,7 @@ void RenderBackgroundLayer::render(PaintParameters& parameters) {
         }
     }
 }
+#endif // MLN_LEGACY_RENDERER
 
 std::optional<Color> RenderBackgroundLayer::getSolidBackground() const {
     const auto& evaluated = getEvaluated<BackgroundLayerProperties>(evaluatedProperties);
@@ -180,6 +203,119 @@ void RenderBackgroundLayer::prepare(const LayerPrepareParameters& params) {
         addPatternIfNeeded(evaluated.get<BackgroundPattern>().from.id(), params);
         addPatternIfNeeded(evaluated.get<BackgroundPattern>().to.id(), params);
     }
+
+#if MLN_DRAWABLE_RENDERER
+    updateRenderTileIDs();
+#endif // MLN_DRAWABLE_RENDERER
 }
+
+#if MLN_DRAWABLE_RENDERER
+static constexpr std::string_view BackgroundPlainShaderName = "BackgroundShader";
+static constexpr std::string_view BackgroundPatternShaderName = "BackgroundPatternShader";
+
+void RenderBackgroundLayer::update(gfx::ShaderRegistry& shaders,
+                                   gfx::Context& context,
+                                   const TransformState& state,
+                                   [[maybe_unused]] const RenderTree& renderTree,
+                                   [[maybe_unused]] UniqueChangeRequestVec& changes) {
+    std::unique_lock<std::mutex> guard(mutex);
+
+    const auto zoom = state.getIntegerZoom();
+    const auto tileCover = util::tileCover(state, zoom);
+
+    // renderTiles is always empty, we use tileCover instead
+    if (tileCover.empty()) {
+        removeAllDrawables();
+        return;
+    }
+
+    const auto& evaluated = getEvaluated<BackgroundLayerProperties>(evaluatedProperties);
+    const bool hasPattern = !evaluated.get<BackgroundPattern>().to.empty();
+
+    // TODO: If background is solid, we can skip drawables and rely on the clear color
+    const auto drawPasses = evaluated.get<style::BackgroundOpacity>() == 0.0f ? RenderPass::None
+                            : (!unevaluated.get<style::BackgroundPattern>().isUndefined() ||
+                               evaluated.get<style::BackgroundOpacity>() < 1.0f ||
+                               evaluated.get<style::BackgroundColor>().a < 1.0f)
+                                ? RenderPass::Translucent
+                                : RenderPass::Opaque |
+                                      RenderPass::Translucent; // evaluated based on opaquePassCutoff in render()
+
+    // If the result is transparent or missing, just remove any existing drawables and stop
+    if (drawPasses == RenderPass::None) {
+        removeAllDrawables();
+        return;
+    }
+
+    if (!layerGroup) {
+        if (auto layerGroup_ = context.createTileLayerGroup(layerIndex, /*initialCapacity=*/64, getID())) {
+            layerGroup_->setLayerTweaker(std::make_shared<BackgroundLayerTweaker>(evaluatedProperties));
+            setLayerGroup(std::move(layerGroup_), changes);
+        }
+    }
+    auto* tileLayerGroup = static_cast<TileLayerGroup*>(layerGroup.get());
+
+    if (!hasPattern && !plainShader) {
+        plainShader = context.getGenericShader(shaders, std::string(BackgroundPlainShaderName));
+    }
+    if (hasPattern && !patternShader) {
+        patternShader = context.getGenericShader(shaders, std::string(BackgroundPatternShaderName));
+    }
+
+    const auto& curShader = hasPattern ? patternShader : plainShader;
+    if (!curShader) {
+        removeAllDrawables();
+        return;
+    }
+
+    const auto tileVertices = RenderStaticData::tileVertices();
+    const auto vertexCount = tileVertices.elements();
+    constexpr auto vertSize = sizeof(decltype(tileVertices)::Vertex::a1);
+    std::vector<std::uint8_t> rawVertices(vertexCount * vertSize);
+    for (auto i = 0ULL; i < vertexCount; ++i) {
+        std::memcpy(&rawVertices[i * vertSize], &tileVertices.vector()[i].a1, vertSize);
+    }
+
+    const auto indexes = RenderStaticData::quadTriangleIndices();
+    const auto segs = RenderStaticData::tileTriangleSegments();
+
+    std::unique_ptr<gfx::DrawableBuilder> builder;
+
+    tileLayerGroup->visitDrawables([&](gfx::Drawable& drawable) -> bool {
+        // Has this tile dropped out of the cover set?
+        return (!drawable.getTileID() || hasRenderTile(*drawable.getTileID()));
+    });
+
+    // For each tile in the cover set, add a tile drawable if one doesn't already exist.
+    for (const auto& tileID : tileCover) {
+        // If we already have drawables for this tile, skip.
+        // If a drawable needs to be updated, that's handled in the layer tweaker.
+        if (tileLayerGroup->getDrawableCount(drawPasses, tileID) > 0) {
+            continue;
+        }
+
+        // We actually need to build things, so set up a builder if we haven't already
+        if (!builder) {
+            builder = context.createDrawableBuilder("background");
+            builder->setRenderPass(drawPasses);
+            builder->setShader(curShader);
+            builder->setDepthType(gfx::DepthMaskType::ReadWrite);
+            builder->setColorMode(drawPasses == RenderPass::Translucent ? gfx::ColorMode::alphaBlended()
+                                                                        : gfx::ColorMode::unblended());
+        }
+
+        auto verticesCopy = rawVertices;
+        builder->setRawVertices(std::move(verticesCopy), vertexCount, gfx::AttributeDataType::Short2);
+        builder->setSegments(gfx::Triangles(), indexes.vector(), segs.data(), segs.size());
+        builder->flush();
+
+        for (auto& drawable : builder->clearDrawables()) {
+            drawable->setTileID(tileID);
+            tileLayerGroup->addDrawable(drawPasses, tileID, std::move(drawable));
+            ++stats.drawablesAdded;
+        }
+    }
+}
+#endif
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_background_layer.hpp
+++ b/src/mbgl/renderer/layers/render_background_layer.hpp
@@ -5,12 +5,32 @@
 #include <mbgl/style/layers/background_layer_impl.hpp>
 #include <mbgl/style/layers/background_layer_properties.hpp>
 
+#include <optional>
+#include <memory>
+#include <vector>
+
 namespace mbgl {
+
+namespace gfx {
+class Drawable;
+using DrawablePtr = std::shared_ptr<Drawable>;
+} // namespace gfx
+
+class ChangeRequest;
 
 class RenderBackgroundLayer final : public RenderLayer {
 public:
     explicit RenderBackgroundLayer(Immutable<style::BackgroundLayer::Impl>);
     ~RenderBackgroundLayer() override;
+
+#if MLN_DRAWABLE_RENDERER
+    /// Generate any changes needed by the layer
+    void update(gfx::ShaderRegistry&,
+                gfx::Context&,
+                const TransformState&,
+                const RenderTree&,
+                UniqueChangeRequestVec&) override;
+#endif
 
 private:
     void transition(const TransitionParameters&) override;
@@ -18,16 +38,27 @@ private:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     std::optional<Color> getSolidBackground() const override;
+
+#if MLN_LEGACY_RENDERER
     void render(PaintParameters&) override;
+#endif
+
     void prepare(const LayerPrepareParameters&) override;
 
     // Paint properties
     style::BackgroundPaintProperties::Unevaluated unevaluated;
     SegmentVector<BackgroundAttributes> segments;
 
+#if MLN_LEGACY_RENDERER
     // Programs
     std::shared_ptr<BackgroundProgram> backgroundProgram;
     std::shared_ptr<BackgroundPatternProgram> backgroundPatternProgram;
+#endif
+#if MLN_DRAWABLE_RENDERER
+    // Drawable shaders
+    gfx::ShaderProgramBasePtr plainShader;
+    gfx::ShaderProgramBasePtr patternShader;
+#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_circle_layer.hpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.hpp
@@ -13,12 +13,25 @@ public:
     explicit RenderCircleLayer(Immutable<style::CircleLayer::Impl>);
     ~RenderCircleLayer() final = default;
 
+#if MLN_DRAWABLE_RENDERER
+    /// Generate any changes needed by the layer
+    void update(gfx::ShaderRegistry&,
+                gfx::Context&,
+                const TransformState&,
+                const RenderTree&,
+                UniqueChangeRequestVec&) override;
+#endif
+
 private:
+    void prepare(const LayerPrepareParameters&) override;
     void transition(const TransitionParameters&) override;
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
+
+#if MLN_LEGACY_RENDERER
     void render(PaintParameters&) override;
+#endif
 
     bool queryIntersectsFeature(const GeometryCoordinates&,
                                 const GeometryTileFeature&,
@@ -31,8 +44,13 @@ private:
     // Paint properties
     style::CirclePaintProperties::Unevaluated unevaluated;
 
+#if MLN_LEGACY_RENDERER
     // Programs
     std::shared_ptr<CircleProgram> circleProgram;
+#endif
+#if MLN_DRAWABLE_RENDERER
+    gfx::ShaderGroupPtr circleShaderGroup;
+#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_custom_layer.cpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.cpp
@@ -1,15 +1,30 @@
 #include <mbgl/gfx/backend_scope.hpp>
 #include <mbgl/gfx/renderer_backend.hpp>
-#include <mbgl/gl/context.hpp>
-#include <mbgl/gl/custom_layer_impl.hpp>
-#include <mbgl/gl/render_custom_layer.hpp>
-#include <mbgl/gl/renderable_resource.hpp>
+#include <mbgl/style/layers/custom_layer_impl.hpp>
+#include <mbgl/renderer/layers/render_custom_layer.hpp>
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/math/angles.hpp>
-#include <mbgl/platform/gl_functions.hpp>
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/util/mat4.hpp>
+
+#if MLN_LEGACY_RENDERER
+#include <mbgl/platform/gl_functions.hpp>
+#include <mbgl/gl/context.hpp>
+#include <mbgl/gl/renderable_resource.hpp>
+#endif
+
+#if MLN_DRAWABLE_RENDERER
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/gfx/drawable_custom_layer_host_tweaker.hpp>
+#include <mbgl/gfx/drawable_builder.hpp>
+
+#if !MLN_LEGACY_RENDERER
+// TODO: platform agnostic error checks
+#define MBGL_CHECK_ERROR(cmd) (cmd)
+#endif
+#endif
 
 namespace mbgl {
 
@@ -58,6 +73,7 @@ void RenderCustomLayer::markContextDestroyed() {
 
 void RenderCustomLayer::prepare(const LayerPrepareParameters&) {}
 
+#if MLN_LEGACY_RENDERER
 void RenderCustomLayer::render(PaintParameters& paintParameters) {
     if (host != impl(baseImpl).host) {
         // If the context changed, deinitialize the previous one before initializing the new one.
@@ -100,5 +116,57 @@ void RenderCustomLayer::render(PaintParameters& paintParameters) {
     paintParameters.backend.getDefaultRenderable().getResource<gl::RenderableResource>().bind();
     glContext.setDirtyState();
 }
+#endif
+
+#if MLN_DRAWABLE_RENDERER
+void RenderCustomLayer::update([[maybe_unused]] gfx::ShaderRegistry& shaders,
+                               gfx::Context& context,
+                               [[maybe_unused]] const TransformState& state,
+                               [[maybe_unused]] const RenderTree& renderTree,
+                               [[maybe_unused]] UniqueChangeRequestVec& changes) {
+    std::unique_lock<std::mutex> guard(mutex);
+
+    // create layer group
+    if (!layerGroup) {
+        if (auto layerGroup_ = context.createLayerGroup(layerIndex, /*initialCapacity=*/1, getID())) {
+            setLayerGroup(std::move(layerGroup_), changes);
+        }
+    }
+
+    auto* localLayerGroup = static_cast<LayerGroup*>(layerGroup.get());
+
+    // check if host changed and update
+    bool hostChanged = (host != impl(baseImpl).host);
+    if (hostChanged) {
+        // If the context changed, deinitialize the previous one before initializing the new one.
+        if (host && !contextDestroyed) {
+            MBGL_CHECK_ERROR(host->deinitialize());
+        }
+        host = impl(baseImpl).host;
+        MBGL_CHECK_ERROR(host->initialize());
+    }
+
+    // create drawable
+    if (localLayerGroup->getDrawableCount() == 0 || hostChanged) {
+        localLayerGroup->clearDrawables();
+
+        // create tweaker
+        auto tweaker = std::make_shared<gfx::DrawableCustomLayerHostTweaker>(host);
+
+        // create empty drawable using a builder
+        std::unique_ptr<gfx::DrawableBuilder> builder = context.createDrawableBuilder(getID());
+        auto& drawable = builder->getCurrentDrawable(true);
+        drawable->setIsCustom(true);
+        drawable->setRenderPass(RenderPass::Translucent);
+
+        // assign tweaker to drawable
+        drawable->addTweaker(tweaker);
+
+        // add drawable to layer group
+        localLayerGroup->addDrawable(std::move(drawable));
+        ++stats.drawablesAdded;
+    }
+}
+#endif
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_custom_layer.hpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <mbgl/gl/custom_layer_impl.hpp>
+#include <mbgl/style/layers/custom_layer_impl.hpp>
 #include <mbgl/renderer/render_layer.hpp>
 
 namespace mbgl {
@@ -10,6 +10,15 @@ public:
     explicit RenderCustomLayer(Immutable<style::CustomLayer::Impl>);
     ~RenderCustomLayer() override;
 
+#if MLN_DRAWABLE_RENDERER
+    /// Generate any changes needed by the layer
+    void update(gfx::ShaderRegistry&,
+                gfx::Context&,
+                const TransformState&,
+                const RenderTree&,
+                UniqueChangeRequestVec&) override;
+#endif
+
 private:
     void transition(const TransitionParameters&) override {}
     void evaluate(const PropertyEvaluationParameters&) override;
@@ -18,7 +27,9 @@ private:
     void markContextDestroyed() override;
     void prepare(const LayerPrepareParameters&) override;
 
+#if MLN_LEGACY_RENDERER
     void render(PaintParameters&) override;
+#endif
 
     bool contextDestroyed = false;
     std::shared_ptr<style::CustomLayerHost> host;

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -11,18 +11,40 @@
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/renderer/render_static_data.hpp>
 #include <mbgl/renderer/render_tile.hpp>
+#include <mbgl/renderer/tile_render_data.hpp>
 #include <mbgl/style/expression/image.hpp>
 #include <mbgl/style/layers/fill_extrusion_layer_impl.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
 #include <mbgl/tile/tile.hpp>
+#include <mbgl/util/convert.hpp>
 #include <mbgl/util/intersection_tests.hpp>
 #include <mbgl/util/math.hpp>
+
+#if MLN_DRAWABLE_RENDERER
+#include <mbgl/gfx/drawable_atlases_tweaker.hpp>
+#include <mbgl/gfx/drawable_builder.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/layers/fill_extrusion_layer_tweaker.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#endif // MLN_DRAWABLE_RENDERER
 
 namespace mbgl {
 
 using namespace style;
 
 namespace {
+
+#if MLN_DRAWABLE_RENDERER
+
+constexpr std::string_view FillExtrusionShaderName = "FillExtrusionShader";
+constexpr std::string_view FillExtrusionPatternShaderName = "FillExtrusionPatternShader";
+
+constexpr auto PosAttribName = "a_pos";
+constexpr auto NormAttribName = "a_normal_ed";
+
+constexpr auto IconTextureName = "u_image";
+
+#endif // MLN_DRAWABLE_RENDERER
 
 inline const FillExtrusionLayer::Impl& impl_cast(const Immutable<style::Layer::Impl>& impl) {
     assert(impl->getTypeInfo() == FillExtrusionLayer::Impl::staticTypeInfo());
@@ -51,6 +73,12 @@ void RenderFillExtrusionLayer::evaluate(const PropertyEvaluationParameters& para
                  : RenderPass::None;
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
+
+#if MLN_DRAWABLE_RENDERER
+    if (layerGroup) {
+        layerGroup->setLayerTweaker(std::make_shared<FillExtrusionLayerTweaker>(evaluatedProperties));
+    }
+#endif // MLN_DRAWABLE_RENDERER
 }
 
 bool RenderFillExtrusionLayer::hasTransition() const {
@@ -65,14 +93,15 @@ bool RenderFillExtrusionLayer::is3D() const {
     return true;
 }
 
+#if MLN_LEGACY_RENDERER
 void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
     assert(renderTiles);
     if (parameters.pass != RenderPass::Translucent) {
         return;
     }
 
-    if (!parameters.shaders.populate(fillExtrusionProgram)) return;
-    if (!parameters.shaders.populate(fillExtrusionPatternProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(fillExtrusionProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(fillExtrusionPatternProgram)) return;
 
     const auto& evaluated = static_cast<const FillExtrusionLayerProperties&>(*evaluatedProperties).evaluated;
     const auto& crossfade = static_cast<const FillExtrusionLayerProperties&>(*evaluatedProperties).crossfade;
@@ -127,7 +156,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
                     if (!renderData) {
                         continue;
                     }
-                    auto& bucket = static_cast<FillExtrusionBucket&>(*renderData->bucket);
+                    const auto& bucket = static_cast<FillExtrusionBucket&>(*renderData->bucket);
                     draw(*fillExtrusionProgram,
                          evaluated,
                          crossfade,
@@ -175,9 +204,11 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
                     if (!renderData) {
                         continue;
                     }
-                    auto& bucket = static_cast<FillExtrusionBucket&>(*renderData->bucket);
-                    std::optional<ImagePosition> patternPosA = tile.getPattern(fillPatternValue.from.id());
-                    std::optional<ImagePosition> patternPosB = tile.getPattern(fillPatternValue.to.id());
+                    const auto& bucket = static_cast<FillExtrusionBucket&>(*renderData->bucket);
+                    const std::optional<ImagePosition> patternPosA = tile.getPattern(fillPatternValue.from.id());
+                    const std::optional<ImagePosition> patternPosB = tile.getPattern(fillPatternValue.to.id());
+                    const auto numTiles = std::pow(2, tile.id.canonical.z);
+                    const auto heightFactor = static_cast<float>(-numTiles / util::tileSize_D / 8.0);
 
                     draw(*fillExtrusionPatternProgram,
                          evaluated,
@@ -189,20 +220,19 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
                              tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),
                                                        evaluated.get<FillExtrusionTranslateAnchor>(),
                                                        parameters.state),
-                             tile.getIconAtlasTexture().size,
+                             tile.getIconAtlasTexture()->getSize(),
                              crossfade,
                              tile.id,
                              parameters.state,
                              evaluated.get<FillExtrusionOpacity>(),
-                             static_cast<float>(-std::pow(2, tile.id.canonical.z) / util::tileSize_D / 8.0),
+                             heightFactor,
                              parameters.pixelRatio,
                              parameters.evaluatedLight,
                              evaluated.get<FillExtrusionVerticalGradient>()),
                          patternPosA,
                          patternPosB,
                          FillExtrusionPatternProgram::TextureBindings{
-                             textures::image::Value{tile.getIconAtlasTexture().getResource(),
-                                                    gfx::TextureFilterType::Linear},
+                             textures::image::Value{tile.getIconAtlasTextureBinding(gfx::TextureFilterType::Linear)},
                          },
                          name);
                 }
@@ -220,6 +250,7 @@ void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
         drawTiles(parameters.stencilModeFor3D(), parameters.colorModeForRenderPass(), "color");
     }
 }
+#endif // MLN_LEGACY_RENDERER
 
 bool RenderFillExtrusionLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeometry,
                                                       const GeometryTileFeature& feature,
@@ -239,5 +270,250 @@ bool RenderFillExtrusionLayer::queryIntersectsFeature(const GeometryCoordinates&
     return util::polygonIntersectsMultiPolygon(translatedQueryGeometry.value_or(queryGeometry),
                                                feature.getGeometries());
 }
+
+#if MLN_DRAWABLE_RENDERER
+
+void RenderFillExtrusionLayer::update(gfx::ShaderRegistry& shaders,
+                                      gfx::Context& context,
+                                      const TransformState& state,
+                                      const RenderTree& /*renderTree*/,
+                                      UniqueChangeRequestVec& changes) {
+    if (!renderTiles || renderTiles->empty() || passes == RenderPass::None) {
+        removeAllDrawables();
+        return;
+    }
+
+    // Set up a layer group
+    if (!layerGroup) {
+        if (auto layerGroup_ = context.createTileLayerGroup(layerIndex, /*initialCapacity=*/64, getID())) {
+            layerGroup_->setLayerTweaker(std::make_shared<FillExtrusionLayerTweaker>(evaluatedProperties));
+            setLayerGroup(std::move(layerGroup_), changes);
+        }
+    }
+
+    if (!fillExtrusionGroup) {
+        fillExtrusionGroup = shaders.getShaderGroup(std::string(FillExtrusionShaderName));
+    }
+    if (!fillExtrusionPatternGroup) {
+        fillExtrusionPatternGroup = shaders.getShaderGroup(std::string(FillExtrusionPatternShaderName));
+    }
+
+    auto* tileLayerGroup = static_cast<TileLayerGroup*>(layerGroup.get());
+
+    const auto& evaluated = static_cast<const FillExtrusionLayerProperties&>(*evaluatedProperties).evaluated;
+    const auto& crossfade = static_cast<const FillExtrusionLayerProperties&>(*evaluatedProperties).crossfade;
+
+    // `passes` is set to (RenderPass::Translucent | RenderPass::Pass3D), but `render()`
+    // only runs on the translucent pass, so although our output is 3D, it does not render
+    // in the "3D pass".
+    constexpr auto drawPass = RenderPass::Translucent;
+
+    stats.drawablesRemoved += tileLayerGroup->removeDrawablesIf([&](gfx::Drawable& drawable) {
+        // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
+        const auto& tileID = drawable.getTileID();
+        if (drawable.getRenderPass() != passes || (tileID && !hasRenderTile(*tileID))) {
+            return true;
+        }
+        return false;
+    });
+
+    const auto zoom = static_cast<float>(state.getZoom());
+    const auto layerPrefix = getID() + "/";
+    const auto hasPattern = !unevaluated.get<FillExtrusionPattern>().isUndefined();
+    const auto opaque = evaluated.get<FillExtrusionOpacity>() >= 1;
+
+    std::unique_ptr<gfx::DrawableBuilder> depthBuilder;
+    std::unique_ptr<gfx::DrawableBuilder> colorBuilder;
+
+    const auto& shaderGroup = hasPattern ? fillExtrusionPatternGroup : fillExtrusionGroup;
+    if (!shaderGroup) {
+        removeAllDrawables();
+        return;
+    }
+
+    for (const RenderTile& tile : *renderTiles) {
+        const auto& tileID = tile.getOverscaledTileID();
+
+        const auto* optRenderData = getRenderDataForPass(tile, passes);
+        if (!optRenderData || !optRenderData->bucket || !optRenderData->bucket->hasData()) {
+            removeTile(drawPass, tileID);
+            continue;
+        }
+
+        const auto& renderData = *optRenderData;
+        const auto& bucket = static_cast<const FillExtrusionBucket&>(*renderData.bucket);
+
+        const auto prevBucketID = getRenderTileBucketID(tileID);
+        if (prevBucketID != util::SimpleIdentity::Empty && prevBucketID != bucket.getID()) {
+            // This tile was previously set up from a different bucket, drop and re-create any drawables for it.
+            removeTile(passes, tileID);
+        }
+        setRenderTileBucketID(tileID, bucket.getID());
+
+        gfx::DrawableTweakerPtr tweaker;
+        if (depthBuilder) {
+            depthBuilder->clearTweakers();
+        }
+        if (colorBuilder) {
+            colorBuilder->clearTweakers();
+        }
+
+        const auto vertexCount = bucket.vertices.elements();
+        const auto defPattern = mbgl::Faded<expression::Image>{"", ""};
+        const auto fillPatternValue = evaluated.get<FillExtrusionPattern>().constantOr(defPattern);
+        const auto patternPosA = tile.getPattern(fillPatternValue.from.id());
+        const auto patternPosB = tile.getPattern(fillPatternValue.to.id());
+
+        const auto& binders = bucket.paintPropertyBinders.at(getID());
+        if (hasPattern) {
+            binders.setPatternParameters(patternPosA, patternPosB, crossfade);
+        }
+
+        const FillExtrusionInterpolateUBO interpUBO = {
+            /* .base_t = */ std::get<0>(binders.get<FillExtrusionBase>()->interpolationFactor(zoom)),
+            /* .height_t = */ std::get<0>(binders.get<FillExtrusionHeight>()->interpolationFactor(zoom)),
+            /* .color_t = */ std::get<0>(binders.get<FillExtrusionColor>()->interpolationFactor(zoom)),
+            /* .pattern_from_t = */ std::get<0>(binders.get<FillExtrusionPattern>()->interpolationFactor(zoom)),
+            /* .pattern_to_t = */ std::get<0>(binders.get<FillExtrusionPattern>()->interpolationFactor(zoom)),
+            /* .pad = */ 0,
+            0,
+            0};
+
+        const FillExtrusionDrawableTilePropsUBO tilePropsUBO = {
+            /* pattern_from = */ patternPosA ? util::cast<float>(patternPosA->tlbr()) : std::array<float, 4>{0},
+            /* pattern_to = */ patternPosB ? util::cast<float>(patternPosB->tlbr()) : std::array<float, 4>{0},
+        };
+
+        // If we already have drawables for this tile, update them.
+        if (tileLayerGroup->getDrawableCount(drawPass, tileID) > 0) {
+            // Just update the drawables we already created
+            tileLayerGroup->visitDrawables(drawPass, tileID, [&](gfx::Drawable& drawable) {
+                auto& uniforms = drawable.mutableUniformBuffers();
+                uniforms.createOrUpdate(
+                    FillExtrusionLayerTweaker::FillExtrusionTilePropsUBOName, &tilePropsUBO, context);
+                uniforms.createOrUpdate(
+                    FillExtrusionLayerTweaker::FillExtrusionInterpolateUBOName, &interpUBO, context);
+            });
+            continue;
+        }
+
+        gfx::VertexAttributeArray vertexAttrs;
+        const auto uniformProps = vertexAttrs.readDataDrivenPaintProperties<FillExtrusionBase,
+                                                                            FillExtrusionColor,
+                                                                            FillExtrusionHeight,
+                                                                            FillExtrusionPattern>(binders, evaluated);
+
+        const auto shader = std::static_pointer_cast<gfx::ShaderProgramBase>(
+            shaderGroup->getOrCreateShader(context, uniformProps));
+        if (!shader) {
+            assert(false);
+            continue;
+        }
+
+        // The non-pattern path in `render()` only uses two-pass rendering if there's translucency.
+        // The pattern path always uses two passes.
+        const auto doDepthPass = (!opaque || hasPattern);
+
+        if (doDepthPass && !depthBuilder) {
+            if (auto builder = context.createDrawableBuilder(layerPrefix + "depth")) {
+                builder->setShader(shader);
+                builder->setIs3D(true);
+                builder->setEnableStencil(false);
+                builder->setEnableColor(false);
+                builder->setRenderPass(drawPass);
+                builder->setCullFaceMode(gfx::CullFaceMode::backCCW());
+                if (tweaker) {
+                    builder->addTweaker(tweaker);
+                }
+                depthBuilder = std::move(builder);
+            }
+        }
+        if (!colorBuilder) {
+            if (auto builder = context.createDrawableBuilder(layerPrefix + "color")) {
+                builder->setShader(shader);
+                builder->setIs3D(true);
+                builder->setEnableColor(true);
+                builder->setColorMode(gfx::ColorMode::alphaBlended());
+                builder->setRenderPass(drawPass);
+                builder->setCullFaceMode(gfx::CullFaceMode::backCCW());
+                if (tweaker) {
+                    builder->addTweaker(tweaker);
+                }
+                colorBuilder = std::move(builder);
+            }
+        }
+
+        if (hasPattern && !tweaker) {
+            if (const auto& atlases = tile.getAtlasTextures()) {
+                tweaker = std::make_shared<gfx::DrawableAtlasesTweaker>(atlases,
+                                                                        std::string(),
+                                                                        std::string(IconTextureName),
+                                                                        /*isText=*/false);
+                if (depthBuilder) {
+                    depthBuilder->addTweaker(tweaker);
+                }
+                if (colorBuilder) {
+                    colorBuilder->addTweaker(tweaker);
+                }
+            }
+        }
+
+        if (const auto& attr = vertexAttrs.getOrAdd(PosAttribName)) {
+            attr->setSharedRawData(bucket.sharedVertices,
+                                   offsetof(FillExtrusionLayoutVertex, a1),
+                                   /*vertexOffset=*/0,
+                                   sizeof(FillExtrusionLayoutVertex),
+                                   gfx::AttributeDataType::Short2);
+        }
+        if (const auto& attr = vertexAttrs.getOrAdd(NormAttribName)) {
+            attr->setSharedRawData(bucket.sharedVertices,
+                                   offsetof(FillExtrusionLayoutVertex, a2),
+                                   /*vertexOffset=*/0,
+                                   sizeof(FillExtrusionLayoutVertex),
+                                   gfx::AttributeDataType::Short4);
+        }
+
+        colorBuilder->setEnableStencil(doDepthPass);
+        if (doDepthPass) {
+            depthBuilder->setRawVertices({}, vertexCount, gfx::AttributeDataType::Short2);
+        }
+        colorBuilder->setRawVertices({}, vertexCount, gfx::AttributeDataType::Short2);
+
+        if (doDepthPass) {
+            auto copy = vertexAttrs.clone();
+            depthBuilder->setVertexAttributes(std::move(*copy));
+        }
+        colorBuilder->setVertexAttributes(std::move(vertexAttrs));
+
+        const auto finish = [&](gfx::DrawableBuilder& builder) {
+            builder.setSegments(gfx::Triangles(),
+                                bucket.sharedTriangles,
+                                bucket.triangleSegments.data(),
+                                bucket.triangleSegments.size());
+
+            builder.flush();
+
+            for (auto& drawable : builder.clearDrawables()) {
+                drawable->setTileID(tileID);
+
+                auto& uniforms = drawable->mutableUniformBuffers();
+                uniforms.createOrUpdate(
+                    FillExtrusionLayerTweaker::FillExtrusionTilePropsUBOName, &tilePropsUBO, context);
+                uniforms.createOrUpdate(
+                    FillExtrusionLayerTweaker::FillExtrusionInterpolateUBOName, &interpUBO, context);
+
+                tileLayerGroup->addDrawable(drawPass, tileID, std::move(drawable));
+                ++stats.drawablesAdded;
+            }
+        };
+
+        if (doDepthPass) {
+            finish(*depthBuilder);
+        }
+        finish(*colorBuilder);
+    }
+}
+
+#endif // MLN_DRAWABLE_RENDERER
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
@@ -7,8 +7,10 @@
 
 namespace mbgl {
 
+#if MLN_LEGACY_RENDERER
 class FillExtrusionProgram;
 class FillExtrusionPatternProgram;
+#endif // MLN_LEGACY_RENDERER
 
 class RenderFillExtrusionLayer final : public RenderLayer {
 public:
@@ -21,7 +23,19 @@ private:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     bool is3D() const override;
+
+#if MLN_LEGACY_RENDERER
     void render(PaintParameters&) override;
+#endif
+
+#if MLN_DRAWABLE_RENDERER
+    /// Generate any changes needed by the layer
+    void update(gfx::ShaderRegistry&,
+                gfx::Context&,
+                const TransformState&,
+                const RenderTree&,
+                UniqueChangeRequestVec&) override;
+#endif // MLN_DRAWABLE_RENDERER
 
     bool queryIntersectsFeature(const GeometryCoordinates&,
                                 const GeometryTileFeature&,
@@ -34,9 +48,16 @@ private:
     // Paint properties
     style::FillExtrusionPaintProperties::Unevaluated unevaluated;
 
+#if MLN_LEGACY_RENDERER
     // Programs
     std::shared_ptr<FillExtrusionProgram> fillExtrusionProgram;
     std::shared_ptr<FillExtrusionPatternProgram> fillExtrusionPatternProgram;
+#endif
+
+#if MLN_DRAWABLE_RENDERER
+    gfx::ShaderGroupPtr fillExtrusionGroup;
+    gfx::ShaderGroupPtr fillExtrusionPatternGroup;
+#endif // MLN_DRAWABLE_RENDERER
 
     std::unique_ptr<gfx::OffscreenTexture> renderTexture;
 };

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -11,18 +11,40 @@
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/renderer/render_source.hpp>
 #include <mbgl/renderer/render_tile.hpp>
+#include <mbgl/renderer/tile_render_data.hpp>
 #include <mbgl/style/expression/image.hpp>
 #include <mbgl/style/layers/fill_layer_impl.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
 #include <mbgl/tile/tile.hpp>
+#include <mbgl/util/convert.hpp>
 #include <mbgl/util/intersection_tests.hpp>
+#include <mbgl/util/logging.hpp>
 #include <mbgl/util/math.hpp>
+#include <mbgl/util/std.hpp>
+
+#if MLN_DRAWABLE_RENDERER
+#include <mbgl/gfx/drawable_atlases_tweaker.hpp>
+#include <mbgl/gfx/drawable_builder.hpp>
+#include <mbgl/renderer/layers/fill_layer_tweaker.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#endif
 
 namespace mbgl {
 
 using namespace style;
 
 namespace {
+
+#if MLN_DRAWABLE_RENDERER
+constexpr auto FillShaderName = "FillShader";
+constexpr auto FillOutlineShaderName = "FillOutlineShader";
+constexpr auto FillPatternShaderName = "FillPatternShader";
+constexpr auto FillOutlinePatternShaderName = "FillOutlinePatternShader";
+
+constexpr auto PosAttribName = "a_pos";
+constexpr auto IconTextureName = "u_image";
+#endif // MLN_DRAWABLE_RENDERER
 
 inline const FillLayer::Impl& impl_cast(const Immutable<style::Layer::Impl>& impl) {
     assert(impl->getTypeInfo() == FillLayer::Impl::staticTypeInfo());
@@ -36,6 +58,13 @@ RenderFillLayer::RenderFillLayer(Immutable<style::FillLayer::Impl> _impl)
       unevaluated(impl_cast(baseImpl).paint.untransitioned()) {}
 
 RenderFillLayer::~RenderFillLayer() = default;
+
+void RenderFillLayer::prepare(const LayerPrepareParameters& params) {
+    RenderLayer::prepare(params);
+#if MLN_DRAWABLE_RENDERER
+    updateRenderTileIDs();
+#endif // MLN_DRAWABLE_RENDERER
+}
 
 void RenderFillLayer::transition(const TransitionParameters& parameters) {
     unevaluated = impl_cast(baseImpl).paint.transitioned(parameters, std::move(unevaluated));
@@ -61,6 +90,12 @@ void RenderFillLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     }
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
+
+#if MLN_DRAWABLE_RENDERER
+    if (layerGroup) {
+        layerGroup->setLayerTweaker(std::make_shared<FillLayerTweaker>(evaluatedProperties));
+    }
+#endif
 }
 
 bool RenderFillLayer::hasTransition() const {
@@ -71,13 +106,14 @@ bool RenderFillLayer::hasCrossfade() const {
     return getCrossfade<FillLayerProperties>(evaluatedProperties).t != 1;
 }
 
+#if MLN_LEGACY_RENDERER
 void RenderFillLayer::render(PaintParameters& parameters) {
     assert(renderTiles);
 
-    if (!parameters.shaders.populate(fillProgram)) return;
-    if (!parameters.shaders.populate(fillPatternProgram)) return;
-    if (!parameters.shaders.populate(fillOutlineProgram)) return;
-    if (!parameters.shaders.populate(fillOutlinePatternProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(fillProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(fillPatternProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(fillOutlineProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(fillOutlinePatternProgram)) return;
 
     if (unevaluated.get<FillPattern>().isUndefined()) {
         parameters.renderTileClippingMasks(renderTiles);
@@ -187,7 +223,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
                         tile.translatedMatrix(
                             evaluated.get<FillTranslate>(), evaluated.get<FillTranslateAnchor>(), parameters.state),
                         parameters.backend.getDefaultRenderable().getSize(),
-                        tile.getIconAtlasTexture().size,
+                        tile.getIconAtlasTexture()->getSize(),
                         crossfade,
                         tile.id,
                         parameters.state,
@@ -222,8 +258,7 @@ void RenderFillLayer::render(PaintParameters& parameters) {
                      *bucket.triangleIndexBuffer,
                      bucket.triangleSegments,
                      FillPatternProgram::TextureBindings{
-                         textures::image::Value{tile.getIconAtlasTexture().getResource(),
-                                                gfx::TextureFilterType::Linear},
+                         tile.getIconAtlasTextureBinding(gfx::TextureFilterType::Linear),
                      });
             }
             if (evaluated.get<FillAntialias>() && unevaluated.get<FillOutlineColor>().isUndefined()) {
@@ -233,13 +268,13 @@ void RenderFillLayer::render(PaintParameters& parameters) {
                      *bucket.lineIndexBuffer,
                      bucket.lineSegments,
                      FillOutlinePatternProgram::TextureBindings{
-                         textures::image::Value{tile.getIconAtlasTexture().getResource(),
-                                                gfx::TextureFilterType::Linear},
+                         tile.getIconAtlasTextureBinding(gfx::TextureFilterType::Linear),
                      });
             }
         }
     }
 }
+#endif // MLN_LEGACY_RENDERER
 
 bool RenderFillLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeometry,
                                              const GeometryTileFeature& feature,
@@ -258,5 +293,301 @@ bool RenderFillLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeo
     return util::polygonIntersectsMultiPolygon(translatedQueryGeometry.value_or(queryGeometry),
                                                feature.getGeometries());
 }
+
+#if MLN_DRAWABLE_RENDERER
+void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
+                             gfx::Context& context,
+                             const TransformState& state,
+                             [[maybe_unused]] const RenderTree& renderTree,
+                             [[maybe_unused]] UniqueChangeRequestVec& changes) {
+    std::unique_lock<std::mutex> guard(mutex);
+
+    if (!renderTiles || renderTiles->empty()) {
+        removeAllDrawables();
+        return;
+    }
+
+    // Set up a layer group
+    if (!layerGroup) {
+        if (auto layerGroup_ = context.createTileLayerGroup(layerIndex, /*initialCapacity=*/64, getID())) {
+            layerGroup_->setLayerTweaker(std::make_shared<FillLayerTweaker>(evaluatedProperties));
+            setLayerGroup(std::move(layerGroup_), changes);
+        }
+    }
+    auto* tileLayerGroup = static_cast<TileLayerGroup*>(layerGroup.get());
+
+    if (!fillShaderGroup) {
+        fillShaderGroup = shaders.getShaderGroup(std::string(FillShaderName));
+    }
+    if (!outlineShaderGroup) {
+        outlineShaderGroup = shaders.getShaderGroup(std::string(FillOutlineShaderName));
+    }
+    if (!patternShaderGroup) {
+        patternShaderGroup = shaders.getShaderGroup(std::string(FillPatternShaderName));
+    }
+    if (!outlinePatternShaderGroup) {
+        outlinePatternShaderGroup = shaders.getShaderGroup(std::string(FillOutlinePatternShaderName));
+    }
+    if (!fillShaderGroup || !outlineShaderGroup || !patternShaderGroup || !outlinePatternShaderGroup) {
+        removeAllDrawables();
+        return;
+    }
+
+    std::unique_ptr<gfx::DrawableBuilder> fillBuilder;
+    std::unique_ptr<gfx::DrawableBuilder> outlineBuilder;
+    std::unique_ptr<gfx::DrawableBuilder> patternBuilder;
+    std::unique_ptr<gfx::DrawableBuilder> outlinePatternBuilder;
+
+    const auto layerPrefix = getID() + "/";
+    const auto renderPass = static_cast<RenderPass>(evaluatedProperties->renderPasses);
+
+    const auto finish = [&](gfx::DrawableBuilder& builder,
+                            const OverscaledTileID& tileID,
+                            const FillInterpolateUBO& interpUBO,
+                            const FillDrawableTilePropsUBO& tileUBO) {
+        builder.flush();
+
+        for (auto& drawable : builder.clearDrawables()) {
+            drawable->setTileID(tileID);
+            auto& uniforms = drawable->mutableUniformBuffers();
+            uniforms.createOrUpdate(FillLayerTweaker::FillInterpolateUBOName, &interpUBO, context);
+            uniforms.createOrUpdate(FillLayerTweaker::FillTilePropsUBOName, &tileUBO, context);
+            tileLayerGroup->addDrawable(renderPass, tileID, std::move(drawable));
+            ++stats.drawablesAdded;
+        }
+    };
+
+    const auto commonInit = [&](gfx::DrawableBuilder& builder) {
+        builder.setCullFaceMode(gfx::CullFaceMode::disabled());
+        builder.setEnableStencil(true);
+    };
+
+    stats.drawablesRemoved += tileLayerGroup->removeDrawablesIf([&](gfx::Drawable& drawable) {
+        // If the render pass has changed or the tile has dropped out of the cover set, remove it.
+        const auto& tileID = drawable.getTileID();
+        if (drawable.getRenderPass() != passes || (tileID && !hasRenderTile(*tileID))) {
+            return true;
+        }
+        return false;
+    });
+
+    for (const RenderTile& tile : *renderTiles) {
+        const auto& tileID = tile.getOverscaledTileID();
+
+        const LayerRenderData* renderData = getRenderDataForPass(tile, renderPass);
+        if (!renderData || !renderData->bucket || !renderData->bucket->hasData()) {
+            removeTile(renderPass, tileID);
+            continue;
+        }
+
+        auto& bucket = static_cast<FillBucket&>(*renderData->bucket);
+        const auto& binders = bucket.paintPropertyBinders.at(getID());
+
+        const auto prevBucketID = getRenderTileBucketID(tileID);
+        if (prevBucketID != util::SimpleIdentity::Empty && prevBucketID != bucket.getID()) {
+            // This tile was previously set up from a different bucket, drop and re-create any drawables for it.
+            removeTile(renderPass, tileID);
+        }
+        setRenderTileBucketID(tileID, bucket.getID());
+
+        const auto& evaluated = getEvaluated<FillLayerProperties>(renderData->layerProperties);
+        const auto& crossfade = getCrossfade<FillLayerProperties>(renderData->layerProperties);
+
+        const auto& fillPatternValue = evaluated.get<FillPattern>().constantOr(Faded<expression::Image>{"", ""});
+        const auto patternPosA = tile.getPattern(fillPatternValue.from.id());
+        const auto patternPosB = tile.getPattern(fillPatternValue.to.id());
+        binders.setPatternParameters(patternPosA, patternPosB, crossfade);
+
+        const auto zoom = static_cast<float>(state.getZoom());
+        const FillInterpolateUBO interpolateUBO = {
+            /* .color_t = */ std::get<0>(binders.get<FillColor>()->interpolationFactor(zoom)),
+            /* .opacity_t = */ std::get<0>(binders.get<FillOpacity>()->interpolationFactor(zoom)),
+            /* .outline_color_t = */ std::get<0>(binders.get<FillOutlineColor>()->interpolationFactor(zoom)),
+            /* .pattern_from_t = */ std::get<0>(binders.get<FillPattern>()->interpolationFactor(zoom)),
+            /* .pattern_to_t = */ std::get<0>(binders.get<FillPattern>()->interpolationFactor(zoom)),
+            /* .fade = */ crossfade.t,
+            /* .padding = */ 0,
+            0};
+
+        const FillDrawableTilePropsUBO tileProps = {
+            /* pattern_from = */ patternPosA ? util::cast<float>(patternPosA->tlbr()) : std::array<float, 4>{0},
+            /* pattern_to = */ patternPosB ? util::cast<float>(patternPosB->tlbr()) : std::array<float, 4>{0},
+        };
+
+        // `Fill*Program` all use `style::FillPaintProperties`
+        gfx::VertexAttributeArray vertexAttrs;
+        const auto uniformProps =
+            vertexAttrs.readDataDrivenPaintProperties<FillColor, FillOpacity, FillOutlineColor, FillPattern>(binders,
+                                                                                                             evaluated);
+
+        const auto vertexCount = bucket.vertices.elements();
+        if (const auto& attr = vertexAttrs.add(PosAttribName)) {
+            attr->setSharedRawData(bucket.sharedVertices,
+                                   offsetof(FillLayoutVertex, a1),
+                                   /*vertexOffset=*/0,
+                                   sizeof(FillLayoutVertex),
+                                   gfx::AttributeDataType::Short2);
+        }
+
+        // If we already have drawables for this tile, update them.
+        auto updateExisting = [&](gfx::Drawable& drawable) {
+            auto& uniforms = drawable.mutableUniformBuffers();
+            uniforms.createOrUpdate(FillLayerTweaker::FillInterpolateUBOName, &interpolateUBO, context);
+            uniforms.createOrUpdate(FillLayerTweaker::FillTilePropsUBOName, &tileProps, context);
+            drawable.setVertexAttributes(vertexAttrs);
+        };
+        if (0 < tileLayerGroup->visitDrawables(renderPass, tileID, std::move(updateExisting))) {
+            continue;
+        }
+
+        // Share UBO buffers among any drawables created for this tile
+        const auto interpBuffer = context.createUniformBuffer(&interpolateUBO, sizeof(interpolateUBO));
+        const auto tilePropsBuffer = context.createUniformBuffer(&tileProps, sizeof(tileProps));
+
+        if (unevaluated.get<FillPattern>().isUndefined()) {
+            // Fill will occur in opaque or translucent pass based on `opaquePassCutoff`.
+            // Outline always occurs in translucent pass, defaults to fill color
+            const auto doOutline = evaluated.get<FillAntialias>();
+
+            const auto fillShader = std::static_pointer_cast<gfx::ShaderProgramBase>(
+                fillShaderGroup->getOrCreateShader(context, uniformProps));
+            const auto outlineShader = doOutline ? std::static_pointer_cast<gfx::ShaderProgramBase>(
+                                                       outlineShaderGroup->getOrCreateShader(context, uniformProps))
+                                                 : nullptr;
+
+            if (!fillBuilder && fillShader) {
+                if (auto builder = context.createDrawableBuilder(layerPrefix + "fill")) {
+                    commonInit(*builder);
+                    builder->setDepthType((renderPass == RenderPass::Opaque) ? gfx::DepthMaskType::ReadWrite
+                                                                             : gfx::DepthMaskType::ReadOnly);
+                    builder->setColorMode(renderPass == RenderPass::Translucent ? gfx::ColorMode::alphaBlended()
+                                                                                : gfx::ColorMode::unblended());
+                    builder->setSubLayerIndex(0);
+                    builder->setRenderPass(renderPass);
+                    fillBuilder = std::move(builder);
+                }
+            }
+            if (doOutline && !outlineBuilder && outlineShader) {
+                if (auto builder = context.createDrawableBuilder(layerPrefix + "fill-outline")) {
+                    commonInit(*builder);
+                    builder->setLineWidth(2.0f);
+                    builder->setDepthType(gfx::DepthMaskType::ReadOnly);
+                    builder->setColorMode(gfx::ColorMode::alphaBlended());
+                    builder->setSubLayerIndex(unevaluated.get<FillOutlineColor>().isUndefined() ? 2 : 0);
+                    builder->setRenderPass(RenderPass::Translucent);
+                    outlineBuilder = std::move(builder);
+                }
+            }
+
+            if (fillBuilder) {
+                fillBuilder->setShader(fillShader);
+                if (outlineBuilder) {
+                    fillBuilder->setVertexAttributes(vertexAttrs);
+                } else {
+                    fillBuilder->setVertexAttributes(std::move(vertexAttrs));
+                }
+                fillBuilder->setRawVertices({}, vertexCount, gfx::AttributeDataType::Short2);
+                fillBuilder->setSegments(gfx::Triangles(),
+                                         bucket.sharedTriangles,
+                                         bucket.triangleSegments.data(),
+                                         bucket.triangleSegments.size());
+                finish(*fillBuilder, tileID, interpolateUBO, tileProps);
+            }
+            if (outlineBuilder) {
+                outlineBuilder->setShader(outlineShader);
+                outlineBuilder->setVertexAttributes(std::move(vertexAttrs));
+                outlineBuilder->setRawVertices({}, vertexCount, gfx::AttributeDataType::Short2);
+                outlineBuilder->setSegments(
+                    gfx::Lines(2), bucket.sharedLines, bucket.lineSegments.data(), bucket.lineSegments.size());
+                finish(*outlineBuilder, tileID, interpolateUBO, tileProps);
+            }
+        } else { // FillPattern is defined
+            if ((renderPass & RenderPass::Translucent) == 0) {
+                continue;
+            }
+
+            // Outline does not default to fill in the pattern case
+            const auto doOutline = evaluated.get<FillAntialias>() && unevaluated.get<FillOutlineColor>().isUndefined();
+
+            const auto fillShader = std::static_pointer_cast<gfx::ShaderProgramBase>(
+                patternShaderGroup->getOrCreateShader(context, uniformProps));
+            const auto outlineShader = doOutline
+                                           ? std::static_pointer_cast<gfx::ShaderProgramBase>(
+                                                 outlinePatternShaderGroup->getOrCreateShader(context, uniformProps))
+                                           : nullptr;
+
+            if (!patternBuilder) {
+                if (auto builder = context.createDrawableBuilder(layerPrefix + "fill-pattern")) {
+                    commonInit(*builder);
+                    builder->setDepthType(gfx::DepthMaskType::ReadWrite);
+                    builder->setColorMode(gfx::ColorMode::alphaBlended());
+                    builder->setSubLayerIndex(1);
+                    builder->setRenderPass(RenderPass::Translucent);
+                    patternBuilder = std::move(builder);
+                }
+            }
+            if (doOutline && !outlinePatternBuilder) {
+                if (auto builder = context.createDrawableBuilder(layerPrefix + "fill-outline-pattern")) {
+                    commonInit(*builder);
+                    builder->setLineWidth(2.0f);
+                    builder->setDepthType(gfx::DepthMaskType::ReadOnly);
+                    builder->setColorMode(gfx::ColorMode::alphaBlended());
+                    builder->setSubLayerIndex(2);
+                    builder->setRenderPass(RenderPass::Translucent);
+                    outlinePatternBuilder = std::move(builder);
+                }
+            }
+
+            if (patternBuilder) {
+                patternBuilder->clearTweakers();
+            }
+            if (outlinePatternBuilder) {
+                outlinePatternBuilder->clearTweakers();
+            }
+            if (patternBuilder || outlinePatternBuilder) {
+                if (const auto& atlases = tile.getAtlasTextures()) {
+                    auto tweaker = std::make_shared<gfx::DrawableAtlasesTweaker>(atlases,
+                                                                                 /*glyphName=*/std::string(),
+                                                                                 std::string(IconTextureName),
+                                                                                 /*isText=*/false);
+                    if (patternBuilder) {
+                        patternBuilder->addTweaker(tweaker);
+                    }
+                    if (outlinePatternBuilder) {
+                        outlinePatternBuilder->addTweaker(std::move(tweaker));
+                    }
+                }
+            }
+
+            if (patternBuilder) {
+                patternBuilder->setShader(fillShader);
+                patternBuilder->setRenderPass(renderPass);
+                if (outlinePatternBuilder) {
+                    patternBuilder->setVertexAttributes(vertexAttrs);
+                } else {
+                    patternBuilder->setVertexAttributes(std::move(vertexAttrs));
+                }
+                patternBuilder->setRawVertices({}, vertexCount, gfx::AttributeDataType::Short2);
+                patternBuilder->setSegments(gfx::Triangles(),
+                                            bucket.sharedTriangles,
+                                            bucket.triangleSegments.data(),
+                                            bucket.triangleSegments.size());
+
+                finish(*patternBuilder, tileID, interpolateUBO, tileProps);
+            }
+            if (outlinePatternBuilder) {
+                outlinePatternBuilder->setShader(outlineShader);
+                outlinePatternBuilder->setRenderPass(renderPass);
+                outlinePatternBuilder->setVertexAttributes(std::move(vertexAttrs));
+                outlinePatternBuilder->setRawVertices({}, vertexCount, gfx::AttributeDataType::Short2);
+                outlinePatternBuilder->setSegments(
+                    gfx::Lines(2), bucket.sharedLines, bucket.lineSegments.data(), bucket.lineSegments.size());
+
+                finish(*outlinePatternBuilder, tileID, interpolateUBO, tileProps);
+            }
+        }
+    }
+}
+#endif
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -5,6 +5,8 @@
 #include <mbgl/style/layers/fill_layer_properties.hpp>
 #include <mbgl/layout/pattern_layout.hpp>
 
+#include <memory>
+
 namespace mbgl {
 
 class FillBucket;
@@ -18,12 +20,25 @@ public:
     explicit RenderFillLayer(Immutable<style::FillLayer::Impl>);
     ~RenderFillLayer() override;
 
+#if MLN_DRAWABLE_RENDERER
+    /// Generate any changes needed by the layer
+    void update(gfx::ShaderRegistry&,
+                gfx::Context&,
+                const TransformState&,
+                const RenderTree&,
+                UniqueChangeRequestVec&) override;
+#endif
+
 private:
+    void prepare(const LayerPrepareParameters&) override;
     void transition(const TransitionParameters&) override;
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
+
+#if MLN_LEGACY_RENDERER
     void render(PaintParameters&) override;
+#endif
 
     bool queryIntersectsFeature(const GeometryCoordinates&,
                                 const GeometryTileFeature&,
@@ -36,11 +51,19 @@ private:
     // Paint properties
     style::FillPaintProperties::Unevaluated unevaluated;
 
+#if MLN_LEGACY_RENDERER
     // Programs
     std::shared_ptr<FillProgram> fillProgram;
     std::shared_ptr<FillPatternProgram> fillPatternProgram;
     std::shared_ptr<FillOutlineProgram> fillOutlineProgram;
     std::shared_ptr<FillOutlinePatternProgram> fillOutlinePatternProgram;
+#endif
+#if MLN_DRAWABLE_RENDERER
+    gfx::ShaderGroupPtr fillShaderGroup;
+    gfx::ShaderGroupPtr outlineShaderGroup;
+    gfx::ShaderGroupPtr patternShaderGroup;
+    gfx::ShaderGroupPtr outlinePatternShaderGroup;
+#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -207,7 +207,7 @@ void RenderHeatmapLayer::updateColorRamp() {
         if (colorValue.isUndefined()) {
             colorValue = HeatmapLayer::getDefaultHeatmapColor();
         }
-        
+
         if (applyColorRamp(colorValue, *colorRamp)) {
             colorRampTexture = std::nullopt;
         }

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -202,23 +202,15 @@ void RenderHeatmapLayer::render(PaintParameters& parameters) {
 #endif // MLN_LEGACY_RENDERER
 
 void RenderHeatmapLayer::updateColorRamp() {
-    auto colorValue = unevaluated.get<HeatmapColor>().getValue();
-    if (colorValue.isUndefined()) {
-        colorValue = HeatmapLayer::getDefaultHeatmapColor();
-    }
-
-    const auto length = (*colorRamp).bytes();
-
-    for (uint32_t i = 0; i < length; i += 4) {
-        const auto color = colorValue.evaluate(static_cast<double>(i) / length);
-        (*colorRamp).data[i + 0] = static_cast<uint8_t>(std::floor(color.r * 255.f));
-        (*colorRamp).data[i + 1] = static_cast<uint8_t>(std::floor(color.g * 255.f));
-        (*colorRamp).data[i + 2] = static_cast<uint8_t>(std::floor(color.b * 255.f));
-        (*colorRamp).data[i + 3] = static_cast<uint8_t>(std::floor(color.a * 255.f));
-    }
-
-    if (colorRampTexture) {
-        colorRampTexture = std::nullopt;
+    if (colorRamp) {
+        auto colorValue = unevaluated.get<HeatmapColor>().getValue();
+        if (colorValue.isUndefined()) {
+            colorValue = HeatmapLayer::getDefaultHeatmapColor();
+        }
+        
+        if (applyColorRamp(colorValue, *colorRamp)) {
+            colorRampTexture = std::nullopt;
+        }
     }
 }
 

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -5,14 +5,24 @@
 #include <mbgl/renderer/render_static_data.hpp>
 #include <mbgl/programs/programs.hpp>
 #include <mbgl/tile/tile.hpp>
-#include <mbgl/style/layers/heatmap_layer.hpp>
 #include <mbgl/style/layers/heatmap_layer_impl.hpp>
 #include <mbgl/geometry/feature_index.hpp>
+#include <mbgl/gfx/context.hpp>
 #include <mbgl/gfx/cull_face_mode.hpp>
 #include <mbgl/gfx/render_pass.hpp>
-#include <mbgl/gfx/context.hpp>
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/intersection_tests.hpp>
+
+#if MLN_DRAWABLE_RENDERER
+#include <mbgl/renderer/layers/heatmap_layer_tweaker.hpp>
+#include <mbgl/renderer/layers/heatmap_texture_layer_tweaker.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/render_target.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#include <mbgl/gfx/drawable_builder.hpp>
+#include <mbgl/gfx/shader_group.hpp>
+#include <mbgl/gfx/shader_registry.hpp>
+#endif
 
 namespace mbgl {
 
@@ -29,10 +39,18 @@ inline const HeatmapLayer::Impl& impl_cast(const Immutable<Layer::Impl>& impl) {
 
 RenderHeatmapLayer::RenderHeatmapLayer(Immutable<HeatmapLayer::Impl> _impl)
     : RenderLayer(makeMutable<HeatmapLayerProperties>(std::move(_impl))),
-      unevaluated(impl_cast(baseImpl).paint.untransitioned()),
-      colorRamp({256, 1}) {}
+      unevaluated(impl_cast(baseImpl).paint.untransitioned()) {
+    colorRamp = std::make_shared<PremultipliedImage>(Size(256, 1));
+}
 
 RenderHeatmapLayer::~RenderHeatmapLayer() = default;
+
+void RenderHeatmapLayer::prepare(const LayerPrepareParameters& parameters) {
+    RenderLayer::prepare(parameters);
+#if MLN_DRAWABLE_RENDERER
+    updateRenderTileIDs();
+#endif // MLN_DRAWABLE_RENDERER
+}
 
 void RenderHeatmapLayer::transition(const TransitionParameters& parameters) {
     unevaluated = impl_cast(baseImpl).paint.transitioned(parameters, std::move(unevaluated));
@@ -47,6 +65,15 @@ void RenderHeatmapLayer::evaluate(const PropertyEvaluationParameters& parameters
                                                                       : RenderPass::None;
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
+
+#if MLN_DRAWABLE_RENDERER
+    if (renderTarget) {
+        renderTarget->getLayerGroup(0)->setLayerTweaker(std::make_shared<HeatmapLayerTweaker>(evaluatedProperties));
+    }
+    if (layerGroup) {
+        layerGroup->setLayerTweaker(std::make_shared<HeatmapTextureLayerTweaker>(evaluatedProperties));
+    }
+#endif
 }
 
 bool RenderHeatmapLayer::hasTransition() const {
@@ -59,18 +86,19 @@ bool RenderHeatmapLayer::hasCrossfade() const {
 
 void RenderHeatmapLayer::upload(gfx::UploadPass& uploadPass) {
     if (!colorRampTexture) {
-        colorRampTexture = uploadPass.createTexture(colorRamp, gfx::TextureChannelDataType::UnsignedByte);
+        colorRampTexture = uploadPass.createTexture(*colorRamp, gfx::TextureChannelDataType::UnsignedByte);
     }
 }
 
+#if MLN_LEGACY_RENDERER
 void RenderHeatmapLayer::render(PaintParameters& parameters) {
     assert(renderTiles);
     if (parameters.pass == RenderPass::Opaque) {
         return;
     }
 
-    if (!parameters.shaders.populate(heatmapProgram)) return;
-    if (!parameters.shaders.populate(heatmapTextureProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(heatmapProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(heatmapTextureProgram)) return;
 
     if (parameters.pass == RenderPass::Pass3D) {
         const auto& viewportSize = parameters.staticData.backendSize;
@@ -171,6 +199,7 @@ void RenderHeatmapLayer::render(PaintParameters& parameters) {
             getID());
     }
 }
+#endif // MLN_LEGACY_RENDERER
 
 void RenderHeatmapLayer::updateColorRamp() {
     auto colorValue = unevaluated.get<HeatmapColor>().getValue();
@@ -178,14 +207,14 @@ void RenderHeatmapLayer::updateColorRamp() {
         colorValue = HeatmapLayer::getDefaultHeatmapColor();
     }
 
-    const auto length = colorRamp.bytes();
+    const auto length = (*colorRamp).bytes();
 
     for (uint32_t i = 0; i < length; i += 4) {
         const auto color = colorValue.evaluate(static_cast<double>(i) / length);
-        colorRamp.data[i + 0] = static_cast<uint8_t>(std::floor(color.r * 255.f));
-        colorRamp.data[i + 1] = static_cast<uint8_t>(std::floor(color.g * 255.f));
-        colorRamp.data[i + 2] = static_cast<uint8_t>(std::floor(color.b * 255.f));
-        colorRamp.data[i + 3] = static_cast<uint8_t>(std::floor(color.a * 255.f));
+        (*colorRamp).data[i + 0] = static_cast<uint8_t>(std::floor(color.r * 255.f));
+        (*colorRamp).data[i + 1] = static_cast<uint8_t>(std::floor(color.g * 255.f));
+        (*colorRamp).data[i + 2] = static_cast<uint8_t>(std::floor(color.b * 255.f));
+        (*colorRamp).data[i + 3] = static_cast<uint8_t>(std::floor(color.a * 255.f));
     }
 
     if (colorRampTexture) {
@@ -206,5 +235,262 @@ bool RenderHeatmapLayer::queryIntersectsFeature(const GeometryCoordinates& query
     (void)pixelsToTileUnits;
     return false;
 }
+
+#if MLN_DRAWABLE_RENDERER
+namespace {
+void activateRenderTarget(const RenderTargetPtr& renderTarget_, bool activate, UniqueChangeRequestVec& changes) {
+    if (renderTarget_) {
+        if (activate) {
+            // The RenderTree has determined this render target should be included in the renderable set for a frame
+            changes.emplace_back(std::make_unique<AddRenderTargetRequest>(renderTarget_));
+        } else {
+            // The RenderTree is informing us we should not render anything
+            changes.emplace_back(std::make_unique<RemoveRenderTargetRequest>(renderTarget_));
+        }
+    }
+}
+} // namespace
+
+void RenderHeatmapLayer::markLayerRenderable(bool willRender, UniqueChangeRequestVec& changes) {
+    RenderLayer::markLayerRenderable(willRender, changes);
+    activateRenderTarget(renderTarget, willRender, changes);
+}
+
+void RenderHeatmapLayer::removeTile(RenderPass renderPass, const OverscaledTileID& tileID) {
+    auto* tileLayerGroup = static_cast<TileLayerGroup*>(renderTarget->getLayerGroup(0).get());
+    stats.drawablesRemoved += tileLayerGroup->removeDrawables(renderPass, tileID).size();
+}
+
+void RenderHeatmapLayer::removeAllDrawables() {
+    RenderLayer::removeAllDrawables();
+    if (renderTarget) {
+        stats.drawablesRemoved += renderTarget->getLayerGroup(0)->getDrawableCount();
+        renderTarget->getLayerGroup(0)->clearDrawables();
+    }
+}
+
+namespace {
+
+struct alignas(16) HeatmapInterpolateUBO {
+    float weight_t;
+    float radius_t;
+    std::array<float, 2> padding;
+};
+static_assert(sizeof(HeatmapInterpolateUBO) % 16 == 0);
+
+constexpr auto HeatmapShaderGroupName = "HeatmapShader";
+constexpr auto HeatmapTextureShaderGroupName = "HeatmapTextureShader";
+constexpr auto HeatmapInterpolateUBOName = "HeatmapInterpolateUBO";
+constexpr auto VertexAttribName = "a_pos";
+
+} // namespace
+
+void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
+                                gfx::Context& context,
+                                const TransformState& state,
+                                [[maybe_unused]] const RenderTree& renderTree,
+                                UniqueChangeRequestVec& changes) {
+    std::unique_lock<std::mutex> guard(mutex);
+
+    if (!renderTiles || renderTiles->empty()) {
+        removeAllDrawables();
+        return;
+    }
+
+    const auto& viewportSize = state.getSize();
+    const auto size = Size{viewportSize.width / 2, viewportSize.height / 2};
+
+    // Set up a render target
+    if (!renderTarget) {
+        renderTarget = context.createRenderTarget(size, gfx::TextureChannelDataType::HalfFloat);
+        if (!renderTarget) {
+            return;
+        }
+        activateRenderTarget(renderTarget, isRenderable, changes);
+
+        // Set up tile layer group
+        auto tileLayerGroup = context.createTileLayerGroup(0, /*initialCapacity=*/64, getID());
+        if (!tileLayerGroup) {
+            return;
+        }
+        tileLayerGroup->setLayerTweaker(std::make_shared<HeatmapLayerTweaker>(evaluatedProperties));
+        renderTarget->addLayerGroup(tileLayerGroup, /*replace=*/true);
+    }
+
+    if (renderTarget->getTexture()->getSize() != size) {
+        renderTarget->getTexture()->setSize(size);
+    }
+
+    auto* tileLayerGroup = static_cast<TileLayerGroup*>(renderTarget->getLayerGroup(0).get());
+
+    if (!heatmapShaderGroup) {
+        heatmapShaderGroup = shaders.getShaderGroup(HeatmapShaderGroupName);
+    }
+    if (!heatmapShaderGroup) {
+        removeAllDrawables();
+        return;
+    }
+
+    std::unique_ptr<gfx::DrawableBuilder> heatmapBuilder;
+    constexpr auto renderPass = RenderPass::Translucent;
+
+    if (!(mbgl::underlying_type(renderPass) & evaluatedProperties->renderPasses)) {
+        return;
+    }
+
+    stats.drawablesRemoved += tileLayerGroup->removeDrawablesIf(
+        [&](gfx::Drawable& drawable) { return drawable.getTileID() && !hasRenderTile(*drawable.getTileID()); });
+
+    const auto& evaluated = static_cast<const HeatmapLayerProperties&>(*evaluatedProperties).evaluated;
+
+    for (const RenderTile& tile : *renderTiles) {
+        const auto& tileID = tile.getOverscaledTileID();
+
+        const LayerRenderData* renderData = getRenderDataForPass(tile, renderPass);
+        if (!renderData) {
+            removeTile(renderPass, tileID);
+            continue;
+        }
+
+        const auto& bucket = static_cast<HeatmapBucket&>(*renderData->bucket);
+        const auto vertexCount = bucket.vertices.elements();
+        const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
+
+        const auto prevBucketID = getRenderTileBucketID(tileID);
+        if (prevBucketID != util::SimpleIdentity::Empty && prevBucketID != bucket.getID()) {
+            // This tile was previously set up from a different bucket, drop and re-create any drawables for it.
+            removeTile(renderPass, tileID);
+        }
+        setRenderTileBucketID(tileID, bucket.getID());
+
+        const float zoom = static_cast<float>(state.getZoom());
+        const HeatmapInterpolateUBO interpolateUBO = {
+            /* .weight_t = */ std::get<0>(paintPropertyBinders.get<HeatmapWeight>()->interpolationFactor(zoom)),
+            /* .radius_t = */ std::get<0>(paintPropertyBinders.get<HeatmapRadius>()->interpolationFactor(zoom)),
+            /* .padding = */ {0}};
+
+        tileLayerGroup->visitDrawables(renderPass, tileID, [&](gfx::Drawable& drawable) {
+            drawable.mutableUniformBuffers().createOrUpdate(HeatmapInterpolateUBOName, &interpolateUBO, context);
+        });
+
+        if (tileLayerGroup->getDrawableCount(renderPass, tileID) > 0) {
+            continue;
+        }
+
+        gfx::VertexAttributeArray heatmapVertexAttrs;
+
+        const auto propertiesAsUniforms =
+            heatmapVertexAttrs.readDataDrivenPaintProperties<HeatmapWeight, HeatmapRadius>(paintPropertyBinders,
+                                                                                           evaluated);
+
+        const auto heatmapShader = heatmapShaderGroup->getOrCreateShader(context, propertiesAsUniforms);
+        if (!heatmapShader) {
+            continue;
+        }
+
+        if (const auto& attr = heatmapVertexAttrs.add(VertexAttribName)) {
+            attr->setSharedRawData(bucket.sharedVertices,
+                                   offsetof(HeatmapLayoutVertex, a1),
+                                   /*vertexOffset=*/0,
+                                   sizeof(HeatmapLayoutVertex),
+                                   gfx::AttributeDataType::Short2);
+        }
+
+        heatmapBuilder = context.createDrawableBuilder("heatmap");
+        heatmapBuilder->setShader(std::static_pointer_cast<gfx::ShaderProgramBase>(heatmapShader));
+        heatmapBuilder->setDepthType((renderPass == RenderPass::Opaque) ? gfx::DepthMaskType::ReadWrite
+                                                                        : gfx::DepthMaskType::ReadOnly);
+        heatmapBuilder->setColorMode(gfx::ColorMode::additive());
+        heatmapBuilder->setCullFaceMode(gfx::CullFaceMode::disabled());
+        heatmapBuilder->setRenderPass(renderPass);
+        heatmapBuilder->setVertexAttributes(std::move(heatmapVertexAttrs));
+        heatmapBuilder->setRawVertices({}, vertexCount, gfx::AttributeDataType::Short2);
+        heatmapBuilder->setSegments(
+            gfx::Triangles(), bucket.sharedTriangles, bucket.segments.data(), bucket.segments.size());
+
+        heatmapBuilder->flush();
+
+        for (auto& drawable : heatmapBuilder->clearDrawables()) {
+            drawable->setTileID(tileID);
+            drawable->mutableUniformBuffers().createOrUpdate(HeatmapInterpolateUBOName, &interpolateUBO, context);
+
+            tileLayerGroup->addDrawable(renderPass, tileID, std::move(drawable));
+            ++stats.drawablesAdded;
+        }
+    }
+
+    // Set up texture layer group
+    if (!layerGroup) {
+        auto layerGroup_ = context.createLayerGroup(layerIndex, /*initialCapacity=*/1, getID());
+        if (!layerGroup_) {
+            return;
+        }
+        layerGroup_->setLayerTweaker(std::make_shared<HeatmapTextureLayerTweaker>(evaluatedProperties));
+        setLayerGroup(std::move(layerGroup_), changes);
+    }
+
+    if (!heatmapTextureShader) {
+        heatmapTextureShader = context.getGenericShader(shaders, HeatmapTextureShaderGroupName);
+    }
+    if (!heatmapTextureShader) {
+        removeAllDrawables();
+        return;
+    }
+
+    auto* textureLayerGroup = static_cast<LayerGroup*>(layerGroup.get());
+    textureLayerGroup->clearDrawables();
+
+    std::unique_ptr<gfx::DrawableBuilder> heatmapTextureBuilder;
+
+    if (!sharedTextureVertices) {
+        sharedTextureVertices = std::make_shared<TextureVertexVector>(RenderStaticData::heatmapTextureVertices());
+    }
+    const auto textureVertexCount = sharedTextureVertices->elements();
+
+    gfx::VertexAttributeArray textureVertexAttrs;
+    if (const auto& attr = textureVertexAttrs.add(VertexAttribName)) {
+        attr->setSharedRawData(sharedTextureVertices,
+                               offsetof(HeatmapLayoutVertex, a1),
+                               /*vertexOffset=*/0,
+                               sizeof(HeatmapLayoutVertex),
+                               gfx::AttributeDataType::Short2);
+    }
+
+    heatmapTextureBuilder = context.createDrawableBuilder("heatmapTexture");
+    heatmapTextureBuilder->setShader(heatmapTextureShader);
+    heatmapTextureBuilder->setDepthType((renderPass == RenderPass::Opaque) ? gfx::DepthMaskType::ReadWrite
+                                                                           : gfx::DepthMaskType::ReadOnly);
+    heatmapTextureBuilder->setColorMode(gfx::ColorMode::alphaBlended());
+    heatmapTextureBuilder->setCullFaceMode(gfx::CullFaceMode::disabled());
+    heatmapTextureBuilder->setRenderPass(renderPass);
+    heatmapTextureBuilder->setVertexAttributes(std::move(textureVertexAttrs));
+    heatmapTextureBuilder->setRawVertices({}, textureVertexCount, gfx::AttributeDataType::Short2);
+    if (segments.empty()) {
+        segments = RenderStaticData::heatmapTextureSegments();
+    }
+    heatmapTextureBuilder->setSegments(
+        gfx::Triangles(), RenderStaticData::quadTriangleIndices().vector(), segments.data(), segments.size());
+
+    auto imageLocation = heatmapTextureShader->getSamplerLocation("u_image");
+    if (imageLocation.has_value()) {
+        heatmapTextureBuilder->setTexture(renderTarget->getTexture(), imageLocation.value());
+    }
+    auto colorRampLocation = heatmapTextureShader->getSamplerLocation("u_color_ramp");
+    if (colorRampLocation.has_value()) {
+        std::shared_ptr<gfx::Texture2D> texture = context.createTexture2D();
+        texture->setImage(colorRamp);
+        texture->setSamplerConfiguration(
+            {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+        heatmapTextureBuilder->setTexture(std::move(texture), colorRampLocation.value());
+    }
+
+    heatmapTextureBuilder->flush();
+
+    for (auto& drawable : heatmapTextureBuilder->clearDrawables()) {
+        textureLayerGroup->addDrawable(std::move(drawable));
+        ++stats.drawablesAdded;
+    }
+}
+#endif // MLN_DRAWABLE_RENDERER
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_heatmap_layer.hpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.hpp
@@ -16,13 +16,28 @@ public:
     explicit RenderHeatmapLayer(Immutable<style::HeatmapLayer::Impl>);
     ~RenderHeatmapLayer() override;
 
+#if MLN_DRAWABLE_RENDERER
+    void markLayerRenderable(bool willRender, UniqueChangeRequestVec& changes) override;
+
+    /// Generate any changes needed by the layer
+    void update(gfx::ShaderRegistry&,
+                gfx::Context&,
+                const TransformState&,
+                const RenderTree&,
+                UniqueChangeRequestVec&) override;
+#endif
+
 private:
+    void prepare(const LayerPrepareParameters&) override;
     void transition(const TransitionParameters&) override;
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     void upload(gfx::UploadPass&) override;
+
+#if MLN_LEGACY_RENDERER
     void render(PaintParameters&) override;
+#endif
 
     bool queryIntersectsFeature(const GeometryCoordinates&,
                                 const GeometryTileFeature&,
@@ -33,16 +48,35 @@ private:
                                 const FeatureState&) const override;
     void updateColorRamp();
 
+#if MLN_DRAWABLE_RENDERER
+    /// Remove all drawables for the tile from the layer group
+    void removeTile(RenderPass, const OverscaledTileID&) override;
+
+    /// Remove all the drawables for tiles
+    void removeAllDrawables() override;
+#endif
+
     // Paint properties
     style::HeatmapPaintProperties::Unevaluated unevaluated;
-    PremultipliedImage colorRamp;
+    std::shared_ptr<PremultipliedImage> colorRamp;
     std::unique_ptr<gfx::OffscreenTexture> renderTexture;
     std::optional<gfx::Texture> colorRampTexture;
     SegmentVector<HeatmapTextureAttributes> segments;
 
+#if MLN_LEGACY_RENDERER
     // Programs
     std::shared_ptr<HeatmapProgram> heatmapProgram;
     std::shared_ptr<HeatmapTextureProgram> heatmapTextureProgram;
+#endif
+
+#if MLN_DRAWABLE_RENDERER
+    gfx::ShaderGroupPtr heatmapShaderGroup;
+    gfx::ShaderProgramBasePtr heatmapTextureShader;
+    RenderTargetPtr renderTarget;
+
+    using TextureVertexVector = gfx::VertexVector<HeatmapTextureLayoutVertex>;
+    std::shared_ptr<TextureVertexVector> sharedTextureVertices;
+#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -5,8 +5,6 @@
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/renderer/render_static_data.hpp>
 #include <mbgl/programs/programs.hpp>
-#include <mbgl/programs/hillshade_program.hpp>
-#include <mbgl/programs/hillshade_prepare_program.hpp>
 #include <mbgl/tile/tile.hpp>
 #include <mbgl/style/layers/hillshade_layer_impl.hpp>
 #include <mbgl/gfx/cull_face_mode.hpp>
@@ -14,6 +12,19 @@
 #include <mbgl/gfx/render_pass.hpp>
 #include <mbgl/math/angles.hpp>
 #include <mbgl/util/geo.hpp>
+
+#if MLN_DRAWABLE_RENDERER
+#include <mbgl/renderer/layers/hillshade_layer_tweaker.hpp>
+#include <mbgl/renderer/layers/hillshade_prepare_layer_tweaker.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/render_target.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#include <mbgl/gfx/drawable_builder.hpp>
+#include <mbgl/gfx/drawable_impl.hpp>
+#include <mbgl/gfx/hillshade_prepare_drawable_data.hpp>
+#include <mbgl/gfx/shader_group.hpp>
+#include <mbgl/gfx/shader_registry.hpp>
+#endif
 
 namespace mbgl {
 
@@ -60,6 +71,11 @@ void RenderHillshadeLayer::evaluate(const PropertyEvaluationParameters& paramete
                  : RenderPass::None;
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
+#if MLN_DRAWABLE_RENDERER
+    if (layerGroup) {
+        layerGroup->setLayerTweaker(std::make_shared<HillshadeLayerTweaker>(evaluatedProperties));
+    }
+#endif
 }
 
 bool RenderHillshadeLayer::hasTransition() const {
@@ -73,14 +89,19 @@ bool RenderHillshadeLayer::hasCrossfade() const {
 void RenderHillshadeLayer::prepare(const LayerPrepareParameters& params) {
     renderTiles = params.source->getRenderTiles();
     maxzoom = params.source->getMaxZoom();
+
+#if MLN_DRAWABLE_RENDERER
+    updateRenderTileIDs();
+#endif // MLN_DRAWABLE_RENDERER
 }
 
+#if MLN_LEGACY_RENDERER
 void RenderHillshadeLayer::render(PaintParameters& parameters) {
     assert(renderTiles);
     if (parameters.pass != RenderPass::Translucent && parameters.pass != RenderPass::Pass3D) return;
 
-    if (!parameters.shaders.populate(hillshadeProgram)) return;
-    if (!parameters.shaders.populate(hillshadePrepareProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(hillshadeProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(hillshadePrepareProgram)) return;
 
     const auto& evaluated = static_cast<const HillshadeLayerProperties&>(*evaluatedProperties).evaluated;
     auto draw = [&](const mat4& matrix,
@@ -218,5 +239,272 @@ void RenderHillshadeLayer::render(PaintParameters& parameters) {
         }
     }
 }
+#endif // MLN_LEGACY_RENDERER
+
+#if MLN_DRAWABLE_RENDERER
+namespace {
+void activateRenderTarget(const RenderTargetPtr& renderTarget_, bool activate, UniqueChangeRequestVec& changes) {
+    if (renderTarget_) {
+        if (activate) {
+            // The RenderTree has determined this render target should be included in the renderable set for a frame
+            changes.emplace_back(std::make_unique<AddRenderTargetRequest>(renderTarget_));
+        } else {
+            // The RenderTree is informing us we should not render anything
+            changes.emplace_back(std::make_unique<RemoveRenderTargetRequest>(renderTarget_));
+        }
+    }
+}
+} // namespace
+
+void RenderHillshadeLayer::markLayerRenderable(bool willRender, UniqueChangeRequestVec& changes) {
+    RenderLayer::markLayerRenderable(willRender, changes);
+    removeRenderTargets(changes);
+}
+
+void RenderHillshadeLayer::layerRemoved(UniqueChangeRequestVec& changes) {
+    RenderLayer::layerRemoved(changes);
+    removeRenderTargets(changes);
+}
+
+void RenderHillshadeLayer::addRenderTarget(const RenderTargetPtr& renderTarget, UniqueChangeRequestVec& changes) {
+    activateRenderTarget(renderTarget, true, changes);
+    activatedRenderTargets.emplace_back(renderTarget);
+}
+
+void RenderHillshadeLayer::removeRenderTargets(UniqueChangeRequestVec& changes) {
+    for (const auto& renderTarget : activatedRenderTargets) {
+        activateRenderTarget(renderTarget, false, changes);
+    }
+    activatedRenderTargets.clear();
+}
+
+static const std::string HillshadePrepareShaderGroupName = "HillshadePrepareShader";
+static const std::string HillshadeShaderGroupName = "HillshadeShader";
+
+constexpr auto PosAttribName = "a_pos";
+constexpr auto TexturePosAttribName = "a_texture_pos";
+
+void RenderHillshadeLayer::update(gfx::ShaderRegistry& shaders,
+                                  gfx::Context& context,
+                                  [[maybe_unused]] const TransformState& state,
+                                  [[maybe_unused]] const RenderTree& renderTree,
+                                  UniqueChangeRequestVec& changes) {
+    std::unique_lock<std::mutex> guard(mutex);
+
+    if (!renderTiles || renderTiles->empty()) {
+        removeAllDrawables();
+        return;
+    }
+
+    // Set up a layer group
+    if (!layerGroup) {
+        auto layerGroup_ = context.createTileLayerGroup(layerIndex, /*initialCapacity=*/64, getID());
+        if (!layerGroup_) {
+            return;
+        }
+        layerGroup_->setLayerTweaker(std::make_shared<HillshadeLayerTweaker>(evaluatedProperties));
+        setLayerGroup(std::move(layerGroup_), changes);
+    }
+
+    auto* tileLayerGroup = static_cast<TileLayerGroup*>(layerGroup.get());
+
+    if (!hillshadePrepareShader) {
+        hillshadePrepareShader = context.getGenericShader(shaders, HillshadePrepareShaderGroupName);
+    }
+    if (!hillshadeShader) {
+        hillshadeShader = context.getGenericShader(shaders, HillshadeShaderGroupName);
+    }
+    if (!hillshadePrepareShader || !hillshadeShader) {
+        removeAllDrawables();
+        return;
+    }
+
+    auto renderPass = RenderPass::Translucent;
+    if (!(mbgl::underlying_type(renderPass) & evaluatedProperties->renderPasses)) {
+        return;
+    }
+
+    stats.drawablesRemoved += tileLayerGroup->removeDrawablesIf(
+        [&](gfx::Drawable& drawable) { return drawable.getTileID() && !hasRenderTile(*drawable.getTileID()); });
+
+    if (!staticDataSharedVertices) {
+        staticDataSharedVertices = std::make_shared<HillshadeVertexVector>(RenderStaticData::rasterVertices());
+    }
+    const auto staticDataIndices = RenderStaticData::quadTriangleIndices();
+    const auto staticDataSegments = RenderStaticData::rasterSegments();
+
+    std::unique_ptr<gfx::DrawableBuilder> hillshadeBuilder;
+    std::unique_ptr<gfx::DrawableBuilder> hillshadePrepareBuilder;
+
+    for (const RenderTile& tile : *renderTiles) {
+        const auto& tileID = tile.getOverscaledTileID();
+
+        auto* bucket_ = tile.getBucket(*baseImpl);
+        if (!bucket_ || !bucket_->hasData()) {
+            removeTile(renderPass, tileID);
+            continue;
+        }
+
+        auto& bucket = static_cast<HillshadeBucket&>(*bucket_);
+
+        const auto prevBucketID = getRenderTileBucketID(tileID);
+        if (prevBucketID != util::SimpleIdentity::Empty && prevBucketID != bucket.getID()) {
+            // This tile was previously set up from a different bucket, drop and re-create any drawables for it.
+            removeTile(renderPass, tileID);
+        }
+        setRenderTileBucketID(tileID, bucket.getID());
+
+        if (!bucket.renderTargetPrepared) {
+            // Set up tile render target
+            const uint16_t tilesize = bucket.getDEMData().dim;
+            auto renderTarget = context.createRenderTarget({tilesize, tilesize},
+                                                           gfx::TextureChannelDataType::UnsignedByte);
+            if (!renderTarget) {
+                continue;
+            }
+            bucket.renderTarget = renderTarget;
+            bucket.renderTargetPrepared = true;
+            addRenderTarget(renderTarget, changes);
+
+            auto singleTileLayerGroup = context.createTileLayerGroup(0, /*initialCapacity=*/1, getID());
+            if (!singleTileLayerGroup) {
+                return;
+            }
+            singleTileLayerGroup->setLayerTweaker(std::make_shared<HillshadePrepareLayerTweaker>(evaluatedProperties));
+            renderTarget->addLayerGroup(singleTileLayerGroup, /*replace=*/true);
+
+            gfx::VertexAttributeArray hillshadePrepareVertexAttrs;
+
+            if (const auto& attr = hillshadePrepareVertexAttrs.add(PosAttribName)) {
+                attr->setSharedRawData(staticDataSharedVertices,
+                                       offsetof(HillshadeLayoutVertex, a1),
+                                       0,
+                                       sizeof(HillshadeLayoutVertex),
+                                       gfx::AttributeDataType::Short2);
+            }
+            if (const auto& attr = hillshadePrepareVertexAttrs.getOrAdd(TexturePosAttribName)) {
+                attr->setSharedRawData(staticDataSharedVertices,
+                                       offsetof(HillshadeLayoutVertex, a2),
+                                       0,
+                                       sizeof(HillshadeLayoutVertex),
+                                       gfx::AttributeDataType::Short4);
+            }
+
+            hillshadePrepareBuilder = context.createDrawableBuilder("hillshadePrepare");
+            hillshadePrepareBuilder->setShader(hillshadePrepareShader);
+            hillshadePrepareBuilder->setDepthType(gfx::DepthMaskType::ReadOnly);
+            hillshadePrepareBuilder->setColorMode(gfx::ColorMode::alphaBlended());
+            hillshadePrepareBuilder->setCullFaceMode(gfx::CullFaceMode::disabled());
+
+            hillshadePrepareBuilder->setRenderPass(renderPass);
+            hillshadePrepareBuilder->setVertexAttributes(std::move(hillshadePrepareVertexAttrs));
+            hillshadePrepareBuilder->setRawVertices(
+                {}, staticDataSharedVertices->elements(), gfx::AttributeDataType::Short2);
+            hillshadePrepareBuilder->setSegments(
+                gfx::Triangles(), staticDataIndices.vector(), staticDataSegments.data(), staticDataSegments.size());
+
+            auto imageLocation = hillshadePrepareShader->getSamplerLocation("u_image");
+            if (imageLocation.has_value()) {
+                std::shared_ptr<gfx::Texture2D> texture = context.createTexture2D();
+                texture->setImage(bucket.getDEMData().getImagePtr());
+                texture->setSamplerConfiguration(
+                    {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+                hillshadePrepareBuilder->setTexture(texture, imageLocation.value());
+            }
+
+            hillshadePrepareBuilder->flush();
+
+            for (auto& drawable : hillshadePrepareBuilder->clearDrawables()) {
+                drawable->setTileID(tileID);
+                drawable->setData(std::make_unique<gfx::HillshadePrepareDrawableData>(
+                    bucket.getDEMData().stride, bucket.getDEMData().encoding, maxzoom));
+                singleTileLayerGroup->addDrawable(renderPass, tileID, std::move(drawable));
+                ++stats.drawablesAdded;
+            }
+        }
+
+        // Set up tile drawable
+        auto vertices = staticDataSharedVertices;
+        auto* indices = &staticDataIndices;
+        auto* segments = &staticDataSegments;
+
+        if (!bucket.vertices.empty() && !bucket.indices.empty() && !bucket.segments.empty()) {
+            vertices = bucket.sharedVertices;
+            indices = &bucket.indices;
+            segments = &bucket.segments;
+        }
+
+        gfx::VertexAttributeArray hillshadeVertexAttrs;
+
+        if (const auto& attr = hillshadeVertexAttrs.add(PosAttribName)) {
+            attr->setSharedRawData(vertices,
+                                   offsetof(HillshadeLayoutVertex, a1),
+                                   0,
+                                   sizeof(HillshadeLayoutVertex),
+                                   gfx::AttributeDataType::Short2);
+        }
+        if (const auto& attr = hillshadeVertexAttrs.getOrAdd(TexturePosAttribName)) {
+            attr->setSharedRawData(vertices,
+                                   offsetof(HillshadeLayoutVertex, a2),
+                                   0,
+                                   sizeof(HillshadeLayoutVertex),
+                                   gfx::AttributeDataType::Short4);
+        }
+
+        hillshadeBuilder = context.createDrawableBuilder("hillshade");
+
+        if (tileLayerGroup->getDrawableCount(renderPass, tileID) > 0) {
+            tileLayerGroup->visitDrawables(renderPass, tileID, [&](gfx::Drawable& drawable) {
+                drawable.setVertexAttributes(std::move(hillshadeVertexAttrs));
+                drawable.setVertices({}, vertices->elements(), gfx::AttributeDataType::Short2);
+
+                std::vector<std::unique_ptr<gfx::Drawable::DrawSegment>> drawSegments;
+                for (std::size_t i = 0; i < segments->size(); ++i) {
+                    const auto& seg = segments->data()[i];
+                    auto segCopy = SegmentBase{
+                        // no copy constructor
+                        seg.vertexOffset,
+                        seg.indexOffset,
+                        seg.vertexLength,
+                        seg.indexLength,
+                        seg.sortKey,
+                    };
+                    drawSegments.emplace_back(hillshadeBuilder->createSegment(gfx::Triangles(), std::move(segCopy)));
+                }
+                drawable.setIndexData(indices->vector(), std::move(drawSegments));
+
+                auto imageLocation = hillshadeShader->getSamplerLocation("u_image");
+                if (imageLocation.has_value()) {
+                    drawable.setTexture(bucket.renderTarget->getTexture(), imageLocation.value());
+                }
+            });
+            continue;
+        }
+
+        hillshadeBuilder->setShader(hillshadeShader);
+        hillshadeBuilder->setDepthType(gfx::DepthMaskType::ReadOnly);
+        hillshadeBuilder->setColorMode(gfx::ColorMode::alphaBlended());
+        hillshadeBuilder->setCullFaceMode(gfx::CullFaceMode::disabled());
+
+        hillshadeBuilder->setRenderPass(renderPass);
+        hillshadeBuilder->setVertexAttributes(std::move(hillshadeVertexAttrs));
+        hillshadeBuilder->setRawVertices({}, vertices->elements(), gfx::AttributeDataType::Short2);
+        hillshadeBuilder->setSegments(gfx::Triangles(), indices->vector(), segments->data(), segments->size());
+
+        auto imageLocation = hillshadeShader->getSamplerLocation("u_image");
+        if (imageLocation.has_value()) {
+            hillshadeBuilder->setTexture(bucket.renderTarget->getTexture(), imageLocation.value());
+        }
+
+        hillshadeBuilder->flush();
+
+        for (auto& drawable : hillshadeBuilder->clearDrawables()) {
+            drawable->setTileID(tileID);
+            tileLayerGroup->addDrawable(renderPass, tileID, std::move(drawable));
+            ++stats.drawablesAdded;
+        }
+    }
+}
+#endif // MLN_DRAWABLE_RENDERER
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_hillshade_layer.hpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <mbgl/renderer/render_layer.hpp>
+#include <mbgl/programs/hillshade_program.hpp>
+#include <mbgl/programs/hillshade_prepare_program.hpp>
 #include <mbgl/style/layers/hillshade_layer_impl.hpp>
 #include <mbgl/style/layers/hillshade_layer_properties.hpp>
 #include <mbgl/tile/tile_id.hpp>
@@ -15,14 +17,35 @@ public:
     explicit RenderHillshadeLayer(Immutable<style::HillshadeLayer::Impl>);
     ~RenderHillshadeLayer() override;
 
+#if MLN_DRAWABLE_RENDERER
+    void markLayerRenderable(bool willRender, UniqueChangeRequestVec& changes) override;
+
+    void layerRemoved(UniqueChangeRequestVec&) override;
+
+    /// Generate any changes needed by the layer
+    void update(gfx::ShaderRegistry&,
+                gfx::Context&,
+                const TransformState&,
+                const RenderTree&,
+                UniqueChangeRequestVec&) override;
+#endif
+
 private:
     void transition(const TransitionParameters&) override;
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
 
+#if MLN_LEGACY_RENDERER
     void render(PaintParameters&) override;
+#endif
+
     void prepare(const LayerPrepareParameters&) override;
+
+#if MLN_DRAWABLE_RENDERER
+    void addRenderTarget(const RenderTargetPtr&, UniqueChangeRequestVec&);
+    void removeRenderTargets(UniqueChangeRequestVec&);
+#endif
 
     // Paint properties
     style::HillshadePaintProperties::Unevaluated unevaluated;
@@ -31,9 +54,20 @@ private:
     std::array<float, 2> getLatRange(const UnwrappedTileID& id);
     std::array<float, 2> getLight(const PaintParameters& parameters);
 
+#if MLN_LEGACY_RENDERER
     // Programs
     std::shared_ptr<HillshadeProgram> hillshadeProgram;
     std::shared_ptr<HillshadePrepareProgram> hillshadePrepareProgram;
+#endif
+
+#if MLN_DRAWABLE_RENDERER
+    gfx::ShaderProgramBasePtr hillshadePrepareShader;
+    gfx::ShaderProgramBasePtr hillshadeShader;
+    std::vector<RenderTargetPtr> activatedRenderTargets;
+
+    using HillshadeVertexVector = gfx::VertexVector<HillshadeLayoutVertex>;
+    std::shared_ptr<HillshadeVertexVector> staticDataSharedVertices;
+#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -9,6 +9,7 @@
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/renderer/render_source.hpp>
 #include <mbgl/renderer/render_tile.hpp>
+#include <mbgl/renderer/tile_render_data.hpp>
 #include <mbgl/renderer/upload_parameters.hpp>
 #include <mbgl/style/expression/image.hpp>
 #include <mbgl/style/layers/line_layer_impl.hpp>
@@ -16,6 +17,15 @@
 #include <mbgl/tile/tile.hpp>
 #include <mbgl/util/intersection_tests.hpp>
 #include <mbgl/util/math.hpp>
+#include <mbgl/util/convert.hpp>
+
+#if MLN_DRAWABLE_RENDERER
+#include <mbgl/gfx/drawable_builder.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/layers/line_layer_tweaker.hpp>
+#include <mbgl/gfx/line_drawable_data.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#endif
 
 namespace mbgl {
 
@@ -28,12 +38,19 @@ inline const LineLayer::Impl& impl_cast(const Immutable<style::Layer::Impl>& imp
     return static_cast<const LineLayer::Impl&>(*impl);
 }
 
+#if MLN_DRAWABLE_RENDERER
+
+constexpr auto VertexAttribName = "a_pos_normal";
+constexpr auto DataAttribName = "a_data";
+
+#endif // MLN_DRAWABLE_RENDERER
+
 } // namespace
 
 RenderLineLayer::RenderLineLayer(Immutable<style::LineLayer::Impl> _impl)
     : RenderLayer(makeMutable<LineLayerProperties>(std::move(_impl))),
       unevaluated(impl_cast(baseImpl).paint.untransitioned()),
-      colorRamp({256, 1}) {}
+      colorRamp(std::make_shared<PremultipliedImage>(Size(256, 1))) {}
 
 RenderLineLayer::~RenderLineLayer() = default;
 
@@ -55,6 +72,12 @@ void RenderLineLayer::evaluate(const PropertyEvaluationParameters& parameters) {
                  : RenderPass::None;
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
+
+#if MLN_DRAWABLE_RENDERER
+    if (layerGroup && layerGroup->getLayerTweaker()) {
+        layerGroup->setLayerTweaker(std::make_shared<LineLayerTweaker>(evaluatedProperties));
+    }
+#endif
 }
 
 bool RenderLineLayer::hasTransition() const {
@@ -74,31 +97,36 @@ void RenderLineLayer::prepare(const LayerPrepareParameters& params) {
         const auto& evaluated = getEvaluated<LineLayerProperties>(renderData->layerProperties);
         if (evaluated.get<LineDasharray>().from.empty()) continue;
 
-        auto& bucket = static_cast<LineBucket&>(*renderData->bucket);
+        const auto& bucket = static_cast<const LineBucket&>(*renderData->bucket);
         const LinePatternCap cap = bucket.layout.get<LineCap>() == LineCapType::Round ? LinePatternCap::Round
                                                                                       : LinePatternCap::Square;
         // Ensures that the dash data gets added to the atlas.
         params.lineAtlas.getDashPatternTexture(
             evaluated.get<LineDasharray>().from, evaluated.get<LineDasharray>().to, cap);
     }
+
+#if MLN_DRAWABLE_RENDERER
+    updateRenderTileIDs();
+#endif // MLN_DRAWABLE_RENDERER
 }
 
 void RenderLineLayer::upload(gfx::UploadPass& uploadPass) {
     if (!unevaluated.get<LineGradient>().getValue().isUndefined() && !colorRampTexture) {
-        colorRampTexture = uploadPass.createTexture(colorRamp);
+        colorRampTexture = uploadPass.createTexture(*colorRamp);
     }
 }
 
+#if MLN_LEGACY_RENDERER
 void RenderLineLayer::render(PaintParameters& parameters) {
     assert(renderTiles);
     if (parameters.pass == RenderPass::Opaque) {
         return;
     }
 
-    if (!parameters.shaders.populate(lineProgram)) return;
-    if (!parameters.shaders.populate(lineGradientProgram)) return;
-    if (!parameters.shaders.populate(lineSDFProgram)) return;
-    if (!parameters.shaders.populate(linePatternProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(lineProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(lineGradientProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(lineSDFProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(linePatternProgram)) return;
 
     parameters.renderTileClippingMasks(renderTiles);
 
@@ -169,7 +197,7 @@ void RenderLineLayer::render(PaintParameters& parameters) {
 
         } else if (!unevaluated.get<LinePattern>().isUndefined()) {
             const auto& linePatternValue = evaluated.get<LinePattern>().constantOr(Faded<expression::Image>{"", ""});
-            const Size& texsize = tile.getIconAtlasTexture().size;
+            const Size& texsize = tile.getIconAtlasTexture()->getSize();
 
             std::optional<ImagePosition> posA = tile.getPattern(linePatternValue.from.id());
             std::optional<ImagePosition> posB = tile.getPattern(linePatternValue.to.id());
@@ -185,7 +213,7 @@ void RenderLineLayer::render(PaintParameters& parameters) {
                  posA,
                  posB,
                  LinePatternProgram::TextureBindings{
-                     textures::image::Value{tile.getIconAtlasTexture().getResource(), gfx::TextureFilterType::Linear},
+                     tile.getIconAtlasTextureBinding(gfx::TextureFilterType::Linear),
                  });
         } else if (!unevaluated.get<LineGradient>().getValue().isUndefined()) {
             assert(colorRampTexture);
@@ -208,6 +236,7 @@ void RenderLineLayer::render(PaintParameters& parameters) {
         }
     }
 }
+#endif // MLN_LEGACY_RENDERER
 
 namespace {
 
@@ -282,19 +311,31 @@ void RenderLineLayer::updateColorRamp() {
         return;
     }
 
-    const auto length = colorRamp.bytes();
+    const auto length = colorRamp->bytes();
 
     for (uint32_t i = 0; i < length; i += 4) {
         const auto color = colorValue.evaluate(static_cast<double>(i) / length);
-        colorRamp.data[i] = static_cast<uint8_t>(std::floor(color.r * 255.f));
-        colorRamp.data[i + 1] = static_cast<uint8_t>(std::floor(color.g * 255.f));
-        colorRamp.data[i + 2] = static_cast<uint8_t>(std::floor(color.b * 255.f));
-        colorRamp.data[i + 3] = static_cast<uint8_t>(std::floor(color.a * 255.f));
+        colorRamp->data[i] = static_cast<uint8_t>(std::floor(color.r * 255.f));
+        colorRamp->data[i + 1] = static_cast<uint8_t>(std::floor(color.g * 255.f));
+        colorRamp->data[i + 2] = static_cast<uint8_t>(std::floor(color.b * 255.f));
+        colorRamp->data[i + 3] = static_cast<uint8_t>(std::floor(color.a * 255.f));
     }
 
     if (colorRampTexture) {
         colorRampTexture = std::nullopt;
     }
+
+#if MLN_DRAWABLE_RENDERER
+    if (colorRampTexture2D) {
+        colorRampTexture2D.reset();
+
+        // delete all gradient drawables
+        if (layerGroup) {
+            stats.drawablesRemoved += layerGroup->getDrawableCount();
+            layerGroup->clearDrawables();
+        }
+    }
+#endif
 }
 
 float RenderLineLayer::getLineWidth(const GeometryTileFeature& feature,
@@ -311,5 +352,401 @@ float RenderLineLayer::getLineWidth(const GeometryTileFeature& feature,
         return lineWidth;
     }
 }
+
+#if MLN_DRAWABLE_RENDERER
+/// Property interpolation UBOs
+struct alignas(16) LineInterpolationUBO {
+    float color_t;
+    float blur_t;
+    float opacity_t;
+    float gapwidth_t;
+    float offset_t;
+    float width_t;
+
+    float pad1;
+    float pad2;
+};
+static_assert(sizeof(LineInterpolationUBO) % 16 == 0);
+static constexpr std::string_view LineInterpolationUBOName = "LineInterpolationUBO";
+
+struct alignas(16) LineGradientInterpolationUBO {
+    float blur_t;
+    float opacity_t;
+    float gapwidth_t;
+    float offset_t;
+    float width_t;
+
+    float pad1;
+    std::array<float, 2> pad2;
+};
+static_assert(sizeof(LineGradientInterpolationUBO) % 16 == 0);
+static constexpr std::string_view LineGradientInterpolationUBOName = "LineGradientInterpolationUBO";
+
+struct alignas(16) LinePatternInterpolationUBO {
+    float blur_t;
+    float opacity_t;
+    float offset_t;
+    float gapwidth_t;
+    float width_t;
+    float pattern_from_t;
+    float pattern_to_t;
+
+    float pad1;
+};
+static_assert(sizeof(LinePatternInterpolationUBO) % 16 == 0);
+static constexpr std::string_view LinePatternInterpolationUBOName = "LinePatternInterpolationUBO";
+
+struct alignas(16) LineSDFInterpolationUBO {
+    float color_t;
+    float blur_t;
+    float opacity_t;
+    float gapwidth_t;
+    float offset_t;
+    float width_t;
+    float floorwidth_t;
+
+    float pad1;
+};
+static_assert(sizeof(LineSDFInterpolationUBO) % 16 == 0);
+static constexpr std::string_view LineSDFInterpolationUBOName = "LineSDFInterpolationUBO";
+
+/// Evaluated properties that depend on the tile
+struct alignas(16) LinePatternTilePropertiesUBO {
+    std::array<float, 4> pattern_from;
+    std::array<float, 4> pattern_to;
+};
+static_assert(sizeof(LinePatternTilePropertiesUBO) % 16 == 0);
+static constexpr std::string_view LinePatternTilePropertiesUBOName = "LinePatternTilePropertiesUBO";
+
+void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
+                             gfx::Context& context,
+                             const TransformState& state,
+                             [[maybe_unused]] const RenderTree& renderTree,
+                             [[maybe_unused]] UniqueChangeRequestVec& changes) {
+    std::unique_lock<std::mutex> guard(mutex);
+
+    if (!renderTiles || renderTiles->empty()) {
+        removeAllDrawables();
+        return;
+    }
+
+    // Set up a layer group
+    if (!layerGroup) {
+        if (auto layerGroup_ = context.createTileLayerGroup(layerIndex, /*initialCapacity=*/64, getID())) {
+            layerGroup_->setLayerTweaker(std::make_shared<LineLayerTweaker>(evaluatedProperties));
+            setLayerGroup(std::move(layerGroup_), changes);
+        }
+    }
+    auto* tileLayerGroup = static_cast<TileLayerGroup*>(layerGroup.get());
+
+    if (!lineShaderGroup) {
+        lineShaderGroup = shaders.getShaderGroup("LineShader");
+    }
+    if (!lineGradientShaderGroup) {
+        lineGradientShaderGroup = shaders.getShaderGroup("LineGradientShader");
+    }
+    if (!linePatternShaderGroup) {
+        linePatternShaderGroup = shaders.getShaderGroup("LinePatternShader");
+    }
+    if (!lineSDFShaderGroup) {
+        lineSDFShaderGroup = shaders.getShaderGroup("LineSDFShader");
+    }
+
+    const RenderPass renderPass = static_cast<RenderPass>(evaluatedProperties->renderPasses &
+                                                          ~mbgl::underlying_type(RenderPass::Opaque));
+
+    stats.drawablesRemoved += tileLayerGroup->removeDrawablesIf([&](gfx::Drawable& drawable) {
+        // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
+        const auto& tileID = drawable.getTileID();
+        if (drawable.getRenderPass() != passes || (tileID && !hasRenderTile(*tileID))) {
+            return true;
+        }
+        return false;
+    });
+
+    auto createLineBuilder = [&](const std::string& name,
+                                 gfx::ShaderPtr shader) -> std::unique_ptr<gfx::DrawableBuilder> {
+        std::unique_ptr<gfx::DrawableBuilder> builder = context.createDrawableBuilder(name);
+        builder->setShader(std::static_pointer_cast<gfx::ShaderProgramBase>(shader));
+        builder->setRenderPass(renderPass);
+        builder->setSubLayerIndex(0);
+        builder->setDepthType(gfx::DepthMaskType::ReadOnly);
+        builder->setColorMode(renderPass == RenderPass::Translucent ? gfx::ColorMode::alphaBlended()
+                                                                    : gfx::ColorMode::unblended());
+        builder->setCullFaceMode(gfx::CullFaceMode::disabled());
+        builder->setEnableStencil(true);
+        builder->setVertexAttrName(VertexAttribName);
+
+        return builder;
+    };
+
+    auto addAttributes =
+        [&](gfx::DrawableBuilder& builder, const LineBucket& bucket, gfx::VertexAttributeArray&& vertexAttrs) {
+            const auto vertexCount = bucket.vertices.elements();
+            builder.setRawVertices({}, vertexCount, gfx::AttributeDataType::Short4);
+
+            if (const auto& attr = vertexAttrs.add(VertexAttribName)) {
+                attr->setSharedRawData(bucket.sharedVertices,
+                                       offsetof(LineLayoutVertex, a1),
+                                       /*vertexOffset=*/0,
+                                       sizeof(LineLayoutVertex),
+                                       gfx::AttributeDataType::Short2);
+            }
+
+            if (const auto& attr = vertexAttrs.add(DataAttribName)) {
+                attr->setSharedRawData(bucket.sharedVertices,
+                                       offsetof(LineLayoutVertex, a2),
+                                       /*vertexOffset=*/0,
+                                       sizeof(LineLayoutVertex),
+                                       gfx::AttributeDataType::UByte4);
+            }
+
+            builder.setVertexAttributes(std::move(vertexAttrs));
+        };
+
+    auto setSegments = [&](std::unique_ptr<gfx::DrawableBuilder>& builder, const LineBucket& bucket) {
+        builder->setSegments(gfx::Triangles(), bucket.sharedTriangles, bucket.segments.data(), bucket.segments.size());
+    };
+
+    for (const RenderTile& tile : *renderTiles) {
+        const auto& tileID = tile.getOverscaledTileID();
+
+        const LayerRenderData* renderData = getRenderDataForPass(tile, renderPass);
+        if (!renderData) {
+            removeTile(renderPass, tileID);
+            continue;
+        }
+
+        auto& bucket = static_cast<LineBucket&>(*renderData->bucket);
+        const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
+        const auto& evaluated = getEvaluated<LineLayerProperties>(renderData->layerProperties);
+        const auto& crossfade = getCrossfade<LineLayerProperties>(renderData->layerProperties);
+
+        const auto prevBucketID = getRenderTileBucketID(tileID);
+        if (prevBucketID != util::SimpleIdentity::Empty && prevBucketID != bucket.getID()) {
+            // This tile was previously set up from a different bucket, drop and re-create any drawables for it.
+            removeTile(renderPass, tileID);
+        }
+        setRenderTileBucketID(tileID, bucket.getID());
+
+        // interpolation UBOs
+        const float zoom = static_cast<float>(state.getZoom());
+        const LineInterpolationUBO lineInterpolationUBO{
+            /*color_t =*/std::get<0>(paintPropertyBinders.get<LineColor>()->interpolationFactor(zoom)),
+            /*blur_t =*/std::get<0>(paintPropertyBinders.get<LineBlur>()->interpolationFactor(zoom)),
+            /*opacity_t =*/std::get<0>(paintPropertyBinders.get<LineOpacity>()->interpolationFactor(zoom)),
+            /*gapwidth_t =*/std::get<0>(paintPropertyBinders.get<LineGapWidth>()->interpolationFactor(zoom)),
+            /*offset_t =*/std::get<0>(paintPropertyBinders.get<LineOffset>()->interpolationFactor(zoom)),
+            /*width_t =*/std::get<0>(paintPropertyBinders.get<LineWidth>()->interpolationFactor(zoom)),
+            0,
+            0};
+        const LineGradientInterpolationUBO lineGradientInterpolationUBO{
+            /*blur_t =*/std::get<0>(paintPropertyBinders.get<LineBlur>()->interpolationFactor(zoom)),
+            /*opacity_t =*/std::get<0>(paintPropertyBinders.get<LineOpacity>()->interpolationFactor(zoom)),
+            /*gapwidth_t =*/std::get<0>(paintPropertyBinders.get<LineGapWidth>()->interpolationFactor(zoom)),
+            /*offset_t =*/std::get<0>(paintPropertyBinders.get<LineOffset>()->interpolationFactor(zoom)),
+            /*width_t =*/std::get<0>(paintPropertyBinders.get<LineWidth>()->interpolationFactor(zoom)),
+            0,
+            {0, 0}};
+        const LinePatternInterpolationUBO linePatternInterpolationUBO{
+            /*blur_t =*/std::get<0>(paintPropertyBinders.get<LineBlur>()->interpolationFactor(zoom)),
+            /*opacity_t =*/std::get<0>(paintPropertyBinders.get<LineOpacity>()->interpolationFactor(zoom)),
+            /*offset_t =*/std::get<0>(paintPropertyBinders.get<LineOffset>()->interpolationFactor(zoom)),
+            /*gapwidth_t =*/std::get<0>(paintPropertyBinders.get<LineGapWidth>()->interpolationFactor(zoom)),
+            /*width_t =*/std::get<0>(paintPropertyBinders.get<LineWidth>()->interpolationFactor(zoom)),
+            /*pattern_from_t =*/std::get<0>(paintPropertyBinders.get<LinePattern>()->interpolationFactor(zoom)),
+            /*pattern_to_t =*/std::get<1>(paintPropertyBinders.get<LinePattern>()->interpolationFactor(zoom)),
+            0};
+        const LineSDFInterpolationUBO lineSDFInterpolationUBO{
+            /*color_t =*/std::get<0>(paintPropertyBinders.get<LineColor>()->interpolationFactor(zoom)),
+            /*blur_t =*/std::get<0>(paintPropertyBinders.get<LineBlur>()->interpolationFactor(zoom)),
+            /*opacity_t =*/std::get<0>(paintPropertyBinders.get<LineOpacity>()->interpolationFactor(zoom)),
+            /*gapwidth_t =*/std::get<0>(paintPropertyBinders.get<LineGapWidth>()->interpolationFactor(zoom)),
+            /*offset_t =*/std::get<0>(paintPropertyBinders.get<LineOffset>()->interpolationFactor(zoom)),
+            /*width_t =*/std::get<0>(paintPropertyBinders.get<LineWidth>()->interpolationFactor(zoom)),
+            /*floorwidth_t =*/std::get<0>(paintPropertyBinders.get<LineFloorWidth>()->interpolationFactor(zoom)),
+            0};
+
+        // tile dependent properties UBOs:
+        const auto& linePatternValue = evaluated.get<LinePattern>().constantOr(Faded<expression::Image>{"", ""});
+        const std::optional<ImagePosition> patternPosA = tile.getPattern(linePatternValue.from.id());
+        const std::optional<ImagePosition> patternPosB = tile.getPattern(linePatternValue.to.id());
+        const LinePatternTilePropertiesUBO linePatternTilePropertiesUBO{
+            /*pattern_from =*/patternPosA ? util::cast<float>(patternPosA->tlbr()) : std::array<float, 4>{0},
+            /*pattern_to =*/patternPosB ? util::cast<float>(patternPosB->tlbr()) : std::array<float, 4>{0}};
+
+        // update existing drawables
+        tileLayerGroup->visitDrawables(renderPass, tileID, [&](gfx::Drawable& drawable) {
+            // simple line interpolation UBO
+            if (drawable.getShader()->getUniformBlocks().get(std::string(LineInterpolationUBOName))) {
+                drawable.mutableUniformBuffers().createOrUpdate(
+                    LineInterpolationUBOName, &lineInterpolationUBO, context);
+            }
+            // gradient line interpolation UBO
+            else if (drawable.getShader()->getUniformBlocks().get(std::string(LineGradientInterpolationUBOName))) {
+                drawable.mutableUniformBuffers().createOrUpdate(
+                    LineGradientInterpolationUBOName, &lineGradientInterpolationUBO, context);
+            }
+            // pattern line interpolation UBO
+            else if (drawable.getShader()->getUniformBlocks().get(std::string(LinePatternInterpolationUBOName))) {
+                // interpolation
+                drawable.mutableUniformBuffers().createOrUpdate(
+                    LinePatternInterpolationUBOName, &linePatternInterpolationUBO, context);
+                // tile properties
+                drawable.mutableUniformBuffers().createOrUpdate(
+                    LinePatternTilePropertiesUBOName, &linePatternTilePropertiesUBO, context);
+            }
+            // SDF line interpolation UBO
+            else if (drawable.getShader()->getUniformBlocks().get(std::string(LineSDFInterpolationUBOName))) {
+                drawable.mutableUniformBuffers().createOrUpdate(
+                    LineSDFInterpolationUBOName, &lineSDFInterpolationUBO, context);
+            }
+        });
+
+        if (tileLayerGroup->getDrawableCount(renderPass, tileID) > 0) continue;
+
+        if (!evaluated.get<LineDasharray>().from.empty()) {
+            // dash array line (SDF)
+            gfx::VertexAttributeArray vertexAttrs;
+            const auto propertiesAsUniforms = vertexAttrs.readDataDrivenPaintProperties<LineColor,
+                                                                                        LineBlur,
+                                                                                        LineOpacity,
+                                                                                        LineGapWidth,
+                                                                                        LineOffset,
+                                                                                        LineWidth,
+                                                                                        LineFloorWidth>(
+                paintPropertyBinders, evaluated);
+            auto builder = createLineBuilder("lineSDF",
+                                             lineSDFShaderGroup->getOrCreateShader(context, propertiesAsUniforms));
+
+            // vertices, attributes and segments
+            addAttributes(*builder, bucket, std::move(vertexAttrs));
+            setSegments(builder, bucket);
+
+            // finish
+            builder->flush();
+            const LinePatternCap cap = bucket.layout.get<LineCap>() == LineCapType::Round ? LinePatternCap::Round
+                                                                                          : LinePatternCap::Square;
+            for (auto& drawable : builder->clearDrawables()) {
+                drawable->setTileID(tileID);
+                drawable->setData(std::make_unique<gfx::LineDrawableData>(cap));
+                drawable->mutableUniformBuffers().createOrUpdate(
+                    LineSDFInterpolationUBOName, &lineSDFInterpolationUBO, context);
+
+                tileLayerGroup->addDrawable(renderPass, tileID, std::move(drawable));
+                ++stats.drawablesAdded;
+            }
+        } else if (!unevaluated.get<LinePattern>().isUndefined()) {
+            // pattern line
+            gfx::VertexAttributeArray vertexAttrs;
+            paintPropertyBinders.setPatternParameters(patternPosA, patternPosB, crossfade);
+            auto propertiesAsUniforms = vertexAttrs.readDataDrivenPaintProperties<LineBlur,
+                                                                                  LineOpacity,
+                                                                                  LineOffset,
+                                                                                  LineGapWidth,
+                                                                                  LineWidth,
+                                                                                  LinePattern>(paintPropertyBinders,
+                                                                                               evaluated);
+            auto builder = createLineBuilder("linePattern",
+                                             linePatternShaderGroup->getOrCreateShader(context, propertiesAsUniforms));
+
+            // vertices and attributes
+            addAttributes(*builder, bucket, std::move(vertexAttrs));
+
+            // texture
+            if (const auto& atlases = tile.getAtlasTextures(); atlases && atlases->icon) {
+                if (const auto samplerLocation = builder->getShader()->getSamplerLocation("u_image")) {
+                    builder->setTexture(atlases->icon, samplerLocation.value());
+
+                    // segments
+                    setSegments(builder, bucket);
+
+                    // finish
+                    builder->flush();
+                    for (auto& drawable : builder->clearDrawables()) {
+                        drawable->setTileID(tileID);
+                        drawable->mutableUniformBuffers().createOrUpdate(
+                            LinePatternInterpolationUBOName, &linePatternInterpolationUBO, context);
+                        drawable->mutableUniformBuffers().createOrUpdate(
+                            LinePatternTilePropertiesUBOName, &linePatternTilePropertiesUBO, context);
+
+                        tileLayerGroup->addDrawable(renderPass, tileID, std::move(drawable));
+                        ++stats.drawablesAdded;
+                    }
+                }
+            }
+
+        } else if (!unevaluated.get<LineGradient>().getValue().isUndefined()) {
+            // gradient line
+            gfx::VertexAttributeArray vertexAttrs;
+            auto propertiesAsUniforms =
+                vertexAttrs.readDataDrivenPaintProperties<LineBlur, LineOpacity, LineGapWidth, LineOffset, LineWidth>(
+                    paintPropertyBinders, evaluated);
+
+            auto builder = createLineBuilder("lineGradient",
+                                             lineGradientShaderGroup->getOrCreateShader(context, propertiesAsUniforms));
+
+            // vertices and attributes
+            addAttributes(*builder, bucket, std::move(vertexAttrs));
+
+            // texture
+            if (const auto samplerLocation = builder->getShader()->getSamplerLocation("u_image")) {
+                if (!colorRampTexture2D && colorRamp->valid()) {
+                    // create texture. to be reused for all the tiles of the layer
+                    colorRampTexture2D = context.createTexture2D();
+                    colorRampTexture2D->setImage(colorRamp);
+                    colorRampTexture2D->setSamplerConfiguration(
+                        {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+                }
+
+                if (colorRampTexture2D) {
+                    builder->setTexture(colorRampTexture2D, samplerLocation.value());
+
+                    // segments
+                    setSegments(builder, bucket);
+
+                    // finish
+                    builder->flush();
+                    for (auto& drawable : builder->clearDrawables()) {
+                        drawable->setTileID(tileID);
+                        drawable->mutableUniformBuffers().createOrUpdate(
+                            LineGradientInterpolationUBOName, &lineGradientInterpolationUBO, context);
+
+                        tileLayerGroup->addDrawable(renderPass, tileID, std::move(drawable));
+                        ++stats.drawablesAdded;
+                    }
+                }
+            }
+
+        } else {
+            // simple line
+            gfx::VertexAttributeArray vertexAttrs;
+            const auto propertiesAsUniforms = vertexAttrs.readDataDrivenPaintProperties<LineColor,
+                                                                                        LineBlur,
+                                                                                        LineOpacity,
+                                                                                        LineGapWidth,
+                                                                                        LineOffset,
+                                                                                        LineWidth>(paintPropertyBinders,
+                                                                                                   evaluated);
+            auto builder = createLineBuilder("line", lineShaderGroup->getOrCreateShader(context, propertiesAsUniforms));
+
+            // vertices, attributes and segments
+            addAttributes(*builder, bucket, std::move(vertexAttrs));
+            setSegments(builder, bucket);
+
+            // finish
+            builder->flush();
+            for (auto& drawable : builder->clearDrawables()) {
+                drawable->setTileID(tileID);
+                drawable->mutableUniformBuffers().createOrUpdate(
+                    LineInterpolationUBOName, &lineInterpolationUBO, context);
+
+                tileLayerGroup->addDrawable(renderPass, tileID, std::move(drawable));
+                ++stats.drawablesAdded;
+            }
+        }
+    }
+}
+#endif
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -306,24 +306,12 @@ bool RenderLineLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeo
 }
 
 void RenderLineLayer::updateColorRamp() {
-    auto colorValue = unevaluated.get<LineGradient>().getValue();
-    if (colorValue.isUndefined()) {
+    const style::ColorRampPropertyValue colorValue = unevaluated.get<LineGradient>().getValue();
+    if (!colorRamp || !applyColorRamp(colorValue, *colorRamp)) {
         return;
     }
 
-    const auto length = colorRamp->bytes();
-
-    for (uint32_t i = 0; i < length; i += 4) {
-        const auto color = colorValue.evaluate(static_cast<double>(i) / length);
-        colorRamp->data[i] = static_cast<uint8_t>(std::floor(color.r * 255.f));
-        colorRamp->data[i + 1] = static_cast<uint8_t>(std::floor(color.g * 255.f));
-        colorRamp->data[i + 2] = static_cast<uint8_t>(std::floor(color.b * 255.f));
-        colorRamp->data[i + 3] = static_cast<uint8_t>(std::floor(color.a * 255.f));
-    }
-
-    if (colorRampTexture) {
-        colorRampTexture = std::nullopt;
-    }
+    colorRampTexture = std::nullopt;
 
 #if MLN_DRAWABLE_RENDERER
     if (colorRampTexture2D) {

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -8,17 +8,40 @@
 #include <mbgl/layout/pattern_layout.hpp>
 #include <mbgl/gfx/texture.hpp>
 
+#include <optional>
+#include <memory>
+
 namespace mbgl {
 
+#if MLN_LEGACY_RENDERER
 class LineProgram;
 class LineGradientProgram;
 class LineSDFProgram;
 class LinePatternProgram;
+#endif
+
+#if MLN_DRAWABLE_RENDERER
+namespace gfx {
+class ShaderGroup;
+class UniformBuffer;
+using ShaderGroupPtr = std::shared_ptr<ShaderGroup>;
+using UniformBufferPtr = std::shared_ptr<UniformBuffer>;
+} // namespace gfx
+#endif
 
 class RenderLineLayer final : public RenderLayer {
 public:
     explicit RenderLineLayer(Immutable<style::LineLayer::Impl>);
     ~RenderLineLayer() override;
+
+#if MLN_DRAWABLE_RENDERER
+    /// Generate any changes needed by the layer
+    void update(gfx::ShaderRegistry&,
+                gfx::Context&,
+                const TransformState&,
+                const RenderTree&,
+                UniqueChangeRequestVec&) override;
+#endif
 
 private:
     void transition(const TransitionParameters&) override;
@@ -27,7 +50,10 @@ private:
     bool hasCrossfade() const override;
     void prepare(const LayerPrepareParameters&) override;
     void upload(gfx::UploadPass&) override;
+
+#if MLN_LEGACY_RENDERER
     void render(PaintParameters&) override;
+#endif
 
     bool queryIntersectsFeature(const GeometryCoordinates&,
                                 const GeometryTileFeature&,
@@ -43,14 +69,26 @@ private:
     float getLineWidth(const GeometryTileFeature&, float, const FeatureState&) const;
     void updateColorRamp();
 
-    PremultipliedImage colorRamp;
+    std::shared_ptr<PremultipliedImage> colorRamp;
     std::optional<gfx::Texture> colorRampTexture;
 
+#if MLN_DRAWABLE_RENDERER
+    gfx::Texture2DPtr colorRampTexture2D;
+#endif
+
+#if MLN_LEGACY_RENDERER
     // Programs
     std::shared_ptr<LineProgram> lineProgram;
     std::shared_ptr<LineGradientProgram> lineGradientProgram;
     std::shared_ptr<LineSDFProgram> lineSDFProgram;
     std::shared_ptr<LinePatternProgram> linePatternProgram;
+#endif
+#if MLN_DRAWABLE_RENDERER
+    gfx::ShaderGroupPtr lineShaderGroup;
+    gfx::ShaderGroupPtr lineGradientShaderGroup;
+    gfx::ShaderGroupPtr lineSDFShaderGroup;
+    gfx::ShaderGroupPtr linePatternShaderGroup;
+#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -7,9 +7,19 @@
 #include <mbgl/programs/programs.hpp>
 #include <mbgl/programs/raster_program.hpp>
 #include <mbgl/tile/tile.hpp>
+#include <mbgl/gfx/context.hpp>
 #include <mbgl/gfx/cull_face_mode.hpp>
 #include <mbgl/math/angles.hpp>
 #include <mbgl/style/layers/raster_layer_impl.hpp>
+
+#if MLN_DRAWABLE_RENDERER
+#include <mbgl/renderer/layers/raster_layer_tweaker.hpp>
+#include <mbgl/gfx/image_drawable_data.hpp>
+#include <mbgl/gfx/drawable_impl.hpp>
+#include <mbgl/gfx/drawable_builder.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#endif
 
 namespace mbgl {
 
@@ -40,6 +50,12 @@ void RenderRasterLayer::evaluate(const PropertyEvaluationParameters& parameters)
     passes = properties->evaluated.get<style::RasterOpacity>() > 0 ? RenderPass::Translucent : RenderPass::None;
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
+
+#if MLN_DRAWABLE_RENDERER
+    if (layerGroup && layerGroup->getLayerTweaker()) {
+        layerGroup->setLayerTweaker(std::make_shared<RasterLayerTweaker>(evaluatedProperties));
+    }
+#endif
 }
 
 bool RenderRasterLayer::hasTransition() const {
@@ -50,6 +66,7 @@ bool RenderRasterLayer::hasCrossfade() const {
     return false;
 }
 
+#if MLN_LEGACY_RENDERER
 static float saturationFactor(float saturation) {
     if (saturation > 0) {
         return 1.f - 1.f / (1.001f - saturation);
@@ -74,20 +91,26 @@ static std::array<float, 3> spinWeights(float spin) {
         {(2 * c + 1) / 3, (-std::sqrt(3.0f) * s - c + 1) / 3, (std::sqrt(3.0f) * s - c + 1) / 3}};
     return spin_weights;
 }
+#endif
 
 void RenderRasterLayer::prepare(const LayerPrepareParameters& params) {
     renderTiles = params.source->getRenderTiles();
     imageData = params.source->getImageRenderData();
     // It is possible image data is not available until the source loads it.
     assert(renderTiles || imageData || !params.source->isEnabled());
+
+#if MLN_DRAWABLE_RENDERER
+    updateRenderTileIDs();
+#endif // MLN_DRAWABLE_RENDERER
 }
 
+#if MLN_LEGACY_RENDERER
 void RenderRasterLayer::render(PaintParameters& parameters) {
     if (parameters.pass != RenderPass::Translucent || (!renderTiles && !imageData)) {
         return;
     }
 
-    if (!parameters.shaders.populate(rasterProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(rasterProgram)) return;
 
     const auto& evaluated = static_cast<const RasterLayerProperties&>(*evaluatedProperties).evaluated;
     RasterProgram::Binders paintAttributeData{evaluated, 0};
@@ -196,5 +219,343 @@ void RenderRasterLayer::render(PaintParameters& parameters) {
         }
     }
 }
+
+#endif // MLN_LEGACY_RENDERER
+
+#if MLN_DRAWABLE_RENDERER
+void RenderRasterLayer::markLayerRenderable(bool willRender, UniqueChangeRequestVec& changes) {
+    RenderLayer::markLayerRenderable(willRender, changes);
+    activateLayerGroup(imageLayerGroup, willRender, changes);
+}
+
+constexpr auto PosAttribName = "a_pos";
+constexpr auto TexturePosAttribName = "a_texture_pos";
+constexpr auto Image0UniformName = "u_image0";
+constexpr auto Image1UniformName = "u_image1";
+
+void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
+                               gfx::Context& context,
+                               const TransformState& /*state*/,
+                               [[maybe_unused]] const RenderTree& renderTree,
+                               [[maybe_unused]] UniqueChangeRequestVec& changes) {
+    std::unique_lock<std::mutex> guard(mutex);
+
+    if ((!renderTiles || renderTiles->empty()) && !imageData) {
+        if (layerGroup) {
+            stats.drawablesRemoved += layerGroup->clearDrawables();
+        }
+        if (imageLayerGroup) {
+            stats.drawablesRemoved += imageLayerGroup->clearDrawables();
+        }
+        return;
+    }
+
+    auto renderPass = RenderPass::Translucent;
+
+    if (!rasterShader) {
+        rasterShader = context.getGenericShader(shaders, "RasterShader");
+    }
+
+    if (!staticDataSharedVertices) {
+        staticDataSharedVertices = std::make_shared<RasterVertexVector>(RenderStaticData::rasterVertices());
+    }
+    if (!staticDataIndices) {
+        staticDataIndices = std::make_shared<RasterIndexVector>(RenderStaticData::quadTriangleIndices());
+    }
+    if (!staticDataSegments) {
+        staticDataSegments = std::make_shared<RasterSegmentVector>(RenderStaticData::rasterSegments());
+    }
+
+    const auto& evaluated = static_cast<const RasterLayerProperties&>(*evaluatedProperties).evaluated;
+    RasterProgram::Binders paintAttributeData{evaluated, 0};
+
+    const gfx::TextureFilterType filter = evaluated.get<RasterResampling>() == RasterResamplingType::Nearest
+                                              ? gfx::TextureFilterType::Nearest
+                                              : gfx::TextureFilterType::Linear;
+
+    auto createBuilder = [&context, &renderPass, this]() -> std::unique_ptr<gfx::DrawableBuilder> {
+        std::unique_ptr<gfx::DrawableBuilder> builder{context.createDrawableBuilder("raster")};
+        builder->setShader(rasterShader);
+        builder->setRenderPass(renderPass);
+        builder->setSubLayerIndex(0);
+        builder->setDepthType((renderPass == RenderPass::Opaque) ? gfx::DepthMaskType::ReadWrite
+                                                                 : gfx::DepthMaskType::ReadOnly);
+        builder->setColorMode(gfx::ColorMode::alphaBlended());
+        builder->setCullFaceMode(gfx::CullFaceMode::disabled());
+        builder->setVertexAttrName(PosAttribName);
+
+        return builder;
+    };
+
+    auto setTextures = [&context, &filter, this](std::unique_ptr<gfx::DrawableBuilder>& builder,
+                                                 const RasterBucket& bucket) {
+        // textures
+        auto location0 = rasterShader->getSamplerLocation(Image0UniformName);
+        if (location0.has_value()) {
+            std::shared_ptr<gfx::Texture2D> tex0 = context.createTexture2D();
+            tex0->setImage(bucket.image);
+            tex0->setSamplerConfiguration({filter, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+            builder->setTexture(tex0, location0.value());
+        }
+        auto location1 = rasterShader->getSamplerLocation(Image1UniformName);
+        if (location1.has_value()) {
+            std::shared_ptr<gfx::Texture2D> tex1 = context.createTexture2D();
+            tex1->setImage(bucket.image);
+            tex1->setSamplerConfiguration({filter, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+            builder->setTexture(tex1, location1.value());
+        }
+    };
+
+    auto buildTileDrawables = [&setTextures](std::unique_ptr<gfx::DrawableBuilder>& builder,
+                                             const RasterBucket& bucket) {
+        auto buildRenderData = [](const TileMask& mask,
+                                  std::vector<std::array<int16_t, 2>>& vertices,
+                                  std::vector<std::array<int16_t, 2>>& attributes,
+                                  std::vector<uint16_t>& indices,
+                                  std::vector<SegmentBase>& segments) {
+            constexpr const uint16_t vertexLength = 4;
+
+            if (vertices.empty()) {
+                vertices.reserve(mask.size() * vertexLength);
+                attributes.reserve(mask.size() * vertexLength);
+                indices.reserve(mask.size() * 6);
+                segments.reserve(mask.size());
+            }
+            // Create the vertex buffer for the specified tile mask.
+            for (const auto& id : mask) {
+                // Create a quad for every masked tile.
+                const int32_t vertexExtent = util::EXTENT >> id.z;
+
+                const Point<int16_t> tlVertex = {static_cast<int16_t>(id.x * vertexExtent),
+                                                 static_cast<int16_t>(id.y * vertexExtent)};
+                const Point<int16_t> brVertex = {static_cast<int16_t>(tlVertex.x + vertexExtent),
+                                                 static_cast<int16_t>(tlVertex.y + vertexExtent)};
+
+                if (segments.empty() ||
+                    (segments.back().vertexLength + vertexLength > std::numeric_limits<uint16_t>::max())) {
+                    // Move to a new segments because the old one can't hold the geometry.
+                    segments.emplace_back(vertices.size(), indices.size());
+                }
+
+                vertices.emplace_back(std::array<int16_t, 2>{{tlVertex.x, tlVertex.y}});
+                attributes.emplace_back(std::array<int16_t, 2>{{tlVertex.x, tlVertex.y}});
+
+                vertices.emplace_back(std::array<int16_t, 2>{{brVertex.x, tlVertex.y}});
+                attributes.emplace_back(std::array<int16_t, 2>{{brVertex.x, tlVertex.y}});
+
+                vertices.emplace_back(std::array<int16_t, 2>{{tlVertex.x, brVertex.y}});
+                attributes.emplace_back(std::array<int16_t, 2>{{tlVertex.x, brVertex.y}});
+
+                vertices.emplace_back(std::array<int16_t, 2>{{brVertex.x, brVertex.y}});
+                attributes.emplace_back(std::array<int16_t, 2>{{brVertex.x, brVertex.y}});
+
+                auto& segment = segments.back();
+                assert(segment.vertexLength <= std::numeric_limits<uint16_t>::max());
+                const auto offset = static_cast<uint16_t>(segment.vertexLength);
+
+                // 0, 1, 2
+                // 1, 2, 3
+                indices.insert(indices.end(),
+                               {offset,
+                                static_cast<uint16_t>(offset + 1u),
+                                static_cast<uint16_t>(offset + 2u),
+                                static_cast<uint16_t>(offset + 1u),
+                                static_cast<uint16_t>(offset + 2u),
+                                static_cast<uint16_t>(offset + 3u)});
+
+                segment.vertexLength += vertexLength;
+                segment.indexLength += 6;
+            }
+        };
+
+        std::vector<std::array<int16_t, 2>> vertices, attributes;
+        std::vector<uint16_t> indices;
+        std::vector<SegmentBase> segments;
+        buildRenderData(bucket.mask, vertices, attributes, indices, segments);
+        builder->addVertices(vertices, 0, vertices.size());
+        builder->setSegments(gfx::Triangles(), indices, segments.data(), segments.size());
+
+        // attributes
+        {
+            gfx::VertexAttributeArray vertexAttrs;
+            if (const auto& attr = vertexAttrs.getOrAdd(TexturePosAttribName)) {
+                attr->reserve(attributes.size());
+                std::size_t index{0};
+                for (const auto& a : attributes) {
+                    attr->set<gfx::VertexAttribute::int2>(index++, {a[0], a[1]});
+                }
+            }
+            builder->setVertexAttributes(std::move(vertexAttrs));
+        }
+
+        // textures
+        setTextures(builder, bucket);
+    };
+
+    auto updateTileDrawables = [&](std::unique_ptr<gfx::DrawableBuilder>& builder,
+                                   auto* tileLayerGroup,
+                                   const auto& tileID,
+                                   const RasterBucket& bucket) {
+        // Set up tile drawable
+        auto vertices = staticDataSharedVertices;
+        auto indices = staticDataIndices;
+        const RasterSegmentVector* segments = staticDataSegments.get();
+
+        if (!bucket.vertices.empty() && !bucket.indices.empty() && !bucket.segments.empty()) {
+            vertices = bucket.sharedVertices;
+            indices = bucket.sharedTriangles;
+            segments = &bucket.segments;
+        }
+
+        // attributes
+        gfx::VertexAttributeArray vertexAttrs;
+
+        if (const auto& attr = vertexAttrs.add(PosAttribName)) {
+            attr->setSharedRawData(vertices,
+                                   offsetof(RasterLayoutVertex, a1),
+                                   0,
+                                   sizeof(RasterLayoutVertex),
+                                   gfx::AttributeDataType::Short2);
+        }
+        if (const auto& attr = vertexAttrs.getOrAdd(TexturePosAttribName)) {
+            attr->setSharedRawData(vertices,
+                                   offsetof(RasterLayoutVertex, a2),
+                                   0,
+                                   sizeof(RasterLayoutVertex),
+                                   gfx::AttributeDataType::Short4);
+        }
+
+        tileLayerGroup->visitDrawables(renderPass, tileID, [&](gfx::Drawable& drawable) {
+            drawable.setVertexAttributes(std::move(vertexAttrs));
+            drawable.setVertices({}, vertices->elements(), gfx::AttributeDataType::Short2);
+
+            std::vector<std::unique_ptr<gfx::Drawable::DrawSegment>> drawSegments;
+            for (std::size_t i = 0; i < segments->size(); ++i) {
+                const auto& seg = segments->data()[i];
+                auto segCopy = SegmentBase{
+                    // no copy constructor
+                    seg.vertexOffset,
+                    seg.indexOffset,
+                    seg.vertexLength,
+                    seg.indexLength,
+                    seg.sortKey,
+                };
+                drawSegments.emplace_back(builder->createSegment(gfx::Triangles(), std::move(segCopy)));
+            }
+            drawable.setIndexData(indices->vector(), std::move(drawSegments));
+        });
+    };
+
+    auto buildImageDrawables = [&setTextures](std::unique_ptr<gfx::DrawableBuilder>& builder,
+                                              const RasterBucket& bucket) {
+        // attributes
+        {
+            gfx::VertexAttributeArray vertexAttrs;
+
+            if (auto& attr = vertexAttrs.add(PosAttribName)) {
+                attr->setSharedRawData(bucket.sharedVertices,
+                                       offsetof(RasterLayoutVertex, a1),
+                                       /*vertexOffset=*/0,
+                                       sizeof(RasterLayoutVertex),
+                                       gfx::AttributeDataType::Short2);
+            }
+
+            if (auto& attr = vertexAttrs.getOrAdd(TexturePosAttribName)) {
+                std::size_t index{0};
+                for (auto& v : bucket.vertices.vector()) {
+                    attr->set<gfx::VertexAttribute::int2>(index++, {v.a2[0], v.a2[1]});
+                }
+            }
+            builder->setVertexAttributes(std::move(vertexAttrs));
+        }
+
+        builder->setRawVertices({}, bucket.vertices.elements(), gfx::AttributeDataType::Short2);
+        builder->setSegments(gfx::Triangles(), bucket.sharedTriangles, bucket.segments.data(), bucket.segments.size());
+
+        // textures
+        setTextures(builder, bucket);
+    };
+
+    if (imageData) {
+        RasterBucket& bucket = *imageData->bucket;
+        if (!bucket.vertices.empty()) {
+            if (imageLayerGroup) {
+                stats.drawablesRemoved += imageLayerGroup->clearDrawables();
+            } else {
+                // Set up a layer group
+                imageLayerGroup = context.createLayerGroup(layerIndex, /*initialCapacity=*/64, getID());
+                imageLayerGroup->setLayerTweaker(std::make_shared<RasterLayerTweaker>(evaluatedProperties));
+                activateLayerGroup(imageLayerGroup, isRenderable, changes);
+            }
+
+            auto builder = createBuilder();
+            for (const auto& matrix_ : imageData->matrices) {
+                buildImageDrawables(builder, bucket);
+
+                // finish
+                builder->flush();
+
+                for (auto& drawable : builder->clearDrawables()) {
+                    drawable->setData(std::make_unique<gfx::ImageDrawableData>(matrix_));
+                    imageLayerGroup->addDrawable(std::move(drawable));
+                    ++stats.drawablesAdded;
+                }
+            }
+        }
+    } else if (renderTiles) {
+        if (layerGroup) {
+            stats.drawablesRemoved += layerGroup->removeDrawablesIf([&](gfx::Drawable& drawable) {
+                // Has this tile dropped out of the cover set?
+                return drawable.getTileID() && !hasRenderTile(*drawable.getTileID());
+            });
+        } else {
+            // Set up a tile layer group
+            if (auto layerGroup_ = context.createTileLayerGroup(layerIndex, /*initialCapacity=*/64, getID())) {
+                layerGroup_->setLayerTweaker(std::make_shared<RasterLayerTweaker>(evaluatedProperties));
+                setLayerGroup(std::move(layerGroup_), changes);
+            }
+        }
+
+        auto* tileLayerGroup = static_cast<TileLayerGroup*>(layerGroup.get());
+
+        auto builder = createBuilder();
+        for (const RenderTile& tile : *renderTiles) {
+            const auto& tileID = tile.getOverscaledTileID();
+
+            const auto* bucket_ = tile.getBucket(*baseImpl);
+            if (!bucket_ || !bucket_->hasData()) {
+                removeTile(renderPass, tileID);
+                continue;
+            }
+
+            const auto& bucket = static_cast<const RasterBucket&>(*bucket_);
+
+            const auto prevBucketID = getRenderTileBucketID(tileID);
+            if (prevBucketID != util::SimpleIdentity::Empty && prevBucketID != bucket.getID()) {
+                // This tile was previously set up from a different bucket, drop and re-create any drawables for it.
+                removeTile(renderPass, tileID);
+            }
+            setRenderTileBucketID(tileID, bucket.getID());
+
+            if (tileLayerGroup->getDrawableCount(renderPass, tileID) > 0) {
+                updateTileDrawables(builder, tileLayerGroup, tileID, bucket);
+                continue;
+            }
+
+            if (bucket.image) {
+                buildTileDrawables(builder, bucket);
+
+                // finish
+                builder->flush();
+                for (auto& drawable : builder->clearDrawables()) {
+                    drawable->setTileID(tileID);
+                    tileLayerGroup->addDrawable(renderPass, tileID, std::move(drawable));
+                    ++stats.drawablesAdded;
+                }
+            };
+        }
+    }
+}
+#endif // MLN_DRAWABLE_RENDERER
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_raster_layer.hpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <mbgl/renderer/render_layer.hpp>
+#include <mbgl/programs/raster_program.hpp>
 #include <mbgl/style/layers/raster_layer_impl.hpp>
 #include <mbgl/style/layers/raster_layer_properties.hpp>
+#include <mbgl/gfx/context.hpp>
 
 namespace mbgl {
 
@@ -14,20 +16,53 @@ public:
     explicit RenderRasterLayer(Immutable<style::RasterLayer::Impl>);
     ~RenderRasterLayer() override;
 
+#if MLN_DRAWABLE_RENDERER
+    /// Generate any changes needed by the layer
+    void update(gfx::ShaderRegistry&,
+                gfx::Context&,
+                const TransformState&,
+                const RenderTree&,
+                UniqueChangeRequestVec&) override;
+#endif
+
+protected:
+#if MLN_DRAWABLE_RENDERER
+    void markLayerRenderable(bool willRender, UniqueChangeRequestVec&) override;
+#endif // MLN_DRAWABLE_RENDERER
+
 private:
     void transition(const TransitionParameters&) override;
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     void prepare(const LayerPrepareParameters&) override;
+
+#if MLN_LEGACY_RENDERER
     void render(PaintParameters&) override;
+#endif
 
     // Paint properties
     style::RasterPaintProperties::Unevaluated unevaluated;
     const ImageSourceRenderData* imageData = nullptr;
 
+#if MLN_LEGACY_RENDERER
     // Programs
     std::shared_ptr<RasterProgram> rasterProgram;
+#endif
+
+#if MLN_DRAWABLE_RENDERER
+    gfx::ShaderProgramBasePtr rasterShader;
+    LayerGroupPtr imageLayerGroup;
+
+    using RasterVertexVector = gfx::VertexVector<RasterLayoutVertex>;
+    std::shared_ptr<RasterVertexVector> staticDataSharedVertices;
+
+    using RasterIndexVector = gfx::IndexVector<gfx::Triangles>;
+    std::shared_ptr<RasterIndexVector> staticDataIndices;
+
+    using RasterSegmentVector = SegmentVector<RasterAttributes>;
+    std::shared_ptr<RasterSegmentVector> staticDataSegments;
+#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -1,23 +1,35 @@
 #include <mbgl/renderer/layers/render_symbol_layer.hpp>
-#include <mbgl/renderer/buckets/symbol_bucket.hpp>
+
+#include <mbgl/gfx/cull_face_mode.hpp>
+#include <mbgl/layout/symbol_layout.hpp>
+#include <mbgl/programs/collision_box_program.hpp>
+#include <mbgl/programs/programs.hpp>
+#include <mbgl/programs/symbol_program.hpp>
 #include <mbgl/renderer/bucket_parameters.hpp>
+#include <mbgl/renderer/buckets/symbol_bucket.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/renderer/property_evaluation_parameters.hpp>
 #include <mbgl/renderer/render_source.hpp>
 #include <mbgl/renderer/render_tile.hpp>
+#include <mbgl/renderer/tile_render_data.hpp>
 #include <mbgl/renderer/upload_parameters.hpp>
-#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/style/layers/symbol_layer_impl.hpp>
 #include <mbgl/text/glyph_atlas.hpp>
 #include <mbgl/text/shaping.hpp>
-#include <mbgl/programs/programs.hpp>
-#include <mbgl/programs/symbol_program.hpp>
-#include <mbgl/programs/collision_box_program.hpp>
-#include <mbgl/tile/tile.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
-#include <mbgl/style/layers/symbol_layer_impl.hpp>
-#include <mbgl/gfx/cull_face_mode.hpp>
-#include <mbgl/layout/symbol_layout.hpp>
+#include <mbgl/tile/tile.hpp>
+#include <mbgl/util/convert.hpp>
 #include <mbgl/util/math.hpp>
+
+#if MLN_DRAWABLE_RENDERER
+#include <mbgl/gfx/drawable_atlases_tweaker.hpp>
+#include <mbgl/gfx/drawable_builder.hpp>
+#include <mbgl/gfx/symbol_drawable_data.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/layers/symbol_layer_tweaker.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#endif // MLN_DRAWABLE_RENDERER
 
 #include <cmath>
 #include <set>
@@ -27,6 +39,15 @@ namespace mbgl {
 using namespace style;
 namespace {
 
+#if MLN_DRAWABLE_RENDERER
+
+constexpr std::string_view SymbolIconShaderName = "SymbolIconShader";
+constexpr std::string_view SymbolSDFIconShaderName = "SymbolSDFTextShader";
+constexpr std::string_view SymbolSDFTextShaderName = "SymbolSDFIconShader";
+constexpr std::string_view SymbolTextAndIconShaderName = "SymbolTextAndIconShader";
+
+#endif // MLN_DRAWABLE_RENDERER
+
 style::SymbolPropertyValues iconPropertyValues(const style::SymbolPaintProperties::PossiblyEvaluated& evaluated_,
                                                const style::SymbolLayoutProperties::PossiblyEvaluated& layout_) {
     return style::SymbolPropertyValues{layout_.get<style::IconPitchAlignment>(),
@@ -35,7 +56,7 @@ style::SymbolPropertyValues iconPropertyValues(const style::SymbolPaintPropertie
                                        evaluated_.get<style::IconTranslate>(),
                                        evaluated_.get<style::IconTranslateAnchor>(),
                                        evaluated_.get<style::IconHaloColor>().constantOr(Color::black()).a > 0 &&
-                                           evaluated_.get<style::IconHaloWidth>().constantOr(1),
+                                           evaluated_.get<style::IconHaloWidth>().constantOr(1) != 0,
                                        evaluated_.get<style::IconColor>().constantOr(Color::black()).a > 0};
 }
 
@@ -47,12 +68,12 @@ style::SymbolPropertyValues textPropertyValues(const style::SymbolPaintPropertie
                                        evaluated_.get<style::TextTranslate>(),
                                        evaluated_.get<style::TextTranslateAnchor>(),
                                        evaluated_.get<style::TextHaloColor>().constantOr(Color::black()).a > 0 &&
-                                           evaluated_.get<style::TextHaloWidth>().constantOr(1),
+                                           evaluated_.get<style::TextHaloWidth>().constantOr(1) != 0,
                                        evaluated_.get<style::TextColor>().constantOr(Color::black()).a > 0};
 }
 
-using SegmentWrapper = std::reference_wrapper<Segment<SymbolTextAttributes>>;
-using SegmentVectorWrapper = std::reference_wrapper<SegmentVector<SymbolTextAttributes>>;
+using SegmentWrapper = std::reference_wrapper<const Segment<SymbolTextAttributes>>;
+using SegmentVectorWrapper = std::reference_wrapper<const SegmentVector<SymbolTextAttributes>>;
 using SegmentsWrapper = variant<SegmentWrapper, SegmentVectorWrapper>;
 
 struct RenderableSegment {
@@ -61,13 +82,15 @@ struct RenderableSegment {
                       const LayerRenderData& renderData_,
                       const SymbolBucket::PaintProperties& bucketPaintProperties_,
                       float sortKey_,
-                      const SymbolType type_)
+                      const SymbolType type_,
+                      const uint8_t overscaledZ_ = 0)
         : segment(segment_),
           tile(tile_),
           renderData(renderData_),
           bucketPaintProperties(bucketPaintProperties_),
           sortKey(sortKey_),
-          type(type_) {}
+          type(type_),
+          overscaledZ(overscaledZ_) {}
 
     SegmentWrapper segment;
     const RenderTile& tile;
@@ -75,6 +98,7 @@ struct RenderableSegment {
     const SymbolBucket::PaintProperties& bucketPaintProperties;
     float sortKey;
     SymbolType type;
+    uint8_t overscaledZ;
 
     friend bool operator<(const RenderableSegment& lhs, const RenderableSegment& rhs) {
         // Sort renderable segments by a sort key.
@@ -99,6 +123,8 @@ struct RenderableSegment {
     }
 };
 
+#if MLN_LEGACY_RENDERER
+
 template <typename DrawFn>
 void drawIcon(const RenderSymbolLayer::Programs& programs,
               const DrawFn& draw,
@@ -120,18 +146,17 @@ void drawIcon(const RenderSymbolLayer::Programs& programs,
     const bool iconScaled = layout.get<IconSize>().constantOr(1.0) != 1.0 || bucket.iconsNeedLinear;
     const bool iconTransformed = values.rotationAlignment == AlignmentType::Map || parameters.state.getPitch() != 0;
 
-    const gfx::TextureBinding textureBinding{tile.getIconAtlasTexture().getResource(),
-                                             sdfIcons || parameters.state.isChanging() || iconScaled || iconTransformed
-                                                 ? gfx::TextureFilterType::Linear
-                                                 : gfx::TextureFilterType::Nearest};
+    const bool linear = sdfIcons || parameters.state.isChanging() || iconScaled || iconTransformed;
+    const auto filterType = linear ? gfx::TextureFilterType::Linear : gfx::TextureFilterType::Nearest;
+    const gfx::TextureBinding textureBinding = tile.getIconAtlasTextureBinding(filterType);
 
-    const Size& iconSize = tile.getIconAtlasTexture().size;
+    const Size& iconSize = tile.getIconAtlasTexture()->getSize();
     const bool variablePlacedIcon = bucket.hasVariablePlacement && layout.get<IconTextFit>() != IconTextFitType::None;
 
     if (sdfIcons) {
         if (values.hasHalo) {
             draw(*programs.symbolSDFIconProgram,
-                 SymbolSDFIconProgram::layoutUniformValues(false,
+                 SymbolSDFIconProgram::layoutUniformValues(/* isText = */ false,
                                                            variablePlacedIcon,
                                                            values,
                                                            iconSize,
@@ -153,7 +178,7 @@ void drawIcon(const RenderSymbolLayer::Programs& programs,
 
         if (values.hasFill) {
             draw(*programs.symbolSDFIconProgram,
-                 SymbolSDFIconProgram::layoutUniformValues(false,
+                 SymbolSDFIconProgram::layoutUniformValues(/* isText = */ false,
                                                            variablePlacedIcon,
                                                            values,
                                                            iconSize,
@@ -174,7 +199,7 @@ void drawIcon(const RenderSymbolLayer::Programs& programs,
         }
     } else {
         draw(*programs.symbolIconProgram,
-             SymbolIconProgram::layoutUniformValues(false,
+             SymbolIconProgram::layoutUniformValues(/* isText = */ false,
                                                     variablePlacedIcon,
                                                     values,
                                                     iconSize,
@@ -201,19 +226,18 @@ void drawText(const RenderSymbolLayer::Programs& programs,
               SegmentsWrapper textSegments,
               const SymbolBucket::PaintProperties& bucketPaintProperties,
               const PaintParameters& parameters) {
-    auto& bucket = static_cast<SymbolBucket&>(*renderData.bucket);
+    const auto& bucket = static_cast<SymbolBucket&>(*renderData.bucket);
     const auto& evaluated = getEvaluated<SymbolLayerProperties>(renderData.layerProperties);
     const auto& layout = *bucket.layout;
 
-    auto values = textPropertyValues(evaluated, layout);
+    const auto values = textPropertyValues(evaluated, layout);
     const auto& paintPropertyValues = RenderSymbolLayer::textPaintProperties(evaluated);
 
     const bool alongLine = layout.get<SymbolPlacement>() != SymbolPlacementType::Point &&
-                           layout.get<TextRotationAlignment>() == AlignmentType::Map;
+                           values.rotationAlignment == AlignmentType::Map;
 
-    const Size& glyphTexSize = tile.getGlyphAtlasTexture().size;
-    const gfx::TextureBinding glyphTextureBinding{tile.getGlyphAtlasTexture().getResource(),
-                                                  gfx::TextureFilterType::Linear};
+    const Size& glyphTexSize = tile.getGlyphAtlasTexture()->getSize();
+    const gfx::TextureBinding glyphTextureBinding = tile.getGlyphAtlasTextureBinding(gfx::TextureFilterType::Linear);
 
     const auto drawGlyphs = [&](auto& program, const auto& uniforms, const auto& textures, SymbolSDFPart part) {
         draw(program,
@@ -231,12 +255,10 @@ void drawText(const RenderSymbolLayer::Programs& programs,
         const ZoomEvaluatedSize partiallyEvaluatedTextSize = bucket.textSizeBinder->evaluateForZoom(
             static_cast<float>(parameters.state.getZoom()));
         const bool transformed = values.rotationAlignment == AlignmentType::Map || parameters.state.getPitch() != 0;
-        const Size& iconTexSize = tile.getIconAtlasTexture().size;
-        const gfx::TextureBinding iconTextureBinding{
-            tile.getIconAtlasTexture().getResource(),
-            parameters.state.isChanging() || transformed || !partiallyEvaluatedTextSize.isZoomConstant
-                ? gfx::TextureFilterType::Linear
-                : gfx::TextureFilterType::Nearest};
+        const Size& iconTexSize = tile.getIconAtlasTexture()->getSize();
+        const bool linear = parameters.state.isChanging() || transformed || !partiallyEvaluatedTextSize.isZoomConstant;
+        const auto filterType = linear ? gfx::TextureFilterType::Linear : gfx::TextureFilterType::Nearest;
+        const gfx::TextureBinding iconTextureBinding = tile.getIconAtlasTextureBinding(filterType);
         if (values.hasHalo) {
             drawGlyphs(*programs.symbolTextAndIconProgram,
                        SymbolTextAndIconProgram::layoutUniformValues(bucket.hasVariablePlacement,
@@ -273,7 +295,7 @@ void drawText(const RenderSymbolLayer::Programs& programs,
     } else {
         if (values.hasHalo) {
             drawGlyphs(*programs.symbolSDFTextProgram,
-                       SymbolSDFTextProgram::layoutUniformValues(true,
+                       SymbolSDFTextProgram::layoutUniformValues(/* isText = */ true,
                                                                  bucket.hasVariablePlacement,
                                                                  values,
                                                                  glyphTexSize,
@@ -290,7 +312,7 @@ void drawText(const RenderSymbolLayer::Programs& programs,
 
         if (values.hasFill) {
             drawGlyphs(*programs.symbolSDFTextProgram,
-                       SymbolSDFTextProgram::layoutUniformValues(true,
+                       SymbolSDFTextProgram::layoutUniformValues(/* isText = */ true,
                                                                  bucket.hasVariablePlacement,
                                                                  values,
                                                                  glyphTexSize,
@@ -306,6 +328,8 @@ void drawText(const RenderSymbolLayer::Programs& programs,
         }
     }
 }
+
+#endif // MLN_LEGACY_RENDERER
 
 inline const SymbolLayer::Impl& impl_cast(const Immutable<style::Layer::Impl>& impl) {
     assert(impl->getTypeInfo() == SymbolLayer::Impl::staticTypeInfo());
@@ -330,7 +354,7 @@ void RenderSymbolLayer::evaluate(const PropertyEvaluationParameters& parameters)
     auto properties = makeMutable<SymbolLayerProperties>(staticImmutableCast<SymbolLayer::Impl>(baseImpl),
                                                          unevaluated.evaluate(parameters));
     auto& evaluated = properties->evaluated;
-    auto& layout = impl_cast(baseImpl).layout;
+    const auto& layout = impl_cast(baseImpl).layout;
 
     if (hasFormatSectionOverrides) {
         SymbolLayerPaintPropertyOverrides::setOverrides(layout, evaluated);
@@ -347,6 +371,12 @@ void RenderSymbolLayer::evaluate(const PropertyEvaluationParameters& parameters)
                  : RenderPass::None;
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
+
+#if MLN_DRAWABLE_RENDERER
+    if (layerGroup) {
+        layerGroup->setLayerTweaker(std::make_shared<SymbolLayerTweaker>(evaluatedProperties));
+    }
+#endif // MLN_DRAWABLE_RENDERER
 }
 
 bool RenderSymbolLayer::hasTransition() const {
@@ -357,18 +387,20 @@ bool RenderSymbolLayer::hasCrossfade() const {
     return false;
 }
 
+#if MLN_LEGACY_RENDERER
+
 void RenderSymbolLayer::render(PaintParameters& parameters) {
     assert(renderTiles);
     if (parameters.pass == RenderPass::Opaque) {
         return;
     }
 
-    if (!parameters.shaders.populate(programs.symbolIconProgram)) return;
-    if (!parameters.shaders.populate(programs.symbolSDFIconProgram)) return;
-    if (!parameters.shaders.populate(programs.symbolSDFTextProgram)) return;
-    if (!parameters.shaders.populate(programs.symbolTextAndIconProgram)) return;
-    if (!parameters.shaders.populate(programs.collisionBoxProgram)) return;
-    if (!parameters.shaders.populate(programs.collisionCircleProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(programs.symbolIconProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(programs.symbolSDFIconProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(programs.symbolSDFTextProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(programs.symbolTextAndIconProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(programs.collisionBoxProgram)) return;
+    if (!parameters.shaders.getLegacyGroup().populate(programs.collisionCircleProgram)) return;
 
     const bool sortFeaturesByKey = !impl_cast(baseImpl).layout.get<SymbolSortKey>().isUndefined();
     std::multiset<RenderableSegment> renderableSegments;
@@ -376,7 +408,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
     const auto draw = [&parameters, this](auto& programInstance,
                                           const auto& uniformValues,
                                           const auto& buffers,
-                                          auto& segments,
+                                          const auto& segments,
                                           const auto& symbolSizeBinder,
                                           const auto& binders,
                                           const auto& paintProperties,
@@ -394,7 +426,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
         this->checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
 
         segments.match(
-            [&](const std::reference_wrapper<Segment<SymbolTextAttributes>>& segment) {
+            [&](const SegmentWrapper& segment) {
                 programInstance.draw(parameters.context,
                                      *parameters.renderPass,
                                      gfx::Triangles(),
@@ -409,7 +441,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
                                      textureBindings,
                                      this->getID() + "/" + suffix);
             },
-            [&](const std::reference_wrapper<SegmentVector<SymbolTextAttributes>>& segmentVector) {
+            [&](const SegmentVectorWrapper& segmentVector) {
                 programInstance.draw(parameters.context,
                                      *parameters.renderPass,
                                      gfx::Triangles(),
@@ -461,7 +493,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
                          draw,
                          tile,
                          *renderData,
-                         std::ref(bucket.icon.segments),
+                         std::cref(bucket.icon.segments),
                          bucketPaintProperties,
                          parameters,
                          false /*sdfIcon*/
@@ -477,7 +509,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
                          draw,
                          tile,
                          *renderData,
-                         std::ref(bucket.sdfIcon.segments),
+                         std::cref(bucket.sdfIcon.segments),
                          bucketPaintProperties,
                          parameters,
                          true /*sdfIcon*/
@@ -493,7 +525,7 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
                          draw,
                          tile,
                          *renderData,
-                         std::ref(bucket.text.segments),
+                         std::cref(bucket.text.segments),
                          bucketPaintProperties,
                          parameters);
             }
@@ -601,6 +633,8 @@ void RenderSymbolLayer::render(PaintParameters& parameters) {
     }
 }
 
+#endif // MLN_LEGACY_RENDERER
+
 // static
 style::IconPaintProperties::PossiblyEvaluated RenderSymbolLayer::iconPaintProperties(
     const style::SymbolPaintProperties::PossiblyEvaluated& evaluated_) {
@@ -627,6 +661,11 @@ style::TextPaintProperties::PossiblyEvaluated RenderSymbolLayer::textPaintProper
 
 void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
     renderTiles = params.source->getRenderTilesSortedByYPosition();
+
+#if MLN_DRAWABLE_RENDERER
+    updateRenderTileIDs();
+#endif // MLN_DRAWABLE_RENDERER
+
     addRenderPassesFromTiles();
 
     placementData.clear();
@@ -657,5 +696,420 @@ void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
         }
     }
 }
+
+#if MLN_DRAWABLE_RENDERER
+
+namespace {
+
+template <typename TText, typename TIcon>
+const auto& getProperty(const SymbolBucket::PaintProperties& paintProps, bool isText) {
+    return isText ? paintProps.textBinders.get<TText>() : paintProps.iconBinders.get<TIcon>();
+}
+
+template <typename TText, typename TIcon, std::size_t N>
+auto getInterpFactor(const SymbolBucket::PaintProperties& paintProps, bool isText, float currentZoom) {
+    return std::get<N>(getProperty<TText, TIcon>(paintProps, isText)->interpolationFactor(currentZoom));
+}
+
+SymbolDrawableInterpolateUBO buildInterpUBO(const SymbolBucket::PaintProperties& paint, const bool t, const float z) {
+    return {/* .fill_color_t = */ getInterpFactor<TextColor, IconColor, 0>(paint, t, z),
+            /* .halo_color_t = */ getInterpFactor<TextHaloColor, IconHaloColor, 0>(paint, t, z),
+            /* .opacity_t = */ getInterpFactor<TextOpacity, IconOpacity, 0>(paint, t, z),
+            /* .halo_width_t = */ getInterpFactor<TextHaloWidth, IconHaloWidth, 0>(paint, t, z),
+            /* .halo_blur_t = */ getInterpFactor<TextHaloBlur, IconHaloBlur, 0>(paint, t, z),
+            /* .padding = */ 0,
+            0,
+            0};
+}
+
+SymbolDrawableTilePropsUBO buildTileUBO(const SymbolBucket& bucket,
+                                        const gfx::SymbolDrawableData& drawData,
+                                        const float currentZoom) {
+    const bool isText = (drawData.symbolType == SymbolType::Text);
+    const ZoomEvaluatedSize size = isText ? bucket.textSizeBinder->evaluateForZoom(currentZoom)
+                                          : bucket.iconSizeBinder->evaluateForZoom(currentZoom);
+    return {
+        /* .is_text = */ isText,
+        /* .is_halo = */ drawData.isHalo,
+        /* .pitch_with_map = */ (drawData.pitchAlignment == style::AlignmentType::Map),
+        /* .is_size_zoom_constant = */ size.isZoomConstant,
+        /* .is_size_feature_constant = */ size.isFeatureConstant,
+        /* .size_t = */ size.sizeT,
+        /* .size = */ size.size,
+        /* .padding = */ 0,
+    };
+}
+
+constexpr auto dataAttibName = "a_data";
+constexpr auto posOffsetAttribName = "a_pos_offset";
+constexpr auto pixOffsetAttribName = "a_pixeloffset";
+constexpr auto projPosAttribName = "a_projected_pos";
+constexpr auto fadeOpacityAttribName = "a_fade_opacity";
+constexpr auto texUniformName = "u_texture";
+constexpr auto iconTexUniformName = "u_texture_icon";
+
+std::vector<std::string> updateTileAttributes(const SymbolBucket::Buffer& buffer,
+                                              const bool isText,
+                                              const SymbolBucket::PaintProperties& paintProps,
+                                              const SymbolPaintProperties::PossiblyEvaluated& evaluated,
+                                              gfx::VertexAttributeArray& attribs) {
+    if (const auto& attr = attribs.getOrAdd(posOffsetAttribName)) {
+        attr->setSharedRawData(buffer.sharedVertices,
+                               offsetof(SymbolLayoutVertex, a1),
+                               /*vertexOffset=*/0,
+                               sizeof(SymbolLayoutVertex),
+                               gfx::AttributeDataType::Short4);
+    }
+    if (const auto& attr = attribs.getOrAdd(dataAttibName)) {
+        attr->setSharedRawData(buffer.sharedVertices,
+                               offsetof(SymbolLayoutVertex, a2),
+                               /*vertexOffset=*/0,
+                               sizeof(SymbolLayoutVertex),
+                               gfx::AttributeDataType::UShort4);
+    }
+    if (const auto& attr = attribs.getOrAdd(pixOffsetAttribName)) {
+        attr->setSharedRawData(buffer.sharedVertices,
+                               offsetof(SymbolLayoutVertex, a3),
+                               /*vertexOffset=*/0,
+                               sizeof(SymbolLayoutVertex),
+                               gfx::AttributeDataType::Short4);
+    }
+
+    if (const auto& attr = attribs.getOrAdd(projPosAttribName)) {
+        using Vertex = gfx::Vertex<SymbolDynamicLayoutAttributes>;
+        attr->setSharedRawData(buffer.sharedDynamicVertices,
+                               offsetof(Vertex, a1),
+                               /*vertexOffset=*/0,
+                               sizeof(Vertex),
+                               gfx::AttributeDataType::Float3);
+    }
+    if (const auto& attr = attribs.getOrAdd(fadeOpacityAttribName)) {
+        using Vertex = gfx::Vertex<SymbolOpacityAttributes>;
+        attr->setSharedRawData(buffer.sharedOpacityVertices,
+                               offsetof(Vertex, a1),
+                               /*vertexOffset=*/0,
+                               sizeof(Vertex),
+                               gfx::AttributeDataType::Float);
+    }
+
+    return isText
+               ? attribs
+                     .readDataDrivenPaintProperties<TextOpacity, TextColor, TextHaloColor, TextHaloWidth, TextHaloBlur>(
+                         paintProps.textBinders, evaluated)
+               : attribs
+                     .readDataDrivenPaintProperties<IconOpacity, IconColor, IconHaloColor, IconHaloWidth, IconHaloBlur>(
+                         paintProps.iconBinders, evaluated);
+}
+
+void updateTileDrawable(gfx::Drawable& drawable,
+                        gfx::Context& context,
+                        const SymbolBucket& bucket,
+                        const SymbolBucket::PaintProperties& paintProps,
+                        const SymbolPaintProperties::PossiblyEvaluated& evaluated,
+                        const TransformState& state) {
+    if (!drawable.getData()) {
+        return;
+    }
+
+    auto& drawData = static_cast<gfx::SymbolDrawableData&>(*drawable.getData());
+    const auto isText = (drawData.symbolType == SymbolType::Text);
+    const auto sdfIcons = (drawData.symbolType == SymbolType::IconSDF);
+    const auto currentZoom = static_cast<float>(state.getZoom());
+
+    // This property can be set after the initial appearance of the tile, as part of the layout process.
+    drawData.bucketVariablePlacement = bucket.hasVariablePlacement;
+
+    const auto tileUBO = buildTileUBO(bucket, drawData, currentZoom);
+    const auto interpolateUBO = buildInterpUBO(paintProps, isText, currentZoom);
+
+    auto& uniforms = drawable.mutableUniformBuffers();
+    uniforms.createOrUpdate(SymbolLayerTweaker::SymbolDrawableTilePropsUBOName, &tileUBO, context);
+    uniforms.createOrUpdate(SymbolLayerTweaker::SymbolDrawableInterpolateUBOName, &interpolateUBO, context);
+
+    const auto& buffer = isText ? bucket.text : (sdfIcons ? bucket.sdfIcon : bucket.icon);
+    const auto vertexCount = buffer.vertices().elements();
+
+    drawable.setVertices({}, vertexCount, gfx::AttributeDataType::Short4);
+
+    // TODO: detect whether anything has actually changed
+    // See `Placement::updateBucketDynamicVertices`
+
+    gfx::VertexAttributeArray attribs;
+    updateTileAttributes(buffer, isText, paintProps, evaluated, attribs);
+    drawable.setVertexAttributes(std::move(attribs));
+}
+
+} // namespace
+
+void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
+                               gfx::Context& context,
+                               const TransformState& state,
+                               const RenderTree& /*renderTree*/,
+                               UniqueChangeRequestVec& changes) {
+    if (!renderTiles || renderTiles->empty() || passes == RenderPass::None) {
+        removeAllDrawables();
+        return;
+    }
+
+    // Set up a layer group
+    if (!layerGroup) {
+        if (auto layerGroup_ = context.createTileLayerGroup(layerIndex, /*initialCapacity=*/64, getID())) {
+            layerGroup_->setLayerTweaker(std::make_shared<SymbolLayerTweaker>(evaluatedProperties));
+            setLayerGroup(std::move(layerGroup_), changes);
+        }
+    }
+
+    if (!symbolIconGroup) {
+        symbolIconGroup = shaders.getShaderGroup(std::string(SymbolIconShaderName));
+    }
+    if (!symbolSDFIconGroup) {
+        symbolSDFIconGroup = shaders.getShaderGroup(std::string(SymbolSDFIconShaderName));
+    }
+    if (!symbolSDFTextGroup) {
+        symbolSDFTextGroup = shaders.getShaderGroup(std::string(SymbolSDFTextShaderName));
+    }
+    if (!symbolTextAndIconGroup) {
+        symbolTextAndIconGroup = shaders.getShaderGroup(std::string(SymbolTextAndIconShaderName));
+    }
+
+    auto* tileLayerGroup = static_cast<TileLayerGroup*>(layerGroup.get());
+    stats.drawablesRemoved += tileLayerGroup->removeDrawablesIf([&](gfx::Drawable& drawable) {
+        // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
+        const auto& tileID = drawable.getTileID();
+        if (drawable.getRenderPass() != passes || (tileID && !hasRenderTile(*tileID))) {
+            return true;
+        }
+        return false;
+    });
+
+    const bool sortFeaturesByKey = !impl_cast(baseImpl).layout.get<SymbolSortKey>().isUndefined();
+    std::multiset<RenderableSegment> renderableSegments;
+    std::unique_ptr<gfx::DrawableBuilder> builder;
+
+    const auto currentZoom = static_cast<float>(state.getZoom());
+    const auto layerPrefix = getID() + "/";
+
+    for (const RenderTile& tile : *renderTiles) {
+        const auto& tileID = tile.getOverscaledTileID();
+
+        const auto* optRenderData = getRenderDataForPass(tile, passes);
+        if (!optRenderData || !optRenderData->bucket || !optRenderData->bucket->hasData()) {
+            removeTile(passes, tileID);
+            continue;
+        }
+
+        const auto& renderData = *optRenderData;
+        const auto& bucket = static_cast<const SymbolBucket&>(*renderData.bucket);
+
+        const auto prevBucketID = getRenderTileBucketID(tileID);
+        if (prevBucketID != util::SimpleIdentity::Empty && prevBucketID != bucket.getID()) {
+            // This tile was previously set up from a different bucket, drop and re-create any drawables for it.
+            removeTile(passes, tileID);
+        }
+        setRenderTileBucketID(tileID, bucket.getID());
+
+        assert(bucket.paintProperties.find(getID()) != bucket.paintProperties.end());
+        const auto& bucketPaintProperties = bucket.paintProperties.at(getID());
+
+        // If we already have drawables for this tile, update them.
+        if (tileLayerGroup->getDrawableCount(passes, tileID) > 0) {
+            // Just update the drawables we already created
+            tileLayerGroup->visitDrawables(passes, tileID, [&](gfx::Drawable& drawable) {
+                const auto& evaluated = getEvaluated<SymbolLayerProperties>(renderData.layerProperties);
+                updateTileDrawable(drawable, context, bucket, bucketPaintProperties, evaluated, state);
+            });
+            continue;
+        }
+
+        float serialKey = 1.0f;
+        auto addRenderables = [&, it = renderableSegments.begin()](const SymbolBucket::Buffer& buffer,
+                                                                   const SymbolType type) mutable {
+            for (const auto& segment : buffer.segments) {
+                const auto key = sortFeaturesByKey ? segment.sortKey : (serialKey += 1.0);
+                assert(segment.vertexOffset + segment.vertexLength <= buffer.vertices().elements());
+                it = renderableSegments.emplace_hint(
+                    it, std::ref(segment), tile, renderData, bucketPaintProperties, key, type, tileID.overscaledZ);
+            }
+        };
+
+        const auto& atlases = tile.getAtlasTextures();
+        if (!atlases) {
+            continue;
+        }
+
+        if (bucket.hasIconData() && atlases->icon) {
+            addRenderables(bucket.icon, SymbolType::IconRGBA);
+        }
+        if (bucket.hasSdfIconData() && atlases->icon) {
+            addRenderables(bucket.sdfIcon, SymbolType::IconSDF);
+        }
+        if (bucket.hasTextData() && atlases->glyph) {
+            addRenderables(bucket.text, SymbolType::Text);
+        }
+    }
+
+    // We'll be processing renderables across tiles, potentially out-of-order, so keep
+    // track of some things by tile ID so we don't have to re-build them multiple times.
+    using RawVertexVec = std::vector<std::uint8_t>; // <int16_t, 4>
+    struct TileInfo {
+        RawVertexVec textVertices, iconVertices;
+        gfx::DrawableTweakerPtr textTweaker, iconTweaker;
+    };
+    std::unordered_map<UnwrappedTileID, TileInfo> tileCache;
+
+    for (auto& renderable : renderableSegments) {
+        const auto isText = (renderable.type == SymbolType::Text);
+        const auto sdfIcons = (renderable.type == SymbolType::IconSDF);
+
+        const auto& tile = renderable.tile;
+        const auto tileID = tile.id.overscaleTo(renderable.overscaledZ);
+        const auto& bucket = static_cast<const SymbolBucket&>(*renderable.renderData.bucket);
+        const auto& buffer = isText ? bucket.text : (sdfIcons ? bucket.sdfIcon : bucket.icon);
+
+        const auto& evaluated = getEvaluated<SymbolLayerProperties>(renderable.renderData.layerProperties);
+        const auto& bucketPaintProperties = bucket.paintProperties.at(getID());
+
+        const auto& layout = *bucket.layout;
+        const auto values = isText ? textPropertyValues(evaluated, layout) : iconPropertyValues(evaluated, layout);
+
+        const auto& atlases = tile.getAtlasTextures();
+        if (!atlases) {
+            assert(false);
+            continue;
+        }
+
+        auto& tileInfo = tileCache[tile.id];
+
+        const auto vertexCount = buffer.vertices().elements();
+
+        gfx::VertexAttributeArray attribs;
+        const auto uniformProps = updateTileAttributes(buffer, isText, bucketPaintProperties, evaluated, attribs);
+
+        const auto textHalo = evaluated.get<style::TextHaloColor>().constantOr(Color::black()).a > 0.0f &&
+                              evaluated.get<style::TextHaloWidth>().constantOr(1);
+        const auto textFill = evaluated.get<style::TextColor>().constantOr(Color::black()).a > 0.0f;
+
+        const auto iconHalo = evaluated.get<style::IconHaloColor>().constantOr(Color::black()).a > 0.0f &&
+                              evaluated.get<style::IconHaloWidth>().constantOr(1);
+        const auto iconFill = evaluated.get<style::IconColor>().constantOr(Color::black()).a > 0.0f;
+
+        const auto interpolateUBO = buildInterpUBO(bucketPaintProperties, isText, currentZoom);
+
+        if (builder) {
+            builder->clearTweakers();
+        }
+
+        const auto draw = [&](const gfx::ShaderGroupPtr& shaderGroup,
+                              const bool isHalo,
+                              const std::string_view suffix) {
+            if (!shaderGroup) {
+                return;
+            }
+
+            // We can use the same tweakers for all the segments in a tile
+            if (isText && !tileInfo.textTweaker) {
+                tileInfo.textTweaker = std::make_shared<gfx::DrawableAtlasesTweaker>(
+                    atlases, iconTexUniformName, texUniformName, isText);
+            }
+            if (!isText && !tileInfo.iconTweaker) {
+                tileInfo.iconTweaker = std::make_shared<gfx::DrawableAtlasesTweaker>(
+                    atlases, iconTexUniformName, texUniformName, isText);
+            }
+
+            if (!builder) {
+                builder = context.createDrawableBuilder(layerPrefix);
+                builder->setSubLayerIndex(0);
+                builder->setEnableStencil(false);
+                builder->setRenderPass(passes);
+                builder->setCullFaceMode(gfx::CullFaceMode::disabled());
+                builder->setDepthType(gfx::DepthMaskType::ReadOnly);
+                builder->setColorMode(
+                    ((mbgl::underlying_type(passes) & mbgl::underlying_type(RenderPass::Translucent)) != 0)
+                        ? gfx::ColorMode::alphaBlended()
+                        : gfx::ColorMode::unblended());
+                builder->setVertexAttrName(posOffsetAttribName);
+            }
+
+            const auto shader = std::static_pointer_cast<gfx::ShaderProgramBase>(
+                shaderGroup->getOrCreateShader(context, uniformProps, posOffsetAttribName));
+            if (!shader) {
+                return;
+            }
+            builder->setShader(shader);
+
+            builder->clearTweakers();
+            builder->addTweaker(isText ? tileInfo.textTweaker : tileInfo.iconTweaker);
+            builder->setRawVertices({}, vertexCount, gfx::AttributeDataType::Short4);
+            builder->setDrawableName(layerPrefix + std::string(suffix));
+            builder->setVertexAttributes(attribs);
+
+            // TODO: texture filtering
+            // const bool linear = parameters.state.isChanging() || transformed ||
+            // !partiallyEvaluatedTextSize.isZoomConstant; const auto filterType = linear ?
+            // gfx::TextureFilterType::Linear : gfx::TextureFilterType::Nearest;
+
+            builder->setSegments(gfx::Triangles(), buffer.sharedTriangles, &renderable.segment.get(), 1);
+
+            builder->flush();
+
+            for (auto& drawable : builder->clearDrawables()) {
+                drawable->setTileID(tileID);
+
+                auto drawData = std::make_unique<gfx::SymbolDrawableData>(
+                    /*.isHalo=*/isHalo,
+                    /*.bucketVaraiblePlacement=*/bucket.hasVariablePlacement,
+                    /*.symbolType=*/renderable.type,
+                    /*.pitchAlignment=*/values.pitchAlignment,
+                    /*.rotationAlignment=*/values.rotationAlignment,
+                    /*.placement=*/layout.get<SymbolPlacement>(),
+                    /*.textFit=*/layout.get<IconTextFit>());
+
+                const auto tileUBO = buildTileUBO(bucket, *drawData, currentZoom);
+                drawable->setData(std::move(drawData));
+
+                auto& uniforms = drawable->mutableUniformBuffers();
+                uniforms.createOrUpdate(SymbolLayerTweaker::SymbolDrawableTilePropsUBOName, &tileUBO, context);
+                uniforms.createOrUpdate(SymbolLayerTweaker::SymbolDrawableInterpolateUBOName, &interpolateUBO, context);
+
+                tileLayerGroup->addDrawable(passes, tileID, std::move(drawable));
+                ++stats.drawablesAdded;
+            }
+        };
+
+        if (isText) {
+            if (bucket.iconsInText) {
+                if (textHalo) {
+                    draw(symbolTextAndIconGroup, /* isHalo = */ true, "halo");
+                }
+
+                if (textFill) {
+                    draw(symbolTextAndIconGroup, /* isHalo = */ false, "fill");
+                }
+            } else {
+                if (textHalo) {
+                    draw(symbolSDFTextGroup, /* isHalo = */ true, "halo");
+                }
+
+                if (textFill) {
+                    draw(symbolSDFTextGroup, /* isHalo = */ false, "fill");
+                }
+            }
+        } else { // icons
+            if (sdfIcons) {
+                if (iconHalo) {
+                    draw(symbolSDFIconGroup, /* isHalo = */ true, "halo");
+                }
+
+                if (iconFill) {
+                    draw(symbolSDFIconGroup, /* isHalo = */ false, "fill");
+                }
+            } else {
+                draw(symbolIconGroup, /* isHalo = */ false, "icon");
+            }
+        }
+    }
+}
+
+#endif // MLN_DRAWABLE_RENDERER
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.hpp
@@ -6,6 +6,10 @@
 #include <mbgl/style/layers/symbol_layer_impl.hpp>
 #include <mbgl/style/layers/symbol_layer_properties.hpp>
 
+#if MLN_DRAWABLE_RENDERER
+#include <unordered_map>
+#endif // MLN_DRAWABLE_RENDERER
+
 namespace mbgl {
 
 namespace style {
@@ -81,14 +85,28 @@ public:
     static style::TextPaintProperties::PossiblyEvaluated textPaintProperties(
         const style::SymbolPaintProperties::PossiblyEvaluated&);
 
+#if MLN_DRAWABLE_RENDERER
+    /// Generate any changes needed by the layer
+    void update(gfx::ShaderRegistry&,
+                gfx::Context&,
+                const TransformState&,
+                const RenderTree&,
+                UniqueChangeRequestVec&) override;
+#endif // MLN_DRAWABLE_RENDERER
+
 private:
     void transition(const TransitionParameters&) override;
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
+
+#if MLN_LEGACY_RENDERER
     void render(PaintParameters&) override;
+#endif // MLN_LEGACY_RENDERER
+
     void prepare(const LayerPrepareParameters&) override;
 
+private:
     // Paint properties
     style::SymbolPaintProperties::Unevaluated unevaluated;
 
@@ -97,8 +115,17 @@ private:
 
     bool hasFormatSectionOverrides = false;
 
+#if MLN_LEGACY_RENDERER
     // Programs
     Programs programs;
+#endif // MLN_LEGACY_RENDERER
+
+#if MLN_DRAWABLE_RENDERER
+    gfx::ShaderGroupPtr symbolIconGroup;
+    gfx::ShaderGroupPtr symbolSDFIconGroup;
+    gfx::ShaderGroupPtr symbolSDFTextGroup;
+    gfx::ShaderGroupPtr symbolTextAndIconGroup;
+#endif // MLN_DRAWABLE_RENDERER
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
@@ -1,0 +1,191 @@
+#include <mbgl/renderer/layers/symbol_layer_tweaker.hpp>
+
+#include <mbgl/gfx/context.hpp>
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/gfx/renderable.hpp>
+#include <mbgl/gfx/renderer_backend.hpp>
+#include <mbgl/gfx/symbol_drawable_data.hpp>
+#include <mbgl/layout/symbol_projection.hpp>
+#include <mbgl/programs/symbol_program.hpp>
+#include <mbgl/renderer/layer_group.hpp>
+#include <mbgl/renderer/render_tree.hpp>
+#include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/renderer/paint_property_binder.hpp>
+#include <mbgl/shaders/shader_program_base.hpp>
+#include <mbgl/style/layers/symbol_layer_properties.hpp>
+#include <mbgl/util/convert.hpp>
+#include <mbgl/util/std.hpp>
+
+namespace mbgl {
+
+using namespace style;
+
+namespace {
+
+struct alignas(16) SymbolDrawableUBO {
+    /*   0 */ std::array<float, 4 * 4> matrix;
+    /*  64 */ std::array<float, 4 * 4> label_plane_matrix;
+    /* 128 */ std::array<float, 4 * 4> coord_matrix;
+
+    /* 192 */ std::array<float, 2> texsize;
+    /* 200 */ std::array<float, 2> texsize_icon;
+
+    /* 208 */ float gamma_scale;
+    /* 212 */ float device_pixel_ratio;
+
+    /* 216 */ float camera_to_center_distance;
+    /* 220 */ float pitch;
+    /* 224 */ /*bool*/ int rotate_symbol;
+    /* 228 */ float aspect_ratio;
+    /* 232 */ float fade_change;
+    /* 236 */ float pad;
+    /* 240 */
+};
+static_assert(sizeof(SymbolDrawableUBO) == 15 * 16);
+
+/// Evaluated properties that do not depend on the tile
+struct alignas(16) SymbolDrawablePaintUBO {
+    /*  0 */ std::array<float, 4> fill_color;
+    /* 16 */ std::array<float, 4> halo_color;
+    /* 32 */ float opacity;
+    /* 36 */ float halo_width;
+    /* 40 */ float halo_blur;
+    /* 44 */ float padding;
+    /* 48 */
+};
+static_assert(sizeof(SymbolDrawablePaintUBO) == 3 * 16);
+
+Size getTexSize(const gfx::Drawable& drawable, const std::string_view name) {
+    if (const auto& shader = drawable.getShader()) {
+        if (const auto index = shader->getSamplerLocation(name)) {
+            if (const auto& tex = drawable.getTexture(*index)) {
+                return tex->getSize();
+            }
+        }
+    }
+    return {0, 0};
+}
+
+std::array<float, 2> toArray(const Size& s) {
+    return util::cast<float>(std::array<uint32_t, 2>{s.width, s.height});
+}
+
+constexpr auto texUniformName = "u_texture";
+constexpr auto texIconUniformName = "u_texture_icon";
+
+template <typename T, class... Is, class... Ts>
+auto constOrDefault(const IndexedTuple<TypeList<Is...>, TypeList<Ts...>>& evaluated) {
+    return evaluated.template get<T>().constantOr(T::defaultValue());
+}
+
+SymbolDrawablePaintUBO buildPaintUBO(bool isText, const SymbolPaintProperties::PossiblyEvaluated& evaluated) {
+    return {
+        /*.fill_color=*/gfx::VertexAttribute::colorAttrRGBA(isText ? constOrDefault<TextColor>(evaluated)
+                                                                   : constOrDefault<IconColor>(evaluated)),
+        /*.halo_color=*/
+        gfx::VertexAttribute::colorAttrRGBA(isText ? constOrDefault<TextHaloColor>(evaluated)
+                                                   : constOrDefault<IconHaloColor>(evaluated)),
+        /*.opacity=*/isText ? constOrDefault<TextOpacity>(evaluated) : constOrDefault<IconOpacity>(evaluated),
+        /*.halo_width=*/
+        isText ? constOrDefault<TextHaloWidth>(evaluated) : constOrDefault<IconHaloWidth>(evaluated),
+        /*.halo_blur=*/isText ? constOrDefault<TextHaloBlur>(evaluated) : constOrDefault<IconHaloBlur>(evaluated),
+        /*.padding=*/0,
+    };
+}
+
+} // namespace
+
+void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup,
+                                 const RenderTree& renderTree,
+                                 const PaintParameters& parameters) {
+    auto& context = parameters.context;
+    const auto& state = parameters.state;
+    const auto& evaluated = static_cast<const SymbolLayerProperties&>(*evaluatedProperties).evaluated;
+
+    if (layerGroup.empty()) {
+        return;
+    }
+
+#if !defined(NDEBUG)
+    const auto label = layerGroup.getName() + "-update-uniforms";
+    const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
+#endif
+
+    layerGroup.visitDrawables([&](gfx::Drawable& drawable) {
+        if (!drawable.getTileID() || !drawable.getData()) {
+            return;
+        }
+
+        const auto tileID = drawable.getTileID()->toUnwrapped();
+        const auto& symbolData = static_cast<gfx::SymbolDrawableData&>(*drawable.getData());
+        const auto isText = (symbolData.symbolType == SymbolType::Text);
+
+        if (isText && !textPaintBuffer) {
+            const auto props = buildPaintUBO(true, evaluated);
+            textPaintBuffer = parameters.context.createUniformBuffer(&props, sizeof(props));
+        }
+        if (!isText && !iconPaintBuffer) {
+            const auto props = buildPaintUBO(false, evaluated);
+            iconPaintBuffer = parameters.context.createUniformBuffer(&props, sizeof(props));
+        }
+
+        // from RenderTile::translatedMatrix
+        const auto translate = isText ? evaluated.get<style::TextTranslate>() : evaluated.get<style::IconTranslate>();
+        const auto anchor = isText ? evaluated.get<style::TextTranslateAnchor>()
+                                   : evaluated.get<style::IconTranslateAnchor>();
+        constexpr bool nearClipped = false;
+        constexpr bool inViewportPixelUnits = false;
+        const auto matrix = getTileMatrix(
+            tileID, renderTree, state, translate, anchor, nearClipped, inViewportPixelUnits);
+
+        // from symbol_program, makeValues
+        const auto currentZoom = static_cast<float>(state.getZoom());
+        const float pixelsToTileUnits = tileID.pixelsToTileUnits(1.f, currentZoom);
+        const bool pitchWithMap = symbolData.pitchAlignment == style::AlignmentType::Map;
+        const bool rotateWithMap = symbolData.rotationAlignment == style::AlignmentType::Map;
+        const bool alongLine = symbolData.placement != SymbolPlacementType::Point &&
+                               symbolData.rotationAlignment == AlignmentType::Map;
+        const bool hasVariablePlacement = symbolData.bucketVariablePlacement &&
+                                          (isText || symbolData.textFit != IconTextFitType::None);
+        const mat4 labelPlaneMatrix = (alongLine || hasVariablePlacement)
+                                          ? matrix::identity4()
+                                          : getLabelPlaneMatrix(
+                                                matrix, pitchWithMap, rotateWithMap, state, pixelsToTileUnits);
+        const mat4 glCoordMatrix = getGlCoordMatrix(matrix, pitchWithMap, rotateWithMap, state, pixelsToTileUnits);
+
+        const auto camDist = state.getCameraToCenterDistance();
+        const float gammaScale = (symbolData.pitchAlignment == AlignmentType::Map
+                                      ? static_cast<float>(std::cos(state.getPitch())) * camDist
+                                      : 1.0f);
+
+        // Line label rotation happens in `updateLineLabels`/`reprojectLineLabels``
+        // Pitched point labels are automatically rotated by the labelPlaneMatrix projection
+        // Unpitched point labels need to have their rotation applied after projection
+        const bool rotateInShader = rotateWithMap && !pitchWithMap && !alongLine;
+
+        const SymbolDrawableUBO drawableUBO = {
+            /*.matrix=*/util::cast<float>(matrix),
+            /*.label_plane_matrix=*/util::cast<float>(labelPlaneMatrix),
+            /*.coord_matrix=*/util::cast<float>(glCoordMatrix),
+
+            /*.texsize=*/toArray(getTexSize(drawable, texUniformName)),
+            /*.texsize_icon=*/toArray(getTexSize(drawable, texIconUniformName)),
+
+            /*.gamma_scale=*/gammaScale,
+            /*.device_pixel_ratio=*/parameters.pixelRatio,
+
+            /*.camera_to_center_distance=*/camDist,
+            /*.pitch=*/static_cast<float>(state.getPitch()),
+            /*.rotate_symbol=*/rotateInShader,
+            /*.aspect_ratio=*/state.getSize().aspectRatio(),
+            /*.fade_change=*/parameters.symbolFadeChange,
+            /*.pad=*/0,
+        };
+
+        auto& uniforms = drawable.mutableUniformBuffers();
+        uniforms.createOrUpdate(SymbolDrawableUBOName, &drawableUBO, context);
+        uniforms.addOrReplace(SymbolDrawablePaintUBOName, isText ? textPaintBuffer : iconPaintBuffer);
+    });
+}
+
+} // namespace mbgl

--- a/src/mbgl/renderer/layers/symbol_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/symbol_layer_tweaker.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <mbgl/renderer/layer_tweaker.hpp>
+
+#include <string>
+
+namespace mbgl {
+
+/**
+    Symbol layer specific tweaker
+ */
+class SymbolLayerTweaker : public LayerTweaker {
+public:
+    SymbolLayerTweaker(Immutable<style::LayerProperties> properties)
+        : LayerTweaker(properties){};
+
+public:
+    ~SymbolLayerTweaker() override = default;
+
+    void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
+
+    static constexpr std::string_view SymbolDrawableUBOName = "SymbolDrawableUBO";
+    static constexpr std::string_view SymbolDrawablePaintUBOName = "SymbolDrawablePaintUBO";
+    static constexpr std::string_view SymbolDrawableTilePropsUBOName = "SymbolDrawableTilePropsUBO";
+    static constexpr std::string_view SymbolDrawableInterpolateUBOName = "SymbolDrawableInterpolateUBO";
+
+private:
+    gfx::UniformBufferPtr textPaintBuffer;
+    gfx::UniformBufferPtr iconPaintBuffer;
+};
+
+/// Evaluated properties that depend on the tile
+struct alignas(16) SymbolDrawableTilePropsUBO {
+    /*  0 */ /*bool*/ int is_text;
+    /*  4 */ /*bool*/ int is_halo;
+    /*  8 */ /*bool*/ int pitch_with_map;
+    /* 12 */ /*bool*/ int is_size_zoom_constant;
+    /* 16 */ /*bool*/ int is_size_feature_constant;
+    /* 20 */ float size_t;
+    /* 24 */ float size;
+    /* 28 */ float padding;
+    /* 32 */
+};
+static_assert(sizeof(SymbolDrawableTilePropsUBO) == 2 * 16);
+
+/// Attribute interpolations
+struct alignas(16) SymbolDrawableInterpolateUBO {
+    /*  0 */ float fill_color_t;
+    /*  4 */ float halo_color_t;
+    /*  8 */ float opacity_t;
+    /* 12 */ float halo_width_t;
+    /* 16 */ float halo_blur_t;
+    /* 20 */ float pad1, pad2, pad3;
+    /* 32 */
+};
+static_assert(sizeof(SymbolDrawableInterpolateUBO) == 32);
+
+} // namespace mbgl

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -1,13 +1,14 @@
 #include <mbgl/renderer/render_layer.hpp>
 
+#include <mbgl/gfx/context.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/renderer/render_source.hpp>
 #include <mbgl/renderer/render_tile.hpp>
-#include <mbgl/style/types.hpp>
+#include <mbgl/style/color_ramp_property_value.hpp>
 #include <mbgl/style/layer.hpp>
 #include <mbgl/style/layer_properties.hpp>
+#include <mbgl/style/types.hpp>
 #include <mbgl/tile/tile.hpp>
-#include <mbgl/gfx/context.hpp>
 #include <mbgl/util/logging.hpp>
 
 #if MLN_DRAWABLE_RENDERER
@@ -222,5 +223,22 @@ void RenderLayer::activateLayerGroup(const LayerGroupBasePtr& layerGroup_,
     }
 }
 #endif
+
+bool RenderLayer::applyColorRamp(const style::ColorRampPropertyValue& colorValue, PremultipliedImage& image) {
+    if (colorValue.isUndefined()) {
+        return false;
+    }
+
+    const auto length = image.bytes();
+
+    for (uint32_t i = 0; i < length; i += 4) {
+        const auto color = colorValue.evaluate(static_cast<double>(i) / length);
+        image.data[i + 0] = static_cast<uint8_t>(std::floor(color.r * 255.f));
+        image.data[i + 1] = static_cast<uint8_t>(std::floor(color.g * 255.f));
+        image.data[i + 2] = static_cast<uint8_t>(std::floor(color.b * 255.f));
+        image.data[i + 3] = static_cast<uint8_t>(std::floor(color.a * 255.f));
+    }
+    return true;
+}
 
 } // namespace mbgl

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -51,6 +51,10 @@ using UniformBufferPtr = std::shared_ptr<UniformBuffer>;
 #endif
 } // namespace gfx
 
+namespace style {
+class ColorRampPropertyValue;
+} // namespace style
+
 class LayerRenderData {
 public:
     std::shared_ptr<Bucket> bucket;
@@ -223,6 +227,8 @@ protected:
     /// unchanged
     bool setRenderTileBucketID(const OverscaledTileID&, util::SimpleIdentity bucketID);
 #endif // MLN_DRAWABLE_RENDERER
+
+    static bool applyColorRamp(const style::ColorRampPropertyValue&, PremultipliedImage&);
 
 protected:
     // Stores current set of tiles to be rendered for this layer.

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -212,13 +212,15 @@ protected:
     bool hasRenderTile(const OverscaledTileID&) const;
 
     /// Get the bucket ID from which a given tile was built
-    /// @details When a new style is loaded and contains a layer with the same ID, `layerChanged` will be called during style
-    ///          parsing, but the `Bucket` in a tile's `RenderData` will only be replaced when the asynchronous load for the tile
-    ///          is complete, at which point the drawable for the tile may need to be updated or replaced.
+    /// @details When a new style is loaded and contains a layer with the same ID, `layerChanged` will be called during
+    /// style
+    ///          parsing, but the `Bucket` in a tile's `RenderData` will only be replaced when the asynchronous load for
+    ///          the tile is complete, at which point the drawable for the tile may need to be updated or replaced.
     util::SimpleIdentity getRenderTileBucketID(const OverscaledTileID&) const;
 
     /// Set the bucket ID from which a given tile was built
-    /// @return true if updated, false if the tile ID is not present in the set of tiles to be rendered or the ID is unchanged
+    /// @return true if updated, false if the tile ID is not present in the set of tiles to be rendered or the ID is
+    /// unchanged
     bool setRenderTileBucketID(const OverscaledTileID&, util::SimpleIdentity bucketID);
 #endif // MLN_DRAWABLE_RENDERER
 

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -212,10 +212,13 @@ protected:
     bool hasRenderTile(const OverscaledTileID&) const;
 
     /// Get the bucket ID from which a given tile was built
+    /// @details When a new style is loaded and contains a layer with the same ID, `layerChanged` will be called during style
+    ///          parsing, but the `Bucket` in a tile's `RenderData` will only be replaced when the asynchronous load for the tile
+    ///          is complete, at which point the drawable for the tile may need to be updated or replaced.
     util::SimpleIdentity getRenderTileBucketID(const OverscaledTileID&) const;
 
     /// Set the bucket ID from which a given tile was built
-    /// @return true if updated, false if missing or unchanged
+    /// @return true if updated, false if the tile ID is not present in the set of tiles to be rendered or the ID is unchanged
     bool setRenderTileBucketID(const OverscaledTileID&, util::SimpleIdentity bucketID);
 #endif // MLN_DRAWABLE_RENDERER
 

--- a/src/mbgl/style/layer_impl.hpp
+++ b/src/mbgl/style/layer_impl.hpp
@@ -7,11 +7,12 @@
 #include <rapidjson/writer.h>
 #include <rapidjson/stringbuffer.h>
 
-#include <string>
 #include <limits>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace mbgl {
-
 namespace style {
 
 /**

--- a/src/mbgl/style/layers/background_layer_impl.cpp
+++ b/src/mbgl/style/layers/background_layer_impl.cpp
@@ -3,6 +3,10 @@
 namespace mbgl {
 namespace style {
 
+BackgroundLayer::Impl::Impl(const Impl& other)
+    : Layer::Impl(other),
+      paint(other.paint) {}
+
 bool BackgroundLayer::Impl::hasLayoutDifference(const Layer::Impl&) const {
     return false;
 }

--- a/src/mbgl/style/layers/background_layer_impl.hpp
+++ b/src/mbgl/style/layers/background_layer_impl.hpp
@@ -3,17 +3,35 @@
 #include <mbgl/style/layer_impl.hpp>
 #include <mbgl/style/layers/background_layer.hpp>
 #include <mbgl/style/layers/background_layer_properties.hpp>
+#include <mbgl/tile/tile_id.hpp>
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
 
 namespace mbgl {
+namespace gfx {
+
+class Drawable;
+class ShaderProgramBase;
+class ShaderRegistry;
+
+using DrawablePtr = std::shared_ptr<Drawable>;
+using ShaderProgramBasePtr = std::shared_ptr<ShaderProgramBase>;
+
+} // namespace gfx
+
 namespace style {
 
 class BackgroundLayer::Impl : public Layer::Impl {
 public:
     using Layer::Impl::Impl;
+    Impl(const Impl&);
 
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
 
+public:
     BackgroundPaintProperties::Transitionable paint;
 
     DECLARE_LAYER_TYPE_INFO;

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -672,9 +672,12 @@ SymbolInstanceReferences Placement::getSortedSymbols(const BucketPlacementData& 
 
 void Placement::commit() {
     bool placementChanged = false;
-    assert(getPrevPlacement());
+    if (!getPrevPlacement()) {
+        assert(false);
+        return;
+    }
     prevZoomAdjustment = getPrevPlacement()->zoomAdjustment(placementZoom);
-    float increment = getPrevPlacement()->symbolFadeChange(commitTime);
+    const float increment = getPrevPlacement()->symbolFadeChange(commitTime);
 
     // add the opacities from the current placement, and copy their current
     // values from the previous placement
@@ -728,7 +731,8 @@ void Placement::commit() {
         }
     }
 
-    fadeStartTime = placementChanged ? commitTime : getPrevPlacement()->fadeStartTime;
+    fadeStartTime = placementChanged ? commitTime
+                                     : (getPrevPlacement() ? getPrevPlacement()->fadeStartTime : TimePoint{});
 }
 
 void Placement::updateLayerBuckets(const RenderLayer& layer, const TransformState& state, bool updateOpacities) const {
@@ -773,7 +777,7 @@ bool Placement::updateBucketDynamicVertices(SymbolBucket& bucket,
             const bool pitchWithMap = layout.get<style::IconPitchAlignment>() == style::AlignmentType::Map;
             const bool keepUpright = layout.get<style::IconKeepUpright>();
             if (bucket.hasSdfIconData()) {
-                reprojectLineLabels(bucket.sdfIcon.dynamicVertices,
+                reprojectLineLabels(bucket.sdfIcon.dynamicVertices(),
                                     bucket.sdfIcon.placedSymbols,
                                     tile.matrix,
                                     pitchWithMap,
@@ -785,7 +789,7 @@ bool Placement::updateBucketDynamicVertices(SymbolBucket& bucket,
                 result = true;
             }
             if (bucket.hasIconData()) {
-                reprojectLineLabels(bucket.icon.dynamicVertices,
+                reprojectLineLabels(bucket.icon.dynamicVertices(),
                                     bucket.icon.placedSymbols,
                                     tile.matrix,
                                     pitchWithMap,
@@ -801,7 +805,7 @@ bool Placement::updateBucketDynamicVertices(SymbolBucket& bucket,
         if (bucket.hasTextData() && layout.get<TextRotationAlignment>() == AlignmentType::Map) {
             const bool pitchWithMap = layout.get<style::TextPitchAlignment>() == style::AlignmentType::Map;
             const bool keepUpright = layout.get<style::TextKeepUpright>();
-            reprojectLineLabels(bucket.text.dynamicVertices,
+            reprojectLineLabels(bucket.text.dynamicVertices(),
                                 bucket.text.placedSymbols,
                                 tile.matrix,
                                 pitchWithMap,
@@ -813,7 +817,7 @@ bool Placement::updateBucketDynamicVertices(SymbolBucket& bucket,
             result = true;
         }
     } else if (hasVariableAnchors) {
-        bucket.text.dynamicVertices.clear();
+        bucket.text.sharedDynamicVertices->clear();
         bucket.hasVariablePlacement = false;
 
         const auto partiallyEvaluatedSize = bucket.textSizeBinder->evaluateForZoom(static_cast<float>(state.getZoom()));
@@ -842,7 +846,7 @@ bool Placement::updateBucketDynamicVertices(SymbolBucket& bucket,
                 // These symbols are from a justification that is not being
                 // used, or a label that wasn't placed so we don't need to do
                 // the extra math to figure out what incremental shift to apply.
-                hideGlyphs(symbol.glyphOffsets.size(), bucket.text.dynamicVertices);
+                hideGlyphs(symbol.glyphOffsets.size(), bucket.text.dynamicVertices());
             } else {
                 const Point<float> tileAnchor = symbol.anchorPoint;
                 const auto projectedAnchor = project(tileAnchor, pitchWithMap ? tile.matrix : labelPlaneMatrix);
@@ -885,25 +889,26 @@ bool Placement::updateBucketDynamicVertices(SymbolBucket& bucket,
                 }
 
                 for (std::size_t j = 0; j < symbol.glyphOffsets.size(); ++j) {
-                    addDynamicAttributes(shiftedAnchor, symbol.angle, bucket.text.dynamicVertices);
+                    addDynamicAttributes(shiftedAnchor, symbol.angle, bucket.text.dynamicVertices());
                 }
             }
         }
 
         if (updateTextFitIcon && bucket.hasVariablePlacement) {
             auto updateIcon = [&](SymbolBucket::Buffer& iconBuffer) {
-                iconBuffer.dynamicVertices.clear();
+                iconBuffer.sharedDynamicVertices->clear();
                 for (std::size_t i = 0; i < iconBuffer.placedSymbols.size(); ++i) {
                     const PlacedSymbol& placedIcon = iconBuffer.placedSymbols[i];
                     if (placedIcon.hidden || (!placedIcon.placedOrientation && bucket.allowVerticalPlacement)) {
-                        hideGlyphs(placedIcon.glyphOffsets.size(), iconBuffer.dynamicVertices);
+                        hideGlyphs(placedIcon.glyphOffsets.size(), iconBuffer.dynamicVertices());
                     } else {
                         const auto& pair = placedTextShifts.find(i);
                         if (pair == placedTextShifts.end()) {
-                            hideGlyphs(placedIcon.glyphOffsets.size(), iconBuffer.dynamicVertices);
+                            hideGlyphs(placedIcon.glyphOffsets.size(), iconBuffer.dynamicVertices());
                         } else {
                             for (std::size_t j = 0; j < placedIcon.glyphOffsets.size(); ++j) {
-                                addDynamicAttributes(pair->second.second, placedIcon.angle, iconBuffer.dynamicVertices);
+                                addDynamicAttributes(
+                                    pair->second.second, placedIcon.angle, iconBuffer.dynamicVertices());
                             }
                         }
                     }
@@ -916,13 +921,13 @@ bool Placement::updateBucketDynamicVertices(SymbolBucket& bucket,
         result = true;
     } else if (bucket.allowVerticalPlacement && bucket.hasTextData()) {
         const auto updateDynamicVertices = [](SymbolBucket::Buffer& buffer) {
-            buffer.dynamicVertices.clear();
+            buffer.sharedDynamicVertices->clear();
             for (const PlacedSymbol& symbol : buffer.placedSymbols) {
                 if (symbol.hidden || !symbol.placedOrientation) {
-                    hideGlyphs(symbol.glyphOffsets.size(), buffer.dynamicVertices);
+                    hideGlyphs(symbol.glyphOffsets.size(), buffer.dynamicVertices());
                 } else {
                     for (std::size_t j = 0; j < symbol.glyphOffsets.size(); ++j) {
-                        addDynamicAttributes(symbol.anchorPoint, symbol.angle, buffer.dynamicVertices);
+                        addDynamicAttributes(symbol.anchorPoint, symbol.angle, buffer.dynamicVertices());
                     }
                 }
             }
@@ -944,9 +949,9 @@ bool Placement::updateBucketDynamicVertices(SymbolBucket& bucket,
 void Placement::updateBucketOpacities(SymbolBucket& bucket,
                                       const TransformState& state,
                                       std::set<uint32_t>& seenCrossTileIDs) const {
-    if (bucket.hasTextData()) bucket.text.opacityVertices.clear();
-    if (bucket.hasIconData()) bucket.icon.opacityVertices.clear();
-    if (bucket.hasSdfIconData()) bucket.sdfIcon.opacityVertices.clear();
+    if (bucket.hasTextData()) bucket.text.sharedOpacityVertices->clear();
+    if (bucket.hasIconData()) bucket.icon.sharedOpacityVertices->clear();
+    if (bucket.hasSdfIconData()) bucket.sdfIcon.sharedOpacityVertices->clear();
     if (bucket.hasIconCollisionBoxData()) bucket.iconCollisionBox->dynamicVertices.clear();
     if (bucket.hasIconCollisionCircleData()) bucket.iconCollisionCircle->dynamicVertices.clear();
     if (bucket.hasTextCollisionBoxData()) bucket.textCollisionBox->dynamicVertices.clear();
@@ -1011,7 +1016,7 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket,
                 bucket.text.placedSymbols[*symbolInstance.placedVerticalTextIndex].hidden = opacityState.isHidden();
             }
 
-            bucket.text.opacityVertices.extend(textOpacityVerticesSize, opacityVertex);
+            bucket.text.opacityVertices().extend(textOpacityVerticesSize, opacityVertex);
 
             style::TextWritingModeType previousOrientation = style::TextWritingModeType::Horizontal;
             if (bucket.allowVerticalPlacement) {
@@ -1043,7 +1048,7 @@ void Placement::updateBucketOpacities(SymbolBucket& bucket,
                 iconBuffer.placedSymbols[*symbolInstance.placedVerticalIconIndex].hidden = opacityState.isHidden();
             }
 
-            iconBuffer.opacityVertices.extend(iconOpacityVerticesSize, opacityVertex);
+            iconBuffer.opacityVertices().extend(iconOpacityVerticesSize, opacityVertex);
         }
 
         auto updateIconCollisionBox = [&](const auto& feature, const bool placed, const Point<float>& shift) {

--- a/src/mbgl/tile/raster_dem_tile.cpp
+++ b/src/mbgl/tile/raster_dem_tile.cpp
@@ -105,6 +105,9 @@ void RasterDEMTile::backfillBorder(const RasterDEMTile& borderTile, const DEMTil
         // mark HillshadeBucket.prepared as false so it runs through the prepare
         // render pass with the new texture data we just backfilled
         bucket->setPrepared(false);
+#if MLN_DRAWABLE_RENDERER
+        bucket->renderTargetPrepared = false;
+#endif
     }
 }
 

--- a/test/api/custom_layer.test.cpp
+++ b/test/api/custom_layer.test.cpp
@@ -1,7 +1,7 @@
 #include <mbgl/test/util.hpp>
 
 #include <mbgl/gfx/headless_frontend.hpp>
-#include <mbgl/gl/custom_layer.hpp>
+#include <mbgl/style/layers/custom_layer.hpp>
 #include <mbgl/gl/defines.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_options.hpp>


### PR DESCRIPTION
In this last PR we introduce alternative ways of rendering the various layer types using drawables. Within each `RenderLayer` instance drawables are constructed via a new `update` method. Legacy rendering via the `render` method is compiled out in drawable mode. Texture atlases and custom layers are also addressed when running with drawables. New drawable variants of the shaders have also been added, prefixed with `drawable.` Refer to the proceeding PRs #1459 and #1355 for extra context when reviewing.