### PR TITLE
Add codecov token

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -221,6 +221,7 @@ jobs:
         if: '!cancelled()'
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.coverage_report }}
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
Codecov is failing sometimes because it is getting rate limited.

@HarelM Could you help me get a token from codecov.io ?

Organization access is needed.