### PR TITLE
Upload Bloaty report to S3

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -105,19 +105,35 @@ jobs:
           cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DMLN_WITH_CLANG_TIDY=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMLN_WITH_COVERAGE=ON ${{ env.renderer_flag_cmake }}
           cmake --build build --target mbgl-core mbgl-test-runner mbgl-render-test-runner mbgl-expression-test
 
+      # mbgl-render (used for size test)
+
       - name: Build mbgl-render
         if: matrix.renderer == 'drawable'
         run: |
           cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -B build-size -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DMLN_DRAWABLE_RENDERER=ON
           cmake --build build-size --target mbgl-render
 
-      - name: Upload mbgl-render
-        if: matrix.renderer == 'drawable'
+      - name: Upload mbgl-render as artifact
+        if: matrix.renderer == 'drawable' && github.event_name == 'pull_request' 
         uses: actions/upload-artifact@v3
         with:
           name: mbgl-render
           path: |
             build-size/bin/mbgl-render
+
+      - name: Configure AWS Credentials
+        if: github.ref == 'refs/heads/main' && vars.OIDC_AWS_ROLE_TO_ASSUME 
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
+      - name: Upload mbgl-render to S3
+        if: github.ref == 'refs/heads/main' && vars.OIDC_AWS_ROLE_TO_ASSUME 
+        run: aws s3 cp build-size/bin/mbgl-render s3://maplibre-native/mbgl-render-main
+
+      # CodeQL
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/pr-bloaty.yml
+++ b/.github/workflows/pr-bloaty.yml
@@ -8,9 +8,8 @@ on:
     types:
       - completed
 env:
-  # built with commit d38709084a9865fe0bb8300aec70ebf8243b3d43
-  legacy_download_url: https://maplibre-native.s3.eu-central-1.amazonaws.com/mbgl-render-legacy
-  main_download_url: https://maplibre-native.s3.eu-central-1.amazonaws.com/mbgl-render-main
+  download_url: https://maplibre-native.s3.eu-central-1.amazonaws.com/mbgl-render
+  legacy_maplibre_sha: d38709084a9865fe0bb8300aec70ebf8243b3d43
   bloaty_sha: 8be8b448550b37c978e8defd9d421c0464c52cc7
 
 permissions:
@@ -30,10 +29,13 @@ jobs:
           artifact-name: mbgl-render
           expect-files: "mbgl-render"
 
-      - name: Download legacy and main mbgl-render
-        run: |
-          wget -O mbgl-render-legacy "$legacy_download_url"
-          wget -O mbgl-render-main "$main_download_url"
+      - name: Download mbgl-render-main
+        run: wget -O mbgl-render-main "${download_url}-main"
+
+      - name: Download mbgl-render-legacy
+        id: download-mbgl-render-legacy
+        run: wget -O mbgl-render-legacy "${download_url}-${legacy_maplibre_sha}"
+        continue-on-error: true
 
       - name: Get latest CMake and Ninja
         uses: lukka/get-cmake@latest
@@ -56,30 +58,40 @@ jobs:
           path: bloaty/build/bloaty
           key: bloaty-${{ env.bloaty_sha }}
 
-      - name: Download legacy and main mbgl-render
-        run: |
-          wget -O mbgl-render-legacy "$legacy_download_url"
-          wget -O mbgl-render-main "$main_download_url"
-
-      - name: Run Bloaty McBloatface on legacy
-        run: bloaty/build/bloaty mbgl-render -- mbgl-render-legacy -n 0 -s vm -d compileunits > tlus_diff_legacy.txt
-
       - name: Run Bloaty McBloatface on main
         run: bloaty/build/bloaty mbgl-render -- mbgl-render-main -n 0 -s vm -d compileunits > tlus_diff_main.txt
 
-      - name: Prepare Bloaty message
+      - name: Run Bloaty McBloatface on legacy
+        if: steps.download-mbgl-render-legacy.outcome == 'success'
+        run: bloaty/build/bloaty mbgl-render -- mbgl-render-legacy -n 0 -s vm -d compileunits > tlus_diff_legacy.txt
+
+      - name: Prepare Bloaty message (main)
         run: |
