### PR TITLE
[MSVC] Use string view literals with StringIndexer

### DIFF
--- a/include/mbgl/util/string_indexer.hpp
+++ b/include/mbgl/util/string_indexer.hpp
@@ -9,6 +9,8 @@
 #include <mutex>
 #include <shared_mutex>
 
+using namespace std::string_view_literals;
+
 namespace mbgl {
 
 using StringIdentity = size_t;

--- a/src/mbgl/gfx/drawable_builder.cpp
+++ b/src/mbgl/gfx/drawable_builder.cpp
@@ -12,7 +12,7 @@ namespace gfx {
 
 DrawableBuilder::DrawableBuilder(std::string name_)
     : name(std::move(name_)),
-      vertexAttrNameId(StringIndexer::get("a_pos")),
+      vertexAttrNameId(StringIndexer::get("a_pos"sv)),
       renderPass(mbgl::RenderPass::Opaque),
       impl(std::make_unique<Impl>()) {}
 

--- a/src/mbgl/gl/drawable_gl_impl.hpp
+++ b/src/mbgl/gl/drawable_gl_impl.hpp
@@ -51,7 +51,7 @@ public:
     gfx::CullFaceMode cullFaceMode;
     GLfloat pointSize = 0.0f;
 
-    StringIdentity idVertexAttrName = StringIndexer::get("a_pos");
+    StringIdentity idVertexAttrName = StringIndexer::get("a_pos"sv);
 };
 
 struct DrawableGL::DrawSegmentGL final : public gfx::Drawable::DrawSegment {

--- a/src/mbgl/mtl/drawable_impl.hpp
+++ b/src/mbgl/mtl/drawable_impl.hpp
@@ -52,7 +52,7 @@ public:
     gfx::StencilMode stencilMode;
     gfx::CullFaceMode cullFaceMode;
     // GLfloat pointSize = 0.0f;
-    StringIdentity idVertexAttrName = StringIndexer::get("a_pos");
+    StringIdentity idVertexAttrName = StringIndexer::get("a_pos"sv);
 
     gfx::UniqueVertexBufferResource noBindingBuffer;
 };

--- a/src/mbgl/renderer/layers/background_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/background_layer_tweaker.cpp
@@ -19,9 +19,9 @@ using namespace shaders;
 #if !defined(NDEBUG)
 constexpr auto BackgroundPatternShaderName = "BackgroundPatternShader";
 #endif
-static const StringIdentity idBackgroundDrawableUBOName = StringIndexer::get("BackgroundDrawableUBO");
-static const StringIdentity idBackgroundLayerUBOName = StringIndexer::get("BackgroundLayerUBO");
-static const StringIdentity idTexUniformName = StringIndexer::get("u_image");
+static const StringIdentity idBackgroundDrawableUBOName = StringIndexer::get("BackgroundDrawableUBO"sv);
+static const StringIdentity idBackgroundLayerUBOName = StringIndexer::get("BackgroundLayerUBO"sv);
+static const StringIdentity idTexUniformName = StringIndexer::get("u_image"sv);
 
 void BackgroundLayerTweaker::execute(LayerGroupBase& layerGroup, const RenderTree&, const PaintParameters& parameters) {
     const auto& state = parameters.state;

--- a/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
@@ -22,12 +22,12 @@ namespace mbgl {
 using namespace style;
 using namespace shaders;
 
-static const StringIdentity idCircleDrawableUBOName = StringIndexer::get("CircleDrawableUBO");
-static const StringIdentity idCirclePaintParamsUBOName = StringIndexer::get("CirclePaintParamsUBO");
-static const StringIdentity idCircleEvaluatedPropsUBOName = StringIndexer::get("CircleEvaluatedPropsUBO");
+static const StringIdentity idCircleDrawableUBOName = StringIndexer::get("CircleDrawableUBO"sv);
+static const StringIdentity idCirclePaintParamsUBOName = StringIndexer::get("CirclePaintParamsUBO"sv);
+static const StringIdentity idCircleEvaluatedPropsUBOName = StringIndexer::get("CircleEvaluatedPropsUBO"sv);
 
-static const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO");
-static const StringIdentity idCirclePermutationUBOName = StringIndexer::get("CirclePermutationUBO");
+static const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO"sv);
+static const StringIdentity idCirclePermutationUBOName = StringIndexer::get("CirclePermutationUBO"sv);
 
 void CircleLayerTweaker::execute(LayerGroupBase& layerGroup,
                                  const RenderTree& renderTree,

--- a/src/mbgl/renderer/layers/collision_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/collision_layer_tweaker.hpp
@@ -20,9 +20,9 @@ public:
 
     void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) override;
 
-    static constexpr auto CollisionCircleUBOName = "CollisionCircleUBO";
+    static constexpr auto CollisionCircleUBOName = "CollisionCircleUBO"sv;
     static const StringIdentity idCollisionCircleUBOName;
-    static constexpr auto CollisionBoxUBOName = "CollisionBoxUBO";
+    static constexpr auto CollisionBoxUBOName = "CollisionBoxUBO"sv;
     static const StringIdentity idCollisionBoxUBOName;
 };
 

--- a/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.cpp
@@ -22,18 +22,18 @@ using namespace shaders;
 using namespace style;
 
 namespace {
-const StringIdentity idFillExtrusionDrawableUBOName = StringIndexer::get("FillExtrusionDrawableUBO");
-const StringIdentity idFillExtrusionDrawablePropsUBOName = StringIndexer::get("FillExtrusionDrawablePropsUBO");
-const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO");
-const StringIdentity idFillExtrusionPermutationUBOName = StringIndexer::get("FillExtrusionPermutationUBO");
-const StringIdentity idTexImageName = StringIndexer::get("u_image");
+const StringIdentity idFillExtrusionDrawableUBOName = StringIndexer::get("FillExtrusionDrawableUBO"sv);
+const StringIdentity idFillExtrusionDrawablePropsUBOName = StringIndexer::get("FillExtrusionDrawablePropsUBO"sv);
+const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO"sv);
+const StringIdentity idFillExtrusionPermutationUBOName = StringIndexer::get("FillExtrusionPermutationUBO"sv);
+const StringIdentity idTexImageName = StringIndexer::get("u_image"sv);
 
 } // namespace
 
 const StringIdentity FillExtrusionLayerTweaker::idFillExtrusionTilePropsUBOName = StringIndexer::get(
-    "FillExtrusionDrawableTilePropsUBO");
+    "FillExtrusionDrawableTilePropsUBO"sv);
 const StringIdentity FillExtrusionLayerTweaker::idFillExtrusionInterpolateUBOName = StringIndexer::get(
-    "FillExtrusionInterpolateUBO");
+    "FillExtrusionInterpolateUBO"sv);
 
 void FillExtrusionLayerTweaker::execute(LayerGroupBase& layerGroup,
                                         const RenderTree& renderTree,

--- a/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
@@ -24,40 +24,40 @@ namespace mbgl {
 
 using namespace style;
 
-static const StringIdentity idFillDrawableUBOName = StringIndexer::get("FillDrawableUBO");
-static const StringIdentity idFillDrawablePropsUBOName = StringIndexer::get("FillDrawablePropsUBO");
-static const StringIdentity idFillEvaluatedPropsUBOName = StringIndexer::get("FillEvaluatedPropsUBO");
-static const StringIdentity idFillPermutationUBOName = StringIndexer::get("FillPermutationUBO");
+static const StringIdentity idFillDrawableUBOName = StringIndexer::get("FillDrawableUBO"sv);
+static const StringIdentity idFillDrawablePropsUBOName = StringIndexer::get("FillDrawablePropsUBO"sv);
+static const StringIdentity idFillEvaluatedPropsUBOName = StringIndexer::get("FillEvaluatedPropsUBO"sv);
+static const StringIdentity idFillPermutationUBOName = StringIndexer::get("FillPermutationUBO"sv);
 
-const StringIdentity FillLayerTweaker::idFillTilePropsUBOName = StringIndexer::get("FillDrawableTilePropsUBO");
-const StringIdentity FillLayerTweaker::idFillInterpolateUBOName = StringIndexer::get("FillInterpolateUBO");
+const StringIdentity FillLayerTweaker::idFillTilePropsUBOName = StringIndexer::get("FillDrawableTilePropsUBO"sv);
+const StringIdentity FillLayerTweaker::idFillInterpolateUBOName = StringIndexer::get("FillInterpolateUBO"sv);
 const StringIdentity FillLayerTweaker::idFillOutlineInterpolateUBOName = StringIndexer::get(
-    "FillOutlineInterpolateUBO");
+    "FillOutlineInterpolateUBO"sv);
 
-static const StringIdentity idFillOutlineDrawableUBOName = StringIndexer::get("FillOutlineDrawableUBO");
-static const StringIdentity idFillOutlineEvaluatedPropsUBOName = StringIndexer::get("FillOutlineEvaluatedPropsUBO");
-static const StringIdentity idFillOutlinePermutationUBOName = StringIndexer::get("FillOutlinePermutationUBO");
+static const StringIdentity idFillOutlineDrawableUBOName = StringIndexer::get("FillOutlineDrawableUBO"sv);
+static const StringIdentity idFillOutlineEvaluatedPropsUBOName = StringIndexer::get("FillOutlineEvaluatedPropsUBO"sv);
+static const StringIdentity idFillOutlinePermutationUBOName = StringIndexer::get("FillOutlinePermutationUBO"sv);
 
-static const StringIdentity idFillOutlineInterpolateUBOName = StringIndexer::get("FillOutlineInterpolateUBO");
+static const StringIdentity idFillOutlineInterpolateUBOName = StringIndexer::get("FillOutlineInterpolateUBO"sv);
 
-static const StringIdentity idFillPatternDrawableUBOName = StringIndexer::get("FillPatternDrawableUBO");
-static const StringIdentity idFillPatternPermutationUBOName = StringIndexer::get("FillPatternPermutationUBO");
-static const StringIdentity idFillPatternInterpolateUBOName = StringIndexer::get("FillPatternInterpolateUBO");
-static const StringIdentity idFillPatternEvaluatedPropsUBOName = StringIndexer::get("FillPatternEvaluatedPropsUBO");
-static const StringIdentity idFillPatternTilePropsUBOName = StringIndexer::get("FillPatternTilePropsUBO");
+static const StringIdentity idFillPatternDrawableUBOName = StringIndexer::get("FillPatternDrawableUBO"sv);
+static const StringIdentity idFillPatternPermutationUBOName = StringIndexer::get("FillPatternPermutationUBO"sv);
+static const StringIdentity idFillPatternInterpolateUBOName = StringIndexer::get("FillPatternInterpolateUBO"sv);
+static const StringIdentity idFillPatternEvaluatedPropsUBOName = StringIndexer::get("FillPatternEvaluatedPropsUBO"sv);
+static const StringIdentity idFillPatternTilePropsUBOName = StringIndexer::get("FillPatternTilePropsUBO"sv);
 
-static const StringIdentity idFillOutlinePatternDrawableUBOName = StringIndexer::get("FillOutlinePatternDrawableUBO");
+static const StringIdentity idFillOutlinePatternDrawableUBOName = StringIndexer::get("FillOutlinePatternDrawableUBO"sv);
 static const StringIdentity idFillOutlinePatternPermutationUBOName = StringIndexer::get(
-    "FillOutlinePatternPermutationUBO");
+    "FillOutlinePatternPermutationUBO"sv);
 static const StringIdentity idFillOutlinePatternInterpolateUBOName = StringIndexer::get(
-    "FillOutlinePatternInterpolateUBO");
+    "FillOutlinePatternInterpolateUBO"sv);
 static const StringIdentity idFillOutlinePatternEvaluatedPropsUBOName = StringIndexer::get(
-    "FillOutlinePatternEvaluatedPropsUBO");
-static const StringIdentity idFillOutlinePatternTilePropsUBOName = StringIndexer::get("FillOutlinePatternTilePropsUBO");
+    "FillOutlinePatternEvaluatedPropsUBO"sv);
+static const StringIdentity idFillOutlinePatternTilePropsUBOName = StringIndexer::get("FillOutlinePatternTilePropsUBO"sv);
 
