### PR TITLE
Switch to manual iOS pre-releases

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -4,9 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       release:
-        required: false
-        type: boolean
-        description: Makes a release with version platform/ios/VERSION
+        type: choice
+        default: no
+        options:
+          - full
+          - pre
+          - no
+        description: Whether to make a release, choose full release (uses platform/ios/VERSION) or pre-release
   push:
     branches:
       - main
@@ -199,7 +203,7 @@ jobs:
 
       # Make Metal XCFramework release
       - name: Should make release?
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: github.event.inputs.release != 'no'
         run: echo make_release=true >> "$GITHUB_ENV"
 
       - name: Build XCFramework
@@ -208,17 +212,21 @@ jobs:
           echo xcframework="$(bazel info execution_root)"/"$(bazel cquery --output=files --compilation_mode=opt --//:renderer=metal --//:maplibre_platform=ios //platform/ios:MapLibre.dynamic)" >> "$GITHUB_ENV"
 
       - name: Get version (release)
-        if: env.make_release && github.event.inputs.release
-        run: echo version="$(cat VERSION)" >> "$GITHUB_ENV"
+        if: github.event.inputs.release == 'full'
+        run: |
+          echo version="$(cat VERSION)" >> "$GITHUB_ENV"
+          echo changelog_version_heading="## {{ env.version }}" >> "$GITHUB_ENV"
 
       - name: Get version (pre-release)
-        if: env.make_release && !github.event.inputs.release
-        run: echo version="$(cat VERSION)"-pre${{ github.sha }} >> "$GITHUB_ENV"
+        if: github.event.inputs.release == 'pre'
+        run: |
+          echo version="$(cat VERSION)"-pre${{ github.sha }} >> "$GITHUB_ENV"
+          echo changelog_version_heading="## main" >> "$GITHUB_ENV"
 
       - name: Extract changelog for version
         if: env.make_release
         run: |
-          awk '/^##/ { p = 0 }; p == 1 { print }; $0 == "## {{ env.version }}" { p = 1 };' CHANGELOG.md > changelog_for_version.md
+          awk '/^##/ { p = 0 }; p == 1 { print }; $0 == "{{ env.changelog_version_heading }}" { p = 1 };' CHANGELOG.md > changelog_for_version.md
           cat changelog_for_version.md
 
       - name: Create tag
@@ -268,13 +276,13 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/maplibre/maplibre-gl-native-distribution/actions/workflows/$release_workflow_id/dispatches \
             -d '{"ref":"main","inputs":{ \
-              "changelog": '"$(cat changelog_for_version.md)"', \
+              "changelog": "'"$(cat changelog_for_version.md)"'", \
               "version":"${{ env.version }}", \
               "download_url":"${{ fromJSON(steps.github_release.outputs.assets)[0].browser_download_url }}"}}'
 
       - name: Release (CocoaPods)
         shell: bash -leo pipefail {0}  # so pod is found
-        if: env.make_release && github.event.inputs.release
+        if: env.make_release
         run: |
           VERSION=${{ env.version }} COCOAPODS_TRUNK_TOKEN=${{ secrets.COCOAPODS_PASSWORD }} pod trunk push MapLibre.podspec
 

--- a/platform/ios/RELEASE.md
+++ b/platform/ios/RELEASE.md
@@ -1,19 +1,35 @@
 # Instructions for making an iOS release
 
+We make iOS releases to GitHub (a downloadable XCFramework), the [Swift Package Index](https://swiftpackageindex.com/maplibre/maplibre-gl-native-distribution) and [CocoaPods](https://cocoapods.org/). Everyone with write access to the repository is able to make releases using the instructions below.
+
+## Pre-release
+
+Run the `ios-ci` workflow. You can use the [GitHub CLI](https://cli.github.com/manual/gh_workflow_run):
+
+```
+gh workflow run ios-ci.yml -f release=pre --ref main
+```
+
+Or run the workflow from the Actions tab on GitHub.
+
+The items under the `## main` heading in `platform/ios/CHANGELOG.md` will be used as changelog for the pre-release. 
+
+## Full release
+
 1. Make sure the `VERSION` file in `platform/ios/VERSION` contains the version to be released. We use semantic versioning, so any breaking changes require a major version bump.
 
 2. Update the changelog, which can be found in `platform/ios/CHANGELOG.md`. The heading must match `## <VERSION>` exactly, or it will not be picked up. For example, for version 6.0.0:
 
-```
+```md
 ## 6.0.0
 ```
 
 3. Run the `ios-ci` workflow. You can use the [GitHub CLI](https://cli.github.com/manual/gh_workflow_run):
 
 ```
-gh workflow run ios-ci.yml -f release=true --ref main
+gh workflow run ios-ci.yml -f release=full --ref main
 ```
 
 Or run the workflow from the Actions tab on GitHub:
 
-<img width="333" alt="Screenshot 2024-01-07 at 16 23 50" src="https://github.com/maplibre/maplibre-native/assets/649392/a0440e05-c522-49ba-ae85-3fc2193de465">
+<img width="367" alt="Screenshot 2024-01-08 at 11 00 30" src="https://github.com/louwers/workflow-playground/assets/649392/2066da56-0bb2-44ea-a9fc-4a2b160961c8">


### PR DESCRIPTION
Release workflow seems to work. I will probably create a workflow that prepares a PR to update the changelog. For now this one manual step is acceptable.

We had a long period of pre-releases and instability due to the rendering architecture changing and the introduction of Metal. MapLibre Native for iOS 6.0.0 will be released soon. After that I think we will switch to a more regular release cadence.

If deemed necessary we still have the option to put out a pre-release.