### PR TITLE
Render Test: Fill extrusion translate literal opacity

### DIFF
--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -150,7 +150,7 @@ void PaintParameters::renderTileClippingMasks(TIter beg, TIter end, GetTileIDFun
     for (auto i = beg; i != end; ++i) {
         const auto& tileID = f(*i);
 
-        const int32_t stencilID = nextStencilID + 1;
+        const int32_t stencilID = nextStencilID;
         const auto result = tileClippingMaskIDs.insert(std::make_pair(tileID, stencilID));
         if (result.second) {
             // inserted


### PR DESCRIPTION
![image](https://github.com/maplibre/maplibre-native/assets/4198736/60cc189a-7682-426d-b333-712e25fb4cc3)

remaining case of issue #1371 