### PR TITLE
[node][opengl-2] Update vcpkg so windows builds in workflow can succeed

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -36,15 +36,15 @@ if(WIN32)
     find_package(libuv REQUIRED)
 
     target_link_libraries(
-        mbgl-cache PRIVATE uv_a
+        mbgl-cache PRIVATE $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv>
     )
 
     target_link_libraries(
-        mbgl-offline PRIVATE uv_a
+        mbgl-offline PRIVATE $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv>
     )
 
     target_link_libraries(
-        mbgl-render PRIVATE uv_a
+        mbgl-render PRIVATE $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv>
     )
 endif()
 

--- a/platform/glfw/CMakeLists.txt
+++ b/platform/glfw/CMakeLists.txt
@@ -73,7 +73,7 @@ if(WIN32)
         mbgl-glfw
         PRIVATE
             glfw
-            uv_a
+            $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv>
     )
 else()
     target_link_libraries(

--- a/platform/windows/windows.cmake
+++ b/platform/windows/windows.cmake
@@ -225,7 +225,7 @@ target_link_libraries(
         mbgl-compiler-options
         mbgl-benchmark
         -WHOLEARCHIVE:mbgl-benchmark
-        uv_a
+        $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv>
         shlwapi
 )
 
@@ -241,7 +241,10 @@ target_compile_definitions(
 
 target_link_libraries(
     mbgl-render-test-runner
-    PRIVATE mbgl-compiler-options mbgl-render-test uv_a
+    PRIVATE
+        mbgl-compiler-options
+        mbgl-render-test
+        $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv>
 )
 
 # Disable benchmarks in CI as they run in VM environment


### PR DESCRIPTION
This PR updates vcpkg in the 'opengl-2' to match the main branch. This is needed for the windows node builds to succeed

This is a cherry pick of two commits which touch vcpkg 
* Update vcpkg to e65af7b ([#1433](https://github.com/maplibre/maplibre-native/issues/1433))
* [Windows] Update libwebp ([#1662](https://github.com/maplibre/maplibre-native/issues/1662))

there are a few other commits that update vcpkg in main, but they get superseded by the two PRs above, so they don't need to be included.
