### PR TITLE
[cmake] Make most of vendor libraries OBJECT libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1315,10 +1315,10 @@ target_link_libraries(
         Mapbox::Base::cheap-ruler-cpp
         mbgl-compiler-options
         mbgl-vendor-boost
-        mbgl-vendor-csscolorparser
+        $<BUILD_INTERFACE:mbgl-vendor-csscolorparser>
         mbgl-vendor-earcut.hpp
         mbgl-vendor-eternal
-        mbgl-vendor-parsedate
+        $<BUILD_INTERFACE:mbgl-vendor-parsedate>
         mbgl-vendor-polylabel
         mbgl-vendor-protozero
         mbgl-vendor-unique_resource

--- a/platform/android/android.cmake
+++ b/platform/android/android.cmake
@@ -90,8 +90,8 @@ target_link_libraries(
         atomic
         jnigraphics
         log
-        mbgl-vendor-icu
-        mbgl-vendor-sqlite
+        $<BUILD_INTERFACE:mbgl-vendor-icu>
+        $<BUILD_INTERFACE:mbgl-vendor-sqlite>
         z
 )
 

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -144,8 +144,8 @@ target_link_libraries(
         $<$<NOT:$<BOOL:${MLN_USE_BUILTIN_ICU}>>:ICU::uc>
         $<$<BOOL:${MLN_USE_BUILTIN_ICU}>:mbgl-vendor-icu>
         PNG::PNG
-        mbgl-vendor-nunicode
-        mbgl-vendor-sqlite
+        $<BUILD_INTERFACE:mbgl-vendor-nunicode>
+        $<BUILD_INTERFACE:mbgl-vendor-sqlite>
 )
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/bin)

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -144,7 +144,7 @@ target_link_libraries(
         Qt${QT_VERSION_MAJOR}::Network
         $<IF:$<BOOL:${MLN_QT_WITH_INTERNAL_SQLITE}>,mbgl-vendor-sqlite,Qt${QT_VERSION_MAJOR}::Sql>
         $<$<PLATFORM_ID:Linux>:$<IF:$<BOOL:${MLN_QT_WITH_INTERNAL_ICU}>,mbgl-vendor-icu,ICU::uc>>
-        mbgl-vendor-nunicode
+        $<BUILD_INTERFACE:mbgl-vendor-nunicode>
 )
 
 set(qmaplibregl_headers

--- a/platform/windows/windows.cmake
+++ b/platform/windows/windows.cmake
@@ -182,8 +182,8 @@ target_link_libraries(
         $<$<NOT:$<BOOL:${MLN_USE_BUILTIN_ICU}>>:ICU::uc>
         $<$<BOOL:${MLN_USE_BUILTIN_ICU}>:mbgl-vendor-icu>
         PNG::PNG
-        mbgl-vendor-nunicode
-        mbgl-vendor-sqlite
+        $<BUILD_INTERFACE:mbgl-vendor-nunicode>
+        $<BUILD_INTERFACE:mbgl-vendor-sqlite>
 )
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/bin)

--- a/vendor/csscolorparser.cmake
+++ b/vendor/csscolorparser.cmake
@@ -2,11 +2,7 @@ if(TARGET mbgl-vendor-csscolorparser)
     return()
 endif()
 
-if(MLN_WITH_QT AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
-    add_library(mbgl-vendor-csscolorparser OBJECT)
-else()
-    add_library(mbgl-vendor-csscolorparser STATIC)
-endif()
+add_library(mbgl-vendor-csscolorparser OBJECT)
 
 target_sources(
     mbgl-vendor-csscolorparser PRIVATE

--- a/vendor/icu.cmake
+++ b/vendor/icu.cmake
@@ -3,7 +3,7 @@ if(TARGET mbgl-vendor-icu)
 endif()
 
 add_library(
-    mbgl-vendor-icu STATIC
+    mbgl-vendor-icu OBJECT
     ${CMAKE_CURRENT_LIST_DIR}/icu/src/cmemory.cpp
     ${CMAKE_CURRENT_LIST_DIR}/icu/src/cstring.cpp
     ${CMAKE_CURRENT_LIST_DIR}/icu/src/ubidi.cpp

--- a/vendor/nunicode.cmake
+++ b/vendor/nunicode.cmake
@@ -2,11 +2,7 @@ if(TARGET mbgl-vendor-nunicode)
     return()
 endif()
 
-if(MLN_WITH_QT AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
-    add_library(mbgl-vendor-nunicode OBJECT)
-else()
-    add_library(mbgl-vendor-nunicode STATIC)
-endif()
+add_library(mbgl-vendor-nunicode OBJECT)
 
 target_sources(
     mbgl-vendor-nunicode PRIVATE

--- a/vendor/parsedate.cmake
+++ b/vendor/parsedate.cmake
@@ -2,11 +2,7 @@ if(TARGET mbgl-vendor-parsedate)
     return()
 endif()
 
-if(MLN_WITH_QT AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
-    add_library(mbgl-vendor-parsedate OBJECT)
-else()
-    add_library(mbgl-vendor-parsedate STATIC)
-endif()
+add_library(mbgl-vendor-parsedate OBJECT)
 
 target_sources(
     mbgl-vendor-parsedate PRIVATE

--- a/vendor/sqlite.cmake
+++ b/vendor/sqlite.cmake
@@ -3,7 +3,7 @@ if(TARGET mbgl-vendor-sqlite)
 endif()
 
 add_library(
-    mbgl-vendor-sqlite STATIC
+    mbgl-vendor-sqlite OBJECT
     ${CMAKE_CURRENT_LIST_DIR}/sqlite/src/sqlite3.c
 )
 

--- a/vendor/zip-archive.cmake
+++ b/vendor/zip-archive.cmake
@@ -3,7 +3,7 @@ if(TARGET mbgl-vendor-zip-archive)
 endif()
 
 add_library(
-    mbgl-vendor-zip-archive STATIC
+    mbgl-vendor-zip-archive OBJECT
     ${CMAKE_CURRENT_LIST_DIR}/zip-archive/SSZipArchive/SSZipArchive.h
     ${CMAKE_CURRENT_LIST_DIR}/zip-archive/SSZipArchive/SSZipArchive.m
     ${CMAKE_CURRENT_LIST_DIR}/zip-archive/SSZipArchive/SSZipCommon.h


### PR DESCRIPTION
Now that we have new enough CMake we can make most of vendor libraries OBJECT libraries which helps deploying MapLibre Native as a static library in only one file.