### PR TITLE
Enable CI for feature branch PRs

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -25,7 +25,7 @@ on:
       - "!**/*.md"
   pull_request:
     branches:
-      - main
+      - '*'
     paths:
       - CMakeLists.txt
       - 'platform/android/**'
@@ -209,7 +209,7 @@ jobs:
     needs: build
 
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'maplibre' && github.ref == 'refs/heads/main'
+    if: github.repository_owner == 'maplibre' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/android-annotations ')
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -209,7 +209,7 @@ jobs:
     needs: build
 
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'maplibre' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/android-annotations ')
+    if: github.repository_owner == 'maplibre' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/android-annotations')
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -31,7 +31,7 @@ on:
   
   pull_request:
     branches:
-      - main
+      - '*'
     paths:
       - CMakeLists.txt
       - 'platform/ios/**'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -22,7 +22,7 @@ on:
 
   pull_request:
     branches:
-      - main
+      - '*'
     paths:
       - "src/**"
       - "test/**"

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -32,7 +32,7 @@ on:
 
   pull_request:
     branches:
-      - main
+      - '*'
     paths:
       - CMakeLists.txt
       - "platform/linux/**"

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -28,7 +28,7 @@ on:
 
   pull_request:
     branches:
-      - main
+      - '*'
     paths:
       - CMakeLists.txt
       - ".github/actions/qt5-build/**"


### PR DESCRIPTION
In general we use forks for development, but sometimes there is the need for a feature branch and in this case we like to have all PRs in this repo for reference and visibility.

This enables CI for PRs targeting all branches.

It also enables the Android instrumentation tests for the branch @fynngodau is working on (will run once merged).