### PR TITLE
Add explicit frame capture

### DIFF
--- a/include/mbgl/mtl/mtl_fwd.hpp
+++ b/include/mbgl/mtl/mtl_fwd.hpp
@@ -19,6 +19,7 @@ namespace MTL {
 class BlitCommandEncoder;
 class BlitPassDescriptor;
 class Buffer;
+class CaptureScope;
 class CommandBuffer;
 class CommandQueue;
 class Device;
@@ -43,6 +44,7 @@ using CAMetalDrawablePtr = NS::SharedPtr<CA::MetalDrawable>;
 using MTLBlitCommandEncoderPtr = NS::SharedPtr<MTL::BlitCommandEncoder>;
 using MTLBlitPassDescriptorPtr = NS::SharedPtr<MTL::BlitPassDescriptor>;
 using MTLBufferPtr = NS::SharedPtr<MTL::Buffer>;
+using MTLCaptureScopePtr = NS::SharedPtr<MTL::CaptureScope>;
 using MTLCommandBufferPtr = NS::SharedPtr<MTL::CommandBuffer>;
 using MTLCommandQueuePtr = NS::SharedPtr<MTL::CommandQueue>;
 using MTLDevicePtr = NS::SharedPtr<MTL::Device>;

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -29,8 +29,11 @@
 #include <mbgl/mtl/renderer_backend.hpp>
 #include <Metal/MTLCaptureManager.hpp>
 #include <Metal/MTLCaptureScope.hpp>
-#define CAPTURE_FRAME_START 85 // Capture a range of frames to the developer tools (frames are 1-based)
-#define CAPTURE_FRAME_COUNT 10
+/// Enable programmatic Metal frame captures for specific frame numbers.
+/// Requries iOS 13
+constexpr auto EnableMetalCapture = 0;
+constexpr auto CaptureFrameStart = 0; // frames are 0-based
+constexpr auto CaptureFrameCount = 1;
 #else // !MLN_RENDER_BACKEND_METAL
 #include <mbgl/gl/defines.hpp>
 #if MLN_DRAWABLE_RENDERER
@@ -70,65 +73,67 @@ void Renderer::Impl::setObserver(RendererObserver* observer_) {
 void Renderer::Impl::render(const RenderTree& renderTree,
                             [[maybe_unused]] const std::shared_ptr<UpdateParameters>& updateParameters) {
     auto& context = backend.getContext();
-#if MLN_RENDER_BACKEND_METAL && ENABLE_METAL_CAPTURE
-    if (!commandCaptureScope) {
-        auto& mtlBackend = static_cast<mtl::RendererBackend&>(backend);
-        if (const auto& cmdQueue = mtlBackend.getCommandQueue()) {
-            if (const auto captureManager = NS::RetainPtr(MTL::CaptureManager::sharedCaptureManager())) {
-                if ((commandCaptureScope = NS::TransferPtr(captureManager->newCaptureScope(cmdQueue.get())))) {
-                    const auto label = "Renderer::Impl frame=" + util::toString(frameCount);
-                    commandCaptureScope->setLabel(NS::String::string(label.c_str(), NS::UTF8StringEncoding));
-                    captureManager->setDefaultCaptureScope(commandCaptureScope.get());
-                }
-            }
-        }
-    }
-
-#if CAPTURE_FRAME_START && CAPTURE_FRAME_COUNT
-    // if (@available(iOS 13.0, *))
-    // "When you capture a frame programmatically, you can capture Metal commands that span multiple
-    //  frames by using a custom capture scope. For example, by calling begin() at the start of frame
-    //  1 and end() after frame 3, the trace will contain command data from all the buffers that were
-    //  committed in the three frames."
-    // https://developer.apple.com/documentation/metal/debugging_tools/capturing_gpu_command_data_programmatically
-    if (commandCaptureScope) {
+#if MLN_RENDER_BACKEND_METAL
+    if constexpr (EnableMetalCapture) {
         const auto& mtlBackend = static_cast<mtl::RendererBackend&>(backend);
         const auto& mtlDevice = mtlBackend.getDevice();
-        const auto captureManager = NS::RetainPtr(MTL::CaptureManager::sharedCaptureManager());
-        if (frameCount == CAPTURE_FRAME_START) {
-            constexpr auto captureDest = MTL::CaptureDestination::CaptureDestinationDeveloperTools;
-            if (captureManager && !captureManager->isCapturing() && captureManager->supportsDestination(captureDest)) {
-                if (auto captureDesc = NS::TransferPtr(MTL::CaptureDescriptor::alloc()->init())) {
-                    captureDesc->setCaptureObject(mtlDevice.get());
-                    captureDesc->setDestination(captureDest);
-                    NS::Error* errorPtr = nullptr;
-                    if (captureManager->startCapture(captureDesc.get(), &errorPtr)) {
-                        Log::Warning(Event::Render, "Capture Started");
-                    } else {
-                        std::string errStr = "<none>";
-                        if (auto error = NS::TransferPtr(errorPtr)) {
-                            if (auto str = error->localizedDescription()) {
-                                if (auto cstr = str->utf8String()) {
-                                    errStr = cstr;
-                                }
-                            }
-                        }
-                        Log::Warning(Event::Render, "Capture Failed: " + errStr);
+
+        if (!commandCaptureScope) {
+            if (const auto& cmdQueue = mtlBackend.getCommandQueue()) {
+                if (const auto captureManager = NS::RetainPtr(MTL::CaptureManager::sharedCaptureManager())) {
+                    if ((commandCaptureScope = NS::TransferPtr(captureManager->newCaptureScope(cmdQueue.get())))) {
+                        const auto label = "Renderer::Impl frame=" + util::toString(frameCount);
+                        commandCaptureScope->setLabel(NS::String::string(label.c_str(), NS::UTF8StringEncoding));
+                        captureManager->setDefaultCaptureScope(commandCaptureScope.get());
                     }
                 }
             }
         }
-    }
-#endif // CAPTURE_FRAME_START && CAPTURE_FRAME_COUNT
-    if (commandCaptureScope) {
-        commandCaptureScope->beginScope();
 
-        const auto captureManager = NS::RetainPtr(MTL::CaptureManager::sharedCaptureManager());
-        if (captureManager->isCapturing()) {
-            Log::Info(Event::Render, "Capturing frame " + util::toString(frameCount));
+        // "When you capture a frame programmatically, you can capture Metal commands that span multiple
+        //  frames by using a custom capture scope. For example, by calling begin() at the start of frame
+        //  1 and end() after frame 3, the trace will contain command data from all the buffers that were
+        //  committed in the three frames."
+        // https://developer.apple.com/documentation/metal/debugging_tools/capturing_gpu_command_data_programmatically
+        if constexpr (0 < CaptureFrameStart && 0 < CaptureFrameCount) {
+            if (commandCaptureScope) {
+                const auto captureManager = NS::RetainPtr(MTL::CaptureManager::sharedCaptureManager());
+                if (frameCount == CaptureFrameStart) {
+                    constexpr auto captureDest = MTL::CaptureDestination::CaptureDestinationDeveloperTools;
+                    if (captureManager && !captureManager->isCapturing() &&
+                        captureManager->supportsDestination(captureDest)) {
+                        if (auto captureDesc = NS::TransferPtr(MTL::CaptureDescriptor::alloc()->init())) {
+                            captureDesc->setCaptureObject(mtlDevice.get());
+                            captureDesc->setDestination(captureDest);
+                            NS::Error* errorPtr = nullptr;
+                            if (captureManager->startCapture(captureDesc.get(), &errorPtr)) {
+                                Log::Warning(Event::Render, "Capture Started");
+                            } else {
+                                std::string errStr = "<none>";
+                                if (auto error = NS::TransferPtr(errorPtr)) {
+                                    if (auto str = error->localizedDescription()) {
+                                        if (auto cstr = str->utf8String()) {
+                                            errStr = cstr;
+                                        }
+                                    }
+                                }
+                                Log::Warning(Event::Render, "Capture Failed: " + errStr);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (commandCaptureScope) {
+            commandCaptureScope->beginScope();
+
+            const auto captureManager = NS::RetainPtr(MTL::CaptureManager::sharedCaptureManager());
+            if (captureManager->isCapturing()) {
+                Log::Info(Event::Render, "Capturing frame " + util::toString(frameCount));
+            }
         }
     }
-#endif // MLN_RENDER_BACKEND_METAL && ENABLE_METAL_CAPTURE
+#endif // MLN_RENDER_BACKEND_METAL
 
     // Blocks execution until the renderable is available.
     backend.getDefaultRenderable().wait();
@@ -467,19 +472,18 @@ void Renderer::Impl::render(const RenderTree& renderTree,
     // CommandEncoder destructor submits render commands.
     parameters.encoder.reset();
 
-#if MLN_RENDER_BACKEND_METAL && ENABLE_METAL_CAPTURE
-    // #if CAPTURE_FRAME_START && CAPTURE_FRAME_COUNT
-    //  if (@available(iOS 13.0, *))
-    if (commandCaptureScope) {
-        commandCaptureScope->endScope();
+#if MLN_RENDER_BACKEND_METAL
+    if constexpr (EnableMetalCapture) {
+        if (commandCaptureScope) {
+            commandCaptureScope->endScope();
 
-        const auto captureManager = NS::RetainPtr(MTL::CaptureManager::sharedCaptureManager());
-        if (frameCount == CAPTURE_FRAME_START + CAPTURE_FRAME_COUNT && captureManager->isCapturing()) {
-            captureManager->stopCapture();
+            const auto captureManager = NS::RetainPtr(MTL::CaptureManager::sharedCaptureManager());
+            if (frameCount == CaptureFrameStart + CaptureFrameCount - 1 && captureManager->isCapturing()) {
+                captureManager->stopCapture();
+            }
         }
     }
-// #endif // CAPTURE_FRAME_START && CAPTURE_FRAME_COUNT
-#endif // MLN_RENDER_BACKEND_METAL && ENABLE_METAL_CAPTURE
+#endif // MLN_RENDER_BACKEND_METAL
 
     const auto encodingTime = renderTree.getElapsedTime() - renderingTime;
 

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -25,7 +25,13 @@
 #include <limits>
 #endif // MLN_DRAWABLE_RENDERER
 
-#if !MLN_RENDER_BACKEND_METAL
+#if MLN_RENDER_BACKEND_METAL
+#include <mbgl/mtl/renderer_backend.hpp>
+#include <Metal/MTLCaptureManager.hpp>
+#include <Metal/MTLCaptureScope.hpp>
+#define CAPTURE_FRAME_START 85 // Capture a range of frames to the developer tools (frames are 1-based)
+#define CAPTURE_FRAME_COUNT 10
+#else // !MLN_RENDER_BACKEND_METAL
 #include <mbgl/gl/defines.hpp>
 #if MLN_DRAWABLE_RENDERER
 #include <mbgl/gl/drawable_gl.hpp>
@@ -64,6 +70,65 @@ void Renderer::Impl::setObserver(RendererObserver* observer_) {
 void Renderer::Impl::render(const RenderTree& renderTree,
                             [[maybe_unused]] const std::shared_ptr<UpdateParameters>& updateParameters) {
     auto& context = backend.getContext();
+#if MLN_RENDER_BACKEND_METAL && ENABLE_METAL_CAPTURE
+    if (!commandCaptureScope) {
+        auto& mtlBackend = static_cast<mtl::RendererBackend&>(backend);
+        if (const auto& cmdQueue = mtlBackend.getCommandQueue()) {
+            if (const auto captureManager = NS::RetainPtr(MTL::CaptureManager::sharedCaptureManager())) {
+                if ((commandCaptureScope = NS::TransferPtr(captureManager->newCaptureScope(cmdQueue.get())))) {
+                    const auto label = "Renderer::Impl frame=" + util::toString(frameCount);
+                    commandCaptureScope->setLabel(NS::String::string(label.c_str(), NS::UTF8StringEncoding));
+                    captureManager->setDefaultCaptureScope(commandCaptureScope.get());
+                }
+            }
+        }
+    }
+
+#if CAPTURE_FRAME_START && CAPTURE_FRAME_COUNT
+    // if (@available(iOS 13.0, *))
+    // "When you capture a frame programmatically, you can capture Metal commands that span multiple
+    //  frames by using a custom capture scope. For example, by calling begin() at the start of frame
+    //  1 and end() after frame 3, the trace will contain command data from all the buffers that were
+    //  committed in the three frames."
+    // https://developer.apple.com/documentation/metal/debugging_tools/capturing_gpu_command_data_programmatically
+    if (commandCaptureScope) {
+        const auto& mtlBackend = static_cast<mtl::RendererBackend&>(backend);
+        const auto& mtlDevice = mtlBackend.getDevice();
+        const auto captureManager = NS::RetainPtr(MTL::CaptureManager::sharedCaptureManager());
+        if (frameCount == CAPTURE_FRAME_START) {
+            constexpr auto captureDest = MTL::CaptureDestination::CaptureDestinationDeveloperTools;
+            if (captureManager && !captureManager->isCapturing() && captureManager->supportsDestination(captureDest)) {
+                if (auto captureDesc = NS::TransferPtr(MTL::CaptureDescriptor::alloc()->init())) {
+                    captureDesc->setCaptureObject(mtlDevice.get());
+                    captureDesc->setDestination(captureDest);
+                    NS::Error* errorPtr = nullptr;
+                    if (captureManager->startCapture(captureDesc.get(), &errorPtr)) {
+                        Log::Warning(Event::Render, "Capture Started");
+                    } else {
+                        std::string errStr = "<none>";
+                        if (auto error = NS::TransferPtr(errorPtr)) {
+                            if (auto str = error->localizedDescription()) {
+                                if (auto cstr = str->utf8String()) {
+                                    errStr = cstr;
+                                }
+                            }
+                        }
+                        Log::Warning(Event::Render, "Capture Failed: " + errStr);
+                    }
+                }
+            }
+        }
+    }
+#endif // CAPTURE_FRAME_START && CAPTURE_FRAME_COUNT
+    if (commandCaptureScope) {
+        commandCaptureScope->beginScope();
+
+        const auto captureManager = NS::RetainPtr(MTL::CaptureManager::sharedCaptureManager());
+        if (captureManager->isCapturing()) {
+            Log::Info(Event::Render, "Capturing frame " + util::toString(frameCount));
+        }
+    }
+#endif // MLN_RENDER_BACKEND_METAL && ENABLE_METAL_CAPTURE
 
     // Blocks execution until the renderable is available.
     backend.getDefaultRenderable().wait();
@@ -401,6 +466,20 @@ void Renderer::Impl::render(const RenderTree& renderTree,
 
     // CommandEncoder destructor submits render commands.
     parameters.encoder.reset();
+
+#if MLN_RENDER_BACKEND_METAL && ENABLE_METAL_CAPTURE
+    // #if CAPTURE_FRAME_START && CAPTURE_FRAME_COUNT
+    //  if (@available(iOS 13.0, *))
+    if (commandCaptureScope) {
+        commandCaptureScope->endScope();
+
+        const auto captureManager = NS::RetainPtr(MTL::CaptureManager::sharedCaptureManager());
+        if (frameCount == CAPTURE_FRAME_START + CAPTURE_FRAME_COUNT && captureManager->isCapturing()) {
+            captureManager->stopCapture();
+        }
+    }
+// #endif // CAPTURE_FRAME_START && CAPTURE_FRAME_COUNT
+#endif // MLN_RENDER_BACKEND_METAL && ENABLE_METAL_CAPTURE
 
     const auto encodingTime = renderTree.getElapsedTime() - renderingTime;
 

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -5,7 +5,6 @@
 #if MLN_RENDER_BACKEND_METAL
 #include <mbgl/mtl/mtl_fwd.hpp>
 #include <Foundation/Foundation.hpp>
-#define ENABLE_METAL_CAPTURE 0
 #endif // MLN_RENDER_BACKEND_METAL
 
 #include <memory>
@@ -56,7 +55,7 @@ private:
 
     uint64_t frameCount = 0;
 
-#if MLN_RENDER_BACKEND_METAL && ENABLE_METAL_CAPTURE
+#if MLN_RENDER_BACKEND_METAL
     mtl::MTLCaptureScopePtr commandCaptureScope;
 #endif // MLN_RENDER_BACKEND_METAL
 };

--- a/src/mbgl/renderer/renderer_impl.hpp
+++ b/src/mbgl/renderer/renderer_impl.hpp
@@ -2,6 +2,12 @@
 
 #include <mbgl/renderer/render_orchestrator.hpp>
 
+#if MLN_RENDER_BACKEND_METAL
+#include <mbgl/mtl/mtl_fwd.hpp>
+#include <Foundation/Foundation.hpp>
+#define ENABLE_METAL_CAPTURE 0
+#endif // MLN_RENDER_BACKEND_METAL
+
 #include <memory>
 #include <string>
 
@@ -49,6 +55,10 @@ private:
     RenderState renderState = RenderState::Never;
 
     uint64_t frameCount = 0;
+
+#if MLN_RENDER_BACKEND_METAL && ENABLE_METAL_CAPTURE
+    mtl::MTLCaptureScopePtr commandCaptureScope;
+#endif // MLN_RENDER_BACKEND_METAL
 };
 
 } // namespace mbgl


### PR DESCRIPTION
In profiling the benchmark app, I saw some results indicating particular frames, but wasn't able to tie that to what's going on in those frames:

<img width="400" alt="Screenshot 2023-12-07 at 10 18 57 AM" src="https://github.com/maplibre/maplibre-native/assets/71895881/602eee98-8fc6-4fa9-9139-3ac9f598bc05">

This code, when enabled, captures specific frames without involving the Xcode capture UI.  It also allows for capturing more than the arbitrary limit of 5 frames imposed by that UI.

<img width="400" alt="image" src="https://github.com/maplibre/maplibre-native/assets/71895881/a1423041-554e-4400-97c3-1d09b7acf135">
