### PR TITLE
contents: write for ios-ci

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   id-token: write         # needed for AWS
+  contents: write         # allow making a release
 
 jobs:
   pre_job:


### PR DESCRIPTION
ios-ci needs to be able to make a release. This permission now needs to be explicitly added.