+          gist_url="$(gh gist create tlus_diff_main.txt)"
           {
             echo "# Bloaty Results 🐋"
-            echo '<details><summary>Compared to d38709084a9865fe0bb8300aec70ebf8243b3d43</summary>'
+            echo 'Compared to main'
             echo '```'
-            cat tlus_diff_legacy.txt
-            echo '```</details>'
-            echo '<details><summary>Compared to main</summary>'
+            awk 'NR <= 2; END { print }' tlus_diff_main.txt
             echo '```'
-            cat tlus_diff_main.txt
-            echo '```</details>'
+            echo "Full report: $gist_url"
           } >> message.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare Bloaty message (legacy)
+        if: steps.download-mbgl-render-legacy.outcome == 'success'
+        run: |
+          gist_url="$(gh gist create tlus_diff_legacy.txt)"
+          {
+            echo "Compared to $legacy_maplibre_sha"
+            echo '```'
+            awk 'NR <= 2; END { print }' tlus_diff_legacy.txt
+            echo '```'
+            echo "Full report: $gist_url"
+          } >> message.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Leave a comment with Bloaty results
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/pr-bloaty.yml
+++ b/.github/workflows/pr-bloaty.yml
@@ -8,7 +8,7 @@ on:
     types:
       - completed
 env:
-  download_url: https://maplibre-native.s3.eu-central-1.amazonaws.com/mbgl-render
+  download_url: https://maplibre-native.s3.eu-central-1.amazonaws.com
   legacy_maplibre_sha: d38709084a9865fe0bb8300aec70ebf8243b3d43
   bloaty_sha: 8be8b448550b37c978e8defd9d421c0464c52cc7
 
@@ -30,11 +30,11 @@ jobs:
           expect-files: "mbgl-render"
 
       - name: Download mbgl-render-main
-        run: wget -O mbgl-render-main "${download_url}-main"
+        run: wget -O mbgl-render-main "${download_url}/mbgl-render-main"
 
       - name: Download mbgl-render-legacy
         id: download-mbgl-render-legacy
-        run: wget -O mbgl-render-legacy "${download_url}-${legacy_maplibre_sha}"
+        run: wget -O mbgl-render-legacy "${download_url}/mbgl-render-${legacy_maplibre_sha}"
         continue-on-error: true
 
       - name: Get latest CMake and Ninja
@@ -65,9 +65,18 @@ jobs:
         if: steps.download-mbgl-render-legacy.outcome == 'success'
         run: bloaty/build/bloaty mbgl-render -- mbgl-render-legacy -n 0 -s vm -d compileunits > tlus_diff_legacy.txt
 
+      - name: Configure AWS Credentials
+        if: github.ref == 'refs/heads/main' && vars.OIDC_AWS_ROLE_TO_ASSUME 
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
       - name: Prepare Bloaty message (main)
         run: |
-          gist_url="$(gh gist create tlus_diff_main.txt)"
+          report_path=bloaty-results/pr-${{ steps.get-pr-number.outputs.pr-number }}-compared-to-main.txt
+          aws s3 cp tlus_diff_main.txt s3://maplibre-native/"$report_path"
           {
             echo "# Bloaty Results 🐋"
             echo 'Compared to main'
@@ -80,15 +89,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare Bloaty message (legacy)
-        if: steps.download-mbgl-render-legacy.outcome == 'success'
         run: |
-          gist_url="$(gh gist create tlus_diff_legacy.txt)"
+          report_path=bloaty-results/pr-${{ steps.get-pr-number.outputs.pr-number }}-compared-to-legacy.txt
+          aws s3 cp tlus_diff_legacy.txt s3://maplibre-native/"$report_path"
           {
             echo "Compared to $legacy_maplibre_sha"
             echo '```'
             awk 'NR <= 2; END { print }' tlus_diff_legacy.txt
             echo '```'
-            echo "Full report: $gist_url"
+            echo "Full report: $download_url/$report_path"
           } >> message.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Upload `mbgl-render` to S3 on main push.
- Put Bloaty summary in PR comment. Link to full report hosted with S3.
- I still need to build `mbgl-render-d38709084a9865fe0bb8300aec70ebf8243b3d43` on CI so that the paths match.

I don't really have a way to test this locally unfortunately. I need the CI context on this repo, which is only available after merging.