### PR TITLE
Deduplicate job names CI, remove path filtering

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -207,7 +207,7 @@ jobs:
             MapboxGLAndroidSDK/build/intermediates/cmake/debug/obj
 
   android-instrumentation-test:
-    needs: build
+    needs: android-build
 
     runs-on: ubuntu-latest
     if: github.repository_owner == 'maplibre' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/android-annotations')

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -24,25 +24,10 @@ on:
       - "vendor/**"
       - ".gitmodules"
       - "!**/*.md"
+
   pull_request:
     branches:
       - '*'
-    paths:
-      - CMakeLists.txt
-      - 'platform/android/**'
-      - ".github/workflows/android-ci.yml"
-      - "bin/**"
-      - "expression-test/**"
-      - "include/**"
-      - "metrics/**"
-      - "platform/default/**"
-      - "render-test/**"
-      - "scripts/**"
-      - "src/**"
-      - "test/**"
-      - "vendor/**"
-      - ".gitmodules"
-      - "!**/*.md"
 
 concurrency:
   # cancel jobs on PRs only
@@ -50,7 +35,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  build:
+  android-build:
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -61,7 +46,6 @@ jobs:
       IS_LOCAL_DEVELOPMENT: false
       MLN_ANDROID_STL: c++_static
     steps:
-
       - uses: actions/checkout@v3
         with:
           submodules: recursive
@@ -117,7 +101,7 @@ jobs:
         env:
           cache-name: gradle-v1
         with:
-          path: ~/.gradle'
+          path: ~/.gradle
           key: ${{ env.cache-name }}-{{ hashFiles 'gradle/dependencies.gradle' }}-{{ hashFiles 'build.gradle' }}-{{ hashFiles 'gradle/wrapper/gradle-wrapper.properties' }}'
           restore-keys: |
             - ${{ env.cache-name }}
@@ -222,7 +206,7 @@ jobs:
             MapboxGLAndroidSDKTestApp/lint-baseline.xml
             MapboxGLAndroidSDK/build/intermediates/cmake/debug/obj
 
-  instrumentation-test:
+  android-instrumentation-test:
     needs: build
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     concurrency:
       # cancel jobs on PRs only
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.renderer }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     env:
       BUILDTYPE: Debug

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -33,30 +33,9 @@ on:
   pull_request:
     branches:
       - '*'
-    paths:
-      - CMakeLists.txt
-      - 'platform/ios/**'
-      - 'platform/darwin/**'
-      - ".github/workflows/ios-ci.yml"
-      - "bin/**"
-      - "expression-test/**"
-      - "include/**"
-      - "metrics/**"
-      - "platform/default/**"
-      - "render-test/**"
-      - "scripts/**"
-      - "src/**"
-      - "test/**"
-      - "vendor/**"
-      - ".gitmodules"
-      - "!**/*.md"
-      - WORKSPACE
-      - BUILD.bazel
-      - .bazelrc
-      - .bazelversion
 
 jobs:
-  build:
+  ios-build:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -107,7 +107,7 @@ jobs:
           retention-days: 1
 
   linux-test:
-    needs: build
+    needs: linux-build
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -134,7 +134,7 @@ jobs:
         run: xvfb-run -a ./mbgl-test-runner
 
   linux-expression-test:
-    needs: build
+    needs: linux-build
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -149,7 +149,7 @@ jobs:
         run: ./mbgl-expression-test
 
   linux-render-test:
-    needs: build
+    needs: linux-build
     runs-on: ubuntu-22.04
     steps:
       - name: Install dependencies

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - topic/drawable
     paths:
       - "src/**"
       - "test/**"
@@ -24,20 +23,6 @@ on:
   pull_request:
     branches:
       - '*'
-    paths:
-      - "src/**"
-      - "test/**"
-      - "render-test/**"
-      - "expression-test/**"
-      - "include/**"
-      - ".github/workflows/linux-ci.yml"
-      - "vendor/**"
-      - "CMakeLists.txt"
-      - metrics/linux-gcc8-release-style.json
-      - WORKSPACE
-      - BUILD.bazel
-      - .bazelrc
-      - .bazelversion
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -45,7 +30,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  build:
+  linux-build:
     strategy:
       fail-fast: false
       matrix:
@@ -121,7 +106,7 @@ jobs:
           path: build/expression-test/mbgl-expression-test
           retention-days: 1
 
-  test:
+  linux-test:
     needs: build
     runs-on: ubuntu-22.04
     steps:
@@ -148,7 +133,7 @@ jobs:
       - name: Run C++ tests
         run: xvfb-run -a ./mbgl-test-runner
 
