### PR TITLE
cmake: enable MLN_WITH_EGL and OPENGL_USE_GLES for Wayland

### DIFF
--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -15,6 +15,18 @@ find_package(Threads REQUIRED)
 pkg_search_module(WEBP libwebp REQUIRED)
 pkg_search_module(LIBUV libuv REQUIRED)
 
+if(MLN_WITH_WAYLAND)
+    # See https://github.com/maplibre/maplibre-native/pull/2022
+
+    # MLN_WITH_EGL needs to be set for Wayland, otherwise this CMakeLists will
+    # call find_package(OpenGL REQUIRED GLX), which is for X11.
+    set(MLN_WITH_EGL TRUE)
+
+    # OPENGL_USE_GLES2 or OPENGL_USE_GLES3 need to be set, otherwise
+    # FindOpenGL.cmake will include the GLVND library, which is for X11.
+    set(OPENGL_USE_GLES3 TRUE)
+endif()
+
 target_sources(
     mbgl-core
     PRIVATE


### PR DESCRIPTION
### What it achieves

Without these changes, I need to configure with the unintuitive:

```
cmake -DMLN_WITH_EGL=ON -DMLN_WITH_WAYLAND=ON -DOPENGL_USE_GLES3=ON -Bbuild -S.
```

With these changes, I can configure successfully with:

```
cmake -DMLN_WITH_WAYLAND=ON -Bbuild -S.
```

### The change

This change sets two values to TRUE in platform/linux/linux.cmake when `MLN_WITH_WAYLAND` is set:

* MLN_WITH_EGL: without this set, it will try to find the GLX component of OpenGL, which is an X11 thing. Without this change I get the following error:

```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find OpenGL (missing: GLX)
```

* OPENGL_USE_GLES2: without this (or OPENGL_USE_GLES3) set, [the CMake module for OpenGL will include the GLVND library](https://github.com/Kitware/CMake/blob/master/Modules/FindOpenGL.cmake#L432-L435) which is, again, for X11. Without this change I get the following error:

```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY)
```

### Further considerations 

One could ask: "is it not an issue to set OPENGL_USE_GLES2, in case someone wants OPENGL_USE_GLES3?", and my (admittedly limited) understanding is that the FindOpenGL module will still detect the right one, but we need one to be set for the check [here](https://github.com/Kitware/CMake/blob/master/Modules/FindOpenGL.cmake#L432-L435) (otherwise it will look for the GLVND library). In my case, I have glfw-3 installed on my system, and it gets detected even with OPENGL_USE_GLES2 set. Not sure what would happen if I had both installed (my distro doesn't provide both, I can't test :see_no_evil:). Maybe it would be better to set OPENGL_USE_GLES3?

### Notes

This is my suggestion to improve the Wayland build, following my struggling with https://github.com/maplibre/maplibre-native/issues/2019.

@jwinarske: FYI