### PR TITLE
Don't include private headers in iOS build

### DIFF
--- a/platform/darwin/bazel/files.bzl
+++ b/platform/darwin/bazel/files.bzl
@@ -99,6 +99,7 @@ MLN_DARWIN_OBJC_HEADERS = [
     "src/NSExpression+MLNAdditions.h",
     "src/NSPredicate+MLNAdditions.h",
     "src/NSValue+MLNAdditions.h",
+    "src/MLNCustomDrawableStyleLayer.h",
 ]
 
 MLN_DARWIN_OBJCPP_HEADERS = [
@@ -210,7 +211,6 @@ MLN_DARWIN_PUBLIC_OBJCPP_OPENGL_SOURCE = [
 ]
 MLN_DARWIN_PUBLIC_OBJCPP_CUSTOM_DRAWABLE_SOURCE = [
     "src/MLNCustomDrawableStyleLayer_Private.h",
-    "src/MLNCustomDrawableStyleLayer.h",
     "src/MLNCustomDrawableStyleLayer.mm",
 ]
 MLN_DARWIN_PUBLIC_OBJC_SOURCE = [

--- a/platform/ios/BUILD.bazel
+++ b/platform/ios/BUILD.bazel
@@ -99,7 +99,6 @@ public_hdrs = [
     ":ios_public_hdrs",
     ":ios_sdk_hdrs",
     "//platform/darwin:darwin_objc_hdrs",
-    "//platform/darwin:darwin_objcpp_hdrs",
     "//platform/darwin:generated_style_public_hdrs",
 ]
 

--- a/platform/ios/bazel/files.bzl
+++ b/platform/ios/bazel/files.bzl
@@ -14,26 +14,22 @@ MLN_IOS_SDK_HEADERS = [
 ]
 
 MLN_IOS_PUBLIC_HEADERS = [
-    "src/MLNAnnotationContainerView.h",
-    "src/MLNCompactCalloutView.h",
-    "src/MLNFaux3DUserLocationAnnotationView.h",
-    "src/MLNMapAccessibilityElement.h",
-    "src/MLNMapView+Impl.h",
-    "src/MLNMapView+Metal.h",
-    "src/MLNMapView+OpenGL.h",
-    "src/MLNScaleBar.h",
-    "src/MLNUserLocationHeadingArrowLayer.h",
-    "src/MLNUserLocationHeadingBeamLayer.h",
-    "src/MLNUserLocationHeadingIndicator.h",
-    "src/NSOrthography+MLNAdditions.h",
-    "src/UIColor+MLNAdditions.h",
-    "src/UIDevice+MLNAdditions.h",
-    "src/UIImage+MLNAdditions.h",
-    "src/UIView+MLNAdditions.h",
-    "src/UIViewController+MLNAdditions.h",
 ]
 
 MLN_IOS_PRIVATE_HEADERS = [
+    "src/NSOrthography+MLNAdditions.h",
+    "src/UIDevice+MLNAdditions.h",
+    "src/UIImage+MLNAdditions.h",
+    "src/MLNUserLocationHeadingArrowLayer.h",
+    "src/MLNUserLocationHeadingIndicator.h",
+    "src/UIColor+MLNAdditions.h",
+    "src/MLNMapAccessibilityElement.h",
+    "src/UIViewController+MLNAdditions.h",
+    "src/UIView+MLNAdditions.h",
+    "src/MLNScaleBar.h",
+    "src/MLNFaux3DUserLocationAnnotationView.h",
+    "src/MLNUserLocationHeadingBeamLayer.h",
+    "src/MLNAnnotationContainerView.h",
     "src/MLNAnnotationContainerView_Private.h",
     "src/MLNAnnotationImage_Private.h",
     "src/MLNAnnotationView_Private.h",
@@ -41,6 +37,10 @@ MLN_IOS_PRIVATE_HEADERS = [
     "src/MLNMapView_Private.h",
     "src/MLNUserLocationAnnotationView_Private.h",
     "src/MLNUserLocation_Private.h",
+    "src/MLNCompactCalloutView.h",
+    "src/MLNMapView+Impl.h",
+    "src/MLNMapView+Metal.h",
+    "src/MLNMapView+OpenGL.h",
 ]
 
 MLN_IOS_PUBLIC_OBJC_SOURCE = [

--- a/platform/ios/src/Mapbox.template.h
+++ b/platform/ios/src/Mapbox.template.h
@@ -77,6 +77,6 @@ FOUNDATION_EXPORT MLN_EXPORT const unsigned char MapboxVersionString[];
 #import "NSPredicate+MLNAdditions.h"
 #import "NSValue+MLNAdditions.h"
 #import "MLNUserLocationAnnotationViewStyle.h"
-#if MLN_DRAWABLE_RENDERER
+#if defined(MLN_DRAWABLE_RENDERER) || defined(MLN_RENDER_BACKEND_METAL)
 #import "MLNCustomDrawableStyleLayer.h"
 #endif


### PR DESCRIPTION
This removes 'public' headers that are not actually public from the build.

Closes #2009 Xcode will give off warnings when an included framework has headers that are not part of the umbrella header. Thanks @JesseCrocker for reporting.