### PR TITLE
Enable incompatible_disallow_empty_glob

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,7 @@
 # TODO: remove with bazel 7.x
 common --enable_bzlmod
 
+# TODO: remove once bazel flips this flag
+common --incompatible_disallow_empty_glob
+
 coverage --experimental_ui_max_stdouterr_bytes=10485760

--- a/platform/BUILD.bazel
+++ b/platform/BUILD.bazel
@@ -100,10 +100,6 @@ objc_library(
 # Common headers between objc and objcpp libraries.
 objc_library(
     name = "objc-headers",
-    srcs = glob([
-        "darwin/src/*.h",
-        "ios/src/*.h",
-    ]),
     includes = [
         "darwin/src",
         "ios/src",
@@ -203,9 +199,6 @@ objc_library(
             "//platform/darwin:app/LimeGreenStyleLayer.m",
         ],
     }),
-    data = glob([
-        "app/Assets.xcassets/**",
-    ]),
     defines = ["GLES_SILENCE_DEPRECATION"],
     includes = [
         "darwin/app",

--- a/platform/ios/benchmark/BUILD.bazel
+++ b/platform/ios/benchmark/BUILD.bazel
@@ -24,11 +24,10 @@ filegroup(
 filegroup(
     name = "bundle_resources",
     srcs = glob([
-        "benchmark/*.lproj/**",
-        "benchmark/Assets.xcassets/**",
-        "benchmark/assets/**/*.pbf",
-        "benchmark/assets/**/*.json",
-        "benchmark/assets/**/*.png",
+        "*.lproj/**",
+        "Assets.xcassets/**",
+        "assets/**/*.json",
+        "assets/**/*.png",
     ]),
     visibility = ["//platform/ios:__pkg__"],
 )


### PR DESCRIPTION
This just makes it easier to spot accidental bugs where we think we're globbing something when we're not