### PR TITLE
Automated release to Swift Package Index

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -241,6 +241,7 @@ jobs:
 
       # needed to trigger workflow for Swift Package Index release
       - name: Generate token
+        if: env.make_release
         id: generate_token
         uses: tibdex/github-app-token@v2
         with:
@@ -248,6 +249,7 @@ jobs:
           private_key: ${{ secrets.MAPLIBRE_NATIVE_BOT_PRIVATE_KEY }}
 
       - name: Release (Swift Package Index)
+        if: env.make_release
         run: |
           echo "::add-mask::${{ steps.generate_token.outputs.token }}"
           release_workflow_id=81221759  # id of release.yml

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -221,22 +221,48 @@ jobs:
           git tag -a ios-v${{ env.version }} -m "Publish ios-v${{ env.version }}" ${{ github.sha }}
           git push origin ios-v${{ env.version }}
 
+      - name: Add license to XCFramework zip
+        if: env.make_release
+        run: |
+          cp ${{ env.xcframework }} MapLibre.dynamic.xcframework.zip
+          zip MapLibre.dynamic.xcframework.zip LICENSE.md  # add license to zip
+        working-directory: .
+
       - name: Release (GitHub)
         if: env.make_release
-        id: release
+        id: github_release
         uses: softprops/action-gh-release@v1
         with:
           name: ios-v${{ env.version }}
-          files: ${{ env.xcframework }}
+          files: MapLibre.dynamic.xcframework.zip
           tag_name: ios-v${{ env.version }}
           prerelease: ${{ !github.event.inputs.release }}
           fail_on_unmatched_files: true
+
+      # needed to trigger workflow for Swift Package Index release
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.MAPLIBRE_NATIVE_BOT_APP_ID }}
+          private_key: ${{ secrets.MAPLIBRE_NATIVE_BOT_PRIVATE_KEY }}
+
+      - name: Release (Swift Package Index)
+        run: |
+          echo "::add-mask::${{ steps.generate_token.outputs.token }}"
+          release_workflow_id=81221759  # id of release.yml
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ steps.generate_token.outputs.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/maplibre/maplibre-gl-native-distribution/actions/workflows/$release_workflow_id/dispatches \
+            -d '{"ref":"main","inputs":{"version":"${{ env.version }}","download_url":"${{ fromJSON(steps.github_release.outputs.assets)[0].browser_download_url }}"}}'
 
       - name: Release (CocoaPods)
         shell: bash -leo pipefail {0}  # so pod is found
         if: env.make_release
         run: |
-          zip ${{ env.xcframework }} ../../LICENSE.md  # add license to zip
           VERSION=${{ env.version }} COCOAPODS_TRUNK_TOKEN=${{ secrets.COCOAPODS_PASSWORD }} pod trunk push MapLibre.podspec
 
   ios-ci-result:

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -227,16 +227,16 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: ios-v${{ env.version }}
-          files: |
-            ${{ env.xcframework }}
-            LICENSE.md
+          files: ${{ env.xcframework }}
           tag_name: ios-v${{ env.version }}
           prerelease: ${{ !github.event.inputs.release }}
           fail_on_unmatched_files: true
 
       - name: Release (CocoaPods)
+        shell: bash -leo pipefail {0}  # so pod is found
         if: env.make_release
         run: |
+          zip ${{ env.xcframework }} ../../LICENSE.md  # add license to zip
           VERSION=${{ env.version }} COCOAPODS_TRUNK_TOKEN=${{ secrets.COCOAPODS_PASSWORD }} pod trunk push MapLibre.podspec
 
   ios-ci-result:


### PR DESCRIPTION
- Add separate step to include license in zip
- Trigger `release.yml` in `maplibre-gl-native-distribution` repo

Note: I had to remove branch protection from `maplibre-gl-native-distribution` to be able to push changes from the workflow. I think this is an acceptable trade-off, because this repo does not have any active development, so accidential pushes to main are unlikely.

Closes #662