### PR TITLE
Update ios-device-test.yml

### DIFF
--- a/.github/workflows/ios-device-test.yml
+++ b/.github/workflows/ios-device-test.yml
@@ -14,7 +14,6 @@ jobs:
           {artifactName: ios-render-test, xcTestFile: RenderTest.xctest.zip, ipaFile: RenderTestApp.ipa, name: "iOS Render Tests"},
           {artifactName: ios-cpp-unit-tests, xcTestFile: CppUnitTests.xctest.zip, ipaFile: CppUnitTestsApp.ipa, name: "iOS C++ Unit Tests"},
         ]
-      max-parallel: 1
       fail-fast: true
     runs-on: ubuntu-22.04
     if: github.repository_owner == 'maplibre'

--- a/.github/workflows/ios-device-test.yml
+++ b/.github/workflows/ios-device-test.yml
@@ -48,7 +48,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 1200
+          role-duration-seconds: 3600
           role-session-name: MySessionName
 
       - name: Create upload app


### PR DESCRIPTION
The C++ test needs a higher session duration.

Remove

```
      max-parallel: 1
```

so that the iOS device tests can run in parallel (the parallelism is shared across all jobs which is a bit too restrictive).