### PR TITLE
Use vector instead of map for uniform buffer array

### DIFF
--- a/include/mbgl/gfx/uniform_buffer.hpp
+++ b/include/mbgl/gfx/uniform_buffer.hpp
@@ -48,7 +48,8 @@ protected:
 /// Stores a collection of uniform buffers by name
 class UniformBufferArray {
 public:
-    using UniformBufferMap = std::unordered_map<StringIdentity, std::shared_ptr<UniformBuffer>>;
+    using UniformBufferPair = std::pair<StringIdentity, std::shared_ptr<UniformBuffer>>;
+    using UniformBufferMap = std::vector<UniformBufferPair>;
 
     UniformBufferArray() = default;
     UniformBufferArray(UniformBufferArray&&);

--- a/src/mbgl/gfx/uniform_buffer.cpp
+++ b/src/mbgl/gfx/uniform_buffer.cpp
@@ -24,15 +24,20 @@ UniformBufferArray& UniformBufferArray::operator=(const UniformBufferArray& othe
 }
 
 const std::shared_ptr<UniformBuffer>& UniformBufferArray::get(const StringIdentity id) const {
-    const auto result = uniformBufferMap.find(id);
+    const auto result = std::find_if(uniformBufferMap.begin(), uniformBufferMap.end(), [&id](const auto& element) { return element.first == id; });
     return (result != uniformBufferMap.end()) ? result->second : nullref;
 }
 
 const std::shared_ptr<UniformBuffer>& UniformBufferArray::addOrReplace(const StringIdentity id,
                                                                        std::shared_ptr<UniformBuffer> uniformBuffer) {
-    const auto result = uniformBufferMap.insert(std::make_pair(id, std::shared_ptr<UniformBuffer>()));
-    result.first->second = std::move(uniformBuffer);
-    return result.first->second;
+    
+    if(auto it = std::find_if(uniformBufferMap.begin(), uniformBufferMap.end(), [&id](const auto& element) { return element.first == id; }); it != uniformBufferMap.end()) {
+        it->second =  std::move(uniformBuffer);
+        return it->second;
+    } else {
+        uniformBufferMap.emplace_back(std::make_pair(id, std::move(uniformBuffer)));
+        return uniformBufferMap.back().second;
+    }
 }
 
 void UniformBufferArray::createOrUpdate(const StringIdentity id,
@@ -54,10 +59,9 @@ void UniformBufferArray::createOrUpdate(const StringIdentity id,
 
 const std::shared_ptr<UniformBuffer>& UniformBufferArray::add(const StringIdentity id,
                                                               std::shared_ptr<UniformBuffer>&& uniformBuffer) {
-    const auto result = uniformBufferMap.insert(std::make_pair(id, std::shared_ptr<UniformBuffer>()));
-    if (result.second) {
-        result.first->second = std::move(uniformBuffer);
-        return result.first->second;
+    if(auto it = std::find_if(uniformBufferMap.begin(), uniformBufferMap.end(), [&id](const auto& element) { return element.first == id; }); it == uniformBufferMap.end()) {
+        uniformBufferMap.emplace_back(std::make_pair(id, std::move(uniformBuffer)));
+        return uniformBufferMap.back().second;
     } else {
         return nullref;
     }

--- a/src/mbgl/gfx/uniform_buffer.cpp
+++ b/src/mbgl/gfx/uniform_buffer.cpp
@@ -24,15 +24,18 @@ UniformBufferArray& UniformBufferArray::operator=(const UniformBufferArray& othe
 }
 
 const std::shared_ptr<UniformBuffer>& UniformBufferArray::get(const StringIdentity id) const {
-    const auto result = std::find_if(uniformBufferMap.begin(), uniformBufferMap.end(), [&id](const auto& element) { return element.first == id; });
+    const auto result = std::find_if(
+        uniformBufferMap.begin(), uniformBufferMap.end(), [&id](const auto& element) { return element.first == id; });
     return (result != uniformBufferMap.end()) ? result->second : nullref;
 }
 
 const std::shared_ptr<UniformBuffer>& UniformBufferArray::addOrReplace(const StringIdentity id,
                                                                        std::shared_ptr<UniformBuffer> uniformBuffer) {
-    
-    if(auto it = std::find_if(uniformBufferMap.begin(), uniformBufferMap.end(), [&id](const auto& element) { return element.first == id; }); it != uniformBufferMap.end()) {
-        it->second =  std::move(uniformBuffer);
+    if (auto it = std::find_if(uniformBufferMap.begin(),
+                               uniformBufferMap.end(),
+                               [&id](const auto& element) { return element.first == id; });
+        it != uniformBufferMap.end()) {
+        it->second = std::move(uniformBuffer);
         return it->second;
     } else {
         uniformBufferMap.emplace_back(std::make_pair(id, std::move(uniformBuffer)));
@@ -59,7 +62,10 @@ void UniformBufferArray::createOrUpdate(const StringIdentity id,
 
 const std::shared_ptr<UniformBuffer>& UniformBufferArray::add(const StringIdentity id,
                                                               std::shared_ptr<UniformBuffer>&& uniformBuffer) {
-    if(auto it = std::find_if(uniformBufferMap.begin(), uniformBufferMap.end(), [&id](const auto& element) { return element.first == id; }); it == uniformBufferMap.end()) {
+    if (auto it = std::find_if(uniformBufferMap.begin(),
+                               uniformBufferMap.end(),
+                               [&id](const auto& element) { return element.first == id; });
+        it == uniformBufferMap.end()) {
         uniformBufferMap.emplace_back(std::make_pair(id, std::move(uniformBuffer)));
         return uniformBufferMap.back().second;
     } else {


### PR DESCRIPTION
Gains 5-10% on Metal (stats on _iPad 5th gen_)

Run 1 (before)
```
 Benchmarking "boston"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 40.4 ms, FPS: 24.7 (24.5 sync FPS)
 Benchmarking "paris"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 66.7 ms, FPS: 15.0 (14.9 sync FPS)
 Benchmarking "paris2"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 50.2 ms, FPS: 19.9 (19.7 sync FPS)
 Benchmarking "alps"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 40.0 ms, FPS: 25.0 (24.7 sync FPS)
 Benchmarking "us east"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 37.1 ms, FPS: 26.9 (26.6 sync FPS)
 Benchmarking "greater la"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 44.3 ms, FPS: 22.6 (22.3 sync FPS)
 Benchmarking "sf"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 72.0 ms, FPS: 13.9 (13.8 sync FPS)
 Benchmarking "oakland"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 55.0 ms, FPS: 18.2 (18.0 sync FPS)
 Benchmarking "germany"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 53.5 ms, FPS: 18.7 (18.5 sync FPS)
 Benchmark completed.
 Result:
 | boston     | 40.4 ms | 24.7 fps |
 | paris      | 66.7 ms | 15.0 fps |
 | paris2     | 50.2 ms | 19.9 fps |
 | alps       | 40.0 ms | 25.0 fps |
 | us east    | 37.1 ms | 26.9 fps |
 | greater la | 44.3 ms | 22.6 fps |
 | sf         | 72.0 ms | 13.9 fps |
 | oakland    | 55.0 ms | 18.2 fps |
 | germany    | 53.5 ms | 18.7 fps |
 Average frame time: 51.0 ms
 Average FPS: 19.6
```

Run 2 (after)
```
 Benchmarking "boston"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 39.7 ms, FPS: 25.2 (24.9 sync FPS)
 Benchmarking "paris"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 65.2 ms, FPS: 15.3 (15.2 sync FPS)
 Benchmarking "paris2"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 49.5 ms, FPS: 20.2 (20.0 sync FPS)
 Benchmarking "alps"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 39.6 ms, FPS: 25.3 (25.0 sync FPS)
 Benchmarking "us east"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 34.5 ms, FPS: 29.0 (28.6 sync FPS)
 Benchmarking "greater la"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 43.7 ms, FPS: 22.9 (22.7 sync FPS)
 Benchmarking "sf"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 71.2 ms, FPS: 14.1 (14.0 sync FPS)
 Benchmarking "oakland"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 54.4 ms, FPS: 18.4 (18.2 sync FPS)
 Benchmarking "germany"
 - Loading assets...
 - Warming up for 20 frames...
 - Benchmarking for 200 frames...
 - Frame time: 53.3 ms, FPS: 18.8 (18.6 sync FPS)
 Benchmark completed.
 Result:
 | boston     | 39.7 ms | 25.2 fps |
 | paris      | 65.2 ms | 15.3 fps |
 | paris2     | 49.5 ms | 20.2 fps |
 | alps       | 39.6 ms | 25.3 fps |
 | us east    | 34.5 ms | 29.0 fps |
 | greater la | 43.7 ms | 22.9 fps |
 | sf         | 71.2 ms | 14.1 fps |
 | oakland    | 54.4 ms | 18.4 fps |
 | germany    | 53.3 ms | 18.8 fps |
 Average frame time: 50.1 ms
 Average FPS: 20.0
```
