### PR TITLE
Fix old Qt version support for usage in linux distributions

### DIFF
--- a/platform/qt/src/mbgl/http_file_source.cpp
+++ b/platform/qt/src/mbgl/http_file_source.cpp
@@ -43,7 +43,7 @@ void HTTPFileSource::Impl::request(HTTPRequest* req) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     connect(data.first, &QNetworkReply::errorOccurred, this, &HTTPFileSource::Impl::onReplyFinished);
 #else
-    connect(data.first, &QNetworkReply::error, this, &HTTPFileSource::Impl::onReplyFinished);
+    connect(data.first, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onReplyFinished()));
 #endif
 }
 


### PR DESCRIPTION
Fix old Qt version support for usage in Linux distributions. Not super important but was easy to do. The issue is duplicated method name so a simple pointer does not work. Reverting to legacy signal-slot syntax.

Closes #1535.