### PR TITLE
[ci] Cleanup caches in the target repo

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,6 +1,6 @@
 name: cleanup-branch-caches
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
   workflow_dispatch:
@@ -20,19 +20,19 @@ jobs:
       - name: Cleanup
         run: |
           gh extension install actions/gh-actions-cache
-          
-          REPO=${{ github.repository }}
-          BRANCH=refs/pull/${{ github.event.pull_request.number }}/merge
+
+          REPO="${{ github.repository }}"
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
 
           echo "Fetching list of cache key"
-          cacheKeysForPR="$(gh actions-cache list -R "$REPO" -B "$BRANCH" | cut -f 1 )"
+          cacheKeysForPR=$(gh actions-cache list -R "$REPO" -B "$BRANCH" | cut -f 1 )
 
-          ## Setting this to not fail the workflow while deleting cache keys. 
+          # set this to not fail the workflow while deleting cache keys
           set +e
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR
           do
-              gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
+            gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
           done
           echo "Done"
         env:


### PR DESCRIPTION
We need to use `pull_request_target` so that caches from forks are deleted. We only request relevant permissions so this should be safe enough.

Also quote variables, just in case.

Why delete caches? We cache a lot of data and the quota we have is low. This prevents relevant caches to get evicted too soon.