### PR TITLE
Set uniform values based on paint property binders to match `computeAllUniformValues`

### DIFF
--- a/src/mbgl/renderer/layers/heatmap_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/heatmap_layer_tweaker.hpp
@@ -16,9 +16,6 @@ public:
     ~HeatmapLayerTweaker() override = default;
 
     void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
-
-protected:
-    gfx::UniformBufferPtr evaluatedPropsUniformBuffer;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_heatmap_layer.hpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.hpp
@@ -74,6 +74,9 @@ private:
     gfx::ShaderProgramBasePtr heatmapTextureShader;
     RenderTargetPtr renderTarget;
 
+    gfx::UniformBufferPtr evaluatedPropsUniformBuffer;
+    gfx::UniformBufferPtr interpolationUniformBuffer;
+
     using TextureVertexVector = gfx::VertexVector<HeatmapTextureLayoutVertex>;
     std::shared_ptr<TextureVertexVector> sharedTextureVertices;
 #endif


### PR DESCRIPTION
The behavior of `render()` is to compute the uniform values using the paint property binders, which are not available in the tweaker.  To match that, we need to set up and update the property UBO in the render layer.