### PR TITLE
Stencil clear

### DIFF
--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -101,34 +101,11 @@ using GetTileIDFunc = const UnwrappedTileID& (*)(const typename TIter::value_typ
 
 using TileMaskIDMap = std::map<UnwrappedTileID, int32_t>;
 
-// `std::includes` adapted to extract tile IDs from arbitrary collection iterators.
-// This is needed because, although it accepts iterators of different types, they must be:
-// "...such that an object of type InputIt can be dereferenced and then implicitly converted to both of them.​"
-template <class I1, class I2>
-bool includes(I1 beg1, const I1 end1, I2 beg2, const I2 end2, const GetTileIDFunc<I2>& unwrap) {
-    for (; beg2 != end2; ++beg1) {
-        if (beg1 == end1) {
-            return false;
-        }
-        const auto id2 = unwrap(*beg2);
-        if (id2 < beg1->first) {
-            return false;
-        } else if (!(beg1->first < id2)) {
-            ++beg2;
-        }
-    }
-    return true;
-}
-
-const UnwrappedTileID& unwrap(const RenderTiles::element_type::value_type& iter) {
-    return iter.get().id;
-}
-
 // Check whether we can reuse a clip mask for a new set of tiles
 bool tileIDsCovered(const RenderTiles& tiles, const TileMaskIDMap& idMap) {
     return idMap.size() == tiles->size() &&
            std::equal(idMap.cbegin(), idMap.cend(), tiles->cbegin(), tiles->cend(), [=](const auto& a, const auto& b) {
-               return a.first == unwrap(b);
+               return a.first == b.get().id;
            });
 }
 


### PR DESCRIPTION
Reverts the subset-based check for stencil mask reset, which would consider a mask with a superset of the current render tile set valid for reuse.  When multiple sources are in use, this would lead to rendering with incorrect masks causing some tiles to not appear for some layers.  It's no longer necessary to account for different layers of the same source not generating the same set of tile drawables, per #1871, so this should not be a performance problem.

Replaces #1989
Resolves #1981

<img src="https://github.com/maplibre/maplibre-native/assets/71895881/5df99caf-ea6e-4e65-b9af-323dab273187" width="300"/>

