### PR TITLE
Fix tile collection update

### DIFF
--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -195,7 +195,9 @@ void RenderLayer::updateRenderTileIDs() {
         const auto& tileID = tile.get().getOverscaledTileID();
         return std::make_pair(tileID, getRenderTileBucketID(tileID));
     });
+
     renderTileIDs.swap(newRenderTileIDs);
+    newRenderTileIDs.clear();
 }
 
 bool RenderLayer::hasRenderTile(const OverscaledTileID& tileID) const {


### PR DESCRIPTION
I would have been certain that this was being cleared...  

In any case, drawables are sticking around longer than they should, causing various problems.
