### PR TITLE
Use free runner for Draft PRs

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -44,7 +44,7 @@ jobs:
             "!**/*.md"]
 
   android-build:
-    runs-on: MapLibre_Native_Linux_16_core
+    runs-on: ${{ github.event.pull_request && !github.event.pull_request.draft && 'MapLibre_Native_Linux_16_core' || 'ubuntu-22.04' }}
     needs:
       - pre_job
     if: needs.pre_job.outputs.should_skip != 'true'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: true
       matrix:
         renderer: [legacy, drawable]
-    runs-on: MapLibre_Native_Linux_16_core
+    runs-on: ${{ github.event.pull_request && !github.event.pull_request.draft && 'MapLibre_Native_Linux_16_core' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
To save some money, use a free runner when a PR is still a draft.