### PR TITLE
Render tests: Fix regression

### DIFF
--- a/include/mbgl/shaders/gl/collision_circle.hpp
+++ b/include/mbgl/shaders/gl/collision_circle.hpp
@@ -20,7 +20,7 @@ uniform float u_camera_to_center_distance;
 out float v_placed;
 out float v_notUsed;
 out float v_radius;
-out vec2 v_extrude;
+out highp vec2 v_extrude;
 out vec2 v_extrude_scale;
 
 void main() {
@@ -49,7 +49,7 @@ void main() {
 in float v_placed;
 in float v_notUsed;
 in float v_radius;
-in vec2 v_extrude;
+in highp vec2 v_extrude;
 in vec2 v_extrude_scale;
 
 void main() {

--- a/include/mbgl/shaders/gl/drawable_collision_circle.hpp
+++ b/include/mbgl/shaders/gl/drawable_collision_circle.hpp
@@ -23,7 +23,7 @@ layout (std140) uniform CollisionCircleUBO {
 out float v_placed;
 out float v_notUsed;
 out float v_radius;
-out vec2 v_extrude;
+out highp vec2 v_extrude;
 out vec2 v_extrude_scale;
 
 void main() {
@@ -57,7 +57,7 @@ void main() {
 in float v_placed;
 in float v_notUsed;
 in float v_radius;
-in vec2 v_extrude;
+in highp vec2 v_extrude;
 in vec2 v_extrude_scale;
 
 void main() {

--- a/shaders/collision_circle.fragment.glsl
+++ b/shaders/collision_circle.fragment.glsl
@@ -3,7 +3,7 @@ uniform float u_overscale_factor;
 in float v_placed;
 in float v_notUsed;
 in float v_radius;
-in vec2 v_extrude;
+in highp vec2 v_extrude;
 in vec2 v_extrude_scale;
 
 void main() {

--- a/shaders/collision_circle.vertex.glsl
+++ b/shaders/collision_circle.vertex.glsl
@@ -10,7 +10,7 @@ uniform float u_camera_to_center_distance;
 out float v_placed;
 out float v_notUsed;
 out float v_radius;
-out vec2 v_extrude;
+out highp vec2 v_extrude;
 out vec2 v_extrude_scale;
 
 void main() {

--- a/shaders/drawable.collision_circle.fragment.glsl
+++ b/shaders/drawable.collision_circle.fragment.glsl
@@ -8,7 +8,7 @@ layout (std140) uniform CollisionCircleUBO {
 in float v_placed;
 in float v_notUsed;
 in float v_radius;
-in vec2 v_extrude;
+in highp vec2 v_extrude;
 in vec2 v_extrude_scale;
 
 void main() {

--- a/shaders/drawable.collision_circle.vertex.glsl
+++ b/shaders/drawable.collision_circle.vertex.glsl
@@ -13,7 +13,7 @@ layout (std140) uniform CollisionCircleUBO {
 out float v_placed;
 out float v_notUsed;
 out float v_radius;
-out vec2 v_extrude;
+out highp vec2 v_extrude;
 out vec2 v_extrude_scale;
 
 void main() {


### PR DESCRIPTION
Issue #1536 
This fixes the failing render test case on _legacy_ renderer path and `main` branch as well.