### PR TITLE
`Add 10x Test Shapes` (annotations) + `MBXFrameTimeGraphView` update

### DIFF
--- a/platform/ios/app/MBXFrameTimeGraphView.m
+++ b/platform/ios/app/MBXFrameTimeGraphView.m
@@ -1,6 +1,6 @@
 #import "MBXFrameTimeGraphView.h"
 
-const CGFloat MBXFrameTimeExaggeration = 4.f * 1000.f;
+const CGFloat MBXFrameTimeExaggeration = 10.f;
 const CGFloat MBXFrameTimeBarWidth = 4.f;
 
 @interface MBXFrameTimeGraphView ()
@@ -58,7 +58,7 @@ const CGFloat MBXFrameTimeBarWidth = 4.f;
     if (!CGRectEqualToRect(self.scrollLayer.frame, self.bounds)) {
         self.scrollLayer.frame = self.bounds;
 
-        CGRect thresholdLineRect = CGRectMake(0, self.frame.size.height - [self renderDurationTargetMilliseconds], self.frame.size.width, 1);
+        CGRect thresholdLineRect = CGRectMake(0, self.frame.size.height - self.frame.size.height * MBXFrameTimeExaggeration * [self renderDurationTargetMilliseconds], self.frame.size.width, 1);
         
         {
             CGPathRef path = CGPathCreateWithRect(thresholdLineRect, nil);        
@@ -96,8 +96,8 @@ const CGFloat MBXFrameTimeBarWidth = 4.f;
         maximumFramesPerSecond = 60;
     }
 
-    CGFloat target = (1.0 / maximumFramesPerSecond) * MBXFrameTimeExaggeration;
-    return [self roundedFloat:target];
+    CGFloat target = (1.0 / maximumFramesPerSecond);
+    return target;
 }
 
 - (CGFloat)roundedFloat:(CGFloat)f {
@@ -112,7 +112,7 @@ const CGFloat MBXFrameTimeBarWidth = 4.f;
 - (CAShapeLayer *)barWithFrameDuration:(CFTimeInterval)frameDuration {
     CAShapeLayer *bar = [CAShapeLayer layer];
 
-    CGRect barRect = CGRectMake(0, 0, MBXFrameTimeBarWidth, -(fminf(frameDuration * MBXFrameTimeExaggeration, self.frame.size.height)));
+    CGRect barRect = CGRectMake(0, 0, MBXFrameTimeBarWidth, -(fminf(frameDuration * MBXFrameTimeExaggeration * self.frame.size.height, self.frame.size.height)));
     UIBezierPath *barPath = [UIBezierPath bezierPathWithRect:barRect];
     bar.path = barPath.CGPath;
     bar.fillColor = [self colorForFrameDuration:frameDuration].CGColor;
@@ -121,15 +121,15 @@ const CGFloat MBXFrameTimeBarWidth = 4.f;
 }
 
 - (UIColor *)colorForFrameDuration:(CFTimeInterval)frameDuration {
-    CGFloat renderDurationTargetMilliseconds = [self renderDurationTargetMilliseconds];
-    frameDuration *= MBXFrameTimeExaggeration;
+    const double greenLevel = [self renderDurationTargetMilliseconds];
+    const double yellowLevel = greenLevel * 3.0;
 
-    if (frameDuration < renderDurationTargetMilliseconds && frameDuration > (renderDurationTargetMilliseconds * 0.75)) {
-        return self.warningColor;
-    } else if (frameDuration > renderDurationTargetMilliseconds) {
-        return self.dangerColor;
-    } else {
+    if (frameDuration <= greenLevel) {
         return self.safeColor;
+    } else if (frameDuration <= yellowLevel) {
+        return self.warningColor;
+    } else {
+        return self.dangerColor;
     }
 }
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -2439,9 +2439,9 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
     return features;
 }
 
-- (void)mapViewDidFinishRenderingFrame:(MLNMapView *)mapView fullyRendered:(BOOL)fullyRendered {
+- (void)mapViewDidFinishRenderingFrame:(MLNMapView *)mapView fullyRendered:(BOOL)fullyRendered frameTime:(double)frameTime {
     if (self.frameTimeGraphEnabled) {
-        [self.frameTimeGraphView updatePathWithFrameDuration:mapView.frameTime];
+        [self.frameTimeGraphView updatePathWithFrameDuration:frameTime];
     }
 }
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -69,6 +69,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsAnnotationsRows) {
     MBXSettingsAnnotations10000Sprites,
     MBXSettingsAnnotationAnimation,
     MBXSettingsAnnotationsTestShapes,
+    MBXSettingsAnnotationsManyTestShapes,
     MBXSettingsAnnotationsCustomCallout,
     MBXSettingsAnnotationsQueryAnnotations,
     MBXSettingsAnnotationsCustomUserDot,
@@ -400,6 +401,7 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
                 @"Add 10,000 Sprites",
                 @"Animate an Annotation View",
                 @"Add Test Shapes",
+                @"Add 10x Test Shapes",
                 @"Add Point With Custom Callout",
                 @"Query Annotations",
                 [NSString stringWithFormat:@"%@ Custom User Dot", (_customUserLocationAnnnotationEnabled ? @"Disable" : @"Enable")],
@@ -548,7 +550,10 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
                     [self animateAnnotationView];
                     break;
                 case MBXSettingsAnnotationsTestShapes:
-                    [self addTestShapes];
+                    [self addTestShapes:1];
+                    break;
+                case MBXSettingsAnnotationsManyTestShapes:
+                    [self addTestShapes:10];
                     break;
                 case MBXSettingsAnnotationsCustomCallout:
                     [self addAnnotationWithCustomCallout];
@@ -881,102 +886,107 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
         });
     };
 
