### PR TITLE
Move debug layer groups into the Orchestrator

### DIFF
--- a/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
@@ -80,11 +80,9 @@ auto constOrDefault(const IndexedTuple<TypeList<Is...>, TypeList<Ts...>>& evalua
 
 SymbolDrawablePaintUBO buildPaintUBO(bool isText, const SymbolPaintProperties::PossiblyEvaluated& evaluated) {
     return {
-        /*.fill_color=*/isText ? constOrDefault<TextColor>(evaluated)
-                               : constOrDefault<IconColor>(evaluated),
+        /*.fill_color=*/isText ? constOrDefault<TextColor>(evaluated) : constOrDefault<IconColor>(evaluated),
         /*.halo_color=*/
-        isText ? constOrDefault<TextHaloColor>(evaluated)
-               : constOrDefault<IconHaloColor>(evaluated),
+        isText ? constOrDefault<TextHaloColor>(evaluated) : constOrDefault<IconHaloColor>(evaluated),
         /*.opacity=*/isText ? constOrDefault<TextOpacity>(evaluated) : constOrDefault<IconOpacity>(evaluated),
         /*.halo_width=*/
         isText ? constOrDefault<TextHaloWidth>(evaluated) : constOrDefault<IconHaloWidth>(evaluated),

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -781,7 +781,7 @@ void RenderOrchestrator::clearData() {
         entry.second->layerRemoved(changes);
     }
     addChanges(changes);
-    
+
     debugLayerGroups.clear();
 #endif
 

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -781,6 +781,8 @@ void RenderOrchestrator::clearData() {
         entry.second->layerRemoved(changes);
     }
     addChanges(changes);
+    
+    debugLayerGroups.clear();
 #endif
 
     renderSources.clear();
@@ -946,6 +948,29 @@ void RenderOrchestrator::observeRenderTargets(std::function<void(const RenderTar
         f(*renderTarget);
     }
 }
+
+void RenderOrchestrator::updateDebugLayerGroups(const RenderTree& renderTree, PaintParameters& parameters) {
+    for (const RenderItem& item : renderTree.getSourceRenderItems()) {
+        item.updateDebugDrawables(debugLayerGroups, parameters);
+    }
+}
+
+void RenderOrchestrator::observeDebugLayerGroups(std::function<void(LayerGroupBase&)> f) {
+    for (auto& pair : debugLayerGroups) {
+        if (pair.second) {
+            f(*pair.second);
+        }
+    }
+}
+
+void RenderOrchestrator::observeDebugLayerGroups(std::function<void(const LayerGroupBase&)> f) const {
+    for (const auto& pair : debugLayerGroups) {
+        if (pair.second) {
+            f(*pair.second);
+        }
+    }
+}
+
 #endif // MLN_DRAWABLE_RENDERER
 
 void RenderOrchestrator::onGlyphsError(const FontStack& fontStack,

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -119,7 +119,7 @@ public:
     bool removeRenderTarget(const RenderTargetPtr&);
     void observeRenderTargets(std::function<void(RenderTarget&)> f);
     void observeRenderTargets(std::function<void(const RenderTarget&)> f) const;
-    
+
     void updateDebugLayerGroups(const RenderTree& renderTree, PaintParameters& parameters);
     void observeDebugLayerGroups(std::function<void(LayerGroupBase&)>);
     void observeDebugLayerGroups(std::function<void(const LayerGroupBase&)>) const;

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -119,6 +119,10 @@ public:
     bool removeRenderTarget(const RenderTargetPtr&);
     void observeRenderTargets(std::function<void(RenderTarget&)> f);
     void observeRenderTargets(std::function<void(const RenderTarget&)> f) const;
+    
+    void updateDebugLayerGroups(const RenderTree& renderTree, PaintParameters& parameters);
+    void observeDebugLayerGroups(std::function<void(LayerGroupBase&)>);
+    void observeDebugLayerGroups(std::function<void(const LayerGroupBase&)>) const;
 #endif
 
     const ZoomHistory& getZoomHistory() const { return zoomHistory; }
@@ -200,6 +204,7 @@ private:
     bool layerGroupOrderDirty = false;
 
     std::vector<RenderTargetPtr> renderTargets;
+    RenderItem::DebugLayerGroupMap debugLayerGroups;
 #endif
 };
 

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -171,9 +171,7 @@ void Renderer::Impl::render(const RenderTree& renderTree,
         orchestrator.observeRenderTargets([&](RenderTarget& renderTarget) { renderTarget.upload(*uploadPass); });
 
         // Upload the Debug layer group
-        orchestrator.observeDebugLayerGroups([&](LayerGroupBase& layerGroup) {
-            layerGroup.upload(*uploadPass);
-        });
+        orchestrator.observeDebugLayerGroups([&](LayerGroupBase& layerGroup) { layerGroup.upload(*uploadPass); });
     }
 #endif
 

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -153,10 +153,8 @@ void Renderer::Impl::render(const RenderTree& renderTree,
         }
     });
 
-    // Update the debug layer group
-    for (const RenderItem& item : sourceRenderItems) {
-        item.updateDebugDrawables(debugLayerGroups, parameters);
-    }
+    // Update the debug layer groups
+    orchestrator.updateDebugLayerGroups(renderTree, parameters);
 
     // Give the layers a chance to do setup
     // orchestrator.observeLayerGroups([&](LayerGroup& layerGroup) { layerGroup.preRender(orchestrator, parameters);
@@ -173,9 +171,9 @@ void Renderer::Impl::render(const RenderTree& renderTree,
         orchestrator.observeRenderTargets([&](RenderTarget& renderTarget) { renderTarget.upload(*uploadPass); });
 
         // Upload the Debug layer group
-        for (const auto& [debugType, layerGroup] : debugLayerGroups) {
-            layerGroup->upload(*uploadPass);
-        }
+        orchestrator.observeDebugLayerGroups([&](LayerGroupBase& layerGroup) {
+            layerGroup.upload(*uploadPass);
+        });
     }
 #endif
 
@@ -328,9 +326,9 @@ void Renderer::Impl::render(const RenderTree& renderTree,
         // Renders debug overlays.
         {
             const auto debugGroup(parameters.renderPass->createDebugGroup("debug"));
-            for (const auto& [debugType, layerGroup] : debugLayerGroups) {
-                layerGroup->observeDrawables([&](gfx::Drawable& drawable) { drawable.draw(parameters); });
-            }
+            orchestrator.observeDebugLayerGroups([&](LayerGroupBase& layerGroup) {
+                layerGroup.observeDrawables([&](gfx::Drawable& drawable) { drawable.draw(parameters); });
+            });
         }
     };
 #endif // MLN_DRAWABLE_RENDERER

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -47,10 +47,6 @@ private:
     };
 
     RenderState renderState = RenderState::Never;
-
-#if MLN_DRAWABLE_RENDERER
-    RenderItem::DebugLayerGroupMap debugLayerGroups;
-#endif
 };
 
 } // namespace mbgl


### PR DESCRIPTION
Since the Orchestrator owns the other `LayerGroups`, move the debug layer groups there as well.