### PR TITLE
Use 64-bit hashes regardless of platform

### DIFF
--- a/include/mbgl/gfx/shader_group.hpp
+++ b/include/mbgl/gfx/shader_group.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/gfx/shader.hpp>
 #include <mbgl/util/containers.hpp>
+#include <mbgl/util/hash.hpp>
 
 #include <iomanip>
 #include <memory>
@@ -154,8 +155,17 @@ public:
     }
 
 protected:
-    std::string getShaderName(const std::string_view& name, const std::size_t key) {
+    using PropertyHashType = std::uint64_t;
+
+    std::string getShaderName(const std::string_view& name, const PropertyHashType key) {
         return (std::ostringstream() << name << '#' << std::hex << key).str();
+    }
+
+    /// Generate a map key for the specified combination of properties
+    PropertyHashType propertyHash(const mbgl::unordered_set<StringIdentity>& propertiesAsUniforms) {
+        const auto beg = propertiesAsUniforms.cbegin();
+        const auto end = propertiesAsUniforms.cend();
+        return util::order_independent_hash<decltype(beg), PropertyHashType>(beg, end);
     }
 
 private:

--- a/include/mbgl/shaders/gl/shader_group_gl.hpp
+++ b/include/mbgl/shaders/gl/shader_group_gl.hpp
@@ -4,7 +4,6 @@
 #include <mbgl/shaders/gl/shader_program_gl.hpp>
 #include <mbgl/shaders/shader_source.hpp>
 #include <mbgl/programs/program_parameters.hpp>
-#include <mbgl/util/hash.hpp>
 #include <mbgl/util/containers.hpp>
 
 namespace mbgl {
@@ -25,12 +24,9 @@ public:
         constexpr auto& vert = shaders::ShaderSource<ShaderID, gfx::Backend::Type::OpenGL>::vertex;
         constexpr auto& frag = shaders::ShaderSource<ShaderID, gfx::Backend::Type::OpenGL>::fragment;
 
-        // Generate a map key for the specified combination of properties
-        const size_t key = util::order_independent_hash(propertiesAsUniforms.begin(), propertiesAsUniforms.end());
-
         // We could cache these by key here to avoid creating a string key each time, but we
         // would need another mutex.  We could also push string IDs down into `ShaderGroup`.
-        const std::string shaderName = getShaderName(name, key);
+        const std::string shaderName = getShaderName(name, propertyHash(propertiesAsUniforms));
         auto shader = get<gl::ShaderProgramGL>(shaderName);
         if (shader) {
             return shader;

--- a/include/mbgl/shaders/mtl/shader_group.hpp
+++ b/include/mbgl/shaders/mtl/shader_group.hpp
@@ -52,9 +52,7 @@ public:
         constexpr auto& fragMain = ShaderSource::fragmentMainFunction;
         constexpr auto permutations = shaders::ShaderSource<ShaderID, gfx::Backend::Type::Metal>::hasPermutations;
 
-        const size_t key = permutations
-                               ? util::order_independent_hash(propertiesAsUniforms.begin(), propertiesAsUniforms.end())
-                               : 0;
+        const PropertyHashType key = permutations ? propertyHash(propertiesAsUniforms) : 0;
         const std::string shaderName = permutations ? getShaderName(name, key) : name;
 
         auto shader = get<mtl::ShaderProgram>(shaderName);

--- a/src/mbgl/util/hash.hpp
+++ b/src/mbgl/util/hash.hpp
@@ -36,7 +36,7 @@ constexpr T factor() {
 /// Generate a hash key from a collection of integer values which doesn't depend on their order.
 /// Adapted from https://stackoverflow.com/a/76993810/135138
 template <typename TIter, typename TKey = detail::TIterVal<TIter>, TKey factor = factor<TKey>()>
-TKey order_independent_hash(TIter cur, const TIter end) {
+TKey order_independent_hash(std::remove_const_t<TIter> cur, const TIter end) {
     detail::TIterVal<TIter> sum = 0, product = 1;
     for (; cur != end; ++cur) {
         const auto& value = *cur;


### PR DESCRIPTION
Per #1914, use `uint64_t` for hash keys instead of `size_t` for more consistent hash results across platforms.

The unit tests check the shader definitions for collisions alongside testing the hash algorithm with random values, but (so far) only in Metal builds where that doesn't require reflection.

Resolves #1917
