### PR TITLE
Ignore Qt installation when finding ICU

### DIFF
--- a/.github/actions/qt5-build/entrypoint.sh
+++ b/.github/actions/qt5-build/entrypoint.sh
@@ -16,6 +16,7 @@ cmake ../source/ \
   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
   -DCMAKE_INSTALL_PREFIX=../install \
   -DMLN_WITH_QT=ON \
+  -DMLN_QT_IGNORE_ICU=OFF \
   -DMLN_QT_DEPLOYMENT=ON
 ninja
 ninja install

--- a/.github/actions/qt6-build/entrypoint.sh
+++ b/.github/actions/qt6-build/entrypoint.sh
@@ -14,6 +14,7 @@ qt-cmake ../source/ \
   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
   -DCMAKE_INSTALL_PREFIX=../install \
   -DMLN_WITH_QT=ON \
+  -DMLN_QT_IGNORE_ICU=OFF \
   -DMLN_QT_DEPLOYMENT=ON
 ninja
 ninja install

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -269,11 +269,24 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
             -DCMAKE_INSTALL_PREFIX="../install" \
             -DMLN_WITH_QT=ON \
+            -DMLN_QT_DEPLOYMENT=ON
+          ninja
+          ninja install
+
+      - name: Build maplibre-native (Linux, Qt6, custom compiler)
+        if: runner.os == 'Linux' && matrix.qt_version != '5.15.2' && matrix.compiler != ''
+        run: |
+          mkdir build-internal && cd build-internal
+          qt-cmake ../source/ \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+            -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
+            -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
+            -DMLN_WITH_QT=ON \
             -DMLN_QT_DEPLOYMENT=ON \
             -DMLN_QT_WITH_INTERNAL_ICU=ON \
             -DMLN_QT_WITH_INTERNAL_SQLITE=ON
           ninja
-          ninja install
 
       - name: Build maplibre-native (Windows)
         if: runner.os == 'Windows'

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -12,6 +12,34 @@ option(MLN_QT_WITH_HEADLESS "Build MapLibre Native Qt with headless support" ON)
 option(MLN_QT_WITH_INTERNAL_SQLITE "Build MapLibre Native Qt bindings with internal sqlite" OFF)
 option(MLN_QT_DEPLOYMENT "Autogenerate files necessary for deployment" OFF)
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    find_package(Threads REQUIRED)
+
+    option(MLN_QT_WITH_INTERNAL_ICU "Build MapLibre GL Qt bindings with internal ICU" OFF)
+    if(NOT MLN_QT_WITH_INTERNAL_ICU)
+        # find ICU ignoring Qt paths
+        option(MLN_QT_IGNORE_ICU "Ignore Qt-provided ICU library" ON)
+        if(MLN_QT_IGNORE_ICU)
+            set(_CMAKE_PREFIX_PATH_ORIG ${CMAKE_PREFIX_PATH})
+            set(_CMAKE_FIND_ROOT_PATH_ORIG ${CMAKE_FIND_ROOT_PATH})
+            unset(CMAKE_PREFIX_PATH)
+            unset(CMAKE_FIND_ROOT_PATH)
+        endif()
+
+        find_package(ICU COMPONENTS uc REQUIRED)
+
+        if(MLN_QT_IGNORE_ICU)
+            set(CMAKE_PREFIX_PATH ${_CMAKE_PREFIX_PATH_ORIG})
+            set(CMAKE_FIND_ROOT_PATH ${_CMAKE_FIND_ROOT_PATH_ORIG})
+            unset(_CMAKE_PREFIX_PATH_ORIG)
+            unset(_CMAKE_FIND_ROOT_PATH_ORIG)
+        endif()
+    else()
+        message(STATUS "Using internal ICU")
+        include(${PROJECT_SOURCE_DIR}/vendor/icu.cmake)
+    endif()
+endif()
+
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR}
              COMPONENTS Gui
@@ -30,18 +58,6 @@ if(NOT MLN_QT_WITH_INTERNAL_SQLITE)
 else()
     message(STATUS "Using internal sqlite")
     include(${PROJECT_SOURCE_DIR}/vendor/sqlite.cmake)
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    find_package(Threads REQUIRED)
-
-    option(MLN_QT_WITH_INTERNAL_ICU "Build MapLibre Native Qt bindings with internal ICU" OFF)
-    if(NOT MLN_QT_WITH_INTERNAL_ICU)
-       find_package(ICU COMPONENTS uc REQUIRED)
-    else()
-       message(STATUS "Using internal ICU")
-       include(${PROJECT_SOURCE_DIR}/vendor/icu.cmake)
-    endif()
 endif()
 
 # Debugging & ccache on Windows


### PR DESCRIPTION
This is a bit hacky but I can't find another solution. We want to ignore Qt-provided ICU as it has no headers provided so it's impossible to use it out-of-the-box.

Also move Linux-specific commands before Qt setup.