### PR TITLE
Ignore MODULE.bazel.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ node_modules
 /lib
 
 /bazel-*
+/MODULE.bazel.lock
 CMakeLists.txt.user
 CMakeFiles
 __generated__


### PR DESCRIPTION
This file is useful for building offline, but requires keeping in sync when updating dependencies. By ignoring it developers can generate it locally and build offline successfully, but doesn't require the overhead of keeping it up to date.