### PR TITLE
Upload coverage in separate workflow

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -185,15 +185,13 @@ jobs:
             --test_output=errors --local_test_jobs=1 \
             --test_env=DISPLAY --test_env=XAUTHORITY --copt="-DCI_BUILD" \
             //test:core //render-test:render-test //expression-test:test
+          echo coverage_report="$(bazel info output_path)"/_coverage/_coverage_report.dat >> "$GITHUB_ENV"
 
       - name: Upload coverage report
-        if: '!cancelled()'
-        uses: codecov/codecov-action@v3
+        uses: actions/upload-artifact@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ${{ env.coverage_report }}
-          fail_ci_if_error: true
-          verbose: true
+          name: coverage-report
+          path: ${{ env.coverage_report }}
 
   linux-ci-result:
     name: Linux CI Result

--- a/.github/workflows/pr-bloaty.yml
+++ b/.github/workflows/pr-bloaty.yml
@@ -19,6 +19,8 @@ jobs:
   pr-bloaty:
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
+
       - uses: ./.github/actions/download-workflow-run-artifact
         with:
           artifact-name: mbgl-render

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -1,0 +1,29 @@
+name: upload-coverage
+
+on:
+  workflow_run:
+    workflows: [linux-ci]
+    types:
+      - completed
+
+jobs:
+  upload-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/download-workflow-run-artifact
+        with:
+          artifact-name: coverage-report
+          expect-files: "_coverage_report.dat"
+
+      - name: Upload coverage report
+        if: '!cancelled()'
+        uses: codecov/codecov-action@v3
+        with:
+          override_commit: ${{ github.event.workflow_run.head_sha }}
+          override_pr: ${{ github.event.workflow_run.pull_requests[0].number }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: "_coverage_report.dat"
+          fail_ci_if_error: true
+          verbose: true


### PR DESCRIPTION
We need to upload the coverage in a separate workflow, becuase it needs access to the codecov secret.