### PR TITLE
Fix raster geometry updates

### DIFF
--- a/include/mbgl/renderer/layer_tweaker.hpp
+++ b/include/mbgl/renderer/layer_tweaker.hpp
@@ -93,9 +93,12 @@ protected:
     std::vector<std::string> propertiesAsUniforms;
 #endif // MLN_RENDER_BACKEND_METAL
 
+    // Indicates that the evaluated properties have changed
     bool propertiesUpdated = true;
 
-    bool propertiesChanged = true;
+    // Indicates that the properties-as-uniforms has changed
+    bool permutationUpdated = true;
+
     bool overdrawInspector = false;
 };
 

--- a/src/mbgl/gfx/index_vector.hpp
+++ b/src/mbgl/gfx/index_vector.hpp
@@ -41,12 +41,14 @@ public:
     bool isReleased() const { return released; }
 
     void extend(std::size_t n, const uint16_t val) {
+        assert(!released);
         v.resize(v.size() + n, val);
         dirty = true;
     }
 
     uint16_t& at(std::size_t n) {
         assert(n < v.size());
+        assert(!released);
         dirty = true;
         return v.at(n);
     }
@@ -64,8 +66,10 @@ public:
     void clear() {
         dirty = true;
         v.clear();
+        buffer.reset();
     }
 
