### PR TITLE
Use debug build for Android UI tests (CI)

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Build Benchmark, copy to platform/android
         if: github.ref != 'refs/heads/main'
         run: |
-          ./gradlew assembleDrawableRelease assembleDrawableReleaseAndroidTest
+          ./gradlew assembleDrawableRelease assembleDrawableReleaseAndroidTest -PtestBuildType=release
           cp MapboxGLAndroidSDKTestApp/build/outputs/apk/drawable/release/MapboxGLAndroidSDKTestApp-drawable-release.apk .
           cp MapboxGLAndroidSDKTestApp/build/outputs/apk/androidTest/drawable/release/MapboxGLAndroidSDKTestApp-drawable-release-androidTest.apk .
 
@@ -140,7 +140,8 @@ jobs:
 
       - name: Build UI tests
         if: github.ref == 'refs/heads/main'
-        run: make android-ui-test-arm-v8
+        run: |
+          ./gradlew assembleLegacyDebug assembleLegacyDebugAndroidTest -PtestBuildType=debug
 
       - name: Configure AWS Credentials
         if: github.ref == 'refs/heads/main'
@@ -174,8 +175,8 @@ jobs:
       - name: Upload Android UI test
         if: github.ref == 'refs/heads/main'
         run: |
-          curl -T MapboxGLAndroidSDKTestApp/build/outputs/apk/legacy/release/MapboxGLAndroidSDKTestApp-legacy-debug.apk '${{ steps.upload-android-app.outputs.url }}'
-          curl -T MapboxGLAndroidSDKTestApp/build/outputs/apk/androidTest/legacy/release/MapboxGLAndroidSDKTestApp-legacy-debug-androidTest.apk '${{ steps.upload-android-test.outputs.url }}'
+          curl -T MapboxGLAndroidSDKTestApp/build/outputs/apk/legacy/debug/MapboxGLAndroidSDKTestApp-legacy-debug.apk '${{ steps.upload-android-app.outputs.url }}'
+          curl -T MapboxGLAndroidSDKTestApp/build/outputs/apk/androidTest/legacy/debug/MapboxGLAndroidSDKTestApp-legacy-debug-androidTest.apk '${{ steps.upload-android-test.outputs.url }}'
 
       - name: Write uploads.env
         if: github.ref == 'refs/heads/main'

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -7,6 +7,16 @@ plugins {
 
 apply from: "${rootDir}/gradle/native-build.gradle"
 
+def obtainTestBuildType() {
+    def result = "debug";
+
+    if (project.hasProperty("testBuildType")) {
+        result = project.getProperties().get("testBuildType")
+    }
+
+    result
+}
+
 android {
     compileSdkVersion androidVersions.compileSdkVersion
 
@@ -55,7 +65,7 @@ android {
         }
     }
 
-    testBuildType "release" // for benchmark
+    testBuildType obtainTestBuildType()
 
     flavorDimensions += "renderer"
     productFlavors {


### PR DESCRIPTION
I switched the `testBuildType` to `release`, because of the Android benchmark (which needs it), but the UI tests need a debug build (so they started to fail). This PR adds a flag so that it can be configured from the command line.

Idea from https://stackoverflow.com/a/21756133/1929678