### PR TITLE
Last Bloaty fixes

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -113,7 +113,7 @@ jobs:
             build-size/bin/mbgl-render
 
       - name: Configure AWS Credentials
-        if: github.ref == 'refs/heads/main' && vars.OIDC_AWS_ROLE_TO_ASSUME 
+        if: matrix.renderer == 'drawable' && github.ref == 'refs/heads/main' && vars.OIDC_AWS_ROLE_TO_ASSUME 
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-west-2
@@ -121,7 +121,7 @@ jobs:
           role-session-name: ${{ github.run_id }}
 
       - name: Upload mbgl-render to S3
-        if: github.ref == 'refs/heads/main' && vars.OIDC_AWS_ROLE_TO_ASSUME 
+        if: matrix.renderer == 'drawable' && github.ref == 'refs/heads/main' && vars.OIDC_AWS_ROLE_TO_ASSUME 
         run: aws s3 cp build-size/bin/mbgl-render s3://maplibre-native/mbgl-render-main
 
       # CodeQL

--- a/.github/workflows/pr-bloaty.yml
+++ b/.github/workflows/pr-bloaty.yml
@@ -87,7 +87,7 @@ jobs:
             echo '```'
             awk 'NR <= 2; END { print }' tlus_diff_main.txt
             echo '```'
-            echo "Full report: $gist_url"
+            echo "Full report: $report_path"
           } >> message.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
           report_path=bloaty-results/pr-${{ steps.get-pr-number.outputs.pr-number }}-compared-to-legacy.txt
           aws s3 cp tlus_diff_legacy.txt s3://maplibre-native/"$report_path"
           {
-            echo "Compared to $legacy_maplibre_sha"
+            echo "Compared to $legacy_maplibre_sha (legacy)"
             echo '```'
             awk 'NR <= 2; END { print }' tlus_diff_legacy.txt
             echo '```'

--- a/.github/workflows/pr-bloaty.yml
+++ b/.github/workflows/pr-bloaty.yml
@@ -45,6 +45,7 @@ jobs:
           ninjaVersion: latest
 
       - name: Cache Bloaty
+        id: cache-bloaty
         uses: actions/cache@v3
         with:
           path: bloaty/build/bloaty
@@ -53,6 +54,7 @@ jobs:
       # because Google is not making a release...
       # https://github.com/google/bloaty/issues/334
       - name: Compile Bloaty
+        if: ${{ !steps.cache-bloaty.outputs.cache-hit }}
         run: |
           git clone https://github.com/google/bloaty.git
           cd bloaty


### PR DESCRIPTION
- Do not compile Bloaty on cache hit
- Fix report path.
- Only try to upload mbgl-render when it was actually compiled.