-- (void)addTestShapes
+- (void)addTestShapes:(NSUInteger)featuresCount
 {
-    // Pacific Northwest triangle
-    //
-    CLLocationCoordinate2D triangleCoordinates[3] =
-    {
-        CLLocationCoordinate2DMake(44, -122),
-        CLLocationCoordinate2DMake(46, -122),
-        CLLocationCoordinate2DMake(46, -121)
-    };
-
-    MLNPolygon *triangle = [MLNPolygon polygonWithCoordinates:triangleCoordinates count:3];
-
-    [self.mapView addAnnotation:triangle];
-
-    // West coast polyline
-    //
-    CLLocationCoordinate2D lineCoordinates[4] = {
-        CLLocationCoordinate2DMake(47.6025, -122.3327),
-        CLLocationCoordinate2DMake(45.5189, -122.6726),
-        CLLocationCoordinate2DMake(37.7790, -122.4177),
-        CLLocationCoordinate2DMake(34.0532, -118.2349)
-    };
-    MLNPolyline *line = [MLNPolyline polylineWithCoordinates:lineCoordinates count:4];
-    [self.mapView addAnnotation:line];
-
-    // Orcas Island, WA hike polyline
-    //
-    NSDictionary *hike = [NSJSONSerialization JSONObjectWithData:
-                             [NSData dataWithContentsOfFile:
-                                 [[NSBundle mainBundle] pathForResource:@"polyline" ofType:@"geojson"]]
-                                                         options:0
-                                                           error:nil];
-
-    NSArray *hikeCoordinatePairs = hike[@"features"][0][@"geometry"][@"coordinates"];
-
-    CLLocationCoordinate2D *polylineCoordinates = (CLLocationCoordinate2D *)malloc([hikeCoordinatePairs count] * sizeof(CLLocationCoordinate2D));
-
-    for (NSUInteger i = 0; i < [hikeCoordinatePairs count]; i++)
-    {
-        polylineCoordinates[i] = CLLocationCoordinate2DMake([hikeCoordinatePairs[i][1] doubleValue], [hikeCoordinatePairs[i][0] doubleValue]);
-    }
-
-    MLNPolyline *polyline = [MLNPolyline polylineWithCoordinates:polylineCoordinates
-                                                           count:[hikeCoordinatePairs count]];
-
-    [self.mapView addAnnotation:polyline];
-
-    free(polylineCoordinates);
-
-    // PA/NJ/DE polygons
-    //
-    NSDictionary *threestates = [NSJSONSerialization JSONObjectWithData:
-                          [NSData dataWithContentsOfFile:
-                           [[NSBundle mainBundle] pathForResource:@"threestates" ofType:@"geojson"]]
-                                                         options:0
-                                                           error:nil];
-
-    for (NSDictionary *feature in threestates[@"features"])
-    {
-        NSArray *stateCoordinatePairs = feature[@"geometry"][@"coordinates"];
-
-        while ([stateCoordinatePairs count] == 1) stateCoordinatePairs = stateCoordinatePairs[0];
-
-        CLLocationCoordinate2D *polygonCoordinates = (CLLocationCoordinate2D *)malloc([stateCoordinatePairs count] * sizeof(CLLocationCoordinate2D));
-
-        for (NSUInteger i = 0; i < [stateCoordinatePairs count]; i++)
+    for (int featureIndex = 0; featureIndex < featuresCount; ++featureIndex) {
+        double deltaLongitude = featureIndex * 0.01;
+        double deltaLatitude = -featureIndex * 0.01;
+        
+        // Pacific Northwest triangle
+        //
+        CLLocationCoordinate2D triangleCoordinates[3] =
         {
-            polygonCoordinates[i] = CLLocationCoordinate2DMake([stateCoordinatePairs[i][1] doubleValue], [stateCoordinatePairs[i][0] doubleValue]);
+            CLLocationCoordinate2DMake(44 + deltaLatitude, -122 + deltaLongitude),
+            CLLocationCoordinate2DMake(46 + deltaLatitude, -122 + deltaLongitude),
+            CLLocationCoordinate2DMake(46 + deltaLatitude, -121 + deltaLongitude)
+        };
+        
+        MLNPolygon *triangle = [MLNPolygon polygonWithCoordinates:triangleCoordinates count:3];
+        
+        [self.mapView addAnnotation:triangle];
+        
+        // West coast polyline
+        //
+        CLLocationCoordinate2D lineCoordinates[4] = {
+            CLLocationCoordinate2DMake(47.6025 + deltaLatitude, -122.3327 + deltaLongitude),
+            CLLocationCoordinate2DMake(45.5189 + deltaLatitude, -122.6726 + deltaLongitude),
+            CLLocationCoordinate2DMake(37.7790 + deltaLatitude, -122.4177 + deltaLongitude),
+            CLLocationCoordinate2DMake(34.0532 + deltaLatitude, -118.2349 + deltaLongitude)
+        };
+        MLNPolyline *line = [MLNPolyline polylineWithCoordinates:lineCoordinates count:4];
+        [self.mapView addAnnotation:line];
+        
+        // Orcas Island, WA hike polyline
+        //
+        NSDictionary *hike = [NSJSONSerialization JSONObjectWithData:
+                              [NSData dataWithContentsOfFile:
+                               [[NSBundle mainBundle] pathForResource:@"polyline" ofType:@"geojson"]]
+                                                             options:0
+                                                               error:nil];
+        
+        NSArray *hikeCoordinatePairs = hike[@"features"][0][@"geometry"][@"coordinates"];
+        
+        CLLocationCoordinate2D *polylineCoordinates = (CLLocationCoordinate2D *)malloc([hikeCoordinatePairs count] * sizeof(CLLocationCoordinate2D));
+        
+        for (NSUInteger i = 0; i < [hikeCoordinatePairs count]; i++)
+        {
+            polylineCoordinates[i] = CLLocationCoordinate2DMake([hikeCoordinatePairs[i][1] doubleValue] + deltaLatitude, [hikeCoordinatePairs[i][0] doubleValue] + deltaLongitude);
         }
-
-        MLNPolygon *polygon = [MLNPolygon polygonWithCoordinates:polygonCoordinates count:[stateCoordinatePairs count]];
-        polygon.title = feature[@"properties"][@"NAME"];
-
-        [self.mapView addAnnotation:polygon];
-
-        free(polygonCoordinates);
+        
+        MLNPolyline *polyline = [MLNPolyline polylineWithCoordinates:polylineCoordinates
+                                                               count:[hikeCoordinatePairs count]];
+        
+        [self.mapView addAnnotation:polyline];
+        
+        free(polylineCoordinates);
+        
+        // PA/NJ/DE polygons
+        //
+        NSDictionary *threestates = [NSJSONSerialization JSONObjectWithData:
+                                     [NSData dataWithContentsOfFile:
+                                      [[NSBundle mainBundle] pathForResource:@"threestates" ofType:@"geojson"]]
+                                                                    options:0
+                                                                      error:nil];
+        
+        for (NSDictionary *feature in threestates[@"features"])
+        {
+            NSArray *stateCoordinatePairs = feature[@"geometry"][@"coordinates"];
+            
+            while ([stateCoordinatePairs count] == 1) stateCoordinatePairs = stateCoordinatePairs[0];
+            
+            CLLocationCoordinate2D *polygonCoordinates = (CLLocationCoordinate2D *)malloc([stateCoordinatePairs count] * sizeof(CLLocationCoordinate2D));
+            
+            for (NSUInteger i = 0; i < [stateCoordinatePairs count]; i++)
+            {
+                polygonCoordinates[i] = CLLocationCoordinate2DMake([stateCoordinatePairs[i][1] doubleValue] + deltaLatitude, [stateCoordinatePairs[i][0] doubleValue] + deltaLongitude);
+            }
+            
+            MLNPolygon *polygon = [MLNPolygon polygonWithCoordinates:polygonCoordinates count:[stateCoordinatePairs count]];
+            polygon.title = feature[@"properties"][@"NAME"];
+            
+            [self.mapView addAnnotation:polygon];
+            
+            free(polygonCoordinates);
+        }
+        
+        // Null Island polygon with an interior hole
+        //
+        CLLocationCoordinate2D innerCoordinates[] = {
+            CLLocationCoordinate2DMake(-5 + deltaLatitude, -5 + deltaLongitude),
+            CLLocationCoordinate2DMake(-5 + deltaLatitude, 5 + deltaLongitude),
+            CLLocationCoordinate2DMake(5 + deltaLatitude, 5 + deltaLongitude),
+            CLLocationCoordinate2DMake(5 + deltaLatitude, -5 + deltaLongitude),
+        };
+        MLNPolygon *innerPolygon = [MLNPolygon polygonWithCoordinates:innerCoordinates count:sizeof(innerCoordinates) / sizeof(innerCoordinates[0])];
+        CLLocationCoordinate2D outerCoordinates[] = {
+            CLLocationCoordinate2DMake(-10 + deltaLatitude, -10 + deltaLongitude),
+            CLLocationCoordinate2DMake(-10 + deltaLatitude, 10 + deltaLongitude),
+            CLLocationCoordinate2DMake(10 + deltaLatitude, 10 + deltaLongitude),
+            CLLocationCoordinate2DMake(10 + deltaLatitude, -10 + deltaLongitude),
+        };
+        MLNPolygon *outerPolygon = [MLNPolygon polygonWithCoordinates:outerCoordinates count:sizeof(outerCoordinates) / sizeof(outerCoordinates[0]) interiorPolygons:@[innerPolygon]];
+        [self.mapView addAnnotation:outerPolygon];
     }
-
-    // Null Island polygon with an interior hole
-    //
-    CLLocationCoordinate2D innerCoordinates[] = {
-        CLLocationCoordinate2DMake(-5, -5),
-        CLLocationCoordinate2DMake(-5, 5),
-        CLLocationCoordinate2DMake(5, 5),
-        CLLocationCoordinate2DMake(5, -5),
-    };
-    MLNPolygon *innerPolygon = [MLNPolygon polygonWithCoordinates:innerCoordinates count:sizeof(innerCoordinates) / sizeof(innerCoordinates[0])];
-    CLLocationCoordinate2D outerCoordinates[] = {
-        CLLocationCoordinate2DMake(-10, -10),
-        CLLocationCoordinate2DMake(-10, 10),
-        CLLocationCoordinate2DMake(10, 10),
-        CLLocationCoordinate2DMake(10, -10),
-    };
-    MLNPolygon *outerPolygon = [MLNPolygon polygonWithCoordinates:outerCoordinates count:sizeof(outerCoordinates) / sizeof(outerCoordinates[0]) interiorPolygons:@[innerPolygon]];
-    [self.mapView addAnnotation:outerPolygon];
 }
 
 - (void)addAnnotationWithCustomCallout


### PR DESCRIPTION
Add an option to add 10x Shape Annotations in the iOS App.
Also refactor the visual frame time display `MBXFrameTimeGraphView` to reflect frame times from Renderer::Impl::render
![image](https://github.com/maplibre/maplibre-native/assets/4198736/fdb615dc-d989-45a7-98b6-710b1cac56c1)
![image](https://github.com/maplibre/maplibre-native/assets/4198736/18473c72-f651-4bce-b30c-8a2734ea3268)
![image](https://github.com/maplibre/maplibre-native/assets/4198736/44d0424d-44e1-4e51-abb0-9007824de13c)
