### PR TITLE
Update Boost to 1.83, replace Boost Locale with deprecated codecvt STL

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels:
+    - MapLibre_Native_Linux_16_core
+# Configuration variables in array of strings defined in your repository or
+# organization. `null` means disabling configuration variables check.
+# Empty array means no configuration variable is allowed.
+config-variables: null

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "vendor/unique_resource"]
 	path = vendor/unique_resource
 	url = https://github.com/okdshin/unique_resource.git
-[submodule "vendor/boost"]
-	path = vendor/boost
-	url = https://github.com/maplibre/maplibre-gl-native-boost.git
 [submodule "vendor/benchmark"]
 	path = vendor/benchmark
 	url = https://github.com/google/benchmark.git
@@ -52,3 +49,6 @@
 [submodule "platform/windows/vendor/vcpkg"]
 	path = platform/windows/vendor/vcpkg
 	url = https://github.com/microsoft/vcpkg.git
+[submodule "vendor/boost"]
+	path = vendor/boost
+	url = https://github.com/maplibre/maplibre-gl-native-boost.git

--- a/include/mbgl/gfx/renderer_backend.hpp
+++ b/include/mbgl/gfx/renderer_backend.hpp
@@ -62,7 +62,7 @@ protected:
     friend class BackendScope;
 };
 
