### PR TITLE
Bug/stencil tiles

### DIFF
--- a/include/mbgl/renderer/layer_group.hpp
+++ b/include/mbgl/renderer/layer_group.hpp
@@ -13,10 +13,12 @@ namespace mbgl {
 class LayerGroupBase;
 class PaintParameters;
 class RenderOrchestrator;
+class RenderTile;
 class RenderTree;
 class TileLayerGroup;
 
 using LayerGroupBasePtr = std::shared_ptr<LayerGroupBase>;
+using RenderTiles = std::shared_ptr<const std::vector<std::reference_wrapper<const RenderTile>>>;
 
 namespace gfx {
 class Context;
@@ -127,9 +129,15 @@ public:
 
     std::size_t clearDrawables() override;
 
+    void setStencilTiles(RenderTiles);
+
 protected:
     struct Impl;
     std::unique_ptr<Impl> impl;
+
+    // When stencil clipping is enabled for the layer, this is the set
+    // of tile IDs that need to be rendered to the stencil buffer.
+    RenderTiles stencilTiles;
 };
 
 /**

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -347,6 +347,8 @@ void RenderFillExtrusionLayer::update(gfx::ShaderRegistry& shaders,
         return;
     }
 
+    tileLayerGroup->setStencilTiles(renderTiles);
+
     std::unordered_set<StringIdentity> propertiesAsUniforms;
     for (const RenderTile& tile : *renderTiles) {
         const auto& tileID = tile.getOverscaledTileID();
@@ -448,7 +450,6 @@ void RenderFillExtrusionLayer::update(gfx::ShaderRegistry& shaders,
             if (auto builder = context.createDrawableBuilder(layerPrefix + "depth")) {
                 builder->setShader(shader);
                 builder->setIs3D(true);
-                builder->setEnableStencil(false);
                 builder->setEnableColor(false);
                 builder->setRenderPass(drawPass);
                 builder->setCullFaceMode(gfx::CullFaceMode::backCCW());

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -364,6 +364,8 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
         return tileID && !hasRenderTile(*tileID);
     });
 
+    tileLayerGroup->setStencilTiles(renderTiles);
+
     std::unordered_set<StringIdentity> propertiesAsUniforms;
     for (const RenderTile& tile : *renderTiles) {
         const auto& tileID = tile.getOverscaledTileID();

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -561,11 +561,13 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
 
             if (!fillBuilder && fillShader) {
                 if (auto builder = context.createDrawableBuilder(layerPrefix + "fill")) {
+                    // Only write opaque fills to the depth buffer, matching `fillRenderPass` in legacy rendering
+                    const bool opaque = (evaluated.get<FillColor>().constantOr(Color()).a >= 1.0f &&
+                                         evaluated.get<FillOpacity>().constantOr(0) >= 1.0f);
+
                     commonInit(*builder);
-                    builder->setDepthType((renderPass == RenderPass::Opaque) ? gfx::DepthMaskType::ReadWrite
-                                                                             : gfx::DepthMaskType::ReadOnly);
-                    builder->setColorMode(renderPass == RenderPass::Translucent ? gfx::ColorMode::alphaBlended()
-                                                                                : gfx::ColorMode::unblended());
+                    builder->setDepthType(opaque ? gfx::DepthMaskType::ReadWrite : gfx::DepthMaskType::ReadOnly);
+                    builder->setColorMode(opaque ? gfx::ColorMode::unblended() : gfx::ColorMode::alphaBlended());
                     builder->setSubLayerIndex(1);
                     builder->setRenderPass(renderPass);
                     fillBuilder = std::move(builder);

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -435,7 +435,6 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
         heatmapBuilder->setEnableDepth(false);
         heatmapBuilder->setColorMode(gfx::ColorMode::additive());
         heatmapBuilder->setCullFaceMode(gfx::CullFaceMode::disabled());
-        heatmapBuilder->setEnableStencil(false);
         heatmapBuilder->setRenderPass(renderPass);
         heatmapBuilder->setVertexAttributes(std::move(heatmapVertexAttrs));
         heatmapBuilder->setRawVertices({}, vertexCount, gfx::AttributeDataType::Short2);
@@ -509,7 +508,6 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
     heatmapTextureBuilder->setEnableDepth(false);
     heatmapTextureBuilder->setColorMode(gfx::ColorMode::alphaBlended());
     heatmapTextureBuilder->setCullFaceMode(gfx::CullFaceMode::disabled());
-    heatmapTextureBuilder->setEnableStencil(false);
     heatmapTextureBuilder->setRenderPass(renderPass);
     heatmapTextureBuilder->setVertexAttributes(std::move(textureVertexAttrs));
     heatmapTextureBuilder->setRawVertices({}, textureVertexCount, gfx::AttributeDataType::Short2);

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -461,6 +461,8 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
         builder->setSegments(gfx::Triangles(), bucket.sharedTriangles, bucket.segments.data(), bucket.segments.size());
     };
 
+    tileLayerGroup->setStencilTiles(renderTiles);
+
     std::unordered_set<StringIdentity> propertiesAsUniforms;
     for (const RenderTile& tile : *renderTiles) {
         const auto& tileID = tile.getOverscaledTileID();

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -1055,7 +1055,6 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
 
     std::unique_ptr<gfx::DrawableBuilder> collisionBuilder = context.createDrawableBuilder(layerCollisionPrefix);
     collisionBuilder->setSubLayerIndex(0);
-    collisionBuilder->setEnableStencil(false);
     collisionBuilder->setEnableDepth(false);
     collisionBuilder->setRenderPass(passes);
     collisionBuilder->setCullFaceMode(gfx::CullFaceMode::disabled());
@@ -1316,7 +1315,6 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
                 if (!builder) {
                     builder = context.createDrawableBuilder(layerPrefix);
                     builder->setSubLayerIndex(0);
-                    builder->setEnableStencil(false);
                     builder->setRenderPass(passes);
                     builder->setCullFaceMode(gfx::CullFaceMode::disabled());
                     builder->setDepthType(gfx::DepthMaskType::ReadOnly);

--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -265,12 +265,6 @@ void PaintParameters::renderTileClippingMasks(const RenderTiles& renderTiles) {
 #endif // MLN_RENDER_BACKEND_METAL
 }
 
-void PaintParameters::clearTileClippingMasks() {
-    if (!tileClippingMaskIDs.empty()) {
-        clearStencil();
-    }
-}
-
 gfx::StencilMode PaintParameters::stencilModeForClipping(const UnwrappedTileID& tileID) const {
     auto it = tileClippingMaskIDs.find(tileID);
     assert(it != tileClippingMaskIDs.end());

--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -162,16 +162,8 @@ void PaintParameters::clearStencil() {
 }
 
 void PaintParameters::renderTileClippingMasks(const RenderTiles& renderTiles) {
-    if (!renderTiles) {
-        return;
-    }
-    if (!renderPass) {
-        assert(false);
-        return;
-    }
-
-    if (tileIDsCovered(renderTiles, tileClippingMaskIDs)) {
-        // The current stencil mask is for this source already; no need to draw another one.
+    // If the current stencil mask covers this source already, there's no need to draw another one.
+    if (!renderTiles || !renderPass || tileIDsCovered(renderTiles, tileClippingMaskIDs)) {
         return;
     }
 

--- a/src/mbgl/renderer/paint_parameters.hpp
+++ b/src/mbgl/renderer/paint_parameters.hpp
@@ -95,11 +95,7 @@ public:
 
     // Stencil handling
 public:
-#if MLN_LEGACY_RENDERER
     void renderTileClippingMasks(const RenderTiles&);
-#else
-    void renderTileClippingMasks(const std::set<UnwrappedTileID>&);
-#endif // MLN_LEGACY_RENDERER
 
     /// Clear any tile masks and the stencil buffer, if necessary
     void clearTileClippingMasks();

--- a/src/mbgl/renderer/paint_parameters.hpp
+++ b/src/mbgl/renderer/paint_parameters.hpp
@@ -97,9 +97,6 @@ public:
 public:
     void renderTileClippingMasks(const RenderTiles&);
 
-    /// Clear any tile masks and the stencil buffer, if necessary
-    void clearTileClippingMasks();
-
     /// Clear the stencil buffer, even if there are no tile masks (for 3D)
     void clearStencil();
 

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -68,7 +68,6 @@ void TileSourceRenderItem::updateDebugDrawables(DebugLayerGroupMap& debugLayerGr
     builder->setEnableDepth(false);
     builder->setColorMode(gfx::ColorMode::unblended());
     builder->setCullFaceMode(gfx::CullFaceMode::disabled());
-    builder->setEnableStencil(false);
     builder->setVertexAttrNameId(idVertexAttribName);
 
     // add or get the layer group for a debug type

--- a/src/mbgl/renderer/tile_layer_group.cpp
+++ b/src/mbgl/renderer/tile_layer_group.cpp
@@ -142,4 +142,8 @@ std::size_t TileLayerGroup::clearDrawables() {
     return count;
 }
 
+void TileLayerGroup::setStencilTiles(RenderTiles tiles) {
+    stencilTiles = std::move(tiles);
+}
+
 } // namespace mbgl

--- a/src/mbgl/style/layers/custom_drawable_layer.cpp
+++ b/src/mbgl/style/layers/custom_drawable_layer.cpp
@@ -395,7 +395,6 @@ std::unique_ptr<gfx::DrawableBuilder> CustomDrawableLayerHost::Interface::create
     builder_->setEnableDepth(false);
     builder_->setColorMode(gfx::ColorMode::alphaBlended());
     builder_->setCullFaceMode(gfx::CullFaceMode::disabled());
-    builder_->setEnableStencil(false);
     builder_->setRenderPass(RenderPass::Translucent);
 
     return builder_;


### PR DESCRIPTION
Fixes incorrect ordering of tiles rendered to the stencil buffer, causing low-zoom tiles to be rendered over high-zoom tiles in some cases, particularly between the completion of loading prefetch tiles (see `setPrefetchZoomDelta`) and their removal.

This seems to be the root cause of #1845. ... and #1846

Also fixes incorrect use of `renderTiles` in the background layer and depth write options on fill drawables.

[https://osmus.slack.com/archives/C04SSR0S78B/p1700070024256889?thread_ts=1699920382.735459&cid=C04SSR0S78B](https://osmus.slack.com/archives/C04SSR0S78B/p1700070024256889?thread_ts=1699920382.735459&cid=C04SSR0S78B)