-static const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO");
+static const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO"sv);
 
-static const StringIdentity idTexImageName = StringIndexer::get("u_image");
+static const StringIdentity idTexImageName = StringIndexer::get("u_image"sv);
 using namespace shaders;
 
 void FillLayerTweaker::execute(LayerGroupBase& layerGroup,

--- a/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
@@ -53,7 +53,8 @@ static const StringIdentity idFillOutlinePatternInterpolateUBOName = StringIndex
     "FillOutlinePatternInterpolateUBO"sv);
 static const StringIdentity idFillOutlinePatternEvaluatedPropsUBOName = StringIndexer::get(
     "FillOutlinePatternEvaluatedPropsUBO"sv);
-static const StringIdentity idFillOutlinePatternTilePropsUBOName = StringIndexer::get("FillOutlinePatternTilePropsUBO"sv);
+static const StringIdentity idFillOutlinePatternTilePropsUBOName = StringIndexer::get(
+    "FillOutlinePatternTilePropsUBO"sv);
 
 static const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO"sv);
 

--- a/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
@@ -20,10 +20,10 @@ namespace mbgl {
 using namespace style;
 using namespace shaders;
 
-static const StringIdentity idHeatmapDrawableUBOName = StringIndexer::get("HeatmapDrawableUBO");
-static const StringIdentity idHeatmapEvaluatedPropsUBOName = StringIndexer::get("HeatmapEvaluatedPropsUBO");
-static const StringIdentity idHeatmapPermutationUBOName = StringIndexer::get("HeatmapPermutationUBO");
-static const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO");
+static const StringIdentity idHeatmapDrawableUBOName = StringIndexer::get("HeatmapDrawableUBO"sv);
+static const StringIdentity idHeatmapEvaluatedPropsUBOName = StringIndexer::get("HeatmapEvaluatedPropsUBO"sv);
+static const StringIdentity idHeatmapPermutationUBOName = StringIndexer::get("HeatmapPermutationUBO"sv);
+static const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO"sv);
 
 void HeatmapLayerTweaker::execute(LayerGroupBase& layerGroup,
                                   const RenderTree& renderTree,

--- a/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.cpp
@@ -16,7 +16,7 @@ namespace mbgl {
 using namespace style;
 using namespace shaders;
 
-static const StringIdentity idHeatmapTextureDrawableUBOName = StringIndexer::get("HeatmapTextureDrawableUBO");
+static const StringIdentity idHeatmapTextureDrawableUBOName = StringIndexer::get("HeatmapTextureDrawableUBO"sv);
 
 void HeatmapTextureLayerTweaker::execute(LayerGroupBase& layerGroup,
                                          [[maybe_unused]] const RenderTree& renderTree,

--- a/src/mbgl/renderer/layers/hillshade_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/hillshade_layer_tweaker.cpp
@@ -27,8 +27,8 @@ struct alignas(16) HillshadeEvaluatedPropsUBO {
 };
 static_assert(sizeof(HillshadeEvaluatedPropsUBO) % 16 == 0);
 
-static const StringIdentity idHillshadeDrawableUBOName = StringIndexer::get("HillshadeDrawableUBO");
-static const StringIdentity idHillshadeEvaluatedPropsUBOName = StringIndexer::get("HillshadeEvaluatedPropsUBO");
+static const StringIdentity idHillshadeDrawableUBOName = StringIndexer::get("HillshadeDrawableUBO"sv);
+static const StringIdentity idHillshadeEvaluatedPropsUBOName = StringIndexer::get("HillshadeEvaluatedPropsUBO"sv);
 
 std::array<float, 2> getLatRange(const UnwrappedTileID& id) {
     const LatLng latlng0 = LatLng(id);

--- a/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.cpp
@@ -23,7 +23,7 @@ struct alignas(16) HillshadePrepareDrawableUBO {
 };
 static_assert(sizeof(HillshadePrepareDrawableUBO) % 16 == 0);
 
-static const StringIdentity idHillshadePrepareDrawableUBOName = StringIndexer::get("HillshadePrepareDrawableUBO");
+static const StringIdentity idHillshadePrepareDrawableUBOName = StringIndexer::get("HillshadePrepareDrawableUBO"sv);
 
 const std::array<float, 4>& getUnpackVector(Tileset::DEMEncoding encoding) {
     // https://www.mapbox.com/help/access-elevation-data/#mapbox-terrain-rgb

--- a/src/mbgl/renderer/layers/line_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.cpp
@@ -24,18 +24,18 @@ namespace mbgl {
 using namespace style;
 using namespace shaders;
 
-static const StringIdentity idLineUBOName = StringIndexer::get("LineUBO");
-static const StringIdentity idLinePropertiesUBOName = StringIndexer::get("LinePropertiesUBO");
-static const StringIdentity idLineGradientUBOName = StringIndexer::get("LineGradientUBO");
-static const StringIdentity idLineGradientPropertiesUBOName = StringIndexer::get("LineGradientPropertiesUBO");
-static const StringIdentity idLinePatternUBOName = StringIndexer::get("LinePatternUBO");
-static const StringIdentity idLinePatternPropertiesUBOName = StringIndexer::get("LinePatternPropertiesUBO");
-static const StringIdentity idLineSDFUBOName = StringIndexer::get("LineSDFUBO");
-static const StringIdentity idLineSDFPropertiesUBOName = StringIndexer::get("LineSDFPropertiesUBO");
-static const StringIdentity idTexImageName = StringIndexer::get("u_image");
+static const StringIdentity idLineUBOName = StringIndexer::get("LineUBO"sv);
+static const StringIdentity idLinePropertiesUBOName = StringIndexer::get("LinePropertiesUBO"sv);
+static const StringIdentity idLineGradientUBOName = StringIndexer::get("LineGradientUBO"sv);
+static const StringIdentity idLineGradientPropertiesUBOName = StringIndexer::get("LineGradientPropertiesUBO"sv);
+static const StringIdentity idLinePatternUBOName = StringIndexer::get("LinePatternUBO"sv);
+static const StringIdentity idLinePatternPropertiesUBOName = StringIndexer::get("LinePatternPropertiesUBO"sv);
+static const StringIdentity idLineSDFUBOName = StringIndexer::get("LineSDFUBO"sv);
+static const StringIdentity idLineSDFPropertiesUBOName = StringIndexer::get("LineSDFPropertiesUBO"sv);
+static const StringIdentity idTexImageName = StringIndexer::get("u_image"sv);
 
-static const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO");
-static const StringIdentity idLinePermutationUBOName = StringIndexer::get("LinePermutationUBO");
+static const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO"sv);
+static const StringIdentity idLinePermutationUBOName = StringIndexer::get("LinePermutationUBO"sv);
 
 void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
                                const RenderTree& renderTree,

--- a/src/mbgl/renderer/layers/raster_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/raster_layer_tweaker.cpp
@@ -17,7 +17,7 @@ namespace mbgl {
 using namespace style;
 using namespace shaders;
 
-static const StringIdentity idRasterDrawableUBOName = StringIndexer::get("RasterDrawableUBO");
+static const StringIdentity idRasterDrawableUBOName = StringIndexer::get("RasterDrawableUBO"sv);
 
 void RasterLayerTweaker::execute([[maybe_unused]] LayerGroupBase& layerGroup,
                                  [[maybe_unused]] const RenderTree& renderTree,

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -269,8 +269,8 @@ bool RenderCircleLayer::queryIntersectsFeature(const GeometryCoordinates& queryG
 namespace {
 
 constexpr auto CircleShaderGroupName = "CircleShader";
-static const StringIdentity idCircleInterpolateUBOName = StringIndexer::get("CircleInterpolateUBO");
-static const StringIdentity idVertexAttribName = StringIndexer::get("a_pos");
+static const StringIdentity idCircleInterpolateUBOName = StringIndexer::get("CircleInterpolateUBO"sv);
+static const StringIdentity idVertexAttribName = StringIndexer::get("a_pos"sv);
 
 } // namespace
 

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -38,10 +38,10 @@ using namespace shaders;
 namespace {
 
 #if MLN_DRAWABLE_RENDERER
-static const StringIdentity idPosAttribName = StringIndexer::get("a_pos");
-static const StringIdentity idNormAttribName = StringIndexer::get("a_normal_ed");
+static const StringIdentity idPosAttribName = StringIndexer::get("a_pos"sv);
+static const StringIdentity idNormAttribName = StringIndexer::get("a_normal_ed"sv);
 
-static const StringIdentity idIconTextureName = StringIndexer::get("u_image");
+static const StringIdentity idIconTextureName = StringIndexer::get("u_image"sv);
 
 #endif // MLN_DRAWABLE_RENDERER
 

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -46,15 +46,15 @@ constexpr auto FillOutlineShaderName = "FillOutlineShader";
 constexpr auto FillPatternShaderName = "FillPatternShader";
 constexpr auto FillOutlinePatternShaderName = "FillOutlinePatternShader";
 
-static const StringIdentity idFillOutlineInterpolateUBOName = StringIndexer::get("FillOutlineInterpolateUBO");
-static const StringIdentity idFillPatternInterpolateUBOName = StringIndexer::get("FillPatternInterpolateUBO");
-static const StringIdentity idFillPatternTilePropsUBOName = StringIndexer::get("FillPatternTilePropsUBO");
+static const StringIdentity idFillOutlineInterpolateUBOName = StringIndexer::get("FillOutlineInterpolateUBO"sv);
+static const StringIdentity idFillPatternInterpolateUBOName = StringIndexer::get("FillPatternInterpolateUBO"sv);
+static const StringIdentity idFillPatternTilePropsUBOName = StringIndexer::get("FillPatternTilePropsUBO"sv);
 static const StringIdentity idFillOutlinePatternInterpolateUBOName = StringIndexer::get(
-    "FillOutlinePatternInterpolateUBO");
-static const StringIdentity idFillOutlinePatternTilePropsUBOName = StringIndexer::get("FillOutlinePatternTilePropsUBO");
+    "FillOutlinePatternInterpolateUBO"sv);
+static const StringIdentity idFillOutlinePatternTilePropsUBOName = StringIndexer::get("FillOutlinePatternTilePropsUBO"sv);
 
-static const StringIdentity idPosAttribName = StringIndexer::get("a_pos");
-static const StringIdentity idIconTextureName = StringIndexer::get("u_image");
+static const StringIdentity idPosAttribName = StringIndexer::get("a_pos"sv);
+static const StringIdentity idIconTextureName = StringIndexer::get("u_image"sv);
 #endif // MLN_DRAWABLE_RENDERER
 
 inline const FillLayer::Impl& impl_cast(const Immutable<style::Layer::Impl>& impl) {

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -51,7 +51,8 @@ static const StringIdentity idFillPatternInterpolateUBOName = StringIndexer::get
 static const StringIdentity idFillPatternTilePropsUBOName = StringIndexer::get("FillPatternTilePropsUBO"sv);
 static const StringIdentity idFillOutlinePatternInterpolateUBOName = StringIndexer::get(
     "FillOutlinePatternInterpolateUBO"sv);
-static const StringIdentity idFillOutlinePatternTilePropsUBOName = StringIndexer::get("FillOutlinePatternTilePropsUBO"sv);
+static const StringIdentity idFillOutlinePatternTilePropsUBOName = StringIndexer::get(
+    "FillOutlinePatternTilePropsUBO"sv);
 
 static const StringIdentity idPosAttribName = StringIndexer::get("a_pos"sv);
 static const StringIdentity idIconTextureName = StringIndexer::get("u_image"sv);

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -264,10 +264,10 @@ namespace {
 
 constexpr auto HeatmapShaderGroupName = "HeatmapShader";
 constexpr auto HeatmapTextureShaderGroupName = "HeatmapTextureShader";
-static const StringIdentity idHeatmapInterpolateUBOName = StringIndexer::get("HeatmapInterpolateUBO");
-static const StringIdentity idVertexAttribName = StringIndexer::get("a_pos");
-static const StringIdentity idTexImageName = StringIndexer::get("u_image");
-static const StringIdentity idTexColorRampName = StringIndexer::get("u_color_ramp");
+static const StringIdentity idHeatmapInterpolateUBOName = StringIndexer::get("HeatmapInterpolateUBO"sv);
+static const StringIdentity idVertexAttribName = StringIndexer::get("a_pos"sv);
+static const StringIdentity idTexImageName = StringIndexer::get("u_image"sv);
+static const StringIdentity idTexColorRampName = StringIndexer::get("u_color_ramp"sv);
 
 } // namespace
 

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -281,9 +281,9 @@ void RenderHillshadeLayer::removeRenderTargets(UniqueChangeRequestVec& changes) 
 static const std::string HillshadePrepareShaderGroupName = "HillshadePrepareShader";
 static const std::string HillshadeShaderGroupName = "HillshadeShader";
 
-static const StringIdentity idPosAttribName = StringIndexer::get("a_pos");
-static const StringIdentity idTexturePosAttribName = StringIndexer::get("a_texture_pos");
-static const StringIdentity idTexImageName = StringIndexer::get("u_image");
+static const StringIdentity idPosAttribName = StringIndexer::get("a_pos"sv);
+static const StringIdentity idTexturePosAttribName = StringIndexer::get("a_texture_pos"sv);
+static const StringIdentity idTexImageName = StringIndexer::get("u_image"sv);
 
 void RenderHillshadeLayer::update(gfx::ShaderRegistry& shaders,
                                   gfx::Context& context,

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -56,8 +56,8 @@ inline const LineLayer::Impl& impl_cast(const Immutable<style::Layer::Impl>& imp
 
 #if MLN_DRAWABLE_RENDERER
 
-static const StringIdentity idVertexAttribName = StringIndexer::get("a_pos_normal");
-static const StringIdentity idDataAttribName = StringIndexer::get("a_data");
+static const StringIdentity idVertexAttribName = StringIndexer::get("a_pos_normal"sv);
+static const StringIdentity idDataAttribName = StringIndexer::get("a_data"sv);
 
 #endif // MLN_DRAWABLE_RENDERER
 
@@ -357,13 +357,13 @@ float RenderLineLayer::getLineWidth(const GeometryTileFeature& feature,
 
 #if MLN_DRAWABLE_RENDERER
 /// Property interpolation UBOs
-static const StringIdentity idLineInterpolationUBOName = StringIndexer::get("LineInterpolationUBO");
-static const StringIdentity idLineGradientInterpolationUBOName = StringIndexer::get("LineGradientInterpolationUBO");
-static const StringIdentity idLinePatternInterpolationUBOName = StringIndexer::get("LinePatternInterpolationUBO");
-static const StringIdentity idLineSDFInterpolationUBOName = StringIndexer::get("LineSDFInterpolationUBO");
+static const StringIdentity idLineInterpolationUBOName = StringIndexer::get("LineInterpolationUBO"sv);
+static const StringIdentity idLineGradientInterpolationUBOName = StringIndexer::get("LineGradientInterpolationUBO"sv);
+static const StringIdentity idLinePatternInterpolationUBOName = StringIndexer::get("LinePatternInterpolationUBO"sv);
+static const StringIdentity idLineSDFInterpolationUBOName = StringIndexer::get("LineSDFInterpolationUBO"sv);
 
 /// Evaluated properties that depend on the tile
-static const StringIdentity idLinePatternTilePropertiesUBOName = StringIndexer::get("LinePatternTilePropertiesUBO");
+static const StringIdentity idLinePatternTilePropertiesUBOName = StringIndexer::get("LinePatternTilePropertiesUBO"sv);
 void RenderLineLayer::updateLayerTweaker() {
     if (layerGroup) {
         tweaker = std::make_shared<LineLayerTweaker>(getID(), evaluatedProperties);
@@ -375,7 +375,7 @@ void RenderLineLayer::updateLayerTweaker() {
     }
 }
 
-static const StringIdentity idLineImageUniformName = StringIndexer::get("u_image");
+static const StringIdentity idLineImageUniformName = StringIndexer::get("u_image"sv);
 
 void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
                              gfx::Context& context,

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -244,10 +244,10 @@ void RenderRasterLayer::layerIndexChanged(int32_t newLayerIndex, UniqueChangeReq
     }
 }
 
-static const StringIdentity idPosAttribName = StringIndexer::get("a_pos");
-static const StringIdentity idTexturePosAttribName = StringIndexer::get("a_texture_pos");
-static const StringIdentity idTexImage0Name = StringIndexer::get("u_image0");
-static const StringIdentity idTexImage1Name = StringIndexer::get("u_image1");
+static const StringIdentity idPosAttribName = StringIndexer::get("a_pos"sv);
+static const StringIdentity idTexturePosAttribName = StringIndexer::get("a_texture_pos"sv);
+static const StringIdentity idTexImage0Name = StringIndexer::get("u_image0"sv);
+static const StringIdentity idTexImage1Name = StringIndexer::get("u_image1"sv);
 
 void RenderRasterLayer::updateLayerTweaker() {
     if (layerGroup || imageLayerGroup) {

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -749,13 +749,13 @@ SymbolDrawableTilePropsUBO buildTileUBO(const SymbolBucket& bucket,
     };
 }
 
-static const StringIdentity idDataAttibName = StringIndexer::get("a_data");
-static const StringIdentity idPosOffsetAttribName = StringIndexer::get("a_pos_offset");
-static const StringIdentity idPixOffsetAttribName = StringIndexer::get("a_pixeloffset");
-static const StringIdentity idProjPosAttribName = StringIndexer::get("a_projected_pos");
-static const StringIdentity idFadeOpacityAttribName = StringIndexer::get("a_fade_opacity");
-static const StringIdentity idTexUniformName = StringIndexer::get("u_texture");
-static const StringIdentity idTexIconUniformName = StringIndexer::get("u_texture_icon");
+static const StringIdentity idDataAttibName = StringIndexer::get("a_data"sv);
+static const StringIdentity idPosOffsetAttribName = StringIndexer::get("a_pos_offset"sv);
+static const StringIdentity idPixOffsetAttribName = StringIndexer::get("a_pixeloffset"sv);
+static const StringIdentity idProjPosAttribName = StringIndexer::get("a_projected_pos"sv);
+static const StringIdentity idFadeOpacityAttribName = StringIndexer::get("a_fade_opacity"sv);
+static const StringIdentity idTexUniformName = StringIndexer::get("u_texture"sv);
+static const StringIdentity idTexIconUniformName = StringIndexer::get("u_texture_icon"sv);
 
 std::vector<std::string> updateTileAttributes(const SymbolBucket::Buffer& buffer,
                                               const bool isText,
@@ -863,11 +863,11 @@ void updateTileDrawable(gfx::Drawable& drawable,
     drawable.setVertexAttributes(std::move(attribs));
 }
 
-static const StringIdentity idCollisionPosAttribName = StringIndexer::get("a_pos");
-static const StringIdentity idCollisionAnchorPosAttribName = StringIndexer::get("a_anchor_pos");
-static const StringIdentity idCollisionExtrudeAttribName = StringIndexer::get("a_extrude");
-static const StringIdentity idCollisionPlacedAttribName = StringIndexer::get("a_placed");
-static const StringIdentity idCollisionShiftAttribName = StringIndexer::get("a_shift");
+static const StringIdentity idCollisionPosAttribName = StringIndexer::get("a_pos"sv);
+static const StringIdentity idCollisionAnchorPosAttribName = StringIndexer::get("a_anchor_pos"sv);
+static const StringIdentity idCollisionExtrudeAttribName = StringIndexer::get("a_extrude"sv);
+static const StringIdentity idCollisionPlacedAttribName = StringIndexer::get("a_placed"sv);
+static const StringIdentity idCollisionShiftAttribName = StringIndexer::get("a_shift"sv);
 
 gfx::VertexAttributeArray getCollisionVertexAttributes(const SymbolBucket::CollisionBuffer& buffer, bool staticCopy) {
     gfx::VertexAttributeArray vertexAttrs;

--- a/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
@@ -43,10 +43,10 @@ std::array<float, 2> toArray(const Size& s) {
     return util::cast<float>(std::array<uint32_t, 2>{s.width, s.height});
 }
 
-const StringIdentity idTexUniformName = StringIndexer::get("u_texture");
-const StringIdentity idTexIconUniformName = StringIndexer::get("u_texture_icon");
-const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO");
-const StringIdentity idSymbolPermutationUBOName = StringIndexer::get("SymbolPermutationUBO");
+const StringIdentity idTexUniformName = StringIndexer::get("u_texture"sv);
+const StringIdentity idTexIconUniformName = StringIndexer::get("u_texture_icon"sv);
+const StringIdentity idExpressionInputsUBOName = StringIndexer::get("ExpressionInputsUBO"sv);
+const StringIdentity idSymbolPermutationUBOName = StringIndexer::get("SymbolPermutationUBO"sv);
 
 SymbolDrawablePaintUBO buildPaintUBO(bool isText, const SymbolPaintProperties::PossiblyEvaluated& evaluated) {
     return {
@@ -63,13 +63,13 @@ SymbolDrawablePaintUBO buildPaintUBO(bool isText, const SymbolPaintProperties::P
 
 } // namespace
 
-const StringIdentity SymbolLayerTweaker::idSymbolDrawableUBOName = StringIndexer::get("SymbolDrawableUBO");
-const StringIdentity SymbolLayerTweaker::idSymbolDynamicUBOName = StringIndexer::get("SymbolDynamicUBO");
-const StringIdentity SymbolLayerTweaker::idSymbolDrawablePaintUBOName = StringIndexer::get("SymbolDrawablePaintUBO");
+const StringIdentity SymbolLayerTweaker::idSymbolDrawableUBOName = StringIndexer::get("SymbolDrawableUBO"sv);
+const StringIdentity SymbolLayerTweaker::idSymbolDynamicUBOName = StringIndexer::get("SymbolDynamicUBO"sv);
+const StringIdentity SymbolLayerTweaker::idSymbolDrawablePaintUBOName = StringIndexer::get("SymbolDrawablePaintUBO"sv);
 const StringIdentity SymbolLayerTweaker::idSymbolDrawableTilePropsUBOName = StringIndexer::get(
-    "SymbolDrawableTilePropsUBO");
+    "SymbolDrawableTilePropsUBO"sv);
 const StringIdentity SymbolLayerTweaker::idSymbolDrawableInterpolateUBOName = StringIndexer::get(
-    "SymbolDrawableInterpolateUBO");
+    "SymbolDrawableInterpolateUBO"sv);
 
 void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup,
                                  const RenderTree& renderTree,

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -67,8 +67,8 @@ void TileSourceRenderItem::updateDebugDrawables(DebugLayerGroupMap& debugLayerGr
     }
 
     // create a builder
-    static const StringIdentity idVertexAttribName = StringIndexer::get("a_pos");
-    static const StringIdentity idDebugUBOName = StringIndexer::get("DebugUBO");
+    static const StringIdentity idVertexAttribName = StringIndexer::get("a_pos"sv);
+    static const StringIdentity idDebugUBOName = StringIndexer::get("DebugUBO"sv);
     std::unique_ptr<gfx::DrawableBuilder> builder = context.createDrawableBuilder("debug-builder");
     builder->setShader(debugShader);
     builder->setRenderPass(renderPass);
@@ -109,7 +109,7 @@ void TileSourceRenderItem::updateDebugDrawables(DebugLayerGroupMap& debugLayerGr
         texture->setImage(emptyImage);
         texture->setSamplerConfiguration(
             {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
-        static const StringIdentity idDebugOverlayUniformName = StringIndexer::get("u_overlay");
+        static const StringIdentity idDebugOverlayUniformName = StringIndexer::get("u_overlay"sv);
         samplerLocation = debugShader->getSamplerLocation(idDebugOverlayUniformName);
     }
     assert(samplerLocation.has_value());

--- a/test/util/string_indexer.test.cpp
+++ b/test/util/string_indexer.test.cpp
@@ -10,7 +10,7 @@ TEST(StringIndexer, AddStrings) {
     StringIndexer::clear();
     EXPECT_EQ(StringIndexer::size(), 0);
 
-    const auto id1 = StringIndexer::get("test string1");
+    const auto id1 = StringIndexer::get("test string1"sv);
     EXPECT_EQ(id1, 0);
     EXPECT_EQ(StringIndexer::size(), 1);
 
@@ -24,7 +24,7 @@ TEST(StringIndexer, GetString) {
     StringIndexer::clear();
     EXPECT_EQ(StringIndexer::size(), 0);
 
-    constexpr auto str = "test string1";
+    constexpr auto str = "test string1"sv;
 
     const auto id1 = StringIndexer::get(str);
     EXPECT_EQ(id1, 0);
@@ -42,7 +42,7 @@ TEST(StringIndexer, Reallocate) {
     StringIndexer::clear();
     EXPECT_EQ(StringIndexer::size(), 0);
 
-    constexpr auto str = "reallocate test string1";
+    constexpr auto str = "reallocate test string1"sv;
 
     const auto id1 = StringIndexer::get(str);
     EXPECT_EQ(id1, 0);


### PR DESCRIPTION
When building with MSVC, a linker issue can be observed with `StringIndexer::get`. This is apparently caused by string literals above the string SSO size failing to implicitly convert to `std::string_view`s. This PR brings `std::string_view_literals` in with `string_indexer.hpp` and calls to `get` with string literals are explicitly provided as string view literals (`"string"sv).