### PR TITLE
`USE_CPP_TEST_SERVER` for Linux C++ tests

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -77,7 +77,7 @@ jobs:
           CI: 1
         run: |
           cmake --version
-          cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DMLN_WITH_CLANG_TIDY=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMLN_WITH_COVERAGE=ON ${{ env.renderer_flag_cmake }}
+          CI=1 cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DMLN_WITH_CLANG_TIDY=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMLN_WITH_COVERAGE=ON ${{ env.renderer_flag_cmake }}
           cmake --build build --target mbgl-core mbgl-test-runner mbgl-render-test-runner mbgl-expression-test
 
       - name: Perform CodeQL Analysis
@@ -124,11 +124,6 @@ jobs:
           name: mbgl-test-runner
 
       - run: chmod +x ./mbgl-test-runner
-
-      - name: Install npm packages and run test server in background
-        run: |
-          npm install
-          node test/storage/server.js &
 
       - name: Run C++ tests
         run: xvfb-run -a ./mbgl-test-runner

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -229,3 +229,10 @@ set_property(TARGET mbgl-test PROPERTY FOLDER Core)
 if (MLN_WITH_CLANG_TIDY)
     set_target_properties(mbgl-test PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
 endif()
+
+if (CMAKE_SYSTEM_NAME STREQUAL Linux)
+    target_compile_definitions(
+        mbgl-test
+        PRIVATE USE_CPP_TEST_SERVER
+    )
+endif()


### PR DESCRIPTION
The Linux tests fails sometimes, which is especially critical since the checks are required now.

This PR sets `CI=1` so that tests requiring accurate timings are disabled. It also uses the internal C++ test server so that `MainResourceLoader.CachedResourceLowPriority` does not fail.