### PR TITLE
Remove slashes from AWS Device Farm uploads

### DIFF
--- a/.github/actions/aws-device-farm-run/action.yml
+++ b/.github/actions/aws-device-farm-run/action.yml
@@ -112,7 +112,7 @@ runs:
             --app-arn ${{ env.app_arn }} \
             --device-pool-arn ${{ inputs.AWS_DEVICE_FARM_DEVICE_POOL_ARN }} \
             --test type=${{ inputs.testType }},testPackageArn=${{ env.test_package_arn }}${{ inputs.testFilter && ",filter=" }}${{ inputs.testFilter }} \
-            --execution-configuration jobTimeoutMinutes=28800,videoCapture=false \
+            --execution-configuration jobTimeoutMinutes=480,videoCapture=false \
             ${{ inputs.externalData && "--configuration extraDataPackageArn=" }}${{ inputs.externalData }} \
             --output text --query "run.arn")"
           

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -118,19 +118,23 @@ jobs:
             echo "No secrets.MAPLIBRE_DEVELOPER_CONFIG_XML variable set, not copying..."
           fi
 
-      - name: Build Benchmark
+      - name: Build Benchmark, copy to platform/android
         if: github.ref != 'refs/heads/main'
         run: |
           ./gradlew assembleDrawableRelease assembleDrawableReleaseAndroidTest
+          cp MapboxGLAndroidSDKTestApp/build/outputs/apk/drawable/release/MapboxGLAndroidSDKTestApp-drawable-release.apk .
+          cp MapboxGLAndroidSDKTestApp/build/outputs/apk/androidTest/drawable/release/MapboxGLAndroidSDKTestApp-drawable-release-androidTest.apk .
 
-      - uses: actions/upload-artifact@v3
+
+      - name: Create artifact for benchmark APKs 
+        uses: actions/upload-artifact@v3
         if: github.ref != 'refs/heads/main'
         with:
           if-no-files-found: error
           name: benchmarkAPKs
           path: |
-            platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/drawable/release/MapboxGLAndroidSDKTestApp-drawable-release.apk
-            platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/androidTest/drawable/release/MapboxGLAndroidSDKTestApp-drawable-release-androidTest.apk
+            platform/android/MapboxGLAndroidSDKTestApp-drawable-release.apk
+            platform/android/MapboxGLAndroidSDKTestApp-drawable-release-androidTest.apk
 
       - name: Build UI tests
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/android-device-test.yml
+++ b/.github/workflows/android-device-test.yml
@@ -14,8 +14,8 @@ jobs:
           {artifactName: android-render-tests, testFile: RenderTests.apk, appFile: RenderTestsApp.apk, name: "Android Render Tests"},
           {
             artifactName: benchmarkAPKs,
-            testFile: "androidTest/drawable/release/MapboxGLAndroidSDKTestApp-drawable-release-androidTest.apk",
-            appFile: "drawable/release/MapboxGLAndroidSDKTestApp-drawable-release.apk",
+            testFile: "MapboxGLAndroidSDKTestApp-drawable-release-androidTest.apk",
+            appFile: "MapboxGLAndroidSDKTestApp-drawable-release.apk",
             name: "Android Benchmark",
             testFilter: "org.maplibre.android.benchmark.Benchmark",
             # echo '{"styleNames": [...], "styleURLs": [...], "resultsAPI: "..." }' > benchmark-input.json 


### PR DESCRIPTION
Seeing this with uploads:

> Upload type ANDROID_APP expected to have extension '[.apk]'.  Instead found 'upload3741021261188751903drawable'

```
{
    "upload": {
        "arn": "arn:aws:devicefarm:us-west-2:373521797162:upload:20687d72-0e46-403e-8f03-0941850665bc/80fba12a-338c-49cb-9fb0-535ca380898c",
        "name": "drawable/release/MapboxGLAndroidSDKTestApp-drawable-release.apk",
        "created": "2023-12-07T20:27:21.640000+01:00",
        "type": "ANDROID_APP",
        "status": "FAILED",
        "url": "https://prod-us-west-2-uploads.s3-us-west-2.amazonaws.com/arn%3Aaws%3Adevicefarm%3Aus-west-2%3A373521797162%3Aproject%3A20687d72-0e46-403e-8f03-0941850665bc/uploads/arn%3Aaws%3Adevicefarm%3Aus-west-2%3A373521797162%3Aupload%3A20687d72-0e46-403e-8f03-0941850665bc/80fba12a-338c-49cb-9fb0-535ca380898c/drawable/release/MapboxGLAndroidSDKTestApp-drawable-release.apk?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20231207T193053Z&X-Amz-SignedHeaders=host&X-Amz-Expires=86400&X-Amz-Credential=AKIAUJHLTYS5AWNTRO6L%2F20231207%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Signature=1d2d150e615a4529db1c20267e9027e8e81c1b82936bc3fc9e08d651e1f0d8b6",
        "metadata": "{\"errorMessageUrl\":\"https://docs.aws.amazon.com/console/devicefarm/ANDROID_APP_INVALID_EXTENSION\",\"errorMessage\":\"Upload type ANDROID_APP expected to have extension '[.apk]'.  Instead found 'upload3741021261188751903drawable'\",\"errorCode\":\"ANDROID_APP_INVALID_EXTENSION\"}",
        "category": "PRIVATE"
    }
}
```

Weird, but probably has something to do with the slashes.