### PR TITLE
Part 1

### DIFF
--- a/include/mbgl/actor/actor.hpp
+++ b/include/mbgl/actor/actor.hpp
@@ -71,7 +71,7 @@ public:
     ActorRef<std::decay_t<Object>> self() { return parent.self(); }
 
 private:
-    std::shared_ptr<Scheduler> retainer;
+    const std::shared_ptr<Scheduler> retainer;
     AspiringActor<Object> parent;
     EstablishedActor<Object> target;
 };

--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -36,7 +36,7 @@ public:
     virtual ~Scheduler() = default;
 
     /// Enqueues a function for execution.
-    virtual void schedule(std::function<void()>) = 0;
+    virtual void schedule(std::function<void()>&&) = 0;
     /// Makes a weak pointer to this Scheduler.
     virtual mapbox::base::WeakPtr<Scheduler> makeWeakPtr() = 0;
     /// Enqueues a function for execution on the render thread.

--- a/include/mbgl/util/run_loop.hpp
+++ b/include/mbgl/util/run_loop.hpp
@@ -78,7 +78,7 @@ public:
         return std::make_unique<WorkRequest>(task);
     }
 
-    void schedule(std::function<void()> fn) override { invoke(std::move(fn)); }
+    void schedule(std::function<void()>&& fn) override { invoke(std::move(fn)); }
     ::mapbox::base::WeakPtr<Scheduler> makeWeakPtr() override { return weakFactory.makeWeakPtr(); }
 
     class Impl;

--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <string>
 #include <cstdint>
 #include <cstdlib>
-#include <type_traits>
 #include <exception>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <type_traits>
 
 // Polyfill needed by Qt when building for Android with GCC
 #if defined(__ANDROID__) && defined(__GLIBCXX__)