+    /// Indicate that this shared index vector will no longer be updated.
     void release() {
         // If we've already created a buffer, we don't need the raw data any more.
         if (buffer) {
@@ -94,6 +98,7 @@ public:
     template <class... Args>
     void emplace_back(Args&&... args) {
         static_assert(sizeof...(args) == groupSize, "wrong buffer element count");
+        assert(!released);
         util::ignore({(v.emplace_back(std::forward<Args>(args)), 0)...});
     }
 };

--- a/src/mbgl/gfx/index_vector.hpp
+++ b/src/mbgl/gfx/index_vector.hpp
@@ -66,14 +66,13 @@ public:
     void clear() {
         dirty = true;
         v.clear();
-        buffer.reset();
     }
 
     /// Indicate that this shared index vector will no longer be updated.
     void release() {
         // If we've already created a buffer, we don't need the raw data any more.
         if (buffer) {
-            clear();
+            v.clear();
         }
         released = true;
     }

--- a/src/mbgl/gfx/vertex_vector.hpp
+++ b/src/mbgl/gfx/vertex_vector.hpp
@@ -88,14 +88,13 @@ public:
     void clear() {
         dirty = true;
         v.clear();
-        buffer.reset();
     }
 
     /// Indicate that this shared vertex vector instance will no longer be updated.
     void release() {
         // If we've already created a buffer, we don't need the raw data any more.
         if (buffer) {
-            clear();
+            v.clear();
         }
         released = true;
     }

--- a/src/mbgl/gfx/vertex_vector.hpp
+++ b/src/mbgl/gfx/vertex_vector.hpp
@@ -57,16 +57,20 @@ public:
 
     template <typename Arg>
     void emplace_back(Arg&& vertex) {
+        assert(!released);
         v.emplace_back(std::forward<Arg>(vertex));
+        dirty = true;
     }
 
     void extend(std::size_t n, const Vertex& val) {
+        assert(!released);
         v.resize(v.size() + n, val);
         dirty = true;
     }
 
     Vertex& at(std::size_t n) {
         assert(n < v.size());
+        assert(!released);
         dirty = true;
         return v.at(n);
     }
@@ -84,8 +88,10 @@ public:
     void clear() {
         dirty = true;
         v.clear();
+        buffer.reset();
     }
 
+    /// Indicate that this shared vertex vector instance will no longer be updated.
     void release() {
         // If we've already created a buffer, we don't need the raw data any more.
         if (buffer) {

--- a/src/mbgl/mtl/drawable.cpp
+++ b/src/mbgl/mtl/drawable.cpp
@@ -520,7 +520,9 @@ void Drawable::upload(gfx::UploadPass& uploadPass_) {
     auto& context = static_cast<Context&>(contextBase);
     constexpr auto usage = gfx::BufferUsageType::StaticDraw;
 
-    if (!impl->indexes || !impl->indexes->bytes()) {
+    // We need either raw index data or a buffer already created from them.
+    // We can have a buffer and no indexes, but only if it's not marked dirty.
+    if (!impl->indexes || (impl->indexes->empty() && (!impl->indexes->getBuffer() || impl->indexes->getDirty()))) {
         assert(!"Missing index data");
         return;
     }

--- a/src/mbgl/mtl/drawable_builder.cpp
+++ b/src/mbgl/mtl/drawable_builder.cpp
@@ -38,6 +38,7 @@ void DrawableBuilder::init() {
     if (!impl->sharedIndexes && !impl->buildIndexes.empty()) {
         impl->sharedIndexes = std::make_shared<gfx::IndexVectorBase>(std::move(impl->buildIndexes));
     }
+    assert(impl->sharedIndexes && impl->sharedIndexes->elements());
     drawable.setIndexData(std::move(impl->sharedIndexes), std::move(impl->segments));
 
     impl->buildIndexes.clear();

--- a/src/mbgl/renderer/buckets/raster_bucket.cpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.cpp
@@ -13,7 +13,10 @@ RasterBucket::RasterBucket(PremultipliedImage&& image_)
 RasterBucket::RasterBucket(std::shared_ptr<PremultipliedImage> image_)
     : image(std::move(image_)) {}
 
-RasterBucket::~RasterBucket() = default;
+RasterBucket::~RasterBucket() {
+    vertices.release();
+    indices.release();
+}
 
 void RasterBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
     if (!hasData()) {

--- a/src/mbgl/renderer/buckets/raster_bucket.cpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.cpp
@@ -52,6 +52,7 @@ void RasterBucket::clear() {
 void RasterBucket::setImage(std::shared_ptr<PremultipliedImage> image_) {
     image = std::move(image_);
     texture = {};
+    texture2d.reset();
     uploaded = false;
 }
 

--- a/src/mbgl/renderer/buckets/raster_bucket.hpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.hpp
@@ -28,6 +28,7 @@ public:
 
     std::shared_ptr<PremultipliedImage> image;
     std::optional<gfx::Texture> texture;
+    gfx::Texture2DPtr texture2d;
     TileMask mask{{0, 0, 0}};
 
     // Bucket specific vertices are used for Image Sources only

--- a/src/mbgl/renderer/layer_tweaker.cpp
+++ b/src/mbgl/renderer/layer_tweaker.cpp
@@ -70,7 +70,7 @@ shaders::ExpressionInputsUBO LayerTweaker::buildExpressionUBO(double zoom, uint6
 void LayerTweaker::setPropertiesAsUniforms(std::vector<std::string> props) {
     if (props != propertiesAsUniforms) {
         propertiesAsUniforms = std::move(props);
-        propertiesChanged = true;
+        permutationUpdated = true;
     }
 }
 #endif
@@ -93,7 +93,7 @@ AttributeSource LayerTweaker::getAttributeSource(const std::string_view& attribN
 void LayerTweaker::enableOverdrawInspector(bool value) {
     if (overdrawInspector != value) {
         overdrawInspector = value;
-        propertiesChanged = true;
+        permutationUpdated = true;
     }
 }
 

--- a/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
@@ -61,7 +61,7 @@ void CircleLayerTweaker::execute(LayerGroupBase& layerGroup,
 
 #if MLN_RENDER_BACKEND_METAL
     using ShaderClass = shaders::ShaderSource<BuiltIn::CircleShader, gfx::Backend::Type::Metal>;
-    if (propertiesChanged) {
+    if (permutationUpdated) {
         const auto source = [this](const std::string_view& attrName) {
             return hasPropertyAsUniform(attrName) ? AttributeSource::Constant : AttributeSource::PerVertex;
         };
@@ -86,7 +86,7 @@ void CircleLayerTweaker::execute(LayerGroupBase& layerGroup,
             permutationUniformBuffer = context.createUniformBuffer(&permutationUBO, sizeof(permutationUBO));
         }
 
-        propertiesChanged = false;
+        permutationUpdated = false;
     }
     if (!expressionUniformBuffer) {
         const auto expressionUBO = buildExpressionUBO(zoom, parameters.frameCount);

--- a/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.cpp
@@ -77,7 +77,7 @@ void FillExtrusionLayerTweaker::execute(LayerGroupBase& layerGroup,
 
 #if MLN_RENDER_BACKEND_METAL
     const auto zoom = parameters.state.getZoom();
-    if (propertiesChanged) {
+    if (permutationUpdated) {
         const FillExtrusionPermutationUBO permutationUBO = {
             /* .color = */ {/*.source=*/getAttributeSource("a_color"), /*.expression=*/{}},
             /* .base = */ {/*.source=*/getAttributeSource("a_base"), /*.expression=*/{}},
@@ -93,7 +93,7 @@ void FillExtrusionLayerTweaker::execute(LayerGroupBase& layerGroup,
         } else {
             permutationUniformBuffer = context.createUniformBuffer(&permutationUBO, sizeof(permutationUBO));
         }
-        propertiesChanged = false;
+        permutationUpdated = false;
     }
     if (!expressionUniformBuffer) {
         const auto expressionUBO = buildExpressionUBO(zoom, parameters.frameCount);

--- a/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
@@ -93,7 +93,7 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup,
 
 #if MLN_RENDER_BACKEND_METAL
         using ShaderClass = ShaderSource<BuiltIn::FillShader, gfx::Backend::Type::Metal>;
-        if (propertiesChanged || !fillPermutationUniformBuffer) {
+        if (permutationUpdated || !fillPermutationUniformBuffer) {
             const FillPermutationUBO permutationUBO = {
                 /* .color = */ {/*.source=*/source(ShaderClass::attributes[1].name), /*.expression=*/{}},
                 /* .opacity = */ {/*.source=*/source(ShaderClass::attributes[2].name), /*.expression=*/{}},
@@ -132,7 +132,7 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup,
 
 #if MLN_RENDER_BACKEND_METAL
         using ShaderClass = ShaderSource<BuiltIn::FillOutlineShader, gfx::Backend::Type::Metal>;
-        if (propertiesChanged || !fillOutlinePermutationUniformBuffer) {
+        if (permutationUpdated || !fillOutlinePermutationUniformBuffer) {
             const FillOutlinePermutationUBO permutationUBO = {
                 /* .outline_color = */ {/*.source=*/source(ShaderClass::attributes[1].name), /*.expression=*/{}},
                 /* .opacity = */ {/*.source=*/source(ShaderClass::attributes[2].name), /*.expression=*/{}},
@@ -173,7 +173,7 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup,
 
 #if MLN_RENDER_BACKEND_METAL
         using ShaderClass = ShaderSource<BuiltIn::FillOutlinePatternShader, gfx::Backend::Type::Metal>;
-        if (propertiesChanged || !fillPatternPermutationUniformBuffer) {
+        if (permutationUpdated || !fillPatternPermutationUniformBuffer) {
             const FillPatternPermutationUBO permutationUBO = {
                 /* .pattern_from = */ {/*.source=*/source(ShaderClass::attributes[1].name), /*.expression=*/{}},
                 /* .pattern_to = */ {/*.source=*/source(ShaderClass::attributes[2].name), /*.expression=*/{}},
@@ -212,7 +212,7 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup,
 
 #if MLN_RENDER_BACKEND_METAL
         using ShaderClass = ShaderSource<BuiltIn::FillOutlinePatternShader, gfx::Backend::Type::Metal>;
-        if (propertiesChanged || !fillOutlinePermutationUniformBuffer) {
+        if (permutationUpdated || !fillOutlinePatternPermutationUniformBuffer) {
             const FillOutlinePatternPermutationUBO permutationUBO = {
                 /* .pattern_from = */ {/*.source=*/source(ShaderClass::attributes[1].name), /*.expression=*/{}},
                 /* .pattern_to = */ {/*.source=*/source(ShaderClass::attributes[2].name), /*.expression=*/{}},
@@ -362,7 +362,7 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup,
 #endif // MLN_RENDER_BACKEND_METAL
     });
 
-    propertiesChanged = false;
+    permutationUpdated = false;
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
@@ -44,7 +44,7 @@ void HeatmapLayerTweaker::execute(LayerGroupBase& layerGroup,
 
 #if MLN_RENDER_BACKEND_METAL
     using ShaderClass = shaders::ShaderSource<BuiltIn::HeatmapShader, gfx::Backend::Type::Metal>;
-    if (propertiesChanged) {
+    if (permutationUpdated) {
         const auto source = [this](const std::string_view& attrName) {
             return hasPropertyAsUniform(attrName) ? AttributeSource::Constant : AttributeSource::PerVertex;
         };
@@ -66,7 +66,7 @@ void HeatmapLayerTweaker::execute(LayerGroupBase& layerGroup,
             permutationUniformBuffer = context.createUniformBuffer(&permutationUBO, sizeof(permutationUBO));
         }
 
-        propertiesChanged = false;
+        permutationUpdated = false;
     }
     if (!expressionUniformBuffer) {
         const auto expressionUBO = buildExpressionUBO(zoom, parameters.frameCount);

--- a/src/mbgl/renderer/layers/line_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.cpp
@@ -113,7 +113,7 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
 
 #if MLN_RENDER_BACKEND_METAL
     using LineShaderClass = shaders::ShaderSource<BuiltIn::LineShader, gfx::Backend::Type::Metal>;
-    if (propertiesChanged) {
+    if (permutationUpdated) {
         const auto source = [this](const std::string_view& attrName) {
             return hasPropertyAsUniform(attrName) ? AttributeSource::Constant : AttributeSource::PerVertex;
         };
@@ -139,7 +139,7 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup,
         } else {
             permutationUniformBuffer = context.createUniformBuffer(&permutationUBO, sizeof(permutationUBO));
         }
-        propertiesChanged = false;
+        permutationUpdated = false;
     }
     if (!expressionUniformBuffer) {
         const auto expressionUBO = buildExpressionUBO(zoom, parameters.frameCount);

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -512,6 +512,9 @@ void RenderFillExtrusionLayer::update(gfx::ShaderRegistry& shaders,
         colorBuilder->setVertexAttributes(std::move(vertexAttrs));
 
         const auto finish = [&](gfx::DrawableBuilder& builder) {
+            if (!bucket.sharedTriangles->elements()) {
+                return;
+            }
             builder.setSegments(gfx::Triangles(),
                                 bucket.sharedTriangles,
                                 bucket.triangleSegments.data(),

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -375,36 +375,50 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
         setRenderTileBucketID(tileID, bucket.getID());
 
         const float zoom = static_cast<float>(state.getZoom());
-        const HeatmapInterpolateUBO interpolateUBO = {
-            /* .weight_t = */ std::get<0>(paintPropertyBinders.get<HeatmapWeight>()->interpolationFactor(zoom)),
-            /* .radius_t = */ std::get<0>(paintPropertyBinders.get<HeatmapRadius>()->interpolationFactor(zoom)),
-            /* .padding = */ {0}};
 
-        tileLayerGroup->visitDrawables(renderPass, tileID, [&](gfx::Drawable& drawable) {
+        gfx::UniformBufferPtr interpolateBuffer;
+        const auto getInterpolateBuffer = [&](){
+            if (!interpolateBuffer) {
+                const HeatmapInterpolateUBO interpolateUBO = {
+                    /* .weight_t = */ std::get<0>(paintPropertyBinders.get<HeatmapWeight>()->interpolationFactor(zoom)),
+                    /* .radius_t = */ std::get<0>(paintPropertyBinders.get<HeatmapRadius>()->interpolationFactor(zoom)),
+                    /* .padding = */ {0}};
+                interpolateBuffer = context.createUniformBuffer(&interpolateUBO, sizeof(interpolateUBO));
+            }
+            return interpolateBuffer;
+        };
+
+        gfx::VertexAttributeArray heatmapVertexAttrs;
+        const auto propertiesAsUniforms =
+            heatmapVertexAttrs.readDataDrivenPaintProperties<HeatmapWeight, HeatmapRadius>(paintPropertyBinders,
+                                                                                           evaluated);
+        if (layerTweaker) {
+            layerTweaker->setPropertiesAsUniforms(propertiesAsUniforms);
+        }
+
+        const auto updatedCount = tileLayerGroup->visitDrawables(renderPass, tileID, [&](gfx::Drawable& drawable) {
             if (drawable.getLayerTweaker() != layerTweaker) {
                 // This drawable was produced on a previous style/bucket, and should not be updated.
                 return;
             }
-            drawable.mutableUniformBuffers().createOrUpdate(idHeatmapInterpolateUBOName, &interpolateUBO, context);
+
+            // We assume vertex attributes don't change, and so don't update them to avoid re-uploading
+            //drawable.setVertexAttributes(heatmapVertexAttrs);
+
+            auto& uniforms = drawable.mutableUniformBuffers();
+
+            if (auto buffer = getInterpolateBuffer()) {
+                uniforms.addOrReplace(idHeatmapInterpolateUBOName, std::move(buffer));
+            }
         });
 
-        if (tileLayerGroup->getDrawableCount(renderPass, tileID) > 0) {
+        if (updatedCount > 0) {
             continue;
         }
-
-        gfx::VertexAttributeArray heatmapVertexAttrs;
-
-        const auto propertiesAsUniforms =
-            heatmapVertexAttrs.readDataDrivenPaintProperties<HeatmapWeight, HeatmapRadius>(paintPropertyBinders,
-                                                                                           evaluated);
 
         const auto heatmapShader = heatmapShaderGroup->getOrCreateShader(context, propertiesAsUniforms);
         if (!heatmapShader) {
             continue;
-        }
-
-        if (layerTweaker) {
-            layerTweaker->setPropertiesAsUniforms(std::move(propertiesAsUniforms));
         }
 
         if (const auto& attr = heatmapVertexAttrs.add(idVertexAttribName)) {
@@ -433,7 +447,11 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
             drawable->setTileID(tileID);
             drawable->setLayerTweaker(layerTweaker);
 
-            drawable->mutableUniformBuffers().createOrUpdate(idHeatmapInterpolateUBOName, &interpolateUBO, context);
+            auto& uniforms = drawable->mutableUniformBuffers();
+
+            if (auto buffer = getInterpolateBuffer()) {
+                uniforms.addOrReplace(idHeatmapInterpolateUBOName, std::move(buffer));
+            }
 
             tileLayerGroup->addDrawable(renderPass, tileID, std::move(drawable));
             ++stats.drawablesAdded;

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -377,7 +377,7 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
         const float zoom = static_cast<float>(state.getZoom());
 
         gfx::UniformBufferPtr interpolateBuffer;
-        const auto getInterpolateBuffer = [&](){
+        const auto getInterpolateBuffer = [&]() {
             if (!interpolateBuffer) {
                 const HeatmapInterpolateUBO interpolateUBO = {
                     /* .weight_t = */ std::get<0>(paintPropertyBinders.get<HeatmapWeight>()->interpolationFactor(zoom)),
@@ -403,7 +403,7 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
             }
 
             // We assume vertex attributes don't change, and so don't update them to avoid re-uploading
-            //drawable.setVertexAttributes(heatmapVertexAttrs);
+            // drawable.setVertexAttributes(heatmapVertexAttrs);
 
             auto& uniforms = drawable.mutableUniformBuffers();
 

--- a/src/mbgl/renderer/layers/render_hillshade_layer.hpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.hpp
@@ -70,6 +70,7 @@ private:
 #if MLN_DRAWABLE_RENDERER
     gfx::ShaderProgramBasePtr hillshadePrepareShader;
     gfx::ShaderProgramBasePtr hillshadeShader;
+    std::optional<int> hillshadeImageLocation;
     std::vector<RenderTargetPtr> activatedRenderTargets;
 
     using HillshadeVertexVector = gfx::VertexVector<HillshadeLayoutVertex>;

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -469,6 +469,11 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
         }
 
         auto& bucket = static_cast<LineBucket&>(*renderData->bucket);
+        if (!bucket.sharedTriangles->elements()) {
+            removeTile(renderPass, tileID);
+            continue;
+        }
+
         const auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
         const auto& evaluated = getEvaluated<LineLayerProperties>(renderData->layerProperties);
         const auto& crossfade = getCrossfade<LineLayerProperties>(renderData->layerProperties);

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -341,8 +341,7 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
         [this](const gfx::UniqueDrawableBuilder& builder, gfx::Drawable* drawable, const RasterBucket& bucket) {
             // The bucket only fills in geometry for masked tiles,
             // otherwise the standard tile extent geometry should be used.
-            const bool shared = (!bucket.sharedVertices->empty() &&
-                                 !bucket.sharedTriangles->empty() &&
+            const bool shared = (!bucket.sharedVertices->empty() && !bucket.sharedTriangles->empty() &&
                                  !bucket.segments.empty());
             const auto& vertices = shared ? bucket.sharedVertices : staticDataVertices;
             const auto& indices = shared ? bucket.sharedTriangles : staticDataIndices;
@@ -471,8 +470,7 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
                 if (geometryChanged) {
                     removeTile(renderPass, tileID);
                     cleared = true;
-                }
-                else if (0 < updated) {
+                } else if (0 < updated) {
                     // If we modified drawables without removing them, we're done with this tile.
                     continue;
                 }

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -316,7 +316,6 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
 
     const auto setTextures = [&](gfx::UniqueDrawableBuilder& builder, RasterBucket& bucket) {
         if (bucket.image && (rasterSampler0 || rasterSampler1)) {
-            
             if (!bucket.texture2d) {
                 if (auto tex = context.createTexture2D()) {
                     tex->setImage(bucket.image);
@@ -329,7 +328,8 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
                 const bool nearest = evaluated.get<RasterResampling>() == RasterResamplingType::Nearest;
                 const auto filter = nearest ? gfx::TextureFilterType::Nearest : gfx::TextureFilterType::Linear;
 
-                bucket.texture2d->setSamplerConfiguration({filter, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+                bucket.texture2d->setSamplerConfiguration(
+                    {filter, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
 
                 if (rasterSampler0) {
                     builder->setTexture(bucket.texture2d, *rasterSampler0);

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -1261,6 +1261,10 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
         const auto& bucket = static_cast<const SymbolBucket&>(*renderable.renderData.bucket);
         const auto& buffer = isText ? bucket.text : (sdfIcons ? bucket.sdfIcon : bucket.icon);
 
+        if (!buffer.sharedTriangles->elements()) {
+            continue;
+        }
+
         const auto& evaluated = getEvaluated<SymbolLayerProperties>(renderable.renderData.layerProperties);
         const auto& bucketPaintProperties = bucket.paintProperties.at(getID());
 

--- a/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
@@ -90,7 +90,7 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup,
     const auto zoom = parameters.state.getZoom();
 
 #if MLN_RENDER_BACKEND_METAL
-    if (propertiesChanged) {
+    if (permutationUpdated) {
         const SymbolPermutationUBO permutationUBO = {
             /* .fill_color = */ {/*.source=*/getAttributeSource("a_fill_color"), /*.expression=*/{}},
             /* .halo_color = */ {/*.source=*/getAttributeSource("a_halo_color"), /*.expression=*/{}},
@@ -108,7 +108,7 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup,
             permutationUniformBuffer = context.createUniformBuffer(&permutationUBO, sizeof(permutationUBO));
         }
 
-        propertiesChanged = false;
+        permutationUpdated = false;
     }
     if (!expressionUniformBuffer) {
         const auto expressionUBO = buildExpressionUBO(zoom, parameters.frameCount);
@@ -131,7 +131,7 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup,
         const auto& symbolData = static_cast<gfx::SymbolDrawableData&>(*drawable.getData());
         const auto isText = (symbolData.symbolType == SymbolType::Text);
 
-        if (isText && (textPaintBuffer || textPropertiesUpdated)) {
+        if (isText && (!textPaintBuffer || textPropertiesUpdated)) {
             const auto props = buildPaintUBO(true, evaluated);
             textPaintBuffer = parameters.context.createUniformBuffer(&props, sizeof(props));
             textPropertiesUpdated = false;

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -86,7 +86,7 @@ void RenderLayer::replaceTweaker(LayerTweakerPtr& curTweaker,
 
             group->visitDrawables([&](gfx::Drawable& drawable) {
                 if (drawable.getLayerTweaker() == prevTweaker) {
-                    drawable.setLayerTweaker(curTweaker);
+                    drawable.setLayerTweaker(newTweaker);
                 }
             });
         }


### PR DESCRIPTION
Handle the case where the raster bucket changes the geometry after a drawable is created from it.

Allow index vector to be empty if there's a buffer Skip drawable create in some cases where there's no data to draw. Reset buffers as well as values when clearing index/vertex containers.  Add more validation. Fixed a bug in layer tweaker update that prevented it from working.