### PR TITLE
Add Bloaty iOS size test for PRs

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -164,6 +164,45 @@ jobs:
             ${{ env.ios_cpp_test_artifacts_dir }}/CppUnitTests.xctest.zip
             ${{ env.ios_cpp_test_artifacts_dir }}/CppUnitTestsApp.ipa
 
+      # Size test (Bloaty)
+
+      - name: Build dynamic library for size test (Bloaty)
+        if: matrix.renderer == 'drawable'
+        run: |
+          bazel build //platform/ios:MapLibre.dynamic --//:renderer=metal --//:maplibre_platform=ios --compilation_mode="opt" --copt -g --strip never --output_groups=+dsyms --apple_generate_dsym
+          bazel_bin="$(bazel info --compilation_mode="opt" bazel-bin)"
+          unzip "$bazel_bin"/platform/ios/MapLibre.dynamic.xcframework.zip
+          cp "$bazel_bin"/platform/ios/MapLibre.dynamic_dsyms/MapLibre_ios_device.framework.dSYM/Contents/Resources/DWARF/MapLibre_ios_device MapLibre_DWARF
+          cp MapLibre.xcframework/ios-arm64/MapLibre.framework/MapLibre MapLibre_dynamic
+
+      - name: Upload size test as artifact (Bloaty)
+        uses: actions/upload-artifact@v3
+        if: matrix.renderer == 'drawable' && github.event_name == 'pull_request'
+        with:
+          name: ios-size-test-files
+          retention-days: 3
+          if-no-files-found: error
+          path: |
+            platform/ios/MapLibre_DWARF
+            platform/ios/MapLibre_dynamic
+
+      - name: Configure AWS Credentials
+        if: matrix.renderer == 'drawable' && github.ref == 'refs/heads/main' && vars.OIDC_AWS_ROLE_TO_ASSUME 
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+      
+      - name: Upload MapLibre_DWARF & MapLibre_dynamic to S3
+        if: matrix.renderer == 'drawable' && github.ref == 'refs/heads/main' && vars.OIDC_AWS_ROLE_TO_ASSUME 
+        run: | 
+          aws s3 cp MapLibre_DWARF s3://maplibre-native/size-test-ios/MapLibre_DWARF-main
+          aws s3 cp MapLibre_dynamic s3://maplibre-native/size-test-ios/MapLibre_dynamic-main
+
+      - if: github.event_name == 'pull_request'
+        uses: ./.github/actions/save-pr-number
+
       # Make Metal XCFramework release
       - name: Should make release?
         if: ${{ github.ref == 'refs/heads/main' && matrix.renderer == 'metal' }}

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Build dynamic library for size test (Bloaty)
         if: matrix.renderer == 'drawable'
         run: |
-          bazel build //platform/ios:MapLibre.dynamic --//:renderer=metal --//:maplibre_platform=ios --compilation_mode="opt" --copt -g --strip never --output_groups=+dsyms --apple_generate_dsym
+          bazel build //platform/ios:MapLibre.dynamic --//:renderer=metal --//:maplibre_platform=ios --compilation_mode="opt" --copt -g --copt="-Oz" --strip never --output_groups=+dsyms --apple_generate_dsym
           bazel_bin="$(bazel info --compilation_mode="opt" bazel-bin)"
           unzip "$bazel_bin"/platform/ios/MapLibre.dynamic.xcframework.zip
           cp "$bazel_bin"/platform/ios/MapLibre.dynamic_dsyms/MapLibre_ios_device.framework.dSYM/Contents/Resources/DWARF/MapLibre_ios_device MapLibre_DWARF

--- a/.github/workflows/pr-bloaty-ios.yml
+++ b/.github/workflows/pr-bloaty-ios.yml
@@ -1,0 +1,80 @@
+name: pr-bloaty-ios
+
+on:
+  workflow_run:
+    workflows: [ios-ci]
+    types:
+      - completed
+env:
+  download_url: https://maplibre-native.s3.eu-central-1.amazonaws.com
+
+permissions:
+  pull-requests: write
+  id-token: write      # This is required for requesting the AWS JWT
+
+jobs:
+  pr-bloaty-ios:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get latest CMake and Ninja
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: latest
+          ninjaVersion: latest
+
+      - name: Cache Bloaty
+        id: cache-bloaty
+        uses: actions/cache@v3
+        with:
+          path: bloaty/build/bloaty
+          key: bloaty-${{ env.bloaty_sha }}
+
+      # because Google is not making a release...
+      # https://github.com/google/bloaty/issues/334
+      - name: Compile Bloaty
+        if: ${{ !steps.cache-bloaty.outputs.cache-hit }}
+        run: |
+          git clone https://github.com/google/bloaty.git
+          cd bloaty
+          git checkout "$bloaty_sha"
+          cmake -B build -G Ninja -S .
+          cmake --build build
+
+      - name: Download MapLibre_dynamic-main, MapLibre_DWARF-main
+        run: |
+          wget -O MapLibre_dynamic-main "${download_url}/size-test-ios/MapLibre_dynamic-main"
+          wget -O MapLibre_DWARF-main "${download_url}/size-test-ios/MapLibre_DWARF-main"
+
+      - uses: ./.github/actions/get-pr-number
+        id: get-pr-number
+
+      - uses: ./.github/actions/download-workflow-run-artifact
+        with:
+          artifact-name: ios-size-test-files
+          expect-files: "MapLibre_dynamic,MapLibre_DWARF"
+
+      - name: Run Bloaty
+        run: bloaty/build/bloaty --debug-file MapLibre_DWARF --debug-file MapLibre_DWARF-main MapLibre_dynamic -n 0 -s vm -d compileunits -- MapLibre_dynamic-main > bloaty_diff.txt
+
+      - name: Prepare Bloaty message
+        run: |
+          report_path=bloaty-results-ios/pr-${{ steps.get-pr-number.outputs.pr-number }}-compared-to-main.txt
+          aws s3 cp bloaty_diff.txt s3://maplibre-native/"$report_path"
+          {
+            echo "# Bloaty Results (iOS) 🐋"
+            echo 'Compared to main'
+            echo '```'
+            awk 'NR <= 2; END { print }' bloaty_diff.txt
+            echo '```'
+            echo "Full report: $download_url/$report_path"
+            echo "---"
+          } >> message.md
+
+      - name: Leave a comment with Bloaty results
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.get-pr-number.outputs.pr-number }}
+          header: bloaty-ios
+          path: message.md


### PR DESCRIPTION
Closes  #1797 to report size tests results generated with Bloaty on iOS. These tests should be a bit more reliable than the Linux size test we have now.

As always working on GitHub actions workflows may take a couple of tries to get it right. There is some duplication between `pr-bloaty_ios.yml` and `pr-tests.yml` but let's fix that once we decide if we want to keep the Linux size test (and this new one works).