### PR TITLE
Make the `StringIndexer` default constructor protected

### DIFF
--- a/include/mbgl/util/string_indexer.hpp
+++ b/include/mbgl/util/string_indexer.hpp
@@ -14,9 +14,10 @@ namespace mbgl {
 using StringIdentity = std::size_t;
 
 class StringIndexer {
-public:
+protected:
     StringIndexer();
 
+public:
     StringIndexer(StringIndexer const&) = delete;
     StringIndexer(StringIndexer&&) = delete;
     void operator=(StringIndexer const&) = delete;
@@ -29,6 +30,8 @@ public:
     size_t size();
 
 protected:
+    friend StringIndexer& stringIndexer();
+
     std::unordered_map<std::string_view, StringIdentity> stringToIdentity;
     std::vector<StringIdentity> identityToString;
     std::vector<char> buffer;

--- a/src/mbgl/util/string_indexer.cpp
+++ b/src/mbgl/util/string_indexer.cpp
@@ -76,6 +76,8 @@ size_t StringIndexer::size() {
 }
 
 StringIndexer& stringIndexer() {
+    // This is a static local rather than a global or member of `StringIndexer` so
+    // that static initializers can use it without worrying about ordering.
     static StringIndexer inst;
     return inst;
 }

--- a/test/util/string_indexer.test.cpp
+++ b/test/util/string_indexer.test.cpp
@@ -4,7 +4,13 @@
 
 #include <cstdint>
 
-using namespace mbgl;
+using mbgl::stringIndexer;
+
+// Allow public default construction
+class StringIndexer : public mbgl::StringIndexer {
+public:
+    StringIndexer() {}
+};
 
 TEST(StringIndexer, SingletonStringIndexer) {
     EXPECT_GE(stringIndexer().size(), 0);


### PR DESCRIPTION
Make the default constructor protected so that accidentally using `StringIndexer().get()` instead of `stringIndexer().get()` produces a compile error rather than a runtime error.