### PR TITLE
UV timer hack

### DIFF
--- a/test/util/timer.test.cpp
+++ b/test/util/timer.test.cpp
@@ -17,7 +17,7 @@ TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(Basic)) {
     const auto expectedTotalTime = interval;
 
     const auto first = MonotonicTimer::now();
-    const auto elapsed = [=]{
+    const auto elapsed = [=] {
         return std::chrono::duration_cast<mbgl::Milliseconds>(MonotonicTimer::now() - first);
     };
     std::optional<mbgl::Milliseconds> callbackTime;

--- a/test/util/timer.test.cpp
+++ b/test/util/timer.test.cpp
@@ -1,8 +1,10 @@
 #include <mbgl/test/util.hpp>
 
 #include <mbgl/util/chrono.hpp>
-#include <mbgl/util/timer.hpp>
+#include <mbgl/util/monotonic_timer.hpp>
 #include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/string.hpp>
+#include <mbgl/util/timer.hpp>
 
 #include <memory>
 
@@ -11,27 +13,30 @@ using namespace mbgl::util;
 TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(Basic)) {
     RunLoop loop;
 
-    Timer timer;
+    const auto interval = mbgl::Milliseconds(300);
+    const auto expectedTotalTime = interval;
 
-    auto callback = [&loop] {
+    const auto first = MonotonicTimer::now();
+    const auto elapsed = [=]{
+        return std::chrono::duration_cast<mbgl::Milliseconds>(MonotonicTimer::now() - first);
+    };
+    std::optional<mbgl::Milliseconds> callbackTime;
+    auto callback = [&] {
+        callbackTime = elapsed();
         loop.stop();
     };
 
-    auto interval = mbgl::Milliseconds(300);
-    auto expectedTotalTime = interval;
-
-    auto first = mbgl::Clock::now();
-    timer.start(interval, mbgl::Duration::zero(), callback);
+    Timer timer;
+    timer.start(interval, mbgl::Duration::zero(), std::move(callback));
 
     loop.run();
 
-    auto totalTime = std::chrono::duration_cast<mbgl::Milliseconds>(mbgl::Clock::now() - first);
+    const auto totalTime = elapsed();
 
-    // These are not high precision timers. Especially libuv uses
-    // cached time from the beginning of of the main loop iteration
-    // and it is very prone to fire earlier, which is, odd.
-    EXPECT_GE(totalTime, expectedTotalTime * 0.8);
-    EXPECT_LE(totalTime, expectedTotalTime * 1.2);
+    SCOPED_TRACE("Timer callback: " + (callbackTime ? toString(callbackTime->count()) : "(never)"));
+
+    EXPECT_GE(totalTime.count(), (expectedTotalTime * 0.99).count());
+    EXPECT_LE(totalTime.count(), (expectedTotalTime * 1.10).count());
 }
 
 TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(Repeat)) {

--- a/test/util/timer.test.cpp
+++ b/test/util/timer.test.cpp
@@ -7,6 +7,7 @@
 #include <mbgl/util/timer.hpp>
 
 #include <memory>
+#include <optional>
 
 using namespace mbgl::util;
 


### PR DESCRIPTION
On some Linux systems (the AWS-hosted one provided by @louwers and @stefankarschti's local one) but not CI, the following minimal set of tests reliably fails:

    ./mbgl-test-runner --gtest_filter=Thread.InvokeBeforeChildStarts:Thread.DeleteBeforeChildStarts:Timer.Basic

Investigation shows that the run loop is running and the timer is calling the callback, but with no delay and always resulting in an actual elapsed time of zero milliseconds.

The comment in `Timer.Basic` implies that the timer is not reliable anyway, and a +/- 20% range is allowed.

Adding a call to [uv_update_time](https://docs.libuv.org/en/v1.x/loop.html#c.uv_update_time) seems to resolve the issue, and allows the range to be narrowed to +/- 1% on my system, so I conclude that the previous behavior documented in the comment is a less severe effect of the same problem, and I've narrowed the range to be more conservative.

I suspect that there's a deeper issue indicated by the interaction of the three tests listed, but this change at least improves the behavior of timers without any apparent drawbacks.

@louwers FYI, `pre-commit run --all-files` produces numerous updates to Bazel files, but I didn't commit them.