### PR TITLE
Handle the case where styles update without a bucket change, fixing `…

### DIFF
--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -365,13 +365,14 @@ void RenderCircleLayer::update(gfx::ShaderRegistry& shaders,
         auto updateExisting = [&](gfx::Drawable& drawable) {
             if (drawable.getLayerTweaker() != layerTweaker) {
                 // This drawable was produced on a previous style/bucket, and should not be updated.
-                return;
+                return false;
             }
 
             auto& uniforms = drawable.mutableUniformBuffers();
             uniforms.createOrUpdate(idCircleInterpolateUBOName, &interpolateUBO, context);
+            return true;
         };
-        if (0 < tileLayerGroup->visitDrawables(renderPass, tileID, std::move(updateExisting))) {
+        if (updateTile(renderPass, tileID, std::move(updateExisting))) {
             continue;
         }
 

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -404,24 +404,18 @@ void RenderFillExtrusionLayer::update(gfx::ShaderRegistry& shaders,
         };
 
         // If we already have drawables for this tile, update them.
-        if (tileLayerGroup->getDrawableCount(drawPass, tileID) > 0) {
-            // Just update the drawables we already created
-            tileLayerGroup->visitDrawables(drawPass, tileID, [&](gfx::Drawable& drawable) {
-                if (drawable.getLayerTweaker() != layerTweaker) {
-                    // This drawable was produced on a previous style/bucket, and should not be updated.
-                    return;
-                }
+        auto updateExisting = [&](gfx::Drawable& drawable) {
+            if (drawable.getLayerTweaker() != layerTweaker) {
+                // This drawable was produced on a previous style/bucket, and should not be updated.
+                return false;
+            }
 
-                auto& uniforms = drawable.mutableUniformBuffers();
-                uniforms.createOrUpdate(
-                    FillExtrusionLayerTweaker::idFillExtrusionTilePropsUBOName, &tilePropsUBO, context);
-                uniforms.createOrUpdate(
-                    FillExtrusionLayerTweaker::idFillExtrusionInterpolateUBOName, &interpUBO, context);
-            });
-            continue;
-        }
-
-        if (!shaderGroup) {
+            auto& uniforms = drawable.mutableUniformBuffers();
+            uniforms.createOrUpdate(FillExtrusionLayerTweaker::idFillExtrusionTilePropsUBOName, &tilePropsUBO, context);
+            uniforms.createOrUpdate(FillExtrusionLayerTweaker::idFillExtrusionInterpolateUBOName, &interpUBO, context);
+            return true;
+        };
+        if (updateTile(drawPass, tileID, std::move(updateExisting))) {
             continue;
         }
 

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -518,7 +518,7 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
         auto updateExisting = [&](gfx::Drawable& drawable) {
             if (drawable.getLayerTweaker() != layerTweaker) {
                 // This drawable was produced on a previous style/bucket, and should not be updated.
-                return;
+                return false;
             }
 
             auto& uniforms = drawable.mutableUniformBuffers();
@@ -539,8 +539,9 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
             }
 
             drawable.setVertexAttributes(vertexAttrs);
+            return true;
         };
-        if (0 < tileLayerGroup->visitDrawables(renderPass, tileID, std::move(updateExisting))) {
+        if (updateTile(renderPass, tileID, std::move(updateExisting))) {
             continue;
         }
 

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -491,7 +491,7 @@ void RenderHillshadeLayer::update(gfx::ShaderRegistry& shaders,
             // Only current drawables are updated, ones produced for
             // a previous style retain the attribute values for that style.
             if (drawable.getLayerTweaker() != layerTweaker) {
-                return;
+                return false;
             }
 
             drawable.setVertexAttributes(std::move(hillshadeVertexAttrs));
@@ -516,8 +516,9 @@ void RenderHillshadeLayer::update(gfx::ShaderRegistry& shaders,
             if (hillshadeImageLocation) {
                 drawable.setTexture(bucket.renderTarget->getTexture(), *hillshadeImageLocation);
             }
+            return true;
         };
-        if (0 < tileLayerGroup->visitDrawables(renderPass, tileID, std::move(updateExisting))) {
+        if (updateTile(renderPass, tileID, std::move(updateExisting))) {
             continue;
         }
 

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -537,11 +537,10 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
             /*pattern_from =*/patternPosA ? util::cast<float>(patternPosA->tlbr()) : std::array<float, 4>{0},
             /*pattern_to =*/patternPosB ? util::cast<float>(patternPosB->tlbr()) : std::array<float, 4>{0}};
 
-        // update existing drawables
-        tileLayerGroup->visitDrawables(renderPass, tileID, [&](gfx::Drawable& drawable) {
+        auto updateExisting = [&](gfx::Drawable& drawable) {
             if (drawable.getLayerTweaker() != layerTweaker) {
                 // This drawable was produced on a previous style/bucket, and should not be updated.
-                return;
+                return false;
             }
 
             const auto& shader = drawable.getShader();
@@ -572,9 +571,9 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
             }
 
             // TODO: vertex attributes or `propertiesAsUniforms` updated, is that needed?
-        });
-
-        if (tileLayerGroup->getDrawableCount(renderPass, tileID) > 0) {
+            return true;
+        };
+        if (updateTile(renderPass, tileID, std::move(updateExisting))) {
             continue;
         }
 

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -209,6 +209,16 @@ protected:
     /// Change the layer index on a layer group associated with this layer
     void changeLayerIndex(const LayerGroupBasePtr&, int32_t newLayerIndex, UniqueChangeRequestVec&);
 
+    /// Update the drawables for a tile.
+    /// @param renderPass The pass to consider
+    /// @param tileID The tile to consider
+    /// @param updateFunction A function that updates a single drawable.  Should return true if the drawable
+    ///                       was updated or false if it was skipped because it's for a previous style.
+    /// @return true if drawables were updated
+    bool updateTile(RenderPass renderPass,
+                    const OverscaledTileID& tileID,
+                    std::function<bool(gfx::Drawable&)> updateFunction);
+
     /// Remove all drawables for the tile from the layer group
     /// @return The number of drawables actually removed.
     virtual std::size_t removeTile(RenderPass, const OverscaledTileID&);


### PR DESCRIPTION
…render-tests/regressions/mapbox-gl-js#3426`

<img width="300" alt="image" src="https://github.com/maplibre/maplibre-native/assets/71895881/c736e084-0880-4a5a-981f-652ccd6c35ca">

<img width="300" alt="image" src="https://github.com/maplibre/maplibre-native/assets/71895881/ae32784d-6599-45dd-b40e-4f68cf10454c">

Unfortunately, makes use of even more `std::function`, and more map lookups.