### PR TITLE
update for node 21

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -273,7 +273,7 @@ jobs:
           GALLIUM_DRIVER: softpipe
         run: |
           Invoke-WebRequest https://github.com/pal1000/mesa-dist-win/releases/download/22.3.5/mesa3d-22.3.5-release-msvc.7z -OutFile mesa3d.7z
-          & 'C:\Program Files\7-Zip\7z.exe' e -olib\node-v108 .\mesa3d.7z x64\opengl32.dll x64\libgallium_wgl.dll x64\libGLESv2.dll x64\libglapi.dll
+          & 'C:\Program Files\7-Zip\7z.exe' e -olib\node-v115 .\mesa3d.7z x64\opengl32.dll x64\libgallium_wgl.dll x64\libGLESv2.dll x64\libglapi.dll
           npm test
 
       # On PRs make sure that the npm package can be packaged.

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -146,6 +146,14 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
 
+      # Fixes an issue with the image causing builds to fail - https://github.com/actions/runner-images/issues/8598
+      - name: Remove Strawberry Perl from PATH (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
+          "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Setup cmake (Linux)
         if: runner.os == 'Linux' && runner.arch != 'arm64'
         uses: jwlawson/actions-setup-cmake@v1.14

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: npm ci
         run: npm ci --ignore-scripts

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-20.04
+          - runs-on: ubuntu-22.04
             arch: x86_64
           - runs-on: [self-hosted, linux, ARM64]
             arch: arm64
@@ -69,7 +69,7 @@ jobs:
     needs: bump_version
     continue-on-error: true
     env:
-      BUILDTYPE: 'Release'
+      BUILDTYPE: "Release"
 
     defaults:
       run:
@@ -117,16 +117,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             ccache \
-            cmake \
             ninja-build \
             pkg-config \
             xvfb \
             libcurl4-openssl-dev \
             libglfw3-dev \
             libuv1-dev \
-            g++-10 \
-            libc++-9-dev \
-            libc++abi-9-dev \
+            g++-12 \
             libjpeg-dev \
             libpng-dev \
             libwebp-dev
@@ -135,7 +132,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: npm ci
         run: npm ci --ignore-scripts
@@ -143,6 +140,20 @@ jobs:
       - name: Set up msvc dev cmd (Windows)
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
+
+      # Fixes an issue with the image causing builds to fail - https://github.com/actions/runner-images/issues/8598
+      - name: Remove Strawberry Perl from PATH (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
+          "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Setup cmake (Linux)
+        if: runner.os == 'Linux' && runner.arch != 'arm64'
+        uses: jwlawson/actions-setup-cmake@v1.14
+        with:
+          cmake-version: "3.19.x"
 
       - name: Set up ccache (MacOS/Linux)
         if: runner.os == 'MacOS' || runner.os == 'Linux'
@@ -158,12 +169,19 @@ jobs:
         if: runner.os == 'Windows'
         uses: hendrikmuhs/ccache-action@v1
         with:
-          variant: 'sccache'
+          variant: "sccache"
           key: ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}-${{ github.head_ref }}
           restore-keys: |
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}-${{ github.sha }}
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}-${{ github.ref }}
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}
+
+      - name: Cache cmake-node-module deps
+        uses: actions/cache@v3
+        with:
+          # downloaded with platform/node/cmake/module.cmake
+          path: build/headers
+          key: ${{ runner.os }}-${{ runner.arch }}-cmake-node-module-deps
 
       - name: Configure maplibre-native (MacOS)
         if: runner.os == 'MacOS'
@@ -172,16 +190,19 @@ jobs:
             -G Ninja \
             -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DMLN_WITH_NODE=ON
 
       - name: Configure maplibre-native (Linux)
         if: runner.os == 'Linux'
+        shell: bash -leo pipefail {0}
         run: |
           cmake . -B build \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_C_COMPILER=gcc-10 \
-            -DCMAKE_CXX_COMPILER=g++-10
+            -DCMAKE_C_COMPILER=gcc-12 \
+            -DCMAKE_CXX_COMPILER=g++-12 \
+            -DMLN_WITH_NODE=ON
 
       - name: "Create directory '${{ github.workspace }}/platform/windows/vendor/vcpkg/bincache' (Windows)"
         if: runner.os == 'Windows'
