### PR TITLE
Update minimum CMake version to 3.19

### DIFF
--- a/.github/actions/qt5-build/Dockerfile
+++ b/.github/actions/qt5-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/maplibre/linux-builder:centos7-cmake3.10
+FROM ghcr.io/maplibre/linux-builder:centos7-cmake3.19
 
 # Copy and set the entry point
 COPY entrypoint.sh /entrypoint.sh

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -6,11 +6,11 @@ on:
     branches:
       - main
     tags:
-      - 'android-*'
+      - "android-*"
 
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 concurrency:
   # cancel jobs on PRs only
@@ -62,11 +62,18 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+        with:
+          cmake-version: "3.19.x"
+
+      - run: echo "cmake.dir=$(dirname "$(dirname "$(command -v cmake)")")" >> local.properties
+
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '17'
-      
+          distribution: "temurin"
+          java-version: "17"
+
       - name: Cache node modules
         uses: actions/cache@v3
         env:
@@ -115,7 +122,7 @@ jobs:
           else
             echo "No secrets.MAPLIBRE_DEVELOPER_CONFIG_XML variable set, not copying..."
           fi
-    
+
       - name: Build UI tests
         run: make android-ui-test-arm-v8
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -7,17 +7,17 @@ on:
       - main
       - topic/drawable
     tags:
-      - 'node-*'
+      - "node-*"
     paths:
       - CMakeLists.txt
       - "platform/linux/**"
       - "platform/default/**"
-      - 'platform/node/**'
-      - 'platform/windows/**'
-      - 'platform/darwin/**'
-      - 'platform/macos/**'
-      - 'platform/ios/platform/darwin/**'
-      - 'platform/ios/platform/macos/**'
+      - "platform/node/**"
+      - "platform/windows/**"
+      - "platform/darwin/**"
+      - "platform/macos/**"
+      - "platform/ios/platform/darwin/**"
+      - "platform/ios/platform/macos/**"
       - ".github/workflows/node-ci.yml"
       - "bin/**"
       - "expression-test/**"
@@ -33,17 +33,17 @@ on:
 
   pull_request:
     branches:
-      - '*'
+      - "*"
     paths:
       - CMakeLists.txt
       - "platform/linux/**"
       - "platform/default/**"
-      - 'platform/node/**'
-      - 'platform/windows/**'
-      - 'platform/darwin/**'
-      - 'platform/macos/**'
-      - 'platform/ios/platform/darwin/**'
-      - 'platform/ios/platform/macos/**'
+      - "platform/node/**"
+      - "platform/windows/**"
+      - "platform/darwin/**"
+      - "platform/macos/**"
+      - "platform/ios/platform/darwin/**"
+      - "platform/ios/platform/macos/**"
       - ".github/workflows/node-ci.yml"
       - "bin/**"
       - "expression-test/**"
@@ -77,7 +77,7 @@ jobs:
             arch: x86_64
     continue-on-error: true
     env:
-      BUILDTYPE: 'Release'
+      BUILDTYPE: "Release"
 
     defaults:
       run:
@@ -149,6 +149,12 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Setup cmake (Linux)
+        if: runner.os == 'Linux' && runner.arch != 'arm64'
+        uses: jwlawson/actions-setup-cmake@v1.13
+        with:
+          cmake-version: "3.19.x"
+
       - name: Set up ccache (MacOS/Linux)
         if: runner.os == 'MacOS' || runner.os == 'Linux'
         uses: hendrikmuhs/ccache-action@v1
@@ -163,7 +169,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: hendrikmuhs/ccache-action@v1
         with:
-          variant: 'sccache'
+          variant: "sccache"
           key: ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}-${{ github.head_ref }}
           restore-keys: |
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}
@@ -269,4 +275,3 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: |
           npm pack --dry-run
-          

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -193,6 +193,7 @@ jobs:
 
       - name: Configure maplibre-native (Linux)
         if: runner.os == 'Linux'
+        shell: bash -leo pipefail {0}
         run: |
           cmake . -B build \
             -G Ninja \

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -122,7 +122,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             ccache \
-            cmake \
             ninja-build \
             pkg-config \
             xvfb \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
 
 option(MLN_WITH_CORE_ONLY "Build only the core bits, no platform code" OFF)
 option(MLN_WITH_CLANG_TIDY "Build with clang-tidy checks enabled" OFF)
@@ -132,7 +132,7 @@ set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
-if(MLN_WITH_QT AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+if(MLN_WITH_QT)
     add_library(mbgl-core OBJECT)
 else()
     add_library(mbgl-core STATIC)


### PR DESCRIPTION
Update minimum CMake version to 3.19. Will need a separate PR to update to a container that is containing this CMake version but the one we have now should do it by then.

/cc @alanchenboy