### PR TITLE
Topic/metal cache

### DIFF
--- a/include/mbgl/gfx/drawable.hpp
+++ b/include/mbgl/gfx/drawable.hpp
@@ -134,7 +134,7 @@ public:
     bool getEnableStencil() const { return enableStencil; }
 
     /// Set stencil usage
-    void setEnableStencil(bool value) { enableStencil = value; }
+    virtual void setEnableStencil(bool value) { enableStencil = value; }
 
     /// not used for anything yet
     DrawPriority getDrawPriority() const { return drawPriority; }
@@ -142,19 +142,19 @@ public:
 
     /// Whether to enable depth testing
     bool getEnableDepth() { return enableDepth; }
-    void setEnableDepth(bool value) { enableDepth = value; }
+    virtual void setEnableDepth(bool value) { enableDepth = value; }
 
     /// Determines depth range within the layer for 2D drawables
     int32_t getSubLayerIndex() const { return subLayerIndex; }
 
     /// Set sub-layer index
-    void setSubLayerIndex(int32_t value) { subLayerIndex = value; }
+    virtual void setSubLayerIndex(int32_t value) { subLayerIndex = value; }
 
     /// Depth writability for 2D drawables
     DepthMaskType getDepthType() const { return depthType; }
 
     /// Set depth type
-    void setDepthType(DepthMaskType value) { depthType = value; }
+    virtual void setDepthType(DepthMaskType value) { depthType = value; }
 
     /// Uses 3D depth mode
     bool getIs3D() const { return is3D; }

--- a/include/mbgl/mtl/drawable.hpp
+++ b/include/mbgl/mtl/drawable.hpp
@@ -4,8 +4,6 @@
 #include <mbgl/gfx/draw_mode.hpp>
 #include <mbgl/mtl/upload_pass.hpp>
 #include <mbgl/programs/segment.hpp>
-#include <mbgl/mtl/mtl_fwd.hpp>
-#include <mbgl/mtl/render_pass.hpp>
 
 #include <memory>
 
@@ -59,6 +57,11 @@ public:
 
     void setShader(gfx::ShaderProgramBasePtr) override;
 
+    void setEnableStencil(bool) override;
+    void setEnableDepth(bool) override;
+    void setSubLayerIndex(int32_t) override;
+    void setDepthType(gfx::DepthMaskType) override;
+
 protected:
     // For testing only.
     Drawable(std::unique_ptr<Impl>);
@@ -76,12 +79,6 @@ protected:
 
     class Impl;
     const std::unique_ptr<Impl> impl;
-
-    gfx::AttributeBindingArray attributeBindings;
-
-    mutable MTLRenderPipelineStatePtr pipelineState;
-
-    mutable std::optional<gfx::RenderPassDescriptor> renderPassDescriptor;
 };
 
 } // namespace mtl

--- a/include/mbgl/mtl/renderable_resource.hpp
+++ b/include/mbgl/mtl/renderable_resource.hpp
@@ -23,7 +23,7 @@ public:
     virtual const mbgl::mtl::RendererBackend& getBackend() const = 0;
     virtual const mbgl::mtl::MTLCommandBufferPtr& getCommandBuffer() const = 0;
     virtual mbgl::mtl::MTLBlitPassDescriptorPtr getUploadPassDescriptor() const = 0;
-    virtual mbgl::mtl::MTLRenderPassDescriptorPtr getRenderPassDescriptor() const = 0;
+    virtual const mbgl::mtl::MTLRenderPassDescriptorPtr& getRenderPassDescriptor() const = 0;
 };
 
 } // namespace mtl

--- a/platform/ios/src/MLNMapView+Metal.mm
+++ b/platform/ios/src/MLNMapView+Metal.mm
@@ -69,8 +69,12 @@ public:
         return NS::TransferPtr(MTL::BlitPassDescriptor::alloc()->init());
     }
 