@@ -207,7 +228,8 @@ jobs:
           cmake . -B build \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+            -DMLN_WITH_NODE=ON
 
       - name: Build maplibre-native (MacOS/Linux)
         if: runner.os == 'MacOS' || runner.os == 'Linux'
@@ -238,7 +260,7 @@ jobs:
           ./platform/node/scripts/publish.sh --target_arch=arm64
 
   publish_npm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: publish_binaries
 
     defaults:
@@ -257,7 +279,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Publish to NPM (release)
         if: github.ref == 'refs/heads/main' && (github.event.inputs.version == 'patch' || github.event.inputs.version == 'minor' || github.event.inputs.version == 'major')

--- a/platform/node/CMakeLists.txt
+++ b/platform/node/CMakeLists.txt
@@ -6,7 +6,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/module.cmake)
 add_node_module(
     mbgl-node
     INSTALL_PATH ${PROJECT_SOURCE_DIR}/lib/{node_abi}/mbgl.node
-    NAN_VERSION 2.17.0
+    NAN_VERSION 2.18.0
     EXCLUDE_NODE_ABIS
         46
         47

--- a/platform/node/scripts/publish.sh
+++ b/platform/node/scripts/publish.sh
@@ -9,7 +9,7 @@ if [[ "${CIRCLE_TAG}" == "node-v${PACKAGE_JSON_VERSION}" ]] || [[ "${PUBLISH:-}"
     # Changes to the version targets here should happen in tandem with updates to the
     # EXCLUDE_NODE_ABIS property in cmake/node.cmake and the "node" engines property in
     # package.json.
-    for TARGET in 14.0.0 16.0.0 18.0.0; do
+    for TARGET in 16.0.0 18.0.0 20.0.0; do
         rm -rf build/stage
 
         if [[ "${BUILDTYPE}" == "RelWithDebInfo" ]]; then

--- a/platform/node/src/node_request.cpp
+++ b/platform/node/src/node_request.cpp
@@ -1,5 +1,5 @@
-#include "node_request.hpp"
 #include "node_map.hpp"
+#include "node_request.hpp"
 #include <mbgl/storage/response.hpp>
 #include <mbgl/util/chrono.hpp>
 
@@ -7,144 +7,161 @@
 
 namespace node_mbgl {
 
-NodeRequest::NodeRequest(mbgl::FileSource::Callback callback_, NodeAsyncRequest* asyncRequest_)
-    : callback(std::move(callback_)),
-      asyncRequest(asyncRequest_) {
-    asyncRequest->request = this;
+NodeRequest::NodeRequest(mbgl::FileSource::Callback callback_,
+                         NodeAsyncRequest *asyncRequest_)
+    : callback(std::move(callback_)), asyncRequest(asyncRequest_) {
+  asyncRequest->request = this;
 }
 
 NodeRequest::~NodeRequest() {
-    // When this object gets garbage collected, make sure that the
-    // AsyncRequest can no longer attempt to remove the callback function
-    // this object was holding (it can't be fired anymore).
-    if (asyncRequest) {
-        asyncRequest->request = nullptr;
-    }
+  // When this object gets garbage collected, make sure that the
+  // AsyncRequest can no longer attempt to remove the callback function
+  // this object was holding (it can't be fired anymore).
+  if (asyncRequest) {
+    asyncRequest->request = nullptr;
+  }
 }
 
 Nan::Persistent<v8::Function> NodeRequest::constructor;
 
 void NodeRequest::Init(v8::Local<v8::Object> target) {
 #if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 93
-    v8::Local<v8::Context> context = target->CreationContext();
+  v8::Local<v8::Context> context = target->CreationContext();
 #else
-    v8::Local<v8::Context> context = target->GetCreationContext().ToLocalChecked();
+  v8::Local<v8::Context> context =
+      target->GetCreationContext().ToLocalChecked();
 #endif
-    v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+  v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
 
-    tpl->InstanceTemplate()->SetInternalFieldCount(1);
-    tpl->SetClassName(Nan::New("Request").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+  tpl->SetClassName(Nan::New("Request").ToLocalChecked());
 
-    Nan::SetPrototypeMethod(tpl, "respond", HandleCallback);
+  Nan::SetPrototypeMethod(tpl, "respond", HandleCallback);
 
-    constructor.Reset(tpl->GetFunction(context).ToLocalChecked());
+  constructor.Reset(tpl->GetFunction(context).ToLocalChecked());
 }
 
-void NodeRequest::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-    auto target = reinterpret_cast<NodeMap*>(info[0].As<v8::External>()->Value());
-    auto callback = reinterpret_cast<mbgl::FileSource::Callback*>(info[1].As<v8::External>()->Value());
-    auto asyncRequest = reinterpret_cast<NodeAsyncRequest*>(info[2].As<v8::External>()->Value());
+void NodeRequest::New(const Nan::FunctionCallbackInfo<v8::Value> &info) {
+  auto target =
+      reinterpret_cast<NodeMap *>(info[0].As<v8::External>()->Value());
+  auto callback = reinterpret_cast<mbgl::FileSource::Callback *>(
+      info[1].As<v8::External>()->Value());
+  auto asyncRequest =
+      reinterpret_cast<NodeAsyncRequest *>(info[2].As<v8::External>()->Value());
 
-    auto request = new NodeRequest(*callback, asyncRequest);
+  auto request = new NodeRequest(*callback, asyncRequest);
 
-    request->Wrap(info.This());
-    request->Ref();
-    Nan::Set(info.This(), Nan::New("url").ToLocalChecked(), info[3]);
-    Nan::Set(info.This(), Nan::New("kind").ToLocalChecked(), info[4]);
-    v8::Local<v8::Value> argv[] = {info.This()};
-    request->asyncResource->runInAsyncScope(
-        Nan::To<v8::Object>(target->handle()->GetInternalField(1).As<v8::Value>()).ToLocalChecked(), "request", 1, argv);
-    info.GetReturnValue().Set(info.This());
+  request->Wrap(info.This());
+  request->Ref();
+  Nan::Set(info.This(), Nan::New("url").ToLocalChecked(), info[3]);
+  Nan::Set(info.This(), Nan::New("kind").ToLocalChecked(), info[4]);
+  v8::Local<v8::Value> argv[] = {info.This()};
+  request->asyncResource->runInAsyncScope(
+      Nan::To<v8::Object>(target->handle()->GetInternalField(1).As<v8::Value>())
+          .ToLocalChecked(),
+      "request", 1, argv);
+  info.GetReturnValue().Set(info.This());
 }
 
-void NodeRequest::HandleCallback(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-    auto request = Nan::ObjectWrap::Unwrap<NodeRequest>(info.Holder());
+void NodeRequest::HandleCallback(
+    const Nan::FunctionCallbackInfo<v8::Value> &info) {
+  auto request = Nan::ObjectWrap::Unwrap<NodeRequest>(info.Holder());
 
-    // Move out of the object so callback() can only be fired once.
-    auto callback = std::move(request->callback);
-    request->callback = {};
-    if (!callback) {
-        request->unrefRequest();
-        return info.GetReturnValue().SetUndefined();
-    }
-
-    mbgl::Response response;
-
-    if (info.Length() < 1) {
-        response.noContent = true;
-    } else if (info[0]->IsObject()) {
-        auto err = Nan::To<v8::Object>(info[0]).ToLocalChecked();
-        auto msg = Nan::New("message").ToLocalChecked();
-
-        if (Nan::Has(err, msg).FromJust()) {
-            response.error = std::make_unique<mbgl::Response::Error>(
-                mbgl::Response::Error::Reason::Other, *Nan::Utf8String(Nan::Get(err, msg).ToLocalChecked()));
-        }
-    } else if (info[0]->IsString()) {
-        response.error = std::make_unique<mbgl::Response::Error>(mbgl::Response::Error::Reason::Other,
-                                                                 *Nan::Utf8String(info[0]));
-    } else if (info.Length() < 2 || !info[1]->IsObject()) {
-        request->unrefRequest();
-        return Nan::ThrowTypeError("Second argument must be a response object");
-    } else {
-        auto res = Nan::To<v8::Object>(info[1]).ToLocalChecked();
-
-        if (Nan::Has(res, Nan::New("modified").ToLocalChecked()).FromJust()) {
-            const double modified =
-                Nan::To<double>(Nan::Get(res, Nan::New("modified").ToLocalChecked()).ToLocalChecked()).FromJust();
-            if (!std::isnan(modified)) {
-                response.modified = mbgl::Timestamp{mbgl::Seconds(static_cast<mbgl::Seconds::rep>(modified / 1000))};
-            }
-        }
-
-        if (Nan::Has(res, Nan::New("expires").ToLocalChecked()).FromJust()) {
-            const double expires =
-                Nan::To<double>(Nan::Get(res, Nan::New("expires").ToLocalChecked()).ToLocalChecked()).FromJust();
-            if (!std::isnan(expires)) {
-                response.expires = mbgl::Timestamp{mbgl::Seconds(static_cast<mbgl::Seconds::rep>(expires / 1000))};
-            }
-        }
-
-        if (Nan::Has(res, Nan::New("etag").ToLocalChecked()).FromJust()) {
-            const Nan::Utf8String etag(Nan::Get(res, Nan::New("etag").ToLocalChecked()).ToLocalChecked());
-            response.etag = std::string{*etag, size_t(etag.length())};
-        }
-
-        if (Nan::Has(res, Nan::New("data").ToLocalChecked()).FromJust()) {
-            auto data = Nan::Get(res, Nan::New("data").ToLocalChecked()).ToLocalChecked();
-            if (node::Buffer::HasInstance(data)) {
-                response.data = std::make_shared<std::string>(node::Buffer::Data(data), node::Buffer::Length(data));
-            } else {
-                request->unrefRequest();
-                return Nan::ThrowTypeError("Response data must be a Buffer");
-            }
-        }
-    }
-
-    // Send the response object to the NodeFileSource object
-    callback(response);
+  // Move out of the object so callback() can only be fired once.
+  auto callback = std::move(request->callback);
+  request->callback = {};
+  if (!callback) {
     request->unrefRequest();
-    info.GetReturnValue().SetUndefined();
+    return info.GetReturnValue().SetUndefined();
+  }
+
+  mbgl::Response response;
+
+  if (info.Length() < 1) {
+    response.noContent = true;
+  } else if (info[0]->IsObject()) {
+    auto err = Nan::To<v8::Object>(info[0]).ToLocalChecked();
+    auto msg = Nan::New("message").ToLocalChecked();
+
+    if (Nan::Has(err, msg).FromJust()) {
+      response.error = std::make_unique<mbgl::Response::Error>(
+          mbgl::Response::Error::Reason::Other,
+          *Nan::Utf8String(Nan::Get(err, msg).ToLocalChecked()));
+    }
+  } else if (info[0]->IsString()) {
+    response.error = std::make_unique<mbgl::Response::Error>(
+        mbgl::Response::Error::Reason::Other, *Nan::Utf8String(info[0]));
+  } else if (info.Length() < 2 || !info[1]->IsObject()) {
+    request->unrefRequest();
+    return Nan::ThrowTypeError("Second argument must be a response object");
+  } else {
+    auto res = Nan::To<v8::Object>(info[1]).ToLocalChecked();
+
+    if (Nan::Has(res, Nan::New("modified").ToLocalChecked()).FromJust()) {
+      const double modified =
+          Nan::To<double>(Nan::Get(res, Nan::New("modified").ToLocalChecked())
+                              .ToLocalChecked())
+              .FromJust();
+      if (!std::isnan(modified)) {
+        response.modified = mbgl::Timestamp{
+            mbgl::Seconds(static_cast<mbgl::Seconds::rep>(modified / 1000))};
+      }
+    }
+
+    if (Nan::Has(res, Nan::New("expires").ToLocalChecked()).FromJust()) {
+      const double expires =
+          Nan::To<double>(Nan::Get(res, Nan::New("expires").ToLocalChecked())
+                              .ToLocalChecked())
+              .FromJust();
+      if (!std::isnan(expires)) {
+        response.expires = mbgl::Timestamp{
+            mbgl::Seconds(static_cast<mbgl::Seconds::rep>(expires / 1000))};
+      }
+    }
+
+    if (Nan::Has(res, Nan::New("etag").ToLocalChecked()).FromJust()) {
+      const Nan::Utf8String etag(
+          Nan::Get(res, Nan::New("etag").ToLocalChecked()).ToLocalChecked());
+      response.etag = std::string{*etag, size_t(etag.length())};
+    }
+
+    if (Nan::Has(res, Nan::New("data").ToLocalChecked()).FromJust()) {
+      auto data =
+          Nan::Get(res, Nan::New("data").ToLocalChecked()).ToLocalChecked();
+      if (node::Buffer::HasInstance(data)) {
+        response.data = std::make_shared<std::string>(
+            node::Buffer::Data(data), node::Buffer::Length(data));
+      } else {
+        request->unrefRequest();
+        return Nan::ThrowTypeError("Response data must be a Buffer");
+      }
+    }
+  }
+
+  // Send the response object to the NodeFileSource object
+  callback(response);
+  request->unrefRequest();
+  info.GetReturnValue().SetUndefined();
 }
 
 void NodeRequest::unrefRequest() {
-    Nan::HandleScope scope;
-    delete asyncResource;
-    asyncResource = nullptr;
-    Unref();
+  Nan::HandleScope scope;
+  delete asyncResource;
+  asyncResource = nullptr;
+  Unref();
 }
 
 NodeAsyncRequest::NodeAsyncRequest() = default;
 
 NodeAsyncRequest::~NodeAsyncRequest() {
-    if (request) {
-        // Remove the callback function because the AsyncRequest was
-        // canceled and we are no longer interested in the result.
-        if (request->callback) {
-            request->callback = {};
-        }
-        request->asyncRequest = nullptr;
+  if (request) {
+    // Remove the callback function because the AsyncRequest was
+    // canceled and we are no longer interested in the result.
+    if (request->callback) {
+      request->callback = {};
     }
+    request->asyncRequest = nullptr;
+  }
 }
 
 } // namespace node_mbgl

--- a/platform/node/src/node_request.cpp
+++ b/platform/node/src/node_request.cpp
@@ -53,7 +53,7 @@ void NodeRequest::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     Nan::Set(info.This(), Nan::New("kind").ToLocalChecked(), info[4]);
     v8::Local<v8::Value> argv[] = {info.This()};
     request->asyncResource->runInAsyncScope(
-        Nan::To<v8::Object>(target->handle()->GetInternalField(1)).ToLocalChecked(), "request", 1, argv);
+        Nan::To<v8::Object>(target->handle()->GetInternalField(1).As<v8::Value>()).ToLocalChecked(), "request", 1, argv);
     info.GetReturnValue().Set(info.This());
 }
 

--- a/platform/node/src/node_request.cpp
+++ b/platform/node/src/node_request.cpp
@@ -53,7 +53,10 @@ void NodeRequest::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     Nan::Set(info.This(), Nan::New("kind").ToLocalChecked(), info[4]);
     v8::Local<v8::Value> argv[] = {info.This()};
     request->asyncResource->runInAsyncScope(
-        Nan::To<v8::Object>(target->handle()->GetInternalField(1).As<v8::Value>()).ToLocalChecked(), "request", 1, argv);
+        Nan::To<v8::Object>(target->handle()->GetInternalField(1).As<v8::Value>()).ToLocalChecked(),
+        "request",
+        1,
+        argv);
     info.GetReturnValue().Set(info.This());
 }
 

--- a/platform/node/src/node_request.cpp
+++ b/platform/node/src/node_request.cpp
@@ -1,5 +1,5 @@
-#include "node_map.hpp"
 #include "node_request.hpp"
+#include "node_map.hpp"
 #include <mbgl/storage/response.hpp>
 #include <mbgl/util/chrono.hpp>
 
@@ -7,161 +7,144 @@
 
 namespace node_mbgl {
 
-NodeRequest::NodeRequest(mbgl::FileSource::Callback callback_,
-                         NodeAsyncRequest *asyncRequest_)
-    : callback(std::move(callback_)), asyncRequest(asyncRequest_) {
-  asyncRequest->request = this;
+NodeRequest::NodeRequest(mbgl::FileSource::Callback callback_, NodeAsyncRequest* asyncRequest_)
+    : callback(std::move(callback_)),
+      asyncRequest(asyncRequest_) {
+    asyncRequest->request = this;
 }
 
 NodeRequest::~NodeRequest() {
-  // When this object gets garbage collected, make sure that the
-  // AsyncRequest can no longer attempt to remove the callback function
-  // this object was holding (it can't be fired anymore).
-  if (asyncRequest) {
-    asyncRequest->request = nullptr;
-  }
+    // When this object gets garbage collected, make sure that the
+    // AsyncRequest can no longer attempt to remove the callback function
+    // this object was holding (it can't be fired anymore).
+    if (asyncRequest) {
+        asyncRequest->request = nullptr;
+    }
 }
 
 Nan::Persistent<v8::Function> NodeRequest::constructor;
 
 void NodeRequest::Init(v8::Local<v8::Object> target) {
 #if defined NODE_MODULE_VERSION && NODE_MODULE_VERSION < 93
-  v8::Local<v8::Context> context = target->CreationContext();
+    v8::Local<v8::Context> context = target->CreationContext();
 #else
-  v8::Local<v8::Context> context =
-      target->GetCreationContext().ToLocalChecked();
+    v8::Local<v8::Context> context = target->GetCreationContext().ToLocalChecked();
 #endif
-  v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+    v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
 
-  tpl->InstanceTemplate()->SetInternalFieldCount(1);
-  tpl->SetClassName(Nan::New("Request").ToLocalChecked());
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+    tpl->SetClassName(Nan::New("Request").ToLocalChecked());
 
-  Nan::SetPrototypeMethod(tpl, "respond", HandleCallback);
+    Nan::SetPrototypeMethod(tpl, "respond", HandleCallback);
 
-  constructor.Reset(tpl->GetFunction(context).ToLocalChecked());
+    constructor.Reset(tpl->GetFunction(context).ToLocalChecked());
 }
 
-void NodeRequest::New(const Nan::FunctionCallbackInfo<v8::Value> &info) {
-  auto target =
-      reinterpret_cast<NodeMap *>(info[0].As<v8::External>()->Value());
-  auto callback = reinterpret_cast<mbgl::FileSource::Callback *>(
-      info[1].As<v8::External>()->Value());
-  auto asyncRequest =
-      reinterpret_cast<NodeAsyncRequest *>(info[2].As<v8::External>()->Value());
+void NodeRequest::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+    auto target = reinterpret_cast<NodeMap*>(info[0].As<v8::External>()->Value());
+    auto callback = reinterpret_cast<mbgl::FileSource::Callback*>(info[1].As<v8::External>()->Value());
+    auto asyncRequest = reinterpret_cast<NodeAsyncRequest*>(info[2].As<v8::External>()->Value());
 
-  auto request = new NodeRequest(*callback, asyncRequest);
+    auto request = new NodeRequest(*callback, asyncRequest);
 
-  request->Wrap(info.This());
-  request->Ref();
-  Nan::Set(info.This(), Nan::New("url").ToLocalChecked(), info[3]);
-  Nan::Set(info.This(), Nan::New("kind").ToLocalChecked(), info[4]);
-  v8::Local<v8::Value> argv[] = {info.This()};
-  request->asyncResource->runInAsyncScope(
-      Nan::To<v8::Object>(target->handle()->GetInternalField(1).As<v8::Value>())
-          .ToLocalChecked(),
-      "request", 1, argv);
-  info.GetReturnValue().Set(info.This());
+    request->Wrap(info.This());
+    request->Ref();
+    Nan::Set(info.This(), Nan::New("url").ToLocalChecked(), info[3]);
+    Nan::Set(info.This(), Nan::New("kind").ToLocalChecked(), info[4]);
+    v8::Local<v8::Value> argv[] = {info.This()};
+    request->asyncResource->runInAsyncScope(
+        Nan::To<v8::Object>(target->handle()->GetInternalField(1).As<v8::Value>()).ToLocalChecked(), "request", 1, argv);
+    info.GetReturnValue().Set(info.This());
 }
 
-void NodeRequest::HandleCallback(
-    const Nan::FunctionCallbackInfo<v8::Value> &info) {
-  auto request = Nan::ObjectWrap::Unwrap<NodeRequest>(info.Holder());
+void NodeRequest::HandleCallback(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+    auto request = Nan::ObjectWrap::Unwrap<NodeRequest>(info.Holder());
 
-  // Move out of the object so callback() can only be fired once.
-  auto callback = std::move(request->callback);
-  request->callback = {};
-  if (!callback) {
-    request->unrefRequest();
-    return info.GetReturnValue().SetUndefined();
-  }
-
-  mbgl::Response response;
-
-  if (info.Length() < 1) {
-    response.noContent = true;
-  } else if (info[0]->IsObject()) {
-    auto err = Nan::To<v8::Object>(info[0]).ToLocalChecked();
-    auto msg = Nan::New("message").ToLocalChecked();
-
-    if (Nan::Has(err, msg).FromJust()) {
-      response.error = std::make_unique<mbgl::Response::Error>(
-          mbgl::Response::Error::Reason::Other,
-          *Nan::Utf8String(Nan::Get(err, msg).ToLocalChecked()));
-    }
-  } else if (info[0]->IsString()) {
-    response.error = std::make_unique<mbgl::Response::Error>(
-        mbgl::Response::Error::Reason::Other, *Nan::Utf8String(info[0]));
-  } else if (info.Length() < 2 || !info[1]->IsObject()) {
-    request->unrefRequest();
-    return Nan::ThrowTypeError("Second argument must be a response object");
-  } else {
-    auto res = Nan::To<v8::Object>(info[1]).ToLocalChecked();
-
-    if (Nan::Has(res, Nan::New("modified").ToLocalChecked()).FromJust()) {
-      const double modified =
-          Nan::To<double>(Nan::Get(res, Nan::New("modified").ToLocalChecked())
-                              .ToLocalChecked())
-              .FromJust();
-      if (!std::isnan(modified)) {
-        response.modified = mbgl::Timestamp{
-            mbgl::Seconds(static_cast<mbgl::Seconds::rep>(modified / 1000))};
-      }
-    }
-
-    if (Nan::Has(res, Nan::New("expires").ToLocalChecked()).FromJust()) {
-      const double expires =
-          Nan::To<double>(Nan::Get(res, Nan::New("expires").ToLocalChecked())
-                              .ToLocalChecked())
-              .FromJust();
-      if (!std::isnan(expires)) {
-        response.expires = mbgl::Timestamp{
-            mbgl::Seconds(static_cast<mbgl::Seconds::rep>(expires / 1000))};
-      }
-    }
-
-    if (Nan::Has(res, Nan::New("etag").ToLocalChecked()).FromJust()) {
-      const Nan::Utf8String etag(
-          Nan::Get(res, Nan::New("etag").ToLocalChecked()).ToLocalChecked());
-      response.etag = std::string{*etag, size_t(etag.length())};
-    }
-
-    if (Nan::Has(res, Nan::New("data").ToLocalChecked()).FromJust()) {
-      auto data =
-          Nan::Get(res, Nan::New("data").ToLocalChecked()).ToLocalChecked();
-      if (node::Buffer::HasInstance(data)) {
-        response.data = std::make_shared<std::string>(
-            node::Buffer::Data(data), node::Buffer::Length(data));
-      } else {
+    // Move out of the object so callback() can only be fired once.
+    auto callback = std::move(request->callback);
+    request->callback = {};
+    if (!callback) {
         request->unrefRequest();
-        return Nan::ThrowTypeError("Response data must be a Buffer");
-      }
+        return info.GetReturnValue().SetUndefined();
     }
-  }
 
-  // Send the response object to the NodeFileSource object
-  callback(response);
-  request->unrefRequest();
-  info.GetReturnValue().SetUndefined();
+    mbgl::Response response;
+
+    if (info.Length() < 1) {
+        response.noContent = true;
+    } else if (info[0]->IsObject()) {
+        auto err = Nan::To<v8::Object>(info[0]).ToLocalChecked();
+        auto msg = Nan::New("message").ToLocalChecked();
+
+        if (Nan::Has(err, msg).FromJust()) {
+            response.error = std::make_unique<mbgl::Response::Error>(
+                mbgl::Response::Error::Reason::Other, *Nan::Utf8String(Nan::Get(err, msg).ToLocalChecked()));
+        }
+    } else if (info[0]->IsString()) {
+        response.error = std::make_unique<mbgl::Response::Error>(mbgl::Response::Error::Reason::Other,
+                                                                 *Nan::Utf8String(info[0]));
+    } else if (info.Length() < 2 || !info[1]->IsObject()) {
+        request->unrefRequest();
+        return Nan::ThrowTypeError("Second argument must be a response object");
+    } else {
+        auto res = Nan::To<v8::Object>(info[1]).ToLocalChecked();
+
+        if (Nan::Has(res, Nan::New("modified").ToLocalChecked()).FromJust()) {
+            const double modified =
+                Nan::To<double>(Nan::Get(res, Nan::New("modified").ToLocalChecked()).ToLocalChecked()).FromJust();
+            if (!std::isnan(modified)) {
+                response.modified = mbgl::Timestamp{mbgl::Seconds(static_cast<mbgl::Seconds::rep>(modified / 1000))};
+            }
+        }
+
+        if (Nan::Has(res, Nan::New("expires").ToLocalChecked()).FromJust()) {
+            const double expires =
+                Nan::To<double>(Nan::Get(res, Nan::New("expires").ToLocalChecked()).ToLocalChecked()).FromJust();
+            if (!std::isnan(expires)) {
+                response.expires = mbgl::Timestamp{mbgl::Seconds(static_cast<mbgl::Seconds::rep>(expires / 1000))};
+            }
+        }
+
+        if (Nan::Has(res, Nan::New("etag").ToLocalChecked()).FromJust()) {
+            const Nan::Utf8String etag(Nan::Get(res, Nan::New("etag").ToLocalChecked()).ToLocalChecked());
+            response.etag = std::string{*etag, size_t(etag.length())};
+        }
+
+        if (Nan::Has(res, Nan::New("data").ToLocalChecked()).FromJust()) {
+            auto data = Nan::Get(res, Nan::New("data").ToLocalChecked()).ToLocalChecked();
+            if (node::Buffer::HasInstance(data)) {
+                response.data = std::make_shared<std::string>(node::Buffer::Data(data), node::Buffer::Length(data));
+            } else {
+                request->unrefRequest();
+                return Nan::ThrowTypeError("Response data must be a Buffer");
+            }
+        }
+    }
+
+    // Send the response object to the NodeFileSource object
+    callback(response);
+    request->unrefRequest();
+    info.GetReturnValue().SetUndefined();
 }
 
 void NodeRequest::unrefRequest() {
-  Nan::HandleScope scope;
-  delete asyncResource;
-  asyncResource = nullptr;
-  Unref();
+    Nan::HandleScope scope;
+    delete asyncResource;
+    asyncResource = nullptr;
+    Unref();
 }
 
 NodeAsyncRequest::NodeAsyncRequest() = default;
 
 NodeAsyncRequest::~NodeAsyncRequest() {
-  if (request) {
-    // Remove the callback function because the AsyncRequest was
-    // canceled and we are no longer interested in the result.
-    if (request->callback) {
-      request->callback = {};
+    if (request) {
+        // Remove the callback function because the AsyncRequest was
+        // canceled and we are no longer interested in the result.
+        if (request->callback) {
+            request->callback = {};
+        }
+        request->asyncRequest = nullptr;
     }
-    request->asyncRequest = nullptr;
-  }
 }
 
 } // namespace node_mbgl


### PR DESCRIPTION
Fix broken node workflow

1.) Update NAN from 2.17.0 to 2.18.0
2.) Update syntax of node_request.cpp to work with node 21
3.) Update Ubuntu version to 22.04
4.) Update build node version to 20
5.) Add node 20 to the published binaries. Remove node 14
6.) Workaround cmake issue caused by recent update to Server-2022 image ( https://github.com/actions/runner-images/issues/8598 )