### PR TITLE
Disable stencil instancing

### DIFF
--- a/include/mbgl/shaders/mtl/clipping_mask.hpp
+++ b/include/mbgl/shaders/mtl/clipping_mask.hpp
@@ -44,30 +44,20 @@ struct VertexStage {
 
 struct FragmentStage {
     float4 position [[position, invariant]];
-    uint8_t stencil_ref;
 };
 
 struct FragmentResult {
+    // color output is only needed because we're using implicit stencil writes
     half4 color [[color(0)]];
-    // target is `..._stencil8`, but using `uint8_t` here causes a compile error
-    uint16_t stencil_ref [[stencil]];
 };
 
 FragmentStage vertex vertexMain(VertexStage in [[stage_in]],
-                                uint16_t instanceID [[instance_id]],
-                                device const ClipUBO* clipUBOs [[buffer(1)]]) {
-    device const ClipUBO& clipUBO = clipUBOs[instanceID];
-    return {
-        .position = clipUBO.matrix * float4(float2(in.position.xy), 0, 1),
-        .stencil_ref = static_cast<uint8_t>(clipUBO.stencil_ref),
-    };
+                                device const ClipUBO& clipUBO [[buffer(1)]]) {
+    return { clipUBO.matrix * float4(float2(in.position.xy), 0, 1) };
 }
 
-FragmentResult fragment fragmentMain(FragmentStage in [[stage_in]]) {
-    return {
-        .color = half4(1.0),
-        .stencil_ref = static_cast<uint16_t>(in.stencil_ref),
-    };
+half4 fragment fragmentMain(FragmentStage in [[stage_in]]) {
+    return half4(1.0);
 }
 )";
 };

--- a/src/mbgl/mtl/context.cpp
+++ b/src/mbgl/mtl/context.cpp
@@ -330,6 +330,13 @@ bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,
 
     encoder->setCullMode(MTL::CullModeNone);
     encoder->setVertexBuffer(vertexRes.getMetalBuffer().get(), /*offset=*/0, ShaderClass::attributes[0].index);
+
+    // Instancing is disabled for now because the `[[stencil]]` attribute in the fragment shader output
+    // that we need to apply a different stencil value for each tile causes a problem on some older (A8-A11)
+    // devices, specifically `XPC_ERROR_CONNECTION_INTERRUPTED` when creating a render pipeline state.
+    // Adding a `[[depth(...)]]` output to the shader prevents this error, but the stencil value is
+    // still not written to the stencil attachment on those same devices.
+#if STENCIL_INSTANCING
     encoder->setVertexBuffer(uboBuffer.getMetalBuffer().get(), /*offset=*/0, ShaderClass::uniforms[0].index);
     encoder->drawIndexedPrimitives(MTL::PrimitiveType::PrimitiveTypeTriangle,
                                    indexCount,
@@ -339,6 +346,21 @@ bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,
                                    /*instanceCount=*/static_cast<NS::UInteger>(tileUBOs.size()),
                                    /*baseVertex=*/0,
                                    /*baseInstance=*/0);
+#else
+    for (std::size_t ii = 0; ii < tileUBOs.size(); ++ii) {
+        encoder->setStencilReferenceValue(tileUBOs[ii].stencil_ref);
+        encoder->setVertexBuffer(
+            uboBuffer.getMetalBuffer().get(), /*offset=*/ii * uboSize, ShaderClass::uniforms[0].index);
+        encoder->drawIndexedPrimitives(MTL::PrimitiveType::PrimitiveTypeTriangle,
+                                       indexCount,
+                                       MTL::IndexType::IndexTypeUInt16,
+                                       indexRes->getMetalBuffer().get(),
+                                       /*indexOffset=*/0,
+                                       /*instanceCount=*/1,
+                                       /*baseVertex=*/0,
+                                       /*baseInstance=*/0);
+    }
+#endif
 
     return true;
 }


### PR DESCRIPTION
On my device any effect on frame times is lost in the normal variation, and the mean of only 3 runs actually came out a little faster without instancing.

```
before:
| boston     | 16.4 ms | 16.4 ms | 16.5 ms 
| paris      |  6.5 ms |  6.7 ms | 16.5 ms 
| paris2     | 16.5 ms |  6.5 ms | 16.5 ms 
| alps       | 17.6 ms | 11.5 ms | 13.3 ms 
| us east    |  7.0 ms |  6.8 ms | 16.4 ms 
| greater la | 16.5 ms | 16.5 ms | 16.5 ms 
| sf         | 11.7 ms | 12.0 ms | 15.7 ms 
| oakland    | 16.5 ms | 16.5 ms |  6.4 ms 
| germany    | 14.9 ms | 17.4 ms | 18.4 ms 
Average frame time: 13.7 ms, 12.3, 15.1 mean=13.7

after:
| boston     | 16.5 ms | 16.5 ms | 16.5 ms
| paris      |  6.8 ms |  6.5 ms |  6.6 ms
| paris2     |  6.5 ms | 16.5 ms |  6.5 ms
| alps       | 13.1 ms | 16.5 ms | 16.9 ms
| us east    |  7.0 ms | 16.5 ms | 16.5 ms
| greater la | 16.5 ms | 16.5 ms | 16.5 ms
| sf         | 16.1 ms | 11.3 ms | 17.1 ms
| oakland    | 16.5 ms |  6.5 ms |  6.4 ms
| germany    | 18.6 ms | 17.0 ms | 15.5 ms
Average frame time: 13.1 ms, 13.7, 13.2 mean=13.3
```
