### PR TITLE
Metal enable an ignored render test: map-text-depthtest

### DIFF
--- a/metrics/ignores/platform-ios-metal.json
+++ b/metrics/ignores/platform-ios-metal.json
@@ -1,6 +1,5 @@
 {
     "render-tests/fill-outline-color/zoom-and-property-function": "It will be fixed after triangulated lines will support data driven properties",
     "render-tests/fill-outline-color/property-function": "It will be fixed after triangulated lines will support data driven properties",
-    "render-tests/text-pitch-alignment/map-text-depthtest": "Layer Z Fighting: https://github.com/maplibre/maplibre-native/issues/1847",
     "render-tests/fill-extrusion-color/function": "Layer Z Fighting: https://github.com/maplibre/maplibre-native/issues/1847"
 }


### PR DESCRIPTION
Enabled an ignored render test `render-tests/text-pitch-alignment/map-text-depthtest` that is now passing after fixing the depth issue.