### PR TITLE
Fixes for GCC 13 and LLVM 17

### DIFF
--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     tags:
-      - 'qt-**'
+      - "qt-**"
     paths:
       - CMakeLists.txt
       - ".github/actions/qt5-build/**"
@@ -28,7 +28,7 @@ on:
 
   pull_request:
     branches:
-      - '*'
+      - "*"
     paths:
       - CMakeLists.txt
       - ".github/actions/qt5-build/**"
@@ -63,11 +63,19 @@ jobs:
             build_type: RelWithDebInfo
             qt_version: 5.15.2
             qt_target: desktop
+            compiler: ""
           - name: Linux
             os: ubuntu-22.04
             build_type: RelWithDebInfo
-            qt_version: 6.5.0
+            qt_version: 6.5.3
             qt_target: desktop
+            compiler: ""
+          - name: Linux_GCC13
+            os: ubuntu-22.04
+            build_type: RelWithDebInfo
+            qt_version: 6.5.3
+            qt_target: desktop
+            compiler: "gcc-13"
           - name: macOS
             os: macos-12
             build_type: RelWithDebInfo
@@ -75,13 +83,23 @@ jobs:
             qt_target: desktop
             deployment_target: 10.13
             deployment_arch: "x86_64"
+            compiler: ""
           - name: macOS
             os: macos-12
             build_type: RelWithDebInfo
-            qt_version: 6.5.0
+            qt_version: 6.5.3
             qt_target: desktop
             deployment_target: 11.0
             deployment_arch: "x86_64;arm64"
+            compiler: ""
+          - name: macOS_LLVM17
+            os: macos-13
+            build_type: RelWithDebInfo
+            qt_version: 6.5.3
+            qt_target: desktop
+            deployment_target: 11.0
+            deployment_arch: "x86_64"
+            compiler: "llvm@17"
           - name: win64_msvc2019
             os: windows-2022
             build_type: "RelWithDebInfo;Debug"
@@ -90,16 +108,16 @@ jobs:
             qt_version: 5.15.2
             qt_target: desktop
             qt_arch: win64_msvc2019_64
-            qt_tools: ''
+            qt_tools: ""
           - name: win64_msvc2019
             os: windows-2022
             build_type: "RelWithDebInfo;Debug"
             compiler_type: x64
             compiler_version: 14.29
-            qt_version: 6.5.0
+            qt_version: 6.5.3
             qt_target: desktop
             qt_arch: win64_msvc2019_64
-            qt_tools: ''
+            qt_tools: ""
           - name: win64_mingw
             os: windows-2022
             build_type: RelWithDebInfo
@@ -114,7 +132,7 @@ jobs:
             build_type: RelWithDebInfo
             compiler_type: mingw1120_64
             compiler_version: 11.2.0
-            qt_version: 6.5.0
+            qt_version: 6.5.3
             qt_target: desktop
             qt_arch: win64_mingw
             qt_tools: tools_mingw90
@@ -154,6 +172,38 @@ jobs:
 
       - name: Setup ninja
         uses: seanmiddleditch/gha-setup-ninja@v4
+
+      - name: Install compiler
+        id: install_compiler
+        if: runner.os == 'Linux' && matrix.compiler != ''
+        uses: rlalik/setup-cpp-compiler@master
+        with:
+          compiler: ${{ matrix.compiler }}
+
+      - name: Setup compiler (Linux)
+        if: runner.os == 'Linux' && matrix.compiler != ''
+        env:
+          CC: ${{ steps.install_compiler.outputs.cc }}
+          CXX: ${{ steps.install_compiler.outputs.cxx }}
+        run: |
+          {
+            echo "CC=$CC"
+            echo "CXX=$CXX"
+          } >> "$GITHUB_ENV"
+
+      - name: Setup compiler (macOS)
+        if: runner.os == 'macOS' && matrix.compiler != ''
+        env:
+          MLN_COMPILER: ${{ matrix.compiler }}
+        run: |
+          brew install "$MLN_COMPILER"
+          echo "/usr/local/opt/${MLN_COMPILER}/bin" >> "$GITHUB_PATH"
+          {
+            echo "CC=/usr/local/opt/${MLN_COMPILER}/bin/clang"
+            echo "CXX=/usr/local/opt/${MLN_COMPILER}/bin/clang++"
+            echo "LDFLAGS=\"-L/usr/local/opt/${MLN_COMPILER}/lib\""
+            echo "CPPFLAGS=\"-I/usr/local/opt/${MLN_COMPILER}/include\""
+          } >> "$GITHUB_ENV"
 
       - name: Setup Xcode
         if: runner.os == 'macOS'
@@ -204,8 +254,24 @@ jobs:
         uses: ./source/.github/actions/qt5-build
 
       - name: Build maplibre-native (Linux, Qt6)
