### PR TITLE
Add execution_root to path built xcframework

### DIFF
--- a/platform/ios/MapLibre.podspec
+++ b/platform/ios/MapLibre.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
 
     s.name = 'MapLibre'
     s.version = version
-    s.license = { :type => 'BSD', :file => 'LICENSE.md' }
+    s.license = { :type => 'BSD', :text => '' }
     s.homepage = 'https://maplibre.org/'
     s.authors = { 'MapLibre' => '' }
     s.summary = 'Open source vector map solution for iOS with full styling capabilities.'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
         :http => "https://github.com/maplibre/maplibre-native/releases/download/ios-v#{version.to_s}/MapLibre-#{version.to_s}.zip",
         :flatten => false
     }
-    m.social_media_url  = 'https://mastodon.social/@maplibre'
+    s.social_media_url  = 'https://mastodon.social/@maplibre'
     s.ios.deployment_target = '11.0'
     s.ios.vendored_frameworks = "**/MapLibre.xcframework"
 end

--- a/platform/ios/scripts/deploy-swift-package.sh
+++ b/platform/ios/scripts/deploy-swift-package.sh
@@ -85,7 +85,7 @@ step "Building XCFramework"
 bazel build //platform/ios:MapLibre.dynamic
 
 step "Copying Bazel output"
-BUILT_XCFRAMEWORK="$(bazel cquery --output=files //platform/ios:MapLibre.dynamic)"
+BUILT_XCFRAMEWORK="$(bazel info execution_root)/$(bazel cquery --output=files //platform/ios:MapLibre.dynamic)"
 MAPLIBRE_ZIP_FILE="MapLibre-${PUBLISH_VERSION}.zip"
 cp "$BUILT_XCFRAMEWORK" "$MAPLIBRE_ZIP_FILE"
 


### PR DESCRIPTION
Fixes the path of the built XCFramework in the script.

Also fixes a typo in the Podfile.

The license in the Podfile cannot be read and this is giving a warning. I will include the full license text in the Podfile, but the license still needs to be updated. #1520