### PR TITLE
Add changelog to iOS releases

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -215,6 +215,11 @@ jobs:
         if: env.make_release && !github.event.inputs.release
         run: echo version="$(cat VERSION)"-pre${{ github.sha }} >> "$GITHUB_ENV"
 
+      - name: Extract changelog for version
+        run: |
+          awk '/^##/ { p = 0 }; p == 1 { print }; $0 == "## {{ env.version }}" { p = 1 };' CHANGELOG.md > changelog_for_version.md
+          cat changelog_for_version.md
+
       - name: Create tag
         if: env.make_release
         run: |
@@ -225,6 +230,7 @@ jobs:
         if: env.make_release
         run: |
           cp ${{ env.xcframework }} MapLibre.dynamic.xcframework.zip
+          chmod +w MapLibre.dynamic.xcframework.zip
           zip MapLibre.dynamic.xcframework.zip LICENSE.md  # add license to zip
         working-directory: .
 
@@ -237,6 +243,7 @@ jobs:
           files: MapLibre.dynamic.xcframework.zip
           tag_name: ios-v${{ env.version }}
           prerelease: ${{ !github.event.inputs.release }}
+          body_path: platform/ios/changelog_for_version.md
           fail_on_unmatched_files: true
 
       # needed to trigger workflow for Swift Package Index release
@@ -259,7 +266,10 @@ jobs:
             -H "Authorization: token ${{ steps.generate_token.outputs.token }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/maplibre/maplibre-gl-native-distribution/actions/workflows/$release_workflow_id/dispatches \
-            -d '{"ref":"main","inputs":{"version":"${{ env.version }}","download_url":"${{ fromJSON(steps.github_release.outputs.assets)[0].browser_download_url }}"}}'
+            -d '{"ref":"main","inputs":{ \
+              "changelog": '"$(cat changelog_for_version.md)"' \
+              "version":"${{ env.version }}", \
+              "download_url":"${{ fromJSON(steps.github_release.outputs.assets)[0].browser_download_url }}"}}'
 
       - name: Release (CocoaPods)
         shell: bash -leo pipefail {0}  # so pod is found

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,8 +4,11 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 
 ## main
 
-## 6.0.0-pre0
+## 6.0.0
 
+* This is the first release that uses **Metal** for rendering. This is a graphics API from Apple that replaces OpenGL ES on Apple platforms.
+  * Note that the [snapshotter](https://github.com/maplibre/maplibre-native/issues/1862) has not been implemented yet for the Metal renderer. Hold off updating if your application requires this functionality.
+  * While we had a long period of pre-releases and testing leading up to this release, and no crashes have been reported, it is possible that you come across inconsistencies or problems in production apps. Please report them on [GitHub](https://github.com/maplibre/maplibre-native/issues/1609).
 * 💥 Breaking: Changed the prefix of files, classes, methods, variables and everything from `MGL` to `MLN`. ([#919](https://github.com/maplibre/maplibre-native/pull/919)).
 
   > To migrate:  


### PR DESCRIPTION
This extracts the changelog for a version with `awk` and adds it to the release.

Also fixes a permission problem with the XCFramework.