### PR TITLE
Attempting to improve coverage metrics

### DIFF
--- a/src/mbgl/gfx/index_vector.hpp
+++ b/src/mbgl/gfx/index_vector.hpp
@@ -31,7 +31,8 @@ public:
           buffer(std::move(other.buffer)),
 #endif // MLN_DRAWABLE_RENDERER
           dirty(other.dirty),
-          released(other.released) {}
+          released(other.released) {
+    }
     virtual ~IndexVectorBase() = default;
 
 #if MLN_DRAWABLE_RENDERER

--- a/src/mbgl/gfx/index_vector.hpp
+++ b/src/mbgl/gfx/index_vector.hpp
@@ -27,13 +27,17 @@ public:
         : v(other.v) {} // buffer is not copied
     IndexVectorBase(IndexVectorBase&& other)
         : v(std::move(other.v)),
+#if MLN_DRAWABLE_RENDERER
           buffer(std::move(other.buffer)),
+#endif // MLN_DRAWABLE_RENDERER
           dirty(other.dirty),
           released(other.released) {}
     virtual ~IndexVectorBase() = default;
 
+#if MLN_DRAWABLE_RENDERER
     IndexBufferBase* getBuffer() const { return buffer.get(); }
     void setBuffer(std::unique_ptr<IndexBufferBase>&& value) { buffer = std::move(value); }
+#endif // MLN_DRAWABLE_RENDERER
 
     bool getDirty() const { return dirty; }
     void setDirty(bool value = true) { dirty = value; }
@@ -70,10 +74,12 @@ public:
 
     /// Indicate that this shared index vector will no longer be updated.
     void release() {
+#if MLN_DRAWABLE_RENDERER
         // If we've already created a buffer, we don't need the raw data any more.
         if (buffer) {
             v.clear();
         }
+#endif // MLN_DRAWABLE_RENDERER
         released = true;
     }
 
@@ -82,7 +88,9 @@ public:
     const std::vector<uint16_t>& vector() const { return v; }
 
 protected:
+#if MLN_DRAWABLE_RENDERER
     std::unique_ptr<IndexBufferBase> buffer;
+#endif // MLN_DRAWABLE_RENDERER
     bool dirty = true;
     bool released = false;
 };

--- a/src/mbgl/gfx/vertex_vector.hpp
+++ b/src/mbgl/gfx/vertex_vector.hpp
@@ -17,7 +17,10 @@ public:
     VertexVectorBase() = default;
     VertexVectorBase(const VertexVectorBase&) {} // buffer is not copied
     VertexVectorBase(VertexVectorBase&& other)
-        : buffer(std::move(other.buffer)),
+        : 
+#if MLN_DRAWABLE_RENDERER
+    buffer(std::move(other.buffer)),
+#endif // MLN_DRAWABLE_RENDERER
           dirty(other.dirty),
           released(other.released) {}
     virtual ~VertexVectorBase() = default;
@@ -26,8 +29,10 @@ public:
     virtual std::size_t getRawSize() const = 0;
     virtual std::size_t getRawCount() const = 0;
 
+#if MLN_DRAWABLE_RENDERER
     VertexBufferBase* getBuffer() const { return buffer.get(); }
     void setBuffer(std::unique_ptr<VertexBufferBase>&& value) { buffer = std::move(value); }
+#endif // MLN_DRAWABLE_RENDERER
 
     bool getDirty() const { return dirty; }
     void setDirty(bool value = true) { dirty = value; }
@@ -35,7 +40,9 @@ public:
     bool isReleased() const { return released; }
 
 protected:
+#if MLN_DRAWABLE_RENDERER
     std::unique_ptr<VertexBufferBase> buffer;
+#endif // MLN_DRAWABLE_RENDERER
     bool dirty = true;
     bool released = false;
 };
@@ -92,10 +99,12 @@ public:
 
     /// Indicate that this shared vertex vector instance will no longer be updated.
     void release() {
+#if MLN_DRAWABLE_RENDERER
         // If we've already created a buffer, we don't need the raw data any more.
         if (buffer) {
             v.clear();
         }
+#endif // MLN_DRAWABLE_RENDERER
         released = true;
     }
 

--- a/src/mbgl/gfx/vertex_vector.hpp
+++ b/src/mbgl/gfx/vertex_vector.hpp
@@ -17,12 +17,13 @@ public:
     VertexVectorBase() = default;
     VertexVectorBase(const VertexVectorBase&) {} // buffer is not copied
     VertexVectorBase(VertexVectorBase&& other)
-        : 
+        :
 #if MLN_DRAWABLE_RENDERER
-    buffer(std::move(other.buffer)),
+          buffer(std::move(other.buffer)),
 #endif // MLN_DRAWABLE_RENDERER
           dirty(other.dirty),
-          released(other.released) {}
+          released(other.released) {
+    }
     virtual ~VertexVectorBase() = default;
 
     virtual const void* getRawData() const = 0;

--- a/src/mbgl/renderer/buckets/raster_bucket.cpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.cpp
@@ -14,8 +14,8 @@ RasterBucket::RasterBucket(std::shared_ptr<PremultipliedImage> image_)
     : image(std::move(image_)) {}
 
 RasterBucket::~RasterBucket() {
-    vertices.release();
-    indices.release();
+    clear();
+    setImage({});
 }
 
 void RasterBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {


### PR DESCRIPTION
Exclude code from legacy build which is only used in drawables.
Refactor to reuse methods in `RasterBucket`.