### PR TITLE
OpenGL float support

### DIFF
--- a/src/mbgl/gl/enum.cpp
+++ b/src/mbgl/gl/enum.cpp
@@ -398,6 +398,14 @@ platform::GLenum Enum<gfx::TexturePixelType>::sizedFor<>(const gfx::TexturePixel
                     break;
             }
         }
+        case gfx::TextureChannelDataType::Float: {
+            switch (value) {
+                case gfx::TexturePixelType::RGBA:
+                    return GL_RGBA32F;
+                default:
+                    break;
+            }
+        }
     }
 
     return GL_INVALID_ENUM;
@@ -410,6 +418,8 @@ gfx::TextureChannelDataType Enum<gfx::TextureChannelDataType>::from(const platfo
             return gfx::TextureChannelDataType::UnsignedByte;
         case GL_HALF_FLOAT:
             return gfx::TextureChannelDataType::HalfFloat;
+        case GL_FLOAT:
+            return gfx::TextureChannelDataType::Float;
     }
     return {};
 }
@@ -421,6 +431,8 @@ platform::GLenum Enum<gfx::TextureChannelDataType>::to(const gfx::TextureChannel
             return GL_UNSIGNED_BYTE;
         case gfx::TextureChannelDataType::HalfFloat:
             return GL_HALF_FLOAT;
+        case gfx::TextureChannelDataType::Float:
+            return GL_FLOAT;
     }
     return GL_INVALID_ENUM;
 }


### PR DESCRIPTION
Added float to OpenGL implementation in order to compile.
Float type was added in this PR - https://github.com/maplibre/maplibre-native/pull/1690.