### PR TITLE
Add instructions iOS release and small fix

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Release (CocoaPods)
         shell: bash -leo pipefail {0}  # so pod is found
-        if: env.make_release
+        if: env.make_release && github.event.inputs.release
         run: |
           VERSION=${{ env.version }} COCOAPODS_TRUNK_TOKEN=${{ secrets.COCOAPODS_PASSWORD }} pod trunk push MapLibre.podspec
 

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -268,7 +268,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/maplibre/maplibre-gl-native-distribution/actions/workflows/$release_workflow_id/dispatches \
             -d '{"ref":"main","inputs":{ \
-              "changelog": '"$(cat changelog_for_version.md)"' \
+              "changelog": '"$(cat changelog_for_version.md)"', \
               "version":"${{ env.version }}", \
               "download_url":"${{ fromJSON(steps.github_release.outputs.assets)[0].browser_download_url }}"}}'
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,7 @@ The maintainers of MapLibre Native are committed to a fast and efficient resolut
 6. `[Committer]` A new release is pushed out from the branch that now contains the fix. The release process is automated and documented and can be done by anyone with write access.
 
     - Android: [platform/android/RELEASE.md](https://github.com/maplibre/maplibre-native/blob/main/platform/android/RELEASE.md)
-    - iOS: TODO, please see this issue: https://github.com/maplibre/maplibre-native/issues/1581
+    - iOS: [platform/ios/RELEASE.md](https://github.com/maplibre/maplibre-native/blob/main/platform/android/RELEASE.md)
 
 7. `[Maintainer]` The security advisory is [published](https://github.com/maplibre/maplibre-native/security/advisories?state=published).
 

--- a/platform/ios/RELEASE.md
+++ b/platform/ios/RELEASE.md
@@ -1,0 +1,19 @@
+# Instructions for making an iOS release
+
+1. Make sure the `VERSION` file in `platform/ios/VERSION` contains the version to be released. We use semantic versioning, so any breaking changes require a major version bump.
+
+2. Update the changelog, which can be found in `platform/ios/CHANGELOG.md`. The heading must match `## <VERSION>` exactly, or it will not be picked up. For example, for version 6.0.0:
+
+```
+## 6.0.0
+```
+
+3. Run the `ios-ci` workflow. You can use the [GitHub CLI](https://cli.github.com/manual/gh_workflow_run):
+
+```
+gh workflow run ios-ci.yml -f release=true --ref main
+```
+
+Or run the workflow from the Actions tab on GitHub:
+
+<img width="333" alt="Screenshot 2024-01-07 at 16 23 50" src="https://github.com/maplibre/maplibre-native/assets/649392/a0440e05-c522-49ba-ae85-3fc2193de465">


### PR DESCRIPTION
- Add instructions for making an iOS release, update secutity policy.
- Do not release pre-releases to CocoaPods.
- Add missing comma JSON payload of curl request to kick of Swift Package Index release.