### PR TITLE
Benchmark fixes

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - uses: ./.github/actions/get-pr-number
         id: get-pr-number

--- a/vendor/benchmark.cmake
+++ b/vendor/benchmark.cmake
@@ -30,6 +30,13 @@ target_compile_definitions(
     PRIVATE HAVE_STEADY_CLOCK
 )
 
+if(WIN32)
+    target_compile_definitions(
+        mbgl-vendor-benchmark
+        PUBLIC BENCHMARK_STATIC_DEFINE
+    )
+endif()
+
 target_include_directories(
     mbgl-vendor-benchmark SYSTEM
     PUBLIC ${CMAKE_CURRENT_LIST_DIR}/benchmark/include


### PR DESCRIPTION
- Static Windows build.
- Checkout submodules to pull in `compare.py` script from Google Benchmark