-MBGL_CONSTEXPR bool operator==(const RendererBackend& a, const RendererBackend& b) {
+constexpr bool operator==(const RendererBackend& a, const RendererBackend& b) {
     return &a == &b;
 }
 

--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -45,23 +45,23 @@ enum class MapDebugOptions : EnumType {
     DepthBuffer = 1 << 7,
 };
 
-MBGL_CONSTEXPR MapDebugOptions operator|(MapDebugOptions lhs, MapDebugOptions rhs) {
+constexpr MapDebugOptions operator|(MapDebugOptions lhs, MapDebugOptions rhs) {
     return MapDebugOptions(mbgl::underlying_type(lhs) | mbgl::underlying_type(rhs));
 }
 
-MBGL_CONSTEXPR MapDebugOptions& operator|=(MapDebugOptions& lhs, MapDebugOptions rhs) {
+constexpr MapDebugOptions& operator|=(MapDebugOptions& lhs, MapDebugOptions rhs) {
     return (lhs = MapDebugOptions(mbgl::underlying_type(lhs) | mbgl::underlying_type(rhs)));
 }
 
-MBGL_CONSTEXPR bool operator&(MapDebugOptions lhs, MapDebugOptions rhs) {
+constexpr bool operator&(MapDebugOptions lhs, MapDebugOptions rhs) {
     return mbgl::underlying_type(lhs) & mbgl::underlying_type(rhs);
 }
 
-MBGL_CONSTEXPR MapDebugOptions& operator&=(MapDebugOptions& lhs, MapDebugOptions rhs) {
+constexpr MapDebugOptions& operator&=(MapDebugOptions& lhs, MapDebugOptions rhs) {
     return (lhs = MapDebugOptions(mbgl::underlying_type(lhs) & mbgl::underlying_type(rhs)));
 }
 
-MBGL_CONSTEXPR MapDebugOptions operator~(MapDebugOptions value) {
+constexpr MapDebugOptions operator~(MapDebugOptions value) {
     return MapDebugOptions(~mbgl::underlying_type(value));
 }
 

--- a/include/mbgl/util/bitmask_operations.hpp
+++ b/include/mbgl/util/bitmask_operations.hpp
@@ -6,25 +6,25 @@
 namespace mbgl {
 
 template <typename Enum>
-MBGL_CONSTEXPR Enum operator|(Enum a, Enum b) {
+constexpr Enum operator|(Enum a, Enum b) {
     static_assert(std::is_enum<Enum>::value, "Enum must be an enum type");
     return Enum(mbgl::underlying_type(a) | mbgl::underlying_type(b));
 }
 
 template <typename Enum>
-MBGL_CONSTEXPR Enum& operator|=(Enum& a, Enum b) {
+constexpr Enum& operator|=(Enum& a, Enum b) {
     static_assert(std::is_enum<Enum>::value, "Enum must be an enum type");
     return (a = a | b);
 }
 
 template <typename Enum>
-MBGL_CONSTEXPR bool operator&(Enum a, Enum b) {
+constexpr bool operator&(Enum a, Enum b) {
     static_assert(std::is_enum<Enum>::value, "Enum must be an enum type");
     return bool(mbgl::underlying_type(a) & mbgl::underlying_type(b));
 }
 
 template <typename Enum>
-MBGL_CONSTEXPR Enum operator~(Enum value) {
+constexpr Enum operator~(Enum value) {
     static_assert(std::is_enum<Enum>::value, "Enum must be an enum type");
     return Enum(~mbgl::underlying_type(value));
 }

--- a/include/mbgl/util/convert.hpp
+++ b/include/mbgl/util/convert.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 namespace util {
 
 template <typename To, typename From, std::size_t Size, typename = std::enable_if_t<std::is_convertible_v<From, To>>>
-MBGL_CONSTEXPR std::array<To, Size> convert(const std::array<From, Size>& from) {
+constexpr std::array<To, Size> convert(const std::array<From, Size>& from) {
     std::array<To, Size> to{{}};
     std::copy(std::begin(from), std::end(from), std::begin(to));
     return to;

--- a/include/mbgl/util/util.hpp
+++ b/include/mbgl/util/util.hpp
@@ -13,13 +13,6 @@
 
 #endif
 
-// GCC 4.9 compatibility
-#if !defined(__GNUC__) || __GNUC__ >= 5
-#define MBGL_CONSTEXPR constexpr
-#else
-#define MBGL_CONSTEXPR inline
-#endif
-
 // Compiler defines for making symbols visible, otherwise they
 // will be defined as hidden by default.
 

--- a/platform/default/src/mbgl/util/utf.cpp
+++ b/platform/default/src/mbgl/util/utf.cpp
@@ -1,17 +1,27 @@
 #include <mbgl/util/utf.hpp>
 
-#include <boost/locale/encoding_utf.hpp>
+#include <locale>
+#include <codecvt>
 
 namespace mbgl {
 namespace util {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 std::u16string convertUTF8ToUTF16(const std::string& str) {
-    return boost::locale::conv::utf_to_utf<char16_t>(str);
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
+
+    return conv.from_bytes(str);
 }
 
 std::string convertUTF16ToUTF8(const std::u16string& str) {
-    return boost::locale::conv::utf_to_utf<char>(str);
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
+
+    return conv.to_bytes(str);
 }
+
+#pragma GCC diagnostic pop
 
 } // namespace util
 } // namespace mbgl

--- a/scripts/update-boost.sh
+++ b/scripts/update-boost.sh
@@ -2,30 +2,13 @@
 
 set -eu
 
-pushd "$BOOST"
-if [ ! -f dist/bin/bcp ]; then
-    # Build bcp
-    ./bootstrap.sh
-    ./b2 tools/bcp
-fi
-popd
-
 # Extract boost modules that we need
 rm -rf vendor/boost/include
 mkdir -p vendor/boost/include
-"$BOOST/dist/bin/bcp" --boost="$BOOST" --scan $(find {src,include,test,platform,bin} -name "*.cpp" -o -name "*.hpp") vendor/boost/include
+bcp --boost="$BOOST" --scan $(find {src,include,test,platform,bin,render-test} -name "*.cpp" -o -name "*.hpp") vendor/boost/include
 
 pushd vendor/boost
 VERSION=$(sed -n 's/^#define BOOST_LIB_VERSION "\([^"]*\)"$/\1/p' include/boost/version.hpp)
-echo "libboost ${VERSION/_/.} for Mapbox GL Native" > README.md
+echo "libboost ${VERSION/_/.} for MapLibre Native" > README.md
 git add README.md include
 popd
-
-echo "If everything works, run:"
-echo ""
-echo "    git -C vendor/boost checkout main"
-echo "    git -C vendor/boost commit -m \"update boost to ${VERSION/_/.}\""
-echo "    git -C vendor/boost push"
-echo "    git add vendor/boost"
-echo ""
-echo "and commit."

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -12,7 +12,7 @@
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/style_impl.hpp>
 
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 // Note: LayerManager::annotationsEnabled is defined
 // at compile time, so that linker (with LTO on) is able

--- a/src/mbgl/text/language_tag.cpp
+++ b/src/mbgl/text/language_tag.cpp
@@ -6,8 +6,8 @@
 #endif
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/src/mbgl/util/http_header.cpp
+++ b/src/mbgl/util/http_header.cpp
@@ -9,8 +9,8 @@
 #endif
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
 
 #ifdef _MSC_VER
 #pragma warning(pop)


### PR DESCRIPTION
Cherry-pick of #1660 to the OpenGL 2 branch.