### PR TITLE
Update Python Qt macOS CI

### DIFF
--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -180,7 +180,6 @@ jobs:
         env:
           MLN_COMPILER: ${{ matrix.compiler }}
         run: |
-          brew install --overwrite python@3.11
           brew install "$MLN_COMPILER"
           echo "/usr/local/opt/${MLN_COMPILER}/bin" >> "$GITHUB_PATH"
           {

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -180,6 +180,8 @@ jobs:
         env:
           MLN_COMPILER: ${{ matrix.compiler }}
         run: |
+          # https://github.com/actions/runner-images/issues/8838#issuecomment-1817486924
+          brew link --overwrite python@3.12
           brew install "$MLN_COMPILER"
           echo "/usr/local/opt/${MLN_COMPILER}/bin" >> "$GITHUB_PATH"
           {


### PR DESCRIPTION
Should be already installed

- macos-12 https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
- macos-13 https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md

Fixes https://github.com/maplibre/maplibre-native/issues/1950 (hopefully)