### PR TITLE
Asynchronous GeometryTile deletion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,6 +412,7 @@ list(APPEND INCLUDE_FILES
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/projection.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/range.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/run_loop.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/util/scoped.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/size.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/string.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/util/string_indexer.hpp

--- a/bazel/core.bzl
+++ b/bazel/core.bzl
@@ -828,6 +828,7 @@ MLN_CORE_HEADERS = [
     "include/mbgl/util/projection.hpp",
     "include/mbgl/util/range.hpp",
     "include/mbgl/util/run_loop.hpp",
+    "include/mbgl/util/scoped.hpp",
     "include/mbgl/util/size.hpp",
     "include/mbgl/util/string.hpp",
     "include/mbgl/util/string_indexer.hpp",

--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -40,7 +40,7 @@ public:
     /// Makes a weak pointer to this Scheduler.
     virtual mapbox::base::WeakPtr<Scheduler> makeWeakPtr() = 0;
     /// Enqueues a function for execution on the render thread.
-    virtual void runOnRenderThread(std::function<void()>&&) {};
+    virtual void runOnRenderThread(std::function<void()>&&){};
     virtual void runRenderJobs() {}
 
     /// Returns a closure wrapping the given one.

--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -39,6 +39,9 @@ public:
     virtual void schedule(std::function<void()>) = 0;
     /// Makes a weak pointer to this Scheduler.
     virtual mapbox::base::WeakPtr<Scheduler> makeWeakPtr() = 0;
+    /// Enqueues a function for execution on the render thread.
+    virtual void runOnRenderThread(std::function<void()>&&) {};
+    virtual void runRenderJobs() {}
 
     /// Returns a closure wrapping the given one.
     ///

--- a/include/mbgl/mtl/context.hpp
+++ b/include/mbgl/mtl/context.hpp
@@ -52,6 +52,9 @@ public:
 
     std::unique_ptr<gfx::CommandEncoder> createCommandEncoder() override;
 
+    void beginFrame() override;
+    void endFrame() override;
+    
     /// Create a new buffer object
     /// @param data The raw data to copy, may be `nullptr`
     /// @param size The size of the buffer

--- a/include/mbgl/mtl/context.hpp
+++ b/include/mbgl/mtl/context.hpp
@@ -54,7 +54,7 @@ public:
 
     void beginFrame() override;
     void endFrame() override;
-    
+
     /// Create a new buffer object
     /// @param data The raw data to copy, may be `nullptr`
     /// @param size The size of the buffer

--- a/include/mbgl/util/scoped.hpp
+++ b/include/mbgl/util/scoped.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace mbgl {
+
+/// Run a lambda on scope exit
+template <typename Func>
+struct Scoped {
+    Scoped(Func&& fn) : cb(std::move(fn)) {};
+    ~Scoped() {
+        cb();
+    }
+
+    Scoped(const Scoped&) = delete;
+    Scoped(Scoped&&) noexcept = delete;
+    Scoped& operator=(const Scoped&) = delete;
+    Scoped& operator=(Scoped&&) noexcept = delete;
+
+private:
+    Func cb;
+};
+
+} // namespace mbgl

--- a/include/mbgl/util/scoped.hpp
+++ b/include/mbgl/util/scoped.hpp
@@ -5,10 +5,9 @@ namespace mbgl {
 /// Run a lambda on scope exit
 template <typename Func>
 struct Scoped {
-    Scoped(Func&& fn) : cb(std::move(fn)) {};
-    ~Scoped() {
-        cb();
-    }
+    Scoped(Func&& fn)
+        : cb(std::move(fn)){};
+    ~Scoped() { cb(); }
 
     Scoped(const Scoped&) = delete;
     Scoped(Scoped&&) noexcept = delete;

--- a/src/mbgl/actor/mailbox.cpp
+++ b/src/mbgl/actor/mailbox.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/actor/mailbox.hpp>
 #include <mbgl/actor/message.hpp>
 #include <mbgl/actor/scheduler.hpp>
+#include <mbgl/util/scoped.hpp>
 
 #include <cassert>
 
@@ -32,6 +33,8 @@ void Mailbox::open(Scheduler& scheduler_) {
 }
 
 void Mailbox::close() {
+    abandon();
+    
     // Block until neither receive() nor push() are in progress. Two mutexes are
     // used because receive() must not block send(). Of the two, the receiving
     // mutex must be acquired first, because that is the order that an actor
@@ -44,14 +47,37 @@ void Mailbox::close() {
     closed = true;
 }
 
+void Mailbox::abandon() {
+    auto idleValue = State::Idle;
+    while (!state.compare_exchange_strong(idleValue, State::Abandoned)) {
+        if (state == State::Abandoned) {
+            break;
+        }
+    }
+}
+
 bool Mailbox::isOpen() const {
     return bool(weakScheduler);
 }
 
 void Mailbox::push(std::unique_ptr<Message> message) {
+    auto idleState = State::Idle;
+    while (!state.compare_exchange_strong(idleState, State::Processing)) {
+        if (state == State::Abandoned) {
+            return;
+        }
+    }
+
+    Scoped activityFlag{ [this]() {
+        if (state == State::Processing) {
+            state = State::Idle;
+        }
+    } };
+
     std::lock_guard<std::mutex> pushingLock(pushingMutex);
 
     if (closed) {
+        state = State::Abandoned;
         return;
     }
 
@@ -65,12 +91,25 @@ void Mailbox::push(std::unique_ptr<Message> message) {
 }
 
 void Mailbox::receive() {
+    auto idleState = State::Idle;
+    while (!state.compare_exchange_strong(idleState, State::Processing)) {
+        if (state == State::Abandoned) {
+            return;
+        }
+    }
+
+    Scoped activityFlag{ [this]() {
+        if (state == State::Processing) {
+            state = State::Idle;
+        }
+    } };
     std::lock_guard<std::recursive_mutex> receivingLock(receivingMutex);
 
     auto guard = weakScheduler.lock();
     assert(weakScheduler);
 
     if (closed) {
+        state = State::Abandoned;
         return;
     }
 

--- a/src/mbgl/actor/mailbox.cpp
+++ b/src/mbgl/actor/mailbox.cpp
@@ -34,7 +34,7 @@ void Mailbox::open(Scheduler& scheduler_) {
 
 void Mailbox::close() {
     abandon();
-    
+
     // Block until neither receive() nor push() are in progress. Two mutexes are
     // used because receive() must not block send(). Of the two, the receiving
     // mutex must be acquired first, because that is the order that an actor
@@ -68,11 +68,11 @@ void Mailbox::push(std::unique_ptr<Message> message) {
         }
     }
 
-    Scoped activityFlag{ [this]() {
+    Scoped activityFlag{[this]() {
         if (state == State::Processing) {
             state = State::Idle;
         }
-    } };
+    }};
 
     std::lock_guard<std::mutex> pushingLock(pushingMutex);
 
@@ -98,11 +98,11 @@ void Mailbox::receive() {
         }
     }
 
-    Scoped activityFlag{ [this]() {
+    Scoped activityFlag{[this]() {
         if (state == State::Processing) {
             state = State::Idle;
         }
-    } };
+    }};
     std::lock_guard<std::recursive_mutex> receivingLock(receivingMutex);
 
     auto guard = weakScheduler.lock();

--- a/src/mbgl/gfx/context.hpp
+++ b/src/mbgl/gfx/context.hpp
@@ -65,6 +65,9 @@ public:
     Context& operator=(const Context& other) = delete;
     virtual ~Context() = default;
 
+    virtual void beginFrame() = 0;
+    virtual void endFrame() = 0;
+
     /// Called at the end of a frame.
     virtual void performCleanup() = 0;
 

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -44,6 +44,9 @@ public:
 
     std::unique_ptr<gfx::CommandEncoder> createCommandEncoder() override;
 
+    void beginFrame() override;
+    void endFrame() override;
+
     void initializeExtensions(const std::function<gl::ProcAddress(const char*)>&);
 
     void enableDebugging();

--- a/src/mbgl/mtl/context.cpp
+++ b/src/mbgl/mtl/context.cpp
@@ -22,6 +22,7 @@
 #include <mbgl/util/traits.hpp>
 #include <mbgl/util/std.hpp>
 #include <mbgl/util/logging.hpp>
+#include <mbgl/util/thread_pool.hpp>
 
 #include <Foundation/Foundation.hpp>
 #include <Metal/Metal.hpp>
@@ -42,6 +43,7 @@ Context::Context(RendererBackend& backend_)
 
 Context::~Context() noexcept {
     if (cleanupOnDestruction) {
+        Scheduler::GetBackground()->runRenderJobs();
         performCleanup();
 
         emptyVertexBuffer.reset();
@@ -59,6 +61,12 @@ Context::~Context() noexcept {
         assert(stats.isZero());
     }
 }
+
+void Context::beginFrame() {
+    Scheduler::GetBackground()->runRenderJobs();
+}
+
+void Context::endFrame() {}
 
 std::unique_ptr<gfx::CommandEncoder> Context::createCommandEncoder() {
     return std::make_unique<CommandEncoder>(*this);

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -5,7 +5,6 @@
 
 #include <map>
 #include <mutex>
-#include <shared_mutex>
 #include <string>
 
 namespace mbgl {
@@ -50,7 +49,7 @@ public:
     void notifyIfMissingImageAdded();
     void reduceMemoryUse();
     void reduceMemoryUseIfCacheSizeExceedsLimit();
-    const std::set<std::string>& getAvailableImages() const;
+    std::set<std::string> getAvailableImages() const;
 
     ImageVersionMap updatedImageVersions;
 
@@ -59,7 +58,6 @@ public:
 private:
     void checkMissingAndNotify(ImageRequestor&, const ImageRequestPair&);
     void notify(ImageRequestor&, const ImageRequestPair&) const;
-    void removePattern(const std::string&);
 
     bool loaded = false;
 
@@ -73,7 +71,7 @@ private:
 
     ImageManagerObserver* observer = nullptr;
 
-    std::shared_mutex rwLock;
+    mutable std::recursive_mutex rwLock;
 };
 
 class ImageRequestor {

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -4,6 +4,8 @@
 #include <mbgl/util/immutable.hpp>
 
 #include <map>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 
 namespace mbgl {
@@ -70,6 +72,8 @@ private:
     std::set<std::string> availableImages;
 
     ImageManagerObserver* observer = nullptr;
+
+    std::shared_mutex rwLock;
 };
 
 class ImageRequestor {

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -67,6 +67,7 @@ void Renderer::Impl::render(const RenderTree& renderTree,
 
     // Blocks execution until the renderable is available.
     backend.getDefaultRenderable().wait();
+    context.beginFrame();
 
     if (!staticData) {
         staticData = std::make_unique<RenderStaticData>(pixelRatio, std::make_unique<gfx::ShaderRegistry>());
@@ -401,6 +402,7 @@ void Renderer::Impl::render(const RenderTree& renderTree,
 
     // CommandEncoder destructor submits render commands.
     parameters.encoder.reset();
+    context.endFrame();
 
     const auto encodingTime = renderTree.getElapsedTime() - renderingTime;
 

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -25,7 +25,8 @@ using namespace style;
 static TileObserver nullObserver;
 
 TilePyramid::TilePyramid()
-    : cache(Scheduler::GetBackground()), observer(&nullObserver) {}
+    : cache(Scheduler::GetBackground()),
+      observer(&nullObserver) {}
 
 TilePyramid::~TilePyramid() = default;
 
@@ -235,7 +236,8 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
 
                 if (tilesIt->second) {
                     tilesIt->second->cancel();
-                    Scheduler::GetBackground()->schedule([tile_{ std::shared_ptr<Tile>(std::move(tiles.extract((tilesIt++)->first).mapped())) }]() {});
+                    Scheduler::GetBackground()->schedule(
+                        [tile_{std::shared_ptr<Tile>(std::move(tiles.extract((tilesIt++)->first).mapped()))}]() {});
                 } else {
                     tiles.erase(tilesIt++);
                 }

--- a/src/mbgl/text/glyph_manager.cpp
+++ b/src/mbgl/text/glyph_manager.cpp
@@ -93,7 +93,7 @@ void GlyphManager::processResponse(const Response& res, const FontStack& fontSta
 
     {
         std::unique_lock<std::shared_mutex> readWriteLock(rwLock);
-        
+
         Entry& entry = entries[fontStack];
         GlyphRequest& request = entry.ranges[range];
 
@@ -142,7 +142,7 @@ void GlyphManager::notify(GlyphRequestor& requestor, const GlyphDependencies& gl
     {
         // This could already be locked, we only care that we're locked for reading here.
         std::shared_lock<std::shared_mutex> readLock(rwLock, std::try_to_lock);
-        
+
         for (const auto& dependency : glyphDependencies) {
             const FontStack& fontStack = dependency.first;
             const GlyphIDs& glyphIDs = dependency.second;

--- a/src/mbgl/text/glyph_manager.cpp
+++ b/src/mbgl/text/glyph_manager.cpp
@@ -21,33 +21,36 @@ GlyphManager::~GlyphManager() = default;
 void GlyphManager::getGlyphs(GlyphRequestor& requestor, GlyphDependencies glyphDependencies, FileSource& fileSource) {
     auto dependencies = std::make_shared<GlyphDependencies>(std::move(glyphDependencies));
 
-    // Figure out which glyph ranges need to be fetched. For each range that
-    // does need to be fetched, record an entry mapping the requestor to a
-    // shared pointer containing the dependencies. When the shared pointer
-    // becomes unique, we know that all the dependencies for that requestor have
-    // been fetched, and can notify it of completion.
-    for (const auto& dependency : *dependencies) {
-        const FontStack& fontStack = dependency.first;
-        Entry& entry = entries[fontStack];
+    {
+        std::unique_lock<std::shared_mutex> readWriteLock(rwLock);
+        // Figure out which glyph ranges need to be fetched. For each range that
+        // does need to be fetched, record an entry mapping the requestor to a
+        // shared pointer containing the dependencies. When the shared pointer
+        // becomes unique, we know that all the dependencies for that requestor have
+        // been fetched, and can notify it of completion.
+        for (const auto& dependency : *dependencies) {
+            const FontStack& fontStack = dependency.first;
+            Entry& entry = entries[fontStack];
 
-        const GlyphIDs& glyphIDs = dependency.second;
-        std::unordered_set<GlyphRange> ranges;
-        for (const auto& glyphID : glyphIDs) {
-            if (localGlyphRasterizer->canRasterizeGlyph(fontStack, glyphID)) {
-                if (entry.glyphs.find(glyphID) == entry.glyphs.end()) {
-                    entry.glyphs.emplace(glyphID, makeMutable<Glyph>(generateLocalSDF(fontStack, glyphID)));
+            const GlyphIDs& glyphIDs = dependency.second;
+            std::unordered_set<GlyphRange> ranges;
+            for (const auto& glyphID : glyphIDs) {
+                if (localGlyphRasterizer->canRasterizeGlyph(fontStack, glyphID)) {
+                    if (entry.glyphs.find(glyphID) == entry.glyphs.end()) {
+                        entry.glyphs.emplace(glyphID, makeMutable<Glyph>(generateLocalSDF(fontStack, glyphID)));
+                    }
+                } else {
+                    ranges.insert(getGlyphRange(glyphID));
                 }
-            } else {
-                ranges.insert(getGlyphRange(glyphID));
             }
-        }
 
-        for (const auto& range : ranges) {
-            auto it = entry.ranges.find(range);
-            if (it == entry.ranges.end() || !it->second.parsed) {
-                GlyphRequest& request = entry.ranges[range];
-                request.requestors[&requestor] = dependencies;
-                requestRange(request, fontStack, range, fileSource);
+            for (const auto& range : ranges) {
+                auto it = entry.ranges.find(range);
+                if (it == entry.ranges.end() || !it->second.parsed) {
+                    GlyphRequest& request = entry.ranges[range];
+                    request.requestors[&requestor] = dependencies;
+                    requestRange(request, fontStack, range, fileSource);
+                }
             }
         }
     }
@@ -88,39 +91,43 @@ void GlyphManager::processResponse(const Response& res, const FontStack& fontSta
         return;
     }
 
-    Entry& entry = entries[fontStack];
-    GlyphRequest& request = entry.ranges[range];
+    {
+        std::unique_lock<std::shared_mutex> readWriteLock(rwLock);
+        
+        Entry& entry = entries[fontStack];
+        GlyphRequest& request = entry.ranges[range];
 
-    if (!res.noContent) {
-        std::vector<Glyph> glyphs;
+        if (!res.noContent) {
+            std::vector<Glyph> glyphs;
 
-        try {
-            glyphs = parseGlyphPBF(range, *res.data);
-        } catch (...) {
-            observer->onGlyphsError(fontStack, range, std::current_exception());
-            return;
-        }
+            try {
+                glyphs = parseGlyphPBF(range, *res.data);
+            } catch (...) {
+                observer->onGlyphsError(fontStack, range, std::current_exception());
+                return;
+            }
 
-        for (auto& glyph : glyphs) {
-            auto id = glyph.id;
-            if (!localGlyphRasterizer->canRasterizeGlyph(fontStack, id)) {
-                entry.glyphs.erase(id);
-                entry.glyphs.emplace(id, makeMutable<Glyph>(std::move(glyph)));
+            for (auto& glyph : glyphs) {
+                auto id = glyph.id;
+                if (!localGlyphRasterizer->canRasterizeGlyph(fontStack, id)) {
+                    entry.glyphs.erase(id);
+                    entry.glyphs.emplace(id, makeMutable<Glyph>(std::move(glyph)));
+                }
             }
         }
-    }
 
-    request.parsed = true;
+        request.parsed = true;
 
-    for (auto& pair : request.requestors) {
-        GlyphRequestor& requestor = *pair.first;
-        const std::shared_ptr<GlyphDependencies>& dependencies = pair.second;
-        if (dependencies.unique()) {
-            notify(requestor, *dependencies);
+        for (auto& pair : request.requestors) {
+            GlyphRequestor& requestor = *pair.first;
+            const std::shared_ptr<GlyphDependencies>& dependencies = pair.second;
+            if (dependencies.unique()) {
+                notify(requestor, *dependencies);
+            }
         }
-    }
 
-    request.requestors.clear();
+        request.requestors.clear();
+    }
 
     observer->onGlyphsLoaded(fontStack, range);
 }
@@ -132,19 +139,24 @@ void GlyphManager::setObserver(GlyphManagerObserver* observer_) {
 void GlyphManager::notify(GlyphRequestor& requestor, const GlyphDependencies& glyphDependencies) {
     GlyphMap response;
 
-    for (const auto& dependency : glyphDependencies) {
-        const FontStack& fontStack = dependency.first;
-        const GlyphIDs& glyphIDs = dependency.second;
+    {
+        // This could already be locked, we only care that we're locked for reading here.
+        std::shared_lock<std::shared_mutex> readLock(rwLock, std::try_to_lock);
+        
+        for (const auto& dependency : glyphDependencies) {
+            const FontStack& fontStack = dependency.first;
+            const GlyphIDs& glyphIDs = dependency.second;
 
-        Glyphs& glyphs = response[FontStackHasher()(fontStack)];
-        Entry& entry = entries[fontStack];
+            Glyphs& glyphs = response[FontStackHasher()(fontStack)];
+            Entry& entry = entries[fontStack];
 
-        for (const auto& glyphID : glyphIDs) {
-            auto it = entry.glyphs.find(glyphID);
-            if (it != entry.glyphs.end()) {
-                glyphs.emplace(*it);
-            } else {
-                glyphs.emplace(glyphID, std::nullopt);
+            for (const auto& glyphID : glyphIDs) {
+                auto it = entry.glyphs.find(glyphID);
+                if (it != entry.glyphs.end()) {
+                    glyphs.emplace(*it);
+                } else {
+                    glyphs.emplace(glyphID, std::nullopt);
+                }
             }
         }
     }
@@ -153,6 +165,7 @@ void GlyphManager::notify(GlyphRequestor& requestor, const GlyphDependencies& gl
 }
 
 void GlyphManager::removeRequestor(GlyphRequestor& requestor) {
+    std::unique_lock<std::shared_mutex> readWriteLock(rwLock);
     for (auto& entry : entries) {
         for (auto& range : entry.second.ranges) {
             range.second.requestors.erase(&requestor);
@@ -161,6 +174,7 @@ void GlyphManager::removeRequestor(GlyphRequestor& requestor) {
 }
 
 void GlyphManager::evict(const std::set<FontStack>& keep) {
+    std::unique_lock<std::shared_mutex> readWriteLock(rwLock);
     util::erase_if(entries, [&](const auto& entry) { return keep.count(entry.first) == 0; });
 }
 

--- a/src/mbgl/text/glyph_manager.hpp
+++ b/src/mbgl/text/glyph_manager.hpp
@@ -8,7 +8,6 @@
 #include <mbgl/util/immutable.hpp>
 
 #include <mutex>
-#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 
@@ -74,7 +73,7 @@ private:
 
     std::unique_ptr<LocalGlyphRasterizer> localGlyphRasterizer;
 
-    std::shared_mutex rwLock;
+    std::recursive_mutex rwLock;
 };
 
 } // namespace mbgl

--- a/src/mbgl/text/glyph_manager.hpp
+++ b/src/mbgl/text/glyph_manager.hpp
@@ -7,6 +7,8 @@
 #include <mbgl/util/font_stack.hpp>
 #include <mbgl/util/immutable.hpp>
 
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 
@@ -71,6 +73,8 @@ private:
     GlyphManagerObserver* observer = nullptr;
 
     std::unique_ptr<LocalGlyphRasterizer> localGlyphRasterizer;
+
+    std::shared_mutex rwLock;
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -177,15 +177,14 @@ GeometryTile::GeometryTile(const OverscaledTileID& id_, std::string sourceID_, c
 
 GeometryTile::~GeometryTile() {
     markObsolete();
-    
+
     glyphManager.removeRequestor(*this);
     imageManager.removeRequestor(*this);
 
     if (layoutResult) {
         Scheduler::GetBackground()->runOnRenderThread(
-            [layoutResult_{ std::move(layoutResult) }, atlasTextures_{ std::move(atlasTextures) }]() {});
+            [layoutResult_{std::move(layoutResult)}, atlasTextures_{std::move(atlasTextures)}]() {});
     }
-    
 }
 
 void GeometryTile::cancel() {

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -19,6 +19,7 @@
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/exception.hpp>
 #include <mbgl/util/stopwatch.hpp>
+#include <mbgl/util/thread_pool.hpp>
 
 #include <unordered_set>
 #include <utility>
@@ -44,7 +45,9 @@ GeometryTileWorker::GeometryTileWorker(ActorRef<GeometryTileWorker> self_,
       pixelRatio(pixelRatio_),
       showCollisionBoxes(showCollisionBoxes_) {}
 
-GeometryTileWorker::~GeometryTileWorker() = default;
+GeometryTileWorker::~GeometryTileWorker() {
+    Scheduler::GetBackground()->runOnRenderThread([renderData_{std::move(renderData)}]() {});
+}
 
 /*
    GeometryTileWorker is a state machine. This is its transition diagram.

--- a/src/mbgl/tile/tile_cache.cpp
+++ b/src/mbgl/tile/tile_cache.cpp
@@ -27,7 +27,7 @@ void TileCache::add(const OverscaledTileID& key, std::unique_ptr<Tile> tile) {
         // remove existing tile key
         orderedKeys.remove(key);
         tile->cancel();
-        threadPool->schedule([tile_{ std::shared_ptr<Tile>(std::move(tile)) }]() mutable { tile_ = nullptr; });
+        threadPool->schedule([tile_{std::shared_ptr<Tile>(std::move(tile))}]() mutable { tile_ = nullptr; });
     } else {
         tiles.emplace(key, std::move(tile));
     }
@@ -40,9 +40,7 @@ void TileCache::add(const OverscaledTileID& key, std::unique_ptr<Tile> tile) {
         auto removedTile = pop(orderedKeys.front());
         removedTile->cancel();
 
-        threadPool->schedule(
-            [tile_{std::shared_ptr<Tile>(std::move(removedTile))}]() {}
-        );
+        threadPool->schedule([tile_{std::shared_ptr<Tile>(std::move(removedTile))}]() {});
     }
 
     assert(orderedKeys.size() <= size);

--- a/src/mbgl/tile/tile_cache.cpp
+++ b/src/mbgl/tile/tile_cache.cpp
@@ -27,7 +27,7 @@ void TileCache::add(const OverscaledTileID& key, std::unique_ptr<Tile> tile) {
         // remove existing tile key
         orderedKeys.remove(key);
         tile->cancel();
-        threadPool->schedule([tile_{std::shared_ptr<Tile>(std::move(tile))}]() mutable { tile_ = nullptr; });
+        threadPool->schedule([tile_{std::shared_ptr<Tile>(std::move(tile))}]() {});
     } else {
         tiles.emplace(key, std::move(tile));
     }

--- a/src/mbgl/tile/tile_cache.hpp
+++ b/src/mbgl/tile/tile_cache.hpp
@@ -14,7 +14,8 @@ class Scheduler;
 class TileCache {
 public:
     TileCache(std::shared_ptr<Scheduler> threadPool_, size_t size_ = 0)
-        : threadPool(std::move(threadPool_)), size(size_) {}
+        : threadPool(std::move(threadPool_)),
+          size(size_) {}
 
     void setSize(size_t);
     size_t getSize() const { return size; };

--- a/src/mbgl/tile/tile_cache.hpp
+++ b/src/mbgl/tile/tile_cache.hpp
@@ -9,10 +9,12 @@
 
 namespace mbgl {
 
+class Scheduler;
+
 class TileCache {
 public:
-    TileCache(size_t size_ = 0)
-        : size(size_) {}
+    TileCache(std::shared_ptr<Scheduler> threadPool_, size_t size_ = 0)
+        : threadPool(std::move(threadPool_)), size(size_) {}
 
     void setSize(size_t);
     size_t getSize() const { return size; };
@@ -25,6 +27,7 @@ public:
 private:
     std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;
     std::list<OverscaledTileID> orderedKeys;
+    std::shared_ptr<Scheduler> threadPool;
 
     size_t size;
 };

--- a/src/mbgl/tile/tile_loader.hpp
+++ b/src/mbgl/tile/tile_loader.hpp
@@ -52,7 +52,7 @@ private:
     std::shared_ptr<FileSource> fileSource;
     std::unique_ptr<AsyncRequest> request;
     TileUpdateParameters updateParameters{Duration::zero(), false};
-    
+
     /// @brief It's possible for async requests in flight to mess with the request
     /// object at the same time as the loader's destructor. This construct is shared
     /// with the request lambdas to ensure more tightly controlled synchronization
@@ -61,7 +61,7 @@ private:
         std::shared_mutex requestLock;
         std::atomic_bool aborted{false};
     };
-    
+
     // Allocated as a share_ptr so either the loader or request can outlive the
     // other and still see this.
     std::shared_ptr<Shared> shared;

--- a/src/mbgl/tile/tile_loader.hpp
+++ b/src/mbgl/tile/tile_loader.hpp
@@ -3,6 +3,10 @@
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/tile/tile.hpp>
 
+#include <atomic>
+#include <mutex>
+#include <shared_mutex>
+
 namespace mbgl {
 
 class FileSource;
@@ -48,6 +52,19 @@ private:
     std::shared_ptr<FileSource> fileSource;
     std::unique_ptr<AsyncRequest> request;
     TileUpdateParameters updateParameters{Duration::zero(), false};
+    
+    /// @brief It's possible for async requests in flight to mess with the request
+    /// object at the same time as the loader's destructor. This construct is shared
+    /// with the request lambdas to ensure more tightly controlled synchronization
+    /// to prevent this from happening.
+    struct Shared {
+        std::shared_mutex requestLock;
+        std::atomic_bool aborted{false};
+    };
+    
+    // Allocated as a share_ptr so either the loader or request can outlive the
+    // other and still see this.
+    std::shared_ptr<Shared> shared;
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/tile_loader_impl.hpp
+++ b/src/mbgl/tile/tile_loader_impl.hpp
@@ -30,6 +30,9 @@ TileLoader<T>::TileLoader(T& tile_,
                               Resource::LoadingMethod::CacheOnly)),
       fileSource(parameters.fileSource) {
     assert(!request);
+
+    shared = std::make_shared<Shared>();
+
     if (!fileSource) {
         tile.setError(getCantLoadTileError());
         return;
@@ -55,7 +58,12 @@ TileLoader<T>::TileLoader(T& tile_,
 }
 
 template <typename T>
-TileLoader<T>::~TileLoader() = default;
+TileLoader<T>::~TileLoader() {
+    std::unique_lock<std::shared_mutex> lock(shared->requestLock);
+    shared->aborted = true;
+    tile.cancel();
+    request.reset();
+};
 
 template <typename T>
 void TileLoader<T>::setNecessity(TileNecessity newNecessity) {
@@ -90,30 +98,40 @@ void TileLoader<T>::loadFromCache() {
     }
 
     resource.loadingMethod = Resource::LoadingMethod::CacheOnly;
-    request = fileSource->request(resource, [this](const Response& res) {
-        request.reset();
+    request = fileSource->request(
+        resource,
+        [this, shared_{shared}](const Response& res) {
+            do {
+                if (shared_->requestLock.try_lock_shared()) {
+                    std::shared_lock<std::shared_mutex> lock(shared_->requestLock, std::adopt_lock);
+                    if (shared_->aborted) return;
 
-        tile.setTriedCache();
+                    request.reset();
+                    tile.setTriedCache();
 
-        if (res.error && res.error->reason == Response::Error::Reason::NotFound) {
-            // When the cache-only request could not be satisfied, don't treat
-            // it as an error. A cache lookup could still return data, _and_ an
-            // error, in particular when we were able to find the data, but it
-            // is expired and the Cache-Control headers indicated that we aren't
-            // allowed to use expired responses. In this case, we still get the
-            // data which we can use in our conditional network request.
-            resource.priorModified = res.modified;
-            resource.priorExpires = res.expires;
-            resource.priorEtag = res.etag;
-            resource.priorData = res.data;
-        } else {
-            loadedData(res);
+                    if (res.error && res.error->reason == Response::Error::Reason::NotFound) {
+                        // When the cache-only request could not be satisfied, don't treat
+                        // it as an error. A cache lookup could still return data, _and_ an
+                        // error, in particular when we were able to find the data, but it
+                        // is expired and the Cache-Control headers indicated that we aren't
+                        // allowed to use expired responses. In this case, we still get the
+                        // data which we can use in our conditional network request.
+                        resource.priorModified = res.modified;
+                        resource.priorExpires = res.expires;
+                        resource.priorEtag = res.etag;
+                        resource.priorData = res.data;
+                    } else {
+                        loadedData(res);
+                    }
+
+                    if (necessity == TileNecessity::Required) {
+                        loadFromNetwork();
+                    }
+                    break;
+                }
+            } while (!shared_->aborted);
         }
-
-        if (necessity == TileNecessity::Required) {
-            loadFromNetwork();
-        }
-    });
+    );
 }
 
 template <typename T>
@@ -164,7 +182,19 @@ void TileLoader<T>::loadFromNetwork() {
     resource.minimumUpdateInterval = updateParameters.minimumUpdateInterval;
     resource.storagePolicy = updateParameters.isVolatile ? Resource::StoragePolicy::Volatile
                                                          : Resource::StoragePolicy::Permanent;
-    request = fileSource->request(resource, [this](const Response& res) { loadedData(res); });
+
+    request = fileSource->request(resource, [this, shared_{shared}](const Response& res) {
+        do {
+            if (shared_->requestLock.try_lock_shared()) {
+                std::shared_lock<std::shared_mutex> lock(shared_->requestLock, std::adopt_lock);
+                if (shared_->aborted) return;
+
+                request.reset();
+                loadedData(res);
+                break;
+            }
+        } while (!shared_->aborted);
+    });
 }
 
 } // namespace mbgl

--- a/src/mbgl/util/thread_pool.hpp
+++ b/src/mbgl/util/thread_pool.hpp
@@ -14,7 +14,7 @@ namespace mbgl {
 class ThreadedSchedulerBase : public Scheduler {
 public:
     void schedule(std::function<void()>) override;
-    
+
 protected:
     ThreadedSchedulerBase() = default;
     ~ThreadedSchedulerBase() override;
@@ -67,7 +67,7 @@ public:
                 fn();
             }
         }
-    }    
+    }
 
     mapbox::base::WeakPtr<Scheduler> makeWeakPtr() override { return weakFactory.makeWeakPtr(); }
 

--- a/test/tile/tile_cache.test.cpp
+++ b/test/tile/tile_cache.test.cpp
@@ -7,6 +7,7 @@
 #include <mbgl/tile/vector_tile.hpp>
 #include <mbgl/tile/vector_tile_data.hpp>
 
+#include <mbgl/actor/scheduler.hpp>
 #include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/geometry/feature_index.hpp>
 #include <mbgl/map/transform.hpp>
@@ -58,7 +59,7 @@ public:
 
 TEST(TileCache, Smoke) {
     VectorTileTest test;
-    TileCache cache(1);
+    TileCache cache(Scheduler::GetBackground(), 1);
     OverscaledTileID id(0, 0, 0);
     std::unique_ptr<Tile> tile = std::make_unique<VectorTileMock>(id, "source", test.tileParameters, test.tileset);
 
@@ -70,7 +71,7 @@ TEST(TileCache, Smoke) {
 
 TEST(TileCache, Issue15926) {
     VectorTileTest test;
-    TileCache cache(2);
+    TileCache cache(Scheduler::GetBackground(), 2);
     OverscaledTileID id0(0, 0, 0);
     OverscaledTileID id1(1, 0, 0);
     std::unique_ptr<Tile> tile1 = std::make_unique<VectorTileMock>(id0, "source", test.tileParameters, test.tileset);


### PR DESCRIPTION
General performance augmentation. Defers destruction of a GeometryTile's `mailbox` to a worker thread. These tiles hold OpenGL objects which must be deleted on the correct thread, so those objects are deleted on the render thread.

A number of special concerns around synchronization had to be addressed.

The primary performance problem centers around the mailbox needing to take both mutex locks before it can be properly closed. As this was done on the render thread, it would stall the whole renderer when the map was in motion.