### PR TITLE
[node][main] Update latest release to node-v5.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Renders map tiles with MapLibre Native",
   "keywords": [
     "maplibre",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 ## main
 
+## 5.3.0
+
+* [Note] This is a OpenGL-2 release. It does not include metal support.
+* [Breaking] Removes node 14 binary build and adds node 20 binary build. We are now building binaries for node 16,18,20 @acalcutt https://github.com/maplibre/maplibre-native/pull/1941
+* [Breaking] Linux binary is now built on Ubuntu 22.04 instead of Ubuntu 20.04. it could require a OS update to use this update on linux. @acalcutt https://github.com/maplibre/maplibre-native/pull/1941
 * Make Node Map object options "request" property optional by @tdcosta100 in https://github.com/maplibre/maplibre-native/pull/904
 * Compile Node targets without -std=c++11 option by @tdcosta100 in https://github.com/maplibre/maplibre-native/pull/926
 


### PR DESCRIPTION
This is a cherry pick of the node-v5.3.0 release on the 'opengl-2' branch. This is mainly so main package.json reflects the latest version and the CHANGELOG included the latest information.

In addition to updating the version, this will also make npm pull in the latest binaries when a user does 'npm install', since it uses the version in package.json to know which version to pull.


**Note**
This will not actually make a new release, since node-v5.3.0 is already published.