-        if: runner.os == 'Linux' && matrix.qt_version != '5.15.2'
+        if: runner.os == 'Linux' && matrix.qt_version != '5.15.2' && matrix.compiler == ''
         uses: ./source/.github/actions/qt6-build
+
+      - name: Build maplibre-native (Linux, Qt6, custom compiler)
+        if: runner.os == 'Linux' && matrix.qt_version != '5.15.2' && matrix.compiler != ''
+        run: |
+          mkdir build && cd build
+          qt-cmake ../source/ \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+            -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
+            -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
+            -DCMAKE_INSTALL_PREFIX="../install" \
+            -DMLN_WITH_QT=ON \
+            -DMLN_QT_DEPLOYMENT=ON \
+            -DMLN_QT_WITH_INTERNAL_ICU=ON
+          ninja
+          ninja install
 
       - name: Build maplibre-native (Windows)
         if: runner.os == 'Windows'
@@ -238,7 +304,7 @@ jobs:
           QT_VERSION: ${{ matrix.qt_version }}
         run: |
           pushd install
-          tar cjvf ../maplibre-native_"${QT_ARCH}"_Qt"${QT_VERSION}".tar.bz2 ./*
+          tar cjvf "../maplibre-native_${QT_ARCH}_Qt${QT_VERSION}.tar.bz2" ./*
           popd
 
       - name: Upload artifacts
@@ -254,11 +320,11 @@ jobs:
         include:
           - name: Linux
             os: ubuntu-22.04
-            qt_version: 6.5.0
+            qt_version: 6.5.3
             qt_target: desktop
           - name: macOS
             os: macos-12
-            qt_version: 6.5.0
+            qt_version: 6.5.3
             qt_target: desktop
     runs-on: ${{ matrix.os }}
     env:
@@ -294,9 +360,9 @@ jobs:
       - name: Build test app
         run: |
           mkdir install && cd install
-          tar xf ../maplibre-native_"${QT_ARCH}"_Qt"${QT_VERSION}".tar.bz2
+          tar xf "../maplibre-native_${QT_ARCH}_Qt${QT_VERSION}.tar.bz2"
           cd ..
-          export CMAKE_PREFIX_PATH="$PWD"/install
+          export CMAKE_PREFIX_PATH="$PWD/install"
           mkdir build && cd build
           cmake ../source/platform/qt/app/
           make
@@ -310,27 +376,27 @@ jobs:
       max-parallel: 1
       matrix:
         name: [Linux, macOS, win64_msvc2019, win64_mingw]
-        qt_version: [5.15.2, 6.5.0]
+        qt_version: [5.15.2, 6.5.3]
     permissions:
       contents: write
 
     steps:
-    - name: Download artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: maplibre-native_${{ matrix.name }}_Qt${{ matrix.qt_version }}
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: maplibre-native_${{ matrix.name }}_Qt${{ matrix.qt_version }}
 
-    - name: Name tarball
-      env:
-        TAG_NAME: ${{ github.ref_name }}
-        TAG_PLATFORM: ${{ matrix.name }}
-        QT_VERSION: ${{ matrix.qt_version }}
-      run: |
-        mv maplibre-native_"${TAG_PLATFORM}"_Qt"${QT_VERSION}".tar.bz2 QMapLibreGL_"${TAG_NAME//qt-/}"_Qt"${QT_VERSION}"_"${TAG_PLATFORM}".tar.bz2
+      - name: Name tarball
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+          TAG_PLATFORM: ${{ matrix.name }}
+          QT_VERSION: ${{ matrix.qt_version }}
+        run: |
+          mv "maplibre-native_${TAG_PLATFORM}_Qt${QT_VERSION}.tar.bz2" "QMapLibreGL_${TAG_NAME//qt-/}_Qt${QT_VERSION}_${TAG_PLATFORM}.tar.bz2"
 
-    - name: Release
-      uses: ncipollo/release-action@v1
-      with:
-        artifacts: QMapLibreGL_*.tar.bz2
-        allowUpdates: true
-        draft: true
+      - name: Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: QMapLibreGL_*.tar.bz2
+          allowUpdates: true
+          draft: true

--- a/include/mbgl/gfx/shader_group.hpp
+++ b/include/mbgl/gfx/shader_group.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/include/mbgl/gfx/shader_registry.hpp
+++ b/include/mbgl/gfx/shader_registry.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
 #include <unordered_map>
 
 namespace mbgl {

--- a/include/mbgl/style/transition_options.hpp
+++ b/include/mbgl/style/transition_options.hpp
@@ -18,8 +18,8 @@ public:
     TransitionOptions(std::optional<Duration> duration_ = std::nullopt,
                       std::optional<Duration> delay_ = std::nullopt,
                       bool enablePlacementTransitions_ = true)
-        : duration(std::move(duration_)),
-          delay(std::move(delay_)),
+        : duration(duration_ ? std::move(duration_) : std::nullopt),
+          delay(delay_ ? std::move(delay_) : std::nullopt),
           enablePlacementTransitions(enablePlacementTransitions_) {}
 
     TransitionOptions reverseMerge(const TransitionOptions& defaults) const {

--- a/include/mbgl/util/compression.hpp
+++ b/include/mbgl/util/compression.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace mbgl {

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -314,12 +314,12 @@ RenderTiles RenderTileSource::getRenderTiles() const {
 
 RenderTiles RenderTileSource::getRenderTilesSortedByYPosition() const {
     if (!renderTilesSortedByY) {
-        const auto comp = [bearing = this->bearing](const RenderTile& a, const RenderTile& b) {
+        const auto comp = [sourceBearing = this->bearing](const RenderTile& a, const RenderTile& b) {
             Point<float> pa(static_cast<float>(a.id.canonical.x), static_cast<float>(a.id.canonical.y));
             Point<float> pb(static_cast<float>(b.id.canonical.x), static_cast<float>(b.id.canonical.y));
 
-            auto par = util::rotate(pa, bearing);
-            auto pbr = util::rotate(pb, bearing);
+            auto par = util::rotate(pa, sourceBearing);
+            auto pbr = util::rotate(pb, sourceBearing);
 
             return std::tie(b.id.canonical.z, par.y, par.x) < std::tie(a.id.canonical.z, pbr.y, pbr.x);
         };

--- a/src/mbgl/style/conversion/transition_options.cpp
+++ b/src/mbgl/style/conversion/transition_options.cpp
@@ -12,7 +12,7 @@ std::optional<TransitionOptions> Converter<TransitionOptions>::operator()(const 
         return std::nullopt;
     }
 
-    std::optional<TransitionOptions> result = TransitionOptions{};
+    auto result = TransitionOptions{};
 
     auto duration = objectMember(value, "duration");
     if (duration) {
@@ -21,7 +21,7 @@ std::optional<TransitionOptions> Converter<TransitionOptions>::operator()(const 
             error.message = "duration must be a number";
             return std::nullopt;
         }
-        result->duration = {std::chrono::milliseconds(int64_t(*number))};
+        result.duration = {std::chrono::milliseconds(int64_t(*number))};
     }
 
     auto delay = objectMember(value, "delay");
@@ -31,10 +31,10 @@ std::optional<TransitionOptions> Converter<TransitionOptions>::operator()(const 
             error.message = "delay must be a number";
             return std::nullopt;
         }
-        result->delay = {std::chrono::milliseconds(int64_t(*number))};
+        result.delay = {std::chrono::milliseconds(int64_t(*number))};
     }
 
-    return result;
+    return std::make_optional(std::move(result));
 }
 
 } // namespace conversion

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -26,7 +26,10 @@ class GeoJSONVTData final : public GeoJSONData {
     void getTile(const CanonicalTileID& id, const std::function<void(TileFeatures)>& fn) final {
         assert(fn);
         scheduler->scheduleAndReplyValue(
-            [id, impl = this->impl]() -> TileFeatures { return impl->getTile(id.z, id.x, id.y).features; }, fn);
+            [id, geoJSONVT_impl = this->impl]() -> TileFeatures {
+                return geoJSONVT_impl->getTile(id.z, id.x, id.y).features;
+            },
+            fn);
     }
 
     Features getChildren(const std::uint32_t) final { return {}; }

--- a/test/util/thread.test.cpp
+++ b/test/util/thread.test.cpp
@@ -183,8 +183,10 @@ TEST(Thread, ThreadPoolMessaging) {
 }
 
 TEST(Thread, ReferenceCanOutliveThread) {
+#if defined(__GNUC__) && __GNUC__ >= 12
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuse-after-free" // See AspiringActor<>::object()
+#endif
     auto thread = std::make_unique<Thread<TestWorker>>("Test");
     auto worker = thread->actor();
 
@@ -196,7 +198,9 @@ TEST(Thread, ReferenceCanOutliveThread) {
 
     using namespace std::literals;
     std::this_thread::sleep_for(10s);
+#if defined(__GNUC__) && __GNUC__ >= 12
 #pragma GCC diagnostic pop
+#endif
 }
 
 TEST(Thread, DeletePausedThread) {


### PR DESCRIPTION
Fixes for GCC 13 and LLVM 17:
- missing `cstdint` and `string` includes (GCC 13 got stricter with indirect includes)
- `std::optional` warnings (do not move empty one, make the optional at the end of the function)
- LLVM 17 is picky about lambda bindings reusing the same name, I guess for readability.

Also add CI tests as part of Qt pipeline.