### PR TITLE
Move Meta to Gold sponsorship tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ Platinum:
 
 <a href="https://aws.com"><img src="https://maplibre.org/img/aws-logo.svg" alt="Logo AWS" width="25%"/></a>
 
-Silver:
+Gold:
 
 <a href="https://meta.com"><img src="https://maplibre.org/img/meta-logo.svg" alt="Logo Meta" width="25%"/></a>
+
+Silver:
 
 <a href="https://www.mierune.co.jp/?lang=en"><img src="https://maplibre.org/img/mierune-logo.svg" alt="Logo MIERUNE" width="25%"/></a>
 


### PR DESCRIPTION
Meta is now a Gold Sponsor, reflect this in the readme.