### PR TITLE
[node][opengl-2] Release node-v5.3.0-pre.0 - test node release workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.2.0",
+  "version": "5.3.0-pre.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "5.2.0",
+      "version": "5.3.0-pre.0",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.2.0",
+  "version": "5.3.0-pre.0",
   "description": "Renders map tiles with Maplibre GL",
   "keywords": [
     "maplibre",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -2,15 +2,18 @@
 ## main
 
 * ...Add new stuff here...
-* [Breaking] Remove node 14 support and add node 20 support. We are now building binaries for node 16,18,20
-* [Breaking] Linux binary is now built on Ubuntu 22.04 instead of Ubuntu 20.04. it could require a OS update to use this update on linux.
+* [Note] This is a OpenGL-2 release. It does not include metal support.
+* [Breaking] Removes node 14 binary build and adds node 20 binary build. We are now building binaries for node 16,18,20 @acalcutt https://github.com/maplibre/maplibre-native/pull/1941
+* [Breaking] Linux binary is now built on Ubuntu 22.04 instead of Ubuntu 20.04. it could require a OS update to use this update on linux. @acalcutt https://github.com/maplibre/maplibre-native/pull/1941
 * Make Node Map object options "request" property optional by @tdcosta100 in https://github.com/maplibre/maplibre-native/pull/904
 * Compile Node targets without -std=c++11 option by @tdcosta100 in https://github.com/maplibre/maplibre-native/pull/926
 
+
 ## 5.3.0-pre.0
 
-* [Breaking] Remove node 14 support and add node 20 support. We are now building binaries for node 16,18,20
-* [Breaking] Linux binary is now built on Ubuntu 22.04 instead of Ubuntu 20.04. it could require a OS update to use this update on linux.
+* [Note] This is a OpenGL-2 release. It does not include metal support.
+* [Breaking] Removes node 14 binary build and adds node 20 binary build. We are now building binaries for node 16,18,20 @acalcutt https://github.com/maplibre/maplibre-native/pull/1941
+* [Breaking] Linux binary is now built on Ubuntu 22.04 instead of Ubuntu 20.04. it could require a OS update to use this update on linux. @acalcutt https://github.com/maplibre/maplibre-native/pull/1941
 * Make Node Map object options "request" property optional by @tdcosta100 in https://github.com/maplibre/maplibre-native/pull/904
 * Compile Node targets without -std=c++11 option by @tdcosta100 in https://github.com/maplibre/maplibre-native/pull/926
 

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,6 +1,16 @@
 
 ## main
 
+* ...Add new stuff here...
+* [Breaking] Remove node 14 support and add node 20 support. We are now building binaries for node 16,18,20
+* [Breaking] Linux binary is now built on Ubuntu 22.04 instead of Ubuntu 20.04. it could require a OS update to use this update on linux.
+* Make Node Map object options "request" property optional by @tdcosta100 in https://github.com/maplibre/maplibre-native/pull/904
+* Compile Node targets without -std=c++11 option by @tdcosta100 in https://github.com/maplibre/maplibre-native/pull/926
+
+## 5.3.0-pre.0
+
+* [Breaking] Remove node 14 support and add node 20 support. We are now building binaries for node 16,18,20
+* [Breaking] Linux binary is now built on Ubuntu 22.04 instead of Ubuntu 20.04. it could require a OS update to use this update on linux.
 * Make Node Map object options "request" property optional by @tdcosta100 in https://github.com/maplibre/maplibre-native/pull/904
 * Compile Node targets without -std=c++11 option by @tdcosta100 in https://github.com/maplibre/maplibre-native/pull/926
 

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,14 +1,6 @@
 
 ## main
 
-* ...Add new stuff here...
-* [Note] This is a OpenGL-2 release. It does not include metal support.
-* [Breaking] Removes node 14 binary build and adds node 20 binary build. We are now building binaries for node 16,18,20 @acalcutt https://github.com/maplibre/maplibre-native/pull/1941
-* [Breaking] Linux binary is now built on Ubuntu 22.04 instead of Ubuntu 20.04. it could require a OS update to use this update on linux. @acalcutt https://github.com/maplibre/maplibre-native/pull/1941
-* Make Node Map object options "request" property optional by @tdcosta100 in https://github.com/maplibre/maplibre-native/pull/904
-* Compile Node targets without -std=c++11 option by @tdcosta100 in https://github.com/maplibre/maplibre-native/pull/926
-
-
 ## 5.3.0-pre.0
 
 * [Note] This is a OpenGL-2 release. It does not include metal support.


### PR DESCRIPTION
This PR should push a release 'node-v5.3.0-pre.0' from the 'opengl-2' branch.  This should allow new node binaries for node 16/18/20

In the changelog, since this is a pre-release, I copied the unreleased changes from main. I wasn't sure if I should keep them under main also. i decided to leave them in both spots until a full release was made

I added two breaking changes
1.) The removal node 14 binary
2.) The change to ubuntu 22.04 may change OS requirements.