### PR TITLE
[qt] Make WASM build run without crashes with latest Qt

### DIFF
--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -269,7 +269,8 @@ jobs:
             -DCMAKE_INSTALL_PREFIX="../install" \
             -DMLN_WITH_QT=ON \
             -DMLN_QT_DEPLOYMENT=ON \
-            -DMLN_QT_WITH_INTERNAL_ICU=ON
+            -DMLN_QT_WITH_INTERNAL_ICU=ON \
+            -DMLN_QT_WITH_INTERNAL_SQLITE=ON
           ninja
           ninja install
 

--- a/platform/qt/src/mbgl/http_request.cpp
+++ b/platform/qt/src/mbgl/http_request.cpp
@@ -34,6 +34,8 @@ QNetworkRequest HTTPRequest::networkRequest() const {
     QNetworkRequest req = QNetworkRequest(requestUrl());
     req.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);
 
+    // User-Agent can not be set on WASM
+#ifndef Q_OS_WASM
     static const QByteArray agent =
         !m_context->getClientOptions().name().empty()
             ? QString("%1/%2 (%3) MapLibreGL/%4 (Qt %5)")
@@ -45,6 +47,7 @@ QNetworkRequest HTTPRequest::networkRequest() const {
                   .toLatin1()
             : QString("MapLibreGL/%1 (Qt %2)").arg(version::revision).arg(QT_VERSION_STR).toLatin1();
     req.setRawHeader("User-Agent", agent);
+#endif
 
     if (m_resource.priorEtag) {
         const auto etag = m_resource.priorEtag;

--- a/vendor/csscolorparser.cmake
+++ b/vendor/csscolorparser.cmake
@@ -2,7 +2,7 @@ if(TARGET mbgl-vendor-csscolorparser)
     return()
 endif()
 
-if(MLN_WITH_QT AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+if(MLN_WITH_QT)
     add_library(mbgl-vendor-csscolorparser OBJECT)
 else()
     add_library(mbgl-vendor-csscolorparser STATIC)

--- a/vendor/icu.cmake
+++ b/vendor/icu.cmake
@@ -2,8 +2,14 @@ if(TARGET mbgl-vendor-icu)
     return()
 endif()
 
-add_library(
-    mbgl-vendor-icu STATIC
+if(MLN_WITH_QT)
+    add_library(mbgl-vendor-icu OBJECT)
+else()
+    add_library(mbgl-vendor-icu STATIC)
+endif()
+
+target_sources(
+    mbgl-vendor-icu PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/icu/src/cmemory.cpp
     ${CMAKE_CURRENT_LIST_DIR}/icu/src/cstring.cpp
     ${CMAKE_CURRENT_LIST_DIR}/icu/src/ubidi.cpp

--- a/vendor/nunicode.cmake
+++ b/vendor/nunicode.cmake
@@ -2,7 +2,7 @@ if(TARGET mbgl-vendor-nunicode)
     return()
 endif()
 
-if(MLN_WITH_QT AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+if(MLN_WITH_QT)
     add_library(mbgl-vendor-nunicode OBJECT)
 else()
     add_library(mbgl-vendor-nunicode STATIC)

--- a/vendor/parsedate.cmake
+++ b/vendor/parsedate.cmake
@@ -2,7 +2,7 @@ if(TARGET mbgl-vendor-parsedate)
     return()
 endif()
 
-if(MLN_WITH_QT AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+if(MLN_WITH_QT)
     add_library(mbgl-vendor-parsedate OBJECT)
 else()
     add_library(mbgl-vendor-parsedate STATIC)

--- a/vendor/sqlite.cmake
+++ b/vendor/sqlite.cmake
@@ -2,8 +2,14 @@ if(TARGET mbgl-vendor-sqlite)
     return()
 endif()
 
-add_library(
-    mbgl-vendor-sqlite STATIC
+if(MLN_WITH_QT)
+    add_library(mbgl-vendor-sqlite OBJECT)
+else()
+    add_library(mbgl-vendor-sqlite STATIC)
+endif()
+
+target_sources(
+    mbgl-vendor-sqlite PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/sqlite/src/sqlite3.c
 )
 
@@ -32,3 +38,7 @@ export(TARGETS
     mbgl-vendor-sqlite
     APPEND FILE MapboxCoreTargets.cmake
 )
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    set_target_properties(mbgl-vendor-sqlite PROPERTIES COMPILE_FLAGS "-pthread")
+endif()


### PR DESCRIPTION
Make WASM build run without crashes with latest Qt (6.5.3). The "screen" is still black but there are no errors in the console.

To build:
- Setup Emscripten 3.1.25
- Setup Qt 6.5.3 with WASM (multithreaded) support
- Run
```
qt-cmake ../../maplibre-gl-native \
-G Ninja \
-DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-DMLN_WITH_QT=ON \
-DMLN_QT_STATIC=ON \
-DMLN_QT_WITH_INTERNAL_SQLITE=ON
```

/cc @louwers @birkskyum 