### PR TITLE
Topic/drawable fixes

### DIFF
--- a/render-test/ios/iosTestRunner.mm
+++ b/render-test/ios/iosTestRunner.mm
@@ -69,13 +69,13 @@
 
         BOOL fileFound = [fileManager fileExistsAtPath: self.styleResultPath];
         if (fileFound == NO) {
-            NSLog(@"Style test result file '%@' doese not exit ", self.styleResultPath);
+            NSLog(@"Style test result file '%@' does not exit ", self.styleResultPath);
             self.testStatus = NO;
         }
 
         fileFound = [fileManager fileExistsAtPath: self.metricResultPath];
         if (fileFound == NO) {
-            NSLog(@"Metric test result file '%@' doese not exit ", self.metricResultPath);
+            NSLog(@"Metric test result file '%@' does not exit ", self.metricResultPath);
             self.testStatus = NO;
         }
 
@@ -96,7 +96,7 @@
             }
         }
         else {
-           NSLog(@"Metric path '%@' doese not exit ", rebaselinePath);
+           NSLog(@"Metric path '%@' does not exit ", rebaselinePath);
         }
 
         if (needArchiving) {

--- a/render-test/ios/tests/Tests.m
+++ b/render-test/ios/tests/Tests.m
@@ -25,7 +25,7 @@
     
     NSFileManager *fileManager = [NSFileManager defaultManager];
     BOOL fileFound = [fileManager fileExistsAtPath: styleResult];
-    XCTAssert(fileFound, @"Test result html '%@' doese not exit", styleResult);
+    XCTAssert(fileFound, @"Test result html '%@' does not exit", styleResult);
     NSURL *styleURL = [NSURL fileURLWithPath:styleResult];
     XCTAttachment *attachment1URL = [XCTAttachment attachmentWithContentsOfFileAtURL: styleURL];
     XCTAssert(attachment1URL, @"Failed to attach test result '%@'", styleResult);
@@ -33,7 +33,7 @@
     [self addAttachment:attachment1URL];
 
     fileFound = [fileManager fileExistsAtPath: metricResult];
-    XCTAssert(fileFound, @"Test result html '%@' doese not exit", metricResult);
+    XCTAssert(fileFound, @"Test result html '%@' does not exit", metricResult);
     NSURL *metricURL = [NSURL fileURLWithPath:metricResult];
     XCTAttachment *attachment2URL = [XCTAttachment attachmentWithContentsOfFileAtURL: metricURL];
     XCTAssert(attachment2URL, @"Failed to attach test result '%@'", metricResult);

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -773,6 +773,14 @@ void RenderOrchestrator::clearData() {
     if (!layerImpls->empty()) layerImpls = makeMutable<std::vector<Immutable<style::Layer::Impl>>>();
     if (!imageImpls->empty()) imageImpls = makeMutable<std::vector<Immutable<style::Image::Impl>>>();
 
+#if MLN_DRAWABLE_RENDERER
+    UniqueChangeRequestVec changes;
+    for (const auto& entry : renderLayers) {
+        entry.second->layerRemoved(changes);
+    }
+    addChanges(changes);
+#endif
+
     renderSources.clear();
     renderLayers.clear();
 


### PR DESCRIPTION
Layers weren't being notified of deletion before being deleted when the render orchestrator was cleared between individual tile render operations.