### PR TITLE
Fixed metal heatmap render tests

### DIFF
--- a/src/mbgl/mtl/offscreen_texture.cpp
+++ b/src/mbgl/mtl/offscreen_texture.cpp
@@ -21,7 +21,7 @@ public:
         colorTexture->setSize(size);
         colorTexture->setFormat(gfx::TexturePixelType::RGBA, type);
         colorTexture->setSamplerConfiguration(
-            {gfx::TextureFilterType::Nearest, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+            {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
         static_cast<Texture2D*>(colorTexture.get())
             ->setUsage(MTL::TextureUsageShaderRead | MTL::TextureUsageShaderWrite | MTL::TextureUsageRenderTarget);
 
@@ -30,7 +30,7 @@ public:
             depthTexture->setSize(size);
             depthTexture->setFormat(gfx::TexturePixelType::Depth, gfx::TextureChannelDataType::Float);
             depthTexture->setSamplerConfiguration(
-                {gfx::TextureFilterType::Nearest, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+                {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
             static_cast<Texture2D*>(depthTexture.get())
                 ->setUsage(MTL::TextureUsageShaderRead | MTL::TextureUsageShaderWrite | MTL::TextureUsageRenderTarget);
         }
@@ -40,7 +40,7 @@ public:
             stencilTexture->setSize(size);
             stencilTexture->setFormat(gfx::TexturePixelType::Stencil, gfx::TextureChannelDataType::UnsignedByte);
             stencilTexture->setSamplerConfiguration(
-                {gfx::TextureFilterType::Nearest, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+                {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
             static_cast<Texture2D*>(stencilTexture.get())
                 ->setUsage(MTL::TextureUsageShaderRead | MTL::TextureUsageShaderWrite | MTL::TextureUsageRenderTarget);
         }


### PR DESCRIPTION
Before:
![281846425-32871285-6b32-49fd-b6dc-d31decdeac2b](https://github.com/maplibre/maplibre-native/assets/19795769/5d1af424-79d9-44b2-8848-f6d589030547)

After:
<img width="686" alt="Screenshot 2023-11-14 at 19 01 39" src="https://github.com/maplibre/maplibre-native/assets/19795769/66bf0af6-8847-45b5-8b04-3b57c0840728">
