### PR TITLE
[node][opengl-2] Release node-v5.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.3.0-pre.0",
+  "version": "5.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "5.3.0-pre.0",
+      "version": "5.3.0",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.3.0-pre.0",
+  "version": "5.3.0",
   "description": "Renders map tiles with Maplibre GL",
   "keywords": [
     "maplibre",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## main
 
-## 5.3.0-pre.0
+## 5.3.0
 
 * [Note] This is a OpenGL-2 release. It does not include metal support.
 * [Breaking] Removes node 14 binary build and adds node 20 binary build. We are now building binaries for node 16,18,20 @acalcutt https://github.com/maplibre/maplibre-native/pull/1941


### PR DESCRIPTION
This PR will make a full release of node-v5.3.0

`Testing`

- I have tested the pre-release on linux, and as expected it does need a OS update. The package works fine in Ubuntu 22.04, but in 20.04 it gets this error (which makes sense since libicu is a different version). Luckily upgrade from 20.04 to 22.04 usually pretty simple, since you can directly migrate.
```
Error: libicui18n.so.70: cannot open shared object file: No such file or directory
    at Module._extensions..node (node:internal/modules/cjs/loader:1452:18)
    at Module.load (node:internal/modules/cjs/loader:1197:32)
    at Module._load (node:internal/modules/cjs/loader:1013:12)
    at Module.require (node:internal/modules/cjs/loader:1225:19)
    at require (node:internal/modules/helpers:177:18)
    at Object.<anonymous> (/opt/tileserver-test/node_modules/@maplibre/maplibre-                                                                   gl-native/platform/node/index.js:5:12)
    at Module._compile (node:internal/modules/cjs/loader:1356:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
    at Module.load (node:internal/modules/cjs/loader:1197:32)
    at Module._load (node:internal/modules/cjs/loader:1013:12) {
  code: 'ERR_DLOPEN_FAILED'
}
```
- On macos arm64, I have confirmed with @mnutt that the package seemed to work there
- On windows this package seems to work great
- I have made a test Tileserver-GL release at https://github.com/maptiler/tileserver-gl/pull/1124 , where I have updated the docker image and instructions. This works well for testing this package. (note, on macos arm, @mnutt mentioned some issues with sharp, but they were unrelated to this package)