### PR TITLE
Separate properties-as-uniforms per drawable

### DIFF
--- a/include/mbgl/renderer/layer_tweaker.hpp
+++ b/include/mbgl/renderer/layer_tweaker.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/shaders/layer_ubo.hpp>
 #include <mbgl/shaders/shader_source.hpp>
 #include <mbgl/util/immutable.hpp>
 
@@ -53,8 +54,10 @@ public:
     static shaders::ExpressionInputsUBO buildExpressionUBO(double zoom, uint64_t frameCount);
 
     /// @brief Check whether a property name exists within the previously set collection.
-    bool hasPropertyAsUniform(StringIdentity) const;
-    shaders::AttributeSource getAttributeSource(StringIdentity) const;
+    shaders::AttributeSource getAttributeSource(const StringIdentity id) {
+        return propertiesAsUniforms.count(id) ? shaders::AttributeSource::Constant
+                                              : shaders::AttributeSource::PerVertex;
+    }
 
     template <shaders::BuiltIn ShaderType>
     shaders::AttributeSource getAttributeSource(size_t index) {

--- a/include/mbgl/util/tiny_unordered_map.hpp
+++ b/include/mbgl/util/tiny_unordered_map.hpp
@@ -159,6 +159,20 @@ public:
         this->Super::clear();
     }
 
+    bool operator==(const TinyUnorderedMap& other) const {
+        if (size() != other.size()) return false;
+        assert(linearSize == other.linearSize);
+        if (linearSize) {
+            return std::equal(
+                       keys.begin(), keys.begin() + linearSize, other.keys.begin(), other.keys.begin() + linearSize) &&
+                   std::equal(values.begin(),
+                              values.begin() + linearSize,
+                              other.values.begin(),
+                              other.values.begin() + linearSize);
+        }
+        return std::operator==(*this, other);
+    }
+
 private:
     std::size_t linearSize = 0;
     std::array<std::optional<Key>, LinearThreshold> keys;

--- a/include/mbgl/util/tiny_unordered_map.hpp
+++ b/include/mbgl/util/tiny_unordered_map.hpp
@@ -78,11 +78,11 @@ public:
 
     /// Move constructor
     TinyUnorderedMap(TinyUnorderedMap&& rhs)
-        : Super(std::move(rhs)),
-          linearSize(rhs.linearSize),
+        : linearSize(rhs.linearSize),
           keys(std::move(rhs.keys)),
           values(std::move(rhs.values)) {
         rhs.linearSize = 0;
+        Super::operator=(std::move(rhs));
     }
 
     /// Copy constructor

