### PR TITLE
CI PR number handling

### DIFF
--- a/.github/actions/get-pr-number/action.yml
+++ b/.github/actions/get-pr-number/action.yml
@@ -1,0 +1,17 @@
+name: 'get-pr-number'
+description: 'Gets the PR number from an artifact'
+outputs:
+  pr-number:
+    description: "PR number"
+    value: ${{ steps.cat.outputs.pr-number }}
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/actions/download-workflow-run-artifact
+      with:
+        artifact-name: pr-number
+        expect-files: "./pr_number"
+
+    - id: cat
+      run: echo pr-number="$(cat ./pr_number)" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/actions/save-pr-number/action.yml
+++ b/.github/actions/save-pr-number/action.yml
@@ -10,7 +10,6 @@ runs:
           echo "${{ github.event.number }}" > ./pr_number
 
       - name: Upload pr_number
-        shell: bash
         uses: actions/upload-artifact@v3
         with:
           name: pr-number

--- a/.github/actions/save-pr-number/action.yml
+++ b/.github/actions/save-pr-number/action.yml
@@ -1,0 +1,17 @@
+name: 'save-pr-number'
+description: 'Saves the current PR number as artifact'
+runs:
+  using: "composite"
+  steps:
+      - name: Save PR number
+        shell: bash
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "${{ github.event.number }}" > ./pr_number
+
+      - name: Upload pr_number
+        shell: bash
+        uses: actions/upload-artifact@v3
+        with:
+          name: pr-number
+          path: ./pr_number

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -29,21 +29,21 @@ jobs:
         with:
           files_yaml: |
             android:
-              - 'CMakeLists.txt',
-              - 'platform/android/**',
-              - '.github/workflows/android-ci.yml',
-              - 'bin/**',
-              - 'expression-test/**',
-              - 'include/**',
-              - 'metrics/**',
-              - 'platform/default/**',
-              - 'render-test/**',
-              - 'scripts/**',
-              - 'src/**',
-              - 'test/**',
-              - 'vendor/**',
-              - '.gitmodules',
-              - '!**/*.md']
+              - 'CMakeLists.txt'
+              - 'platform/android/**'
+              - '.github/workflows/android-ci.yml'
+              - 'bin/**'
+              - 'expression-test/**'
+              - 'include/**'
+              - 'metrics/**'
+              - 'platform/default/**'
+              - 'render-test/**'
+              - 'scripts/**'
+              - 'src/**'
+              - 'test/**'
+              - 'vendor/**'
+              - '.gitmodules'
+              - '!**/*.md'
 
   android-build:
     runs-on: ${{ github.event.pull_request && !github.event.pull_request.draft && 'MapLibre_Native_Linux_16_core' || 'ubuntu-22.04' }}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,7 +1,6 @@
 name: android-ci
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -21,9 +20,13 @@ jobs:
   pre_job:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: steps.changed-files.outputs.android_any_changed != 'true'
+      should_skip: github.event_name != 'workflow_dispatch' && steps.changed-files.outputs.android_any_changed != 'true'
     steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+
       - name: Get all Android files that have changed
+        if: github.event_name != 'workflow_dispatch'
         id: changed-files
         uses: tj-actions/changed-files@v39
         with:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -21,27 +21,29 @@ jobs:
   pre_job:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: steps.changed-files.outputs.android_any_changed != 'true'
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
+      - name: Get all Android files that have changed
+        id: changed-files
+        uses: tj-actions/changed-files@v39
         with:
-          paths: |
-            ["CMakeLists.txt",
-            "platform/android/**",
-            ".github/workflows/android-ci.yml",
-            "bin/**",
-            "expression-test/**",
-            "include/**",
-            "metrics/**",
-            "platform/default/**",
-            "render-test/**",
-            "scripts/**",
-            "src/**",
-            "test/**",
-            "vendor/**",
-            ".gitmodules",
-            "!**/*.md"]
+          files_yaml: |
+            android:
+              - 'CMakeLists.txt',
+              - 'platform/android/**',
+              - '.github/workflows/android-ci.yml',
+              - 'bin/**',
+              - 'expression-test/**',
+              - 'include/**',
+              - 'metrics/**',
+              - 'platform/default/**',
+              - 'render-test/**',
+              - 'scripts/**',
+              - 'src/**',
+              - 'test/**',
+              - 'vendor/**',
+              - '.gitmodules',
+              - '!**/*.md']
 
   android-build:
     runs-on: ${{ github.event.pull_request && !github.event.pull_request.draft && 'MapLibre_Native_Linux_16_core' || 'ubuntu-22.04' }}

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -21,9 +21,13 @@ jobs:
   pre_job:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: steps.changed-files-yaml.outputs.ios_any_changed != 'true'
+      should_skip: github.event_name != 'workflow_dispatch' && steps.changed-files-yaml.outputs.ios_any_changed != 'true'
     steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+
       - name: Get all iOS files that have changed
+        if: github.event_name != 'workflow_dispatch'
         id: changed-files-yaml
         uses: tj-actions/changed-files@v39
         with:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -192,6 +192,9 @@ jobs:
         with:
           name: coverage-report
           path: ${{ env.coverage_report }}
