### PR TITLE
Improve artifact handling CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -183,6 +183,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: github.ref == 'refs/heads/main'
         with:
+          if-no-files-found: error
           name: uploadsEnv
           path: uploads.env
 
@@ -198,6 +199,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: android-render-tests
+          if-no-files-found: error
           path: |
             ./render-test/android/RenderTestsApp.apk
             ./render-test/android/RenderTests.apk

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -127,6 +127,7 @@ jobs:
         if: ${{ matrix.renderer }} = "legacy"
         uses: actions/upload-artifact@v3
         with:
+          if-no-files-found: error
           name: size-test-result
           path: |
             ./size
@@ -155,6 +156,7 @@ jobs:
         with:
           name: ios-render-test
           retention-days: 3
+          if-no-files-found: error
           path: |
             ${{ env.render_test_artifacts_dir }}/RenderTest.xctest.zip
             ${{ env.render_test_artifacts_dir }}/RenderTestApp.ipa
@@ -183,6 +185,7 @@ jobs:
         with:
           name: ios-cpp-unit-tests
           retention-days: 3
+          if-no-files-found: error
           path: |
             ${{ env.ios_cpp_test_artifacts_dir }}/CppUnitTests.xctest.zip
             ${{ env.ios_cpp_test_artifacts_dir }}/CppUnitTestsApp.ipa

--- a/.github/workflows/ios-device-test.yml
+++ b/.github/workflows/ios-device-test.yml
@@ -20,11 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/download-workflow-run-artifact
-        with:
-          artifact-name: ${{ matrix.test.artifactName }}
-          expect-files: "${{ matrix.test.xcTestFile }}, ${{ matrix.test.ipaFile }}"
-
       - name: Generate token
         id: generate_token
         uses: tibdex/github-app-token@v1
@@ -41,7 +36,18 @@ jobs:
           name: ${{ matrix.test.name }}
           sha: ${{ github.event.workflow_run.head_sha }}
 
+      - uses: ./.github/actions/download-workflow-run-artifact
+        with:
+          artifact-name: ${{ matrix.test.artifactName }}
+
+      - name: Check if test files exist (otherwise the parent workflow was skipped)
+        id: check_files
+        uses: andstor/file-existence-action@v2.0.0
+        with:
+          files: "${{ matrix.test.xcTestFile }}, ${{ matrix.test.ipaFile }}"
+
       - name: Configure AWS Credentials
+        if: steps.check_files.outputs.files_exists == 'true'
         uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -52,6 +58,7 @@ jobs:
           role-session-name: MySessionName
 
       - name: Create upload app
+        if: steps.check_files.outputs.files_exists == 'true'
         run: |
           response=$(aws devicefarm create-upload --type IOS_APP --name ${{ matrix.test.ipaFile }} --project-arn ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }})
           echo "$response"
@@ -61,6 +68,7 @@ jobs:
           echo "app_url=$url" >> "$GITHUB_ENV"
 
       - name: Create upload test package
+        if: steps.check_files.outputs.files_exists == 'true'
         run: |
           response=$(aws devicefarm create-upload --type XCTEST_TEST_PACKAGE --name ${{ matrix.test.xcTestFile }} --project-arn ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }})
           echo "$response"
@@ -70,6 +78,7 @@ jobs:
           echo "test_package_url=$url" >> "$GITHUB_ENV"
 
       - name: Upload ${{ matrix.test.name }}
+        if: steps.check_files.outputs.files_exists == 'true'
         run: |
           curl -T ${{ matrix.test.ipaFile }} "${{ env.app_url }}"
           curl -T ${{ matrix.test.xcTestFile }} "${{ env.test_package_url }}"
@@ -96,6 +105,7 @@ jobs:
           done
 
       - name: Schedule test run
+        if: steps.check_files.outputs.files_exists == 'true'
         uses: realm/aws-devicefarm/test-application@master
         with:
           name: MapLibre Native ${{ matrix.test.name }}


### PR DESCRIPTION
As described in #1612

The main iOS workflow kicks off the device test.

But if the main iOS workflow does not produce a (test app) artifact (because it was skipped) then the device test is never run (actually it does run, but it does not create a check). This fixes that, it runs, and passes when no artifact is found. But it also adds a check to make sure that the artifact is not just missing because of a build error.