### PR TITLE
Skip `linux-ci` when not needed

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -5,20 +5,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "src/**"
-      - "test/**"
-      - "render-test/**"
-      - "expression-test/**"
-      - "include/**"
-      - ".github/workflows/linux-ci.yml"
-      - "vendor/**"
-      - "CMakeLists.txt"
-      - metrics/linux-gcc8-release-style.json
-      - WORKSPACE
-      - BUILD.bazel
-      - .bazelrc
-      - .bazelversion
 
   pull_request:
     branches:
@@ -30,6 +16,29 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-22.04
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          paths: |
+            ["src/**",
+            "test/**",
+            "render-test/**",
+            "expression-test/**",
+            "include/**",
+            ".github/workflows/linux-ci.yml",
+            "vendor/**",
+            "CMakeLists.txt",
+            "metrics/linux-gcc8-release-style.json",
+            "WORKSPACE",
+            "BUILD.bazel",
+            ".bazelrc",
+            ".bazelversion"]
+
   linux-build:
     strategy:
       fail-fast: false
@@ -225,3 +234,18 @@ jobs:
           files: ${{ env.coverage_report }}
           fail_ci_if_error: true
           verbose: true
+
+  linux-ci-result:
+    name: Linux CI Result
+    if: needs.pre_job.outputs.should_skip != 'true' && always()
+    runs-on: ubuntu-22.04
+    needs:
+      - pre_job
+      - linux-build
+      - linux-test
+      - linux-render-test
+      - linux-coverage
+    steps:
+      - name: Mark result as failed
+        if: needs.linux-build.result != 'success' || needs.linux-test.result != 'success' || needs.linux-render-test.result != 'success' || needs.linux-coverage.result != 'success'
+        run: exit 1


### PR DESCRIPTION
Uses `fkirc/skip-duplicate-actions@v5` for `linux-ci` just like we do for `ios-ci` already.