+  
+      - if: github.event_name == 'pull_request'
+        uses: ./.github/actions/save-pr-number
 
   linux-ci-result:
     name: Linux CI Result

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: List changed files
         if: steps.changed-files.outputs.linux_any_changed == 'true'  
         run: |
-          echo "Changed file(s): ${{ steps.changed-files.outputs.ios_all_changed_files }}"
+          echo "Changed file(s): ${{ steps.changed-files.outputs.linux_all_changed_files }}"
 
   linux-build-and-test:
     if: needs.pre_job.outputs.should_skip != 'true'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -19,9 +19,13 @@ jobs:
   pre_job:
     runs-on: ubuntu-22.04
     outputs:
-      should_skip: steps.changed-files.outputs.linux_any_changed != 'true'
+      should_skip: github.event_name != 'workflow_dispatch' && steps.changed-files.outputs.linux_any_changed != 'true'
     steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+
       - name: Get all Linux files that have changed
+        if: github.event_name != 'workflow_dispatch'
         id: changed-files
         uses: tj-actions/changed-files@v39
         with:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -150,6 +150,9 @@ jobs:
       - name: Run expression test
         run: build/expression-test/mbgl-expression-test
 
+      - if: github.event_name == 'pull_request'
+        uses: ./.github/actions/save-pr-number
+
   linux-coverage:
     runs-on: ubuntu-22.04
     steps:
@@ -199,9 +202,6 @@ jobs:
         with:
           name: coverage-report
           path: ${{ env.coverage_report }}
-  
-      - if: github.event_name == 'pull_request'
-        uses: ./.github/actions/save-pr-number
 
   linux-ci-result:
     name: Linux CI Result

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -27,18 +27,18 @@ jobs:
         with:
           files_yaml: |
             linux:
-              - 'src/**',
-              - 'test/**',
-              - 'render-test/**',
-              - 'expression-test/**',
-              - 'include/**',
-              - '.github/workflows/linux-ci.yml',
-              - 'vendor/**',
-              - 'CMakeLists.txt',
-              - 'metrics/linux-gcc8-release-style.json',
-              - 'WORKSPACE',
-              - 'BUILD.bazel',
-              - '.bazelrc',
+              - 'src/**'
+              - 'test/**'
+              - 'render-test/**'
+              - 'expression-test/**'
+              - 'include/**'
+              - '.github/workflows/linux-ci.yml'
+              - 'vendor/**'
+              - 'CMakeLists.txt'
+              - 'metrics/linux-gcc8-release-style.json'
+              - 'WORKSPACE'
+              - 'BUILD.bazel'
+              - '.bazelrc'
               - '.bazelversion'
 
       - name: List changed files

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -19,25 +19,32 @@ jobs:
   pre_job:
     runs-on: ubuntu-22.04
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: steps.changed-files.outputs.linux_any_changed != 'true'
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
+      - name: Get all Linux files that have changed
+        id: changed-files
+        uses: tj-actions/changed-files@v39
         with:
-          paths: |
-            ["src/**",
-            "test/**",
-            "render-test/**",
-            "expression-test/**",
-            "include/**",
-            ".github/workflows/linux-ci.yml",
-            "vendor/**",
-            "CMakeLists.txt",
-            "metrics/linux-gcc8-release-style.json",
-            "WORKSPACE",
-            "BUILD.bazel",
-            ".bazelrc",
-            ".bazelversion"]
+          files_yaml: |
+            linux:
+              - 'src/**',
+              - 'test/**',
+              - 'render-test/**',
+              - 'expression-test/**',
+              - 'include/**',
+              - '.github/workflows/linux-ci.yml',
+              - 'vendor/**',
+              - 'CMakeLists.txt',
+              - 'metrics/linux-gcc8-release-style.json',
+              - 'WORKSPACE',
+              - 'BUILD.bazel',
+              - '.bazelrc',
+              - '.bazelversion'
+
+      - name: List changed files
+        if: steps.changed-files.outputs.linux_any_changed == 'true'  
+        run: |
+          echo "Changed file(s): ${{ steps.changed-files.outputs.ios_all_changed_files }}"
 
   linux-build-and-test:
     if: needs.pre_job.outputs.should_skip != 'true'

--- a/.github/workflows/pr-bloaty.yml
+++ b/.github/workflows/pr-bloaty.yml
@@ -18,10 +18,12 @@ permissions:
 
 jobs:
   pr-bloaty:
-    if: github.event.workflow_run.pull_requests.length
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/get-pr-number
+        id: get-pr-number
 
       - uses: ./.github/actions/download-workflow-run-artifact
         with:
@@ -82,6 +84,6 @@ jobs:
       - name: Leave a comment with Bloaty results
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          number: ${{ steps.get-pr-number.outputs.pr-number }}
           header: bloaty
           path: message.md


### PR DESCRIPTION
Turns out `github.event.workflow_run.pull_requests[0].number` is an unreliable way to get the pull request number in a `workflow_run` workflow triggered by a `pull_request` workflow.

I am reverting to writing the pull request number to an artifact, but I wrote two composite actions to make saving and retrieving the PR number involve a little less boilerplate.

I am also getingt rid of `tj-actions/changed-files@v39` in this PR, and use a simple PR files diff with `tj-actions/changed-files@v39` to determine if workflows need to be run.