@@ -74,6 +76,10 @@ inline std::string toString(float t, bool decimal = false) {
 
 inline std::string toString(long double t, bool decimal = false) {
     return toString(static_cast<double>(t), decimal);
+}
+
+inline std::string toString(std::thread::id threadId) {
+    return (std::ostringstream() << threadId).str();
 }
 
 std::string toString(const std::exception_ptr &);

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/map_renderer.cpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/map_renderer.cpp
@@ -60,7 +60,7 @@ ActorRef<Renderer> MapRenderer::actor() const {
     return *rendererRef;
 }
 
-void MapRenderer::schedule(std::function<void()> scheduled) {
+void MapRenderer::schedule(std::function<void()>&& scheduled) {
     try {
         // Create a runnable
         android::UniqueEnv _env = android::AttachEnv();

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/map_renderer.hpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/map_renderer.hpp
@@ -66,7 +66,7 @@ public:
 
     // From Scheduler. Schedules by using callbacks to the
     // JVM to process the mailbox on the right thread.
-    void schedule(std::function<void()> scheduled) override;
+    void schedule(std::function<void()>&& scheduled) override;
     mapbox::base::WeakPtr<Scheduler> makeWeakPtr() override { return weakFactory.makeWeakPtr(); }
 
     void requestRender();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/maps/renderer/textureview/TextureViewMapRenderer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/maps/renderer/textureview/TextureViewMapRenderer.java
@@ -35,6 +35,7 @@ public class TextureViewMapRenderer extends MapRenderer {
     super(context, localIdeographFontFamily);
     this.translucentSurface = translucentSurface;
     renderThread = new TextureViewRenderThread(textureView, this);
+    renderThread.setName("TextureViewRenderer");
     renderThread.start();
   }
 

--- a/src/mbgl/gfx/context.hpp
+++ b/src/mbgl/gfx/context.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/actor/scheduler.hpp>
 #include <mbgl/gfx/backend.hpp>
 #include <mbgl/gfx/command_encoder.hpp>
 #include <mbgl/gfx/draw_scope.hpp>
@@ -53,7 +54,8 @@ using VertexAttributeArrayPtr = std::shared_ptr<VertexAttributeArray>;
 class Context {
 protected:
     Context(uint32_t maximumVertexBindingCount_)
-        : maximumVertexBindingCount(maximumVertexBindingCount_) {}
+        : maximumVertexBindingCount(maximumVertexBindingCount_),
+          backgroundScheduler(Scheduler::GetBackground()) {}
 
 public:
     static constexpr const uint32_t minimumRequiredVertexBindingCount = 8;
@@ -161,6 +163,8 @@ protected:
     virtual std::unique_ptr<DrawScopeResource> createDrawScopeResource() = 0;
 
     gfx::RenderingStats stats;
+
+    std::shared_ptr<Scheduler> backgroundScheduler;
 };
 
 } // namespace gfx

--- a/src/mbgl/test/vector_tile_test.hpp
+++ b/src/mbgl/test/vector_tile_test.hpp
@@ -1,0 +1,39 @@
+#include <mbgl/map/transform.hpp>
+#include <mbgl/renderer/tile_parameters.hpp>
+#include <mbgl/renderer/image_manager.hpp>
+#include <mbgl/style/style.hpp>
+#include <mbgl/test/fake_file_source.hpp>
+#include <mbgl/text/glyph_manager.hpp>
+#include <mbgl/util/run_loop.hpp>
+
+#include <memory>
+
+#include <mbgl/test/util.hpp>
+#include <mbgl/util/logging.hpp>
+#include <mbgl/util/string.hpp>
+
+namespace mbgl {
+
+class VectorTileTest {
+public:
+    std::shared_ptr<FileSource> fileSource = std::make_shared<FakeFileSource>();
+    TransformState transformState;
+    util::RunLoop loop;
+    style::Style style{fileSource, 1};
+    AnnotationManager annotationManager{style};
+    ImageManager imageManager;
+    GlyphManager glyphManager;
+    Tileset tileset{{"https://example.com"}, {0, 22}, "none"};
+
+    TileParameters tileParameters{1.0,
+                                  MapDebugOptions(),
+                                  transformState,
+                                  fileSource,
+                                  MapMode::Continuous,
+                                  annotationManager.makeWeakPtr(),
+                                  imageManager,
+                                  glyphManager,
+                                  0};
+};
+
+} // namespace mbgl

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -76,7 +76,7 @@ public:
     // render data with the given properties.
     //
     // Returns `true` if the corresponding render layer data is present in this
-    // tile (and i.e. it was succesfully updated); returns `false` otherwise.
+    // tile (and i.e. it was successfully updated); returns `false` otherwise.
     virtual bool layerPropertiesUpdated(const Immutable<style::LayerProperties>& layerProperties) = 0;
     virtual void setShowCollisionBoxes(const bool) {}
     virtual void setLayers(const std::vector<Immutable<style::LayerProperties>>&) {}

--- a/src/mbgl/tile/tile_cache.hpp
+++ b/src/mbgl/tile/tile_cache.hpp
@@ -17,13 +17,20 @@ public:
         : threadPool(std::move(threadPool_)),
           size(size_) {}
 
+    /// Change the maximum size of the cache.
     void setSize(size_t);
-    size_t getSize() const { return size; };
-    void add(const OverscaledTileID& key, std::unique_ptr<Tile> tile);
+
+    /// Get the maximum size
+    size_t getMaxSize() const { return size; }
+
+    void add(const OverscaledTileID& key, std::unique_ptr<Tile>&& tile);
     std::unique_ptr<Tile> pop(const OverscaledTileID& key);
     Tile* get(const OverscaledTileID& key);
     bool has(const OverscaledTileID& key);
     void clear();
+
+protected:
+    void deferredRelease(std::unique_ptr<Tile>&&);
 
 private:
     std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;

--- a/src/mbgl/util/thread_pool.cpp
+++ b/src/mbgl/util/thread_pool.cpp
@@ -25,7 +25,7 @@ std::thread ThreadedSchedulerBase::makeSchedulerThread(size_t index) {
             platform::setCurrentThreadPriority(*priority);
         }
 
-        platform::setCurrentThreadName(std::string{"Worker "} + util::toString(index + 1));
+        platform::setCurrentThreadName("Worker " + util::toString(index + 1));
         platform::attachThread();
 
         while (true) {
@@ -46,7 +46,7 @@ std::thread ThreadedSchedulerBase::makeSchedulerThread(size_t index) {
     });
 }
 
-void ThreadedSchedulerBase::schedule(std::function<void()> fn) {
+void ThreadedSchedulerBase::schedule(std::function<void()>&& fn) {
     assert(fn);
     {
         std::lock_guard<std::mutex> lock(mutex);

--- a/test/actor/actor.test.cpp
+++ b/test/actor/actor.test.cpp
@@ -91,7 +91,7 @@ TEST(Actor, DestructionBlocksOnSend) {
 
         ~TestScheduler() override { EXPECT_TRUE(waited.load()); }
 
-        void schedule(std::function<void()>) final {
+        void schedule(std::function<void()>&&) final {
             promise.set_value();
             future.wait();
             std::this_thread::sleep_for(1ms);

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -1452,11 +1452,14 @@ TEST(Map, KeepRenderData) {
     test.map.getStyle().loadURL("maptiler://maps/streets");
     const int iterations = 3;
     const int resourcesCount = 4 /*tiles*/;
+
+    requestsCount = 0;
     // Keep render data.
     for (int i = 1; i <= iterations; ++i) {
         test.frontend.render(test.map);
         EXPECT_EQ(resourcesCount, requestsCount);
     }
+
     requestsCount = 0;
     // Clear render data.
     for (int i = 1; i <= iterations; ++i) {

--- a/test/tile/tile_cache.test.cpp
+++ b/test/tile/tile_cache.test.cpp
@@ -17,34 +17,13 @@
 #include <mbgl/renderer/tile_parameters.hpp>
 #include <mbgl/style/layers/symbol_layer.hpp>
 #include <mbgl/style/style.hpp>
+#include <mbgl/test/vector_tile_test.hpp>
 #include <mbgl/text/glyph_manager.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 #include <memory>
 
 using namespace mbgl;
-
-class VectorTileTest {
-public:
-    std::shared_ptr<FileSource> fileSource = std::make_shared<FakeFileSource>();
-    TransformState transformState;
-    util::RunLoop loop;
-    style::Style style{fileSource, 1};
-    AnnotationManager annotationManager{style};
-    ImageManager imageManager;
-    GlyphManager glyphManager;
-    Tileset tileset{{"https://example.com"}, {0, 22}, "none"};
-
-    TileParameters tileParameters{1.0,
-                                  MapDebugOptions(),
-                                  transformState,
-                                  fileSource,
-                                  MapMode::Continuous,
-                                  annotationManager.makeWeakPtr(),
-                                  imageManager,
-                                  glyphManager,
-                                  0};
-};
 
 class VectorTileMock : public VectorTile {
 public:
@@ -60,8 +39,8 @@ public:
 TEST(TileCache, Smoke) {
     VectorTileTest test;
     TileCache cache(Scheduler::GetBackground(), 1);
-    OverscaledTileID id(0, 0, 0);
-    std::unique_ptr<Tile> tile = std::make_unique<VectorTileMock>(id, "source", test.tileParameters, test.tileset);
+    const OverscaledTileID id(0, 0, 0);
+    auto tile = std::make_unique<VectorTileMock>(id, "source", test.tileParameters, test.tileset);
 
     cache.add(id, std::move(tile));
     EXPECT_TRUE(cache.has(id));
@@ -72,11 +51,11 @@ TEST(TileCache, Smoke) {
 TEST(TileCache, Issue15926) {
     VectorTileTest test;
     TileCache cache(Scheduler::GetBackground(), 2);
-    OverscaledTileID id0(0, 0, 0);
-    OverscaledTileID id1(1, 0, 0);
-    std::unique_ptr<Tile> tile1 = std::make_unique<VectorTileMock>(id0, "source", test.tileParameters, test.tileset);
-    std::unique_ptr<Tile> tile2 = std::make_unique<VectorTileMock>(id0, "source", test.tileParameters, test.tileset);
-    std::unique_ptr<Tile> tile3 = std::make_unique<VectorTileMock>(id1, "source", test.tileParameters, test.tileset);
+    const OverscaledTileID id0(0, 0, 0);
+    const OverscaledTileID id1(1, 0, 0);
+    auto tile1 = std::make_unique<VectorTileMock>(id0, "source", test.tileParameters, test.tileset);
+    auto tile2 = std::make_unique<VectorTileMock>(id0, "source", test.tileParameters, test.tileset);
+    auto tile3 = std::make_unique<VectorTileMock>(id1, "source", test.tileParameters, test.tileset);
 
     cache.add(id0, std::move(tile1));
     EXPECT_TRUE(cache.has(id0));

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -15,34 +15,12 @@
 #include <mbgl/geometry/feature_index.hpp>
 #include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/renderer/image_manager.hpp>
+#include <mbgl/test/vector_tile_test.hpp>
 #include <mbgl/text/glyph_manager.hpp>
 
 #include <memory>
 
 using namespace mbgl;
-
-class VectorTileTest {
-public:
-    std::shared_ptr<FileSource> fileSource = std::make_shared<FakeFileSource>(ResourceOptions::Default(),
-                                                                              ClientOptions());
-    TransformState transformState;
-    util::RunLoop loop;
-    style::Style style{fileSource, 1};
-    AnnotationManager annotationManager{style};
-    ImageManager imageManager;
-    GlyphManager glyphManager;
-    Tileset tileset{{"https://example.com"}, {0, 22}, "none"};
-
-    TileParameters tileParameters{1.0,
-                                  MapDebugOptions(),
-                                  transformState,
-                                  fileSource,
-                                  MapMode::Continuous,
-                                  annotationManager.makeWeakPtr(),
-                                  imageManager,
-                                  glyphManager,
-                                  0};
-};
 
 TEST(VectorTile, setError) {
     VectorTileTest test;


### PR DESCRIPTION
Explicit move semantics on task scheduling.
Context retains the background scheduler so `Scheduler` doesn't recycle it. Combine `VectorTileTest` definitions.
Prevent edge case causing captures to prevent destruction defer. De-template scheduler classes for code size.
Reset global count in `Map.KeepRenderData` to avoid failures in repeated test runs.