--- a/src/mbgl/gfx/symbol_drawable_data.hpp
+++ b/src/mbgl/gfx/symbol_drawable_data.hpp
@@ -34,8 +34,6 @@ struct SymbolDrawableData : public DrawableData {
           propertiesAsUniforms(std::move(propertiesAsUniforms_)) {}
     ~SymbolDrawableData() override = default;
 
-    void setPropertiesAsUniforms(PropertyMapType&& value) { propertiesAsUniforms = std::move(value); }
-
     const bool isHalo;
     bool bucketVariablePlacement;
     const style::SymbolType symbolType;
@@ -43,7 +41,7 @@ struct SymbolDrawableData : public DrawableData {
     const style::AlignmentType rotationAlignment;
     const style::SymbolPlacementType placement;
     const style::IconTextFitType textFit;
-    PropertyMapType propertiesAsUniforms;
+    const PropertyMapType propertiesAsUniforms;
 };
 
 using UniqueSymbolDrawableData = std::unique_ptr<SymbolDrawableData>;

--- a/src/mbgl/gfx/symbol_drawable_data.hpp
+++ b/src/mbgl/gfx/symbol_drawable_data.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/gfx/drawable_data.hpp>
 #include <mbgl/style/types.hpp>
+#include <mbgl/util/tiny_unordered_map.hpp>
 
 #include <memory>
 
@@ -12,21 +13,28 @@ enum class SymbolType : uint8_t;
 namespace gfx {
 
 struct SymbolDrawableData : public DrawableData {
+    constexpr static std::size_t LinearThreshold = 10;
+    using PropertyMapType = util::TinyUnorderedMap<StringIdentity, bool, LinearThreshold>;
+
     SymbolDrawableData(const bool isHalo_,
                        const bool bucketVariablePlacement_,
                        const style::SymbolType symbolType_,
                        const style::AlignmentType pitchAlignment_,
                        const style::AlignmentType rotationAlignment_,
                        const style::SymbolPlacementType placement_,
-                       const style::IconTextFitType textFit_)
+                       const style::IconTextFitType textFit_,
+                       PropertyMapType&& propertiesAsUniforms_)
         : isHalo(isHalo_),
           bucketVariablePlacement(bucketVariablePlacement_),
           symbolType(symbolType_),
           pitchAlignment(pitchAlignment_),
           rotationAlignment(rotationAlignment_),
           placement(placement_),
-          textFit(textFit_) {}
+          textFit(textFit_),
+          propertiesAsUniforms(std::move(propertiesAsUniforms_)) {}
     ~SymbolDrawableData() override = default;
+
+    void setPropertiesAsUniforms(PropertyMapType&& value) { propertiesAsUniforms = std::move(value); }
 
     const bool isHalo;
     bool bucketVariablePlacement;
@@ -35,6 +43,7 @@ struct SymbolDrawableData : public DrawableData {
     const style::AlignmentType rotationAlignment;
     const style::SymbolPlacementType placement;
     const style::IconTextFitType textFit;
+    PropertyMapType propertiesAsUniforms;
 };
 
 using UniqueSymbolDrawableData = std::unique_ptr<SymbolDrawableData>;

--- a/src/mbgl/renderer/layer_tweaker.cpp
+++ b/src/mbgl/renderer/layer_tweaker.cpp
@@ -64,15 +64,6 @@ shaders::ExpressionInputsUBO LayerTweaker::buildExpressionUBO(double zoom, uint6
             /* .pad = */ 0,
             0};
 }
-
-bool LayerTweaker::hasPropertyAsUniform(const StringIdentity attrNameID) const {
-    return propertiesAsUniforms.find(attrNameID) != propertiesAsUniforms.end();
-}
-
-using namespace shaders;
-AttributeSource LayerTweaker::getAttributeSource(const StringIdentity attribNameID) const {
-    return hasPropertyAsUniform(attribNameID) ? AttributeSource::Constant : AttributeSource::PerVertex;
-}
 #endif // MLN_RENDER_BACKEND_METAL
 
 void LayerTweaker::setPropertiesAsUniforms([[maybe_unused]] const std::unordered_set<StringIdentity>& props) {

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -818,8 +818,7 @@ void updateTileAttributes(const SymbolBucket::Buffer& buffer,
     }
 }
 
-void updateTileDrawable(RenderSymbolLayer* ths,
-                        gfx::Drawable& drawable,
+void updateTileDrawable(gfx::Drawable& drawable,
                         gfx::Context& context,
                         const SymbolBucket& bucket,
                         const SymbolBucket::PaintProperties& paintProps,
@@ -1201,8 +1200,6 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
 
             // Just update the drawables we already created
             tileLayerGroup->visitDrawables(passes, tileID, [&](gfx::Drawable& drawable) {
-                auto& drawData = static_cast<gfx::SymbolDrawableData&>(*drawable.getData());
-
                 if (drawable.getLayerTweaker() != layerTweaker) {
                     // This drawable was produced on a previous style/bucket, and should not be updated.
                     return;
@@ -1211,8 +1208,7 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
                 propertiesAsUniforms.clear();
 
                 const auto& evaluated = getEvaluated<SymbolLayerProperties>(renderData.layerProperties);
-                updateTileDrawable(this,
-                                   drawable,
+                updateTileDrawable(drawable,
                                    context,
                                    bucket,
                                    bucketPaintProperties,
@@ -1224,6 +1220,7 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
 
                 // We assume that the properties-as-uniforms doesn't change without the style changing.
                 // That would require updating the shader as well.
+                [[maybe_unused]] const auto& drawData = static_cast<gfx::SymbolDrawableData&>(*drawable.getData());
                 assert(drawData.propertiesAsUniforms == toMap(propertiesAsUniforms));
             });
 

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -1221,7 +1221,10 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
                                    textInterpUBO,
                                    iconInterpUBO,
                                    propertiesAsUniforms);
-                drawData.setPropertiesAsUniforms(toMap(propertiesAsUniforms));
+
+                // We assume that the properties-as-uniforms doesn't change without the style changing.
+                // That would require updating the shader as well.
+                assert(drawData.propertiesAsUniforms == toMap(propertiesAsUniforms));
             });
 
             // re-create collision drawables

--- a/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
@@ -89,26 +89,6 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
     const auto zoom = parameters.state.getZoom();
 
 #if MLN_RENDER_BACKEND_METAL
-    if (permutationUpdated) {
-        const SymbolPermutationUBO permutationUBO = {
-            /* .fill_color = */ {/*.source=*/getAttributeSource<BuiltIn::SymbolSDFIconShader>(5), /*.expression=*/{}},
-            /* .halo_color = */ {/*.source=*/getAttributeSource<BuiltIn::SymbolSDFIconShader>(6), /*.expression=*/{}},
-            /* .opacity = */ {/*.source=*/getAttributeSource<BuiltIn::SymbolSDFIconShader>(7), /*.expression=*/{}},
-            /* .halo_width = */ {/*.source=*/getAttributeSource<BuiltIn::SymbolSDFIconShader>(8), /*.expression=*/{}},
-            /* .halo_blur = */ {/*.source=*/getAttributeSource<BuiltIn::SymbolSDFIconShader>(9), /*.expression=*/{}},
-            /* .overdrawInspector = */ overdrawInspector,
-            /* .pad = */ 0,
-            0,
-            0};
-
-        if (permutationUniformBuffer) {
-            permutationUniformBuffer->update(&permutationUBO, sizeof(permutationUBO));
-        } else {
-            permutationUniformBuffer = context.createUniformBuffer(&permutationUBO, sizeof(permutationUBO));
-        }
-
-        permutationUpdated = false;
-    }
     if (!expressionUniformBuffer) {
         const auto expressionUBO = buildExpressionUBO(zoom, parameters.frameCount);
         expressionUniformBuffer = context.createUniformBuffer(&expressionUBO, sizeof(expressionUBO));
@@ -201,8 +181,28 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
         uniforms.addOrReplace(idSymbolDrawablePaintUBOName, isText ? textPaintBuffer : iconPaintBuffer);
 
 #if MLN_RENDER_BACKEND_METAL
+        assert(propertiesAsUniforms.empty());
+
+        using namespace shaders;
+        using ShaderClass = ShaderSource<BuiltIn::SymbolSDFIconShader, gfx::Backend::Type::Metal>;
+        const auto source = [&](int index) {
+            const auto nameID = ShaderClass::attributes[index].nameID;
+            const bool uniform = symbolData.propertiesAsUniforms.count(nameID);
+            return uniform ? AttributeSource::Constant : AttributeSource::PerVertex;
+        };
+
+        const SymbolPermutationUBO permutationUBO = {/* .fill_color = */ {/*.source=*/source(5), /*.expression=*/{}},
+                                                     /* .halo_color = */ {/*.source=*/source(6), /*.expression=*/{}},
+                                                     /* .opacity = */ {/*.source=*/source(7), /*.expression=*/{}},
+                                                     /* .halo_width = */ {/*.source=*/source(8), /*.expression=*/{}},
+                                                     /* .halo_blur = */ {/*.source=*/source(9), /*.expression=*/{}},
+                                                     /* .overdrawInspector = */ overdrawInspector,
+                                                     /* .pad = */ 0,
+                                                     0,
+                                                     0};
+        uniforms.createOrUpdate(idSymbolPermutationUBOName, &permutationUBO, context);
+
         uniforms.addOrReplace(idExpressionInputsUBOName, expressionUniformBuffer);
-        uniforms.addOrReplace(idSymbolPermutationUBOName, permutationUniformBuffer);
 #endif // MLN_RENDER_BACKEND_METAL
     });
 }


### PR DESCRIPTION
Individual drawables can end up with different combinations of uniform/attribute properties.  This shows up when a layer produces text and icons, one with a constant property (e.g., color, opacity) and the other with a data-driven version of that same property.  For example, the `label-poi` layer in the Facebook Dark style

<img src="https://github.com/maplibre/maplibre-native/assets/71895881/8fbf7a8b-f627-4af8-ad8b-6595eab161c8" width="300"/>

Most symbol drawables use one of a few combinations of properties-as-uniforms, so there's some opportunity for improvement by combining them, but I don't see a way to do it without significant complexity. 