-    mbgl::mtl::MTLRenderPassDescriptorPtr getRenderPassDescriptor() const override {
-        return NS::RetainPtr((__bridge MTL::RenderPassDescriptor*)mtlView.currentRenderPassDescriptor);
+    const mbgl::mtl::MTLRenderPassDescriptorPtr& getRenderPassDescriptor() const override {
+        if (!cachedRenderPassDescriptor) {
+            auto* mtlDesc = mtlView.currentRenderPassDescriptor;
+            cachedRenderPassDescriptor = NS::RetainPtr((__bridge MTL::RenderPassDescriptor*)mtlDesc);
+        }
+        return cachedRenderPassDescriptor;
     }
 
     void swap() override {
@@ -83,6 +87,8 @@ public:
 
         commandBuffer = nil;
         commandBufferPtr.reset();
+
+        cachedRenderPassDescriptor.reset();
     }
 
     mbgl::Size framebufferSize() {
@@ -94,6 +100,7 @@ public:
 private:
     MLNMapViewMetalImpl& backend;
     mbgl::mtl::MTLCommandBufferPtr commandBufferPtr;
+    mutable mbgl::mtl::MTLRenderPassDescriptorPtr cachedRenderPassDescriptor;
 
 public:
     MLNMapViewImplDelegate* delegate = nil;

--- a/src/mbgl/mtl/drawable.cpp
+++ b/src/mbgl/mtl/drawable.cpp
@@ -123,12 +123,32 @@ MTL::Winding mapWindingMode(const gfx::CullFaceWindingType mode) {
 } // namespace
 
 void Drawable::setColorMode(const gfx::ColorMode& value) {
-    pipelineState.reset();
+    impl->pipelineState.reset();
     gfx::Drawable::setColorMode(value);
 }
 
+void Drawable::setEnableStencil(bool value) {
+    gfx::Drawable::setEnableStencil(value);
+    impl->depthStencilState.reset();
+}
+
+void Drawable::setEnableDepth(bool value) {
+    gfx::Drawable::setEnableDepth(value);
+    impl->depthStencilState.reset();
+}
+
+void Drawable::setSubLayerIndex(int32_t value) {
+    gfx::Drawable::setSubLayerIndex(value);
+    impl->depthStencilState.reset();
+}
+
+void Drawable::setDepthType(gfx::DepthMaskType value) {
+    gfx::Drawable::setDepthType(value);
+    impl->depthStencilState.reset();
+}
+
 void Drawable::setShader(gfx::ShaderProgramBasePtr value) {
-    pipelineState.reset();
+    impl->pipelineState.reset();
     gfx::Drawable::setShader(value);
 }
 
@@ -151,36 +171,20 @@ void Drawable::draw(PaintParameters& parameters) const {
         return;
     }
 
-    if (renderPassDescriptor.has_value() && renderPass.getDescriptor() != renderPassDescriptor.value()) {
-        pipelineState.reset();
+    const auto& descriptor = renderPass.getDescriptor();
+    if (impl->renderPassDescriptor && descriptor != *impl->renderPassDescriptor) {
+        impl->pipelineState.reset();
     }
-    renderPassDescriptor.emplace(gfx::RenderPassDescriptor{renderPass.getDescriptor().renderable,
-                                                           renderPass.getDescriptor().clearColor,
-                                                           renderPass.getDescriptor().clearDepth,
-                                                           renderPass.getDescriptor().clearStencil});
+    impl->renderPassDescriptor.emplace(gfx::RenderPassDescriptor{descriptor.renderable,
+                                                                 descriptor.clearColor,
+                                                                 descriptor.clearDepth,
+                                                                 descriptor.clearStencil});
 
     const auto& shaderMTL = static_cast<const ShaderProgram&>(*shader);
 
 #if !defined(NDEBUG)
     const auto debugGroup = parameters.encoder->createDebugGroup(debugLabel(*this));
 #endif
-
-    /*
-     context.setDepthMode(getIs3D() ? parameters.depthModeFor3D()
-                                    : parameters.depthModeForSublayer(getSubLayerIndex(), getDepthType()));
-
-     // force disable depth test for debugging
-     // context.setDepthMode({gfx::DepthFunctionType::Always, gfx::DepthMaskType::ReadOnly, {0,1}});
-
-     // For 3D mode, stenciling is handled by the layer group
-     if (!is3D) {
-         context.setStencilMode(makeStencilMode(parameters));
-     }
-
-     context.setColorMode(getColorMode());
-     context.setCullFaceMode(getCullFaceMode());
-
-     */
 
     bindAttributes(renderPass);
     bindUniformBuffers(renderPass);
@@ -207,11 +211,11 @@ void Drawable::draw(PaintParameters& parameters) const {
     encoder->setCullMode(cullMode.enabled ? mapCullMode(cullMode.side) : MTL::CullModeNone);
     encoder->setFrontFacingWinding(mapWindingMode(cullMode.winding));
 
-    if (!pipelineState) {
-        pipelineState = shaderMTL.getRenderPipelineState(renderPassDescriptor, impl->vertexDesc, getColorMode());
+    if (!impl->pipelineState) {
+        impl->pipelineState = shaderMTL.getRenderPipelineState(renderPassDescriptor, impl->vertexDesc, getColorMode());
     }
-    if (pipelineState) {
-        encoder->setRenderPipelineState(pipelineState.get());
+    if (impl->pipelineState) {
+        encoder->setRenderPipelineState(impl->pipelineState.get());
     } else {
         assert(!"Failed to create render pipeline state");
         return;
@@ -219,12 +223,30 @@ void Drawable::draw(PaintParameters& parameters) const {
 
     // For 3D mode, stenciling is handled by the layer group
     if (!is3D) {
-        const auto depthMode = parameters.depthModeForSublayer(getSubLayerIndex(), getDepthType());
-        const auto stencilMode = enableStencil ? parameters.stencilModeForClipping(tileID->toUnwrapped())
-                                               : gfx::StencilMode::disabled();
-        if (auto depthStencilState = context.makeDepthStencilState(depthMode, stencilMode, renderPass)) {
-            encoder->setDepthStencilState(depthStencilState.get());
-            encoder->setStencilReferenceValue(stencilMode.ref);
+        std::optional<gfx::StencilMode> newStencilMode;
+
+        // If we have a stencil state, we may be able to reuse it, if the tile masks haven't changed.
+        // We assume that only the reference value needs to be compared.
+        if (impl->depthStencilState && enableStencil) {
+            newStencilMode = parameters.stencilModeForClipping(tileID->toUnwrapped());
+            if (newStencilMode->ref != impl->previousStencilMode.ref) {
+                // No, need to rebuild it
+                impl->depthStencilState.reset();
+            }
+        }
+        if (!impl->depthStencilState) {
+            if (enableStencil && !newStencilMode) {
+                newStencilMode = parameters.stencilModeForClipping(tileID->toUnwrapped());
+            }
+            const auto depthMode = parameters.depthModeForSublayer(getSubLayerIndex(), getDepthType());
+            const auto stencilMode = enableStencil ? parameters.stencilModeForClipping(tileID->toUnwrapped())
+                                                   : gfx::StencilMode::disabled();
+            impl->depthStencilState = context.makeDepthStencilState(depthMode, stencilMode, renderPass);
+            impl->previousStencilMode = *newStencilMode;
+        }
+        if (impl->depthStencilState) {
+            encoder->setDepthStencilState(impl->depthStencilState.get());
+            encoder->setStencilReferenceValue(impl->previousStencilMode.ref);
         }
     }
 
@@ -266,7 +288,7 @@ void Drawable::draw(PaintParameters& parameters) const {
             assert(mlSegment.indexOffset + mlSegment.indexLength <= indexBufferLength);
             assert(static_cast<std::size_t>(maxIndex) < mlSegment.vertexLength);
 
-            for (const auto& binding : attributeBindings) {
+            for (const auto& binding : impl->attributeBindings) {
                 if (binding) {
                     if (const auto buffer = getMetalBuffer(binding ? binding->vertexBufferResource : nullptr)) {
                         assert((maxIndex + mlSegment.vertexOffset) * binding->vertexStride <= buffer->length());
@@ -348,7 +370,7 @@ void Drawable::bindAttributes(const RenderPass& renderPass) const {
     const auto& encoder = renderPass.getMetalEncoder();
 
     NS::UInteger attributeIndex = 0;
-    for (const auto& binding : attributeBindings) {
+    for (const auto& binding : impl->attributeBindings) {
         if (const auto buffer = getMetalBuffer(binding ? binding->vertexBufferResource : nullptr)) {
             assert(binding->vertexStride * impl->vertexCount <= getBufferSize(binding->vertexBufferResource));
             encoder->setVertexBuffer(buffer, /*offset=*/0, attributeIndex);
@@ -363,7 +385,7 @@ void Drawable::unbindAttributes(const RenderPass& renderPass) const {
     const auto& encoder = renderPass.getMetalEncoder();
 
     NS::UInteger attributeIndex = 0;
-    for (const auto& binding : attributeBindings) {
+    for (const auto& binding : impl->attributeBindings) {
         encoder->setVertexBuffer(nullptr, /*offset=*/0, attributeIndex);
         attributeIndex += 1;
     }
@@ -558,14 +580,14 @@ void Drawable::upload(gfx::UploadPass& uploadPass_) {
         impl->vertexAttributes.visitAttributes(
             [](const auto&, gfx::VertexAttribute& attrib) { attrib.setDirty(false); });
 
-        if (attributeBindings != attributeBindings_) {
-            attributeBindings = attributeBindings_;
+        if (impl->attributeBindings != attributeBindings_) {
+            impl->attributeBindings = attributeBindings_;
 
             // Create a layout descriptor for each attribute
             auto vertDesc = NS::RetainPtr(MTL::VertexDescriptor::vertexDescriptor());
 
             NS::UInteger index = 0;
-            for (auto& binding : attributeBindings) {
+            for (auto& binding : impl->attributeBindings) {
                 if (!binding) {
                     assert("Missing attribute binding");
                     continue;
@@ -595,7 +617,7 @@ void Drawable::upload(gfx::UploadPass& uploadPass_) {
             }
 
             impl->vertexDesc = std::move(vertDesc);
-            pipelineState.reset();
+            impl->pipelineState.reset();
         }
     }
 

--- a/src/mbgl/mtl/drawable_impl.hpp
+++ b/src/mbgl/mtl/drawable_impl.hpp
@@ -8,6 +8,7 @@
 #include <mbgl/gfx/uniform_buffer.hpp>
 #include <mbgl/gfx/vertex_attribute.hpp>
 #include <mbgl/mtl/mtl_fwd.hpp>
+#include <mbgl/mtl/render_pass.hpp>
 #include <mbgl/mtl/uniform_buffer.hpp>
 #include <mbgl/mtl/upload_pass.hpp>
 #include <mbgl/programs/segment.hpp>
@@ -55,6 +56,15 @@ public:
     StringIdentity idVertexAttrName = StringIndexer::get("a_pos");
 
     gfx::UniqueVertexBufferResource noBindingBuffer;
+    
+    gfx::AttributeBindingArray attributeBindings;
+
+    MTLRenderPipelineStatePtr pipelineState;
+
+    std::optional<gfx::RenderPassDescriptor> renderPassDescriptor;
+
+    MTLDepthStencilStatePtr depthStencilState;
+    gfx::StencilMode previousStencilMode;
 };
 
 struct Drawable::DrawSegment final : public gfx::Drawable::DrawSegment {


### PR DESCRIPTION
Avoid re-creating some Metal objects for every drawable on every frame.

Interestingly, the second commit caching the depth-stencil descriptor seems to make a negligible difference in the benchmark (within 0.1 ms), despite having a 99.3% hit rate.

Before:
```
| boston     | 24.8 ms | 40.3 fps |
| paris      | 29.0 ms | 34.5 fps |
| paris2     | 23.2 ms | 43.1 fps |
| alps       | 17.0 ms | 58.9 fps |
| us east    | 15.3 ms | 65.3 fps |
| greater la | 24.8 ms | 40.3 fps |
| sf         | 33.4 ms | 29.9 fps |
| oakland    | 24.1 ms | 41.5 fps |
| germany    | 23.0 ms | 43.5 fps |
Average frame time: 23.8 ms
Average FPS: 41.9
| boston     | 24.8 ms | 40.2 fps |
| paris      | 28.9 ms | 34.6 fps |
| paris2     | 24.5 ms | 40.8 fps |
| alps       | 16.5 ms | 60.5 fps |
| us east    | 17.2 ms | 58.1 fps |
| greater la | 26.0 ms | 38.4 fps |
| sf         | 34.3 ms | 29.1 fps |
| oakland    | 23.9 ms | 41.8 fps |
| germany    | 23.1 ms | 43.4 fps |
Average frame time: 24.4 ms
Average FPS: 41.0
| boston     | 24.8 ms | 40.3 fps |
| paris      | 27.6 ms | 36.2 fps |
| paris2     | 24.3 ms | 41.2 fps |
| alps       | 16.7 ms | 59.8 fps |
| us east    | 16.5 ms | 60.5 fps |
| greater la | 24.8 ms | 40.4 fps |
| sf         | 33.4 ms | 30.0 fps |
| oakland    | 23.9 ms | 41.9 fps |
| germany    | 23.0 ms | 43.5 fps |
Average frame time: 23.9 ms
Average FPS: 41.9
```

After:
```
| boston     | 24.8 ms | 40.3 fps |
| paris      | 27.7 ms | 36.1 fps |
| paris2     | 24.7 ms | 40.4 fps |
| alps       | 15.4 ms | 65.1 fps |
| us east    | 14.3 ms | 70.1 fps |
| greater la | 24.8 ms | 40.3 fps |
| sf         | 33.2 ms | 30.1 fps |
| oakland    | 23.5 ms | 42.5 fps |
| germany    | 23.0 ms | 43.4 fps |
Average frame time: 23.5 ms
Average FPS: 42.6
| boston     | 24.8 ms | 40.4 fps |
| paris      | 27.6 ms | 36.2 fps |
| paris2     | 24.8 ms | 40.4 fps |
| alps       | 14.8 ms | 67.6 fps |
| us east    | 14.2 ms | 70.3 fps |
| greater la | 24.8 ms | 40.3 fps |
| sf         | 33.2 ms | 30.1 fps |
| oakland    | 23.6 ms | 42.4 fps |
| germany    | 23.7 ms | 42.1 fps |
Average frame time: 23.5 ms
Average FPS: 42.5
| boston     | 24.8 ms | 40.3 fps |
| paris      | 27.6 ms | 36.3 fps |
| paris2     | 24.8 ms | 40.3 fps |
| alps       | 14.9 ms | 67.2 fps |
| us east    | 14.1 ms | 70.8 fps |
| greater la | 24.8 ms | 40.3 fps |
| sf         | 33.1 ms | 30.2 fps |
| oakland    | 23.6 ms | 42.3 fps |
| germany    | 23.4 ms | 42.8 fps |
Average frame time: 23.5 ms
Average FPS: 42.6
```

Mean frame time 24.033 => 23.5, 2.2% improvement