-  expression-test:
+  linux-expression-test:
     needs: build
     runs-on: ubuntu-22.04
     steps:
@@ -163,7 +148,7 @@ jobs:
       - name: Run expression test
         run: ./mbgl-expression-test
 
-  render-test:
+  linux-render-test:
     needs: build
     runs-on: ubuntu-22.04
     steps:
@@ -194,7 +179,7 @@ jobs:
           path: |
             metrics/linux-gcc8-release-style.html
 
-  coverage:
+  linux-coverage:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -220,7 +220,7 @@ jobs:
             bazel coverage --combined_report=lcov  --instrumentation_filter="//:mbgl-core" --//:maplibre_platform=linux \
             --test_output=errors --local_test_jobs=1 \
             --test_env=DISPLAY --test_env=XAUTHORITY --copt="-DCI_BUILD" \
-            //test:core //expression-test:test
+            //test:core //render-test:render-test //expression-test:test
 
       - name: Upload coverage report
         if: '!cancelled()'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -220,7 +220,7 @@ jobs:
             bazel coverage --combined_report=lcov  --instrumentation_filter="//:mbgl-core" --//:maplibre_platform=linux \
             --test_output=errors --local_test_jobs=1 \
             --test_env=DISPLAY --test_env=XAUTHORITY --copt="-DCI_BUILD" \
-            //test:core //render-test:render-test //expression-test:test
+            //test:core //expression-test:test
 
       - name: Upload coverage report
         if: '!cancelled()'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,34 @@
 # Security Policy
 
-## Reporting vulnerabilities
+## Workflow for Resolving Critical Vulnerabilities
 
-To report a vulnerability in MapLibre Native, create a [security advisory](https://github.com/maplibre/maplibre-native/security/advisories/new). You will be able to privately discuss the issue with the maintainers of MapLibre Native and we can collaborate on a fix.
+The maintainers of MapLibre Native are committed to a fast and efficient resolution of critical security vulnerabilities. We aim to get back to you within 24 hours of creating the report. However, we cannot guarantee this. Luckily, fixes can be reported, fixed, merged, and released by anyone with write access (committers).
 
-We highly appreciate your reports, but we do not pay out bug bounties at this time.
+1. `[Reporter]` To report a critical security vulnerability in MapLibre Native, create a [security advisory](https://github.com/maplibre/maplibre-native/security/advisories/new). 
 
-We will acknowledge your report in our newsletter with your consent.
+2. `[Reporter or Maintainer]` A private fork will be created. Collaborators (GitHub users) that you believe are able to help work on a fix.
+
+3. `[Reporter, Collaborator or Maintainer]` The `main` branch may contain breaking changes or other changes that need to be tested before they can be released. That is why you should create a branch for each affected platform, where you check out the tag of the latest affected version. For example:
+
+```
+git checkout ios-v5.13.0
+git branch -b ios-fix
+git checkout android-v10.2.0
+git branch -b android-fix
+```
+
+4. `[Committer]` Once a fix has been created for a platform, a branch will be made for the new release on `maplibre/maplibre-native`. For example, `ios-v5.13.0` (tag) -> `ios-5.14.0` (new branch).
+
+5. `[Reporter, Collaborator or Maintainer]*` A PR is created from the fork that targets the new branch on `maplibre/maplibre-native`. It is reviewed and merged.
+
+6. `[Committer]` A new release is pushed out from the branch that now contains the fix. The release process is automated and documented and can be done by anyone with write access.
+
+- Android: https://github.com/maplibre/maplibre-native/blob/main/platform/android/RELEASE.md
+- iOS: TODO, please see this issue: https://github.com/maplibre/maplibre-native/issues/1581
+
+7. `[Maintainer]` The security advisory is [published](https://github.com/maplibre/maplibre-native/security/advisories?state=published).
+
+8. `[Reporter or Maintainer]` Another PR is created that applies the changes to the `main` branch. This step is important so new releases don't inadvertantly re-introduce the same security vulnerability.
 
 ## Mitigation
 


### PR DESCRIPTION
- Deduplicate workflow names.
- Fix cache directory Android workflow.
- Fix issue with concurrency setting iOS that now has a matrix configuration, causing one of the two configs to be cancelled.
- Remove path filtering from Android, iOS and Linux workflows. I want to make them required #770, which means they should not use path filtering:

> It is recommended that you do not use path filtering (as shown in the previous example), or branch filtering, in a workflow that has been configured to be required. For more information, see "[Required workflows](https://docs.github.com/en/actions/using-workflows/required-workflows)."

