### PR TITLE
Render tile masks in order

### DIFF
--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -188,11 +188,17 @@ void PaintParameters::renderTileClippingMasks(const RenderTiles& renderTiles) {
             // already present
             continue;
         }
+    }
 
-        if (tileUBOs.empty()) {
-            tileUBOs.reserve(count);
-        }
+    if (tileUBOs.empty()) {
+        tileUBOs.reserve(count);
+    }
 
+    // Render tile clipping masks in order of tile ID, by increasing
+    // z-value, so that more detailed tiles cover less detailed ones.
+    for (const auto& pair : tileClippingMaskIDs) {
+        const auto& tileID = pair.first;
+        const auto stencilID = pair.second;
         tileUBOs.emplace_back(shaders::ClipUBO{/*.matrix=*/util::cast<float>(matrixForTile(tileID)),
                                                /*.stencil_ref=*/stencilID,
                                                /*.pad=*/0,
@@ -235,6 +241,11 @@ void PaintParameters::renderTileClippingMasks(const RenderTiles& renderTiles) {
             // already present
             continue;
         }
+    }
+
+    for (const auto& pair : tileClippingMaskIDs) {
+        const auto& tileID = pair.first;
+        const auto stencilID = pair.second;
 
         program->draw(context,
                       *renderPass,


### PR DESCRIPTION
Tile masks were being rendered into the stencil buffer in whatever order they ended up in `RenderTiles`.  When multiple sources are present, this can result in lower-detail tiles blocking higher-detail ones from rendering.
