### PR TITLE
Fix a bug with buffer reuse.  Simplify stencil clearing.

### DIFF
--- a/include/mbgl/mtl/context.hpp
+++ b/include/mbgl/mtl/context.hpp
@@ -60,7 +60,7 @@ public:
     MTLSamplerStatePtr createMetalSamplerState(MTLSamplerDescriptorPtr samplerDescriptor) const;
 
     // Actually remove the objects we marked as abandoned with the above methods.
-    void performCleanup() override {}
+    void performCleanup() override;
 
     void reduceMemoryUsage() override {}
 
@@ -134,6 +134,7 @@ private:
     MTLDepthStencilStatePtr clipMaskDepthStencilState;
     MTLRenderPipelineStatePtr clipMaskPipelineState;
     BufferResource clipMaskUniformsBuffer;
+    bool clipMaskUniformsBufferUsed = false;
     const gfx::Renderable* stencilStateRenderable = nullptr;
 
     gfx::RenderingStats stats;

--- a/src/mbgl/renderer/paint_parameters.hpp
+++ b/src/mbgl/renderer/paint_parameters.hpp
@@ -121,7 +121,7 @@ private:
     template <typename TIter>
     using GetTileIDFunc = const UnwrappedTileID& (*)(const typename TIter::value_type&);
     template <typename TIter>
-    void renderTileClippingMasks(TIter beg, TIter end, GetTileIDFunc<TIter> unwrap, bool clear);
+    void renderTileClippingMasks(TIter beg, TIter end, GetTileIDFunc<TIter> unwrap);
 
     // This needs to be an ordered map so that we have the same order as the renderTiles.
     std::map<UnwrappedTileID, int32_t> tileClippingMaskIDs;


### PR DESCRIPTION
Resolves a problem with multiple stencil updates during a frame by reusing only the first buffer, which is all that's used in many cases, and making the rest transient.

Also simplifies the way clearing works; now that stencil rendering is refactored into `Context`, there's less benefit in using the same function with numerous conditional branches for updating and clearing.