### PR TITLE
[opengl-2][node] Release node-v5.3.1-pre.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.3.0",
+  "version": "5.3.1-pre.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "5.3.0",
+      "version": "5.3.1-pre.0",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.3.0",
+  "version": "5.3.1-pre.0",
   "description": "Renders map tiles with Maplibre GL",
   "keywords": [
     "maplibre",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 ## main
 
+## 5.3.1-pre.0
+
+* [Note] This is a OpenGL-2 release. It does not include metal support.
+* Add WebP decoding support to Linux and Windows. @mwilsnd @acalcutt https://github.com/maplibre/maplibre-native/pull/2044
+* Add support for slice and index-of expression @SiarheiFedartsou @acalcutt https://github.com/maplibre/maplibre-native/pull/2023
+
 ## 5.3.0
 
 * [Note] This is a OpenGL-2 release. It does not include metal support.


### PR DESCRIPTION
This PR is to release node-v5.3.1-pre.0 .  

This release adds the following, which have been cherry picked from the main branch

1. Support for 'slice' and 'index-of' expression
2. Support for WEBP decoding in linux and windows


**Testing**
I tested these changes with [@acalcutt/maplibre-gl-native-test 5.3.1-pre.0](https://www.npmjs.com/package/@acalcutt/maplibre-gl-native-test/v/5.3.1-pre.0)


For 'slice' , i tested with the layer provided at 
https://github.com/maptiler/tileserver-gl/issues/576#issuecomment-1591346370
![image](https://github.com/maplibre/maplibre-native/assets/3792408/b7b99e2f-10f3-4b10-be88-cddc5ea114e9)

For 'index-of', I took the style for slice above and changed `["get", "name:latin"],` to `["index-of", "Cuba", ["get", "name:latin"]],` . You can see, where "Cuba" was in the last image has been replaced with '0', where all other labels are '-1' . This looks like index-of worked as expected
![image](https://github.com/maplibre/maplibre-native/assets/3792408/3f8e31ad-f44f-4367-8444-4cdc11204394)

For WEBP support I added the webp terrainrgb from maptiler. I tested using this for hillshade, and with the updates this now worked.
![image](https://github.com/maplibre/maplibre-native/assets/3792408/af4bb39e-1093-40e8-971f-22b6d95a76c7)


**In the previous version, node-v5.3.0**
each of these things failed with the following errors (**which this release fixes**)

For 'slice' 
```
mlgl: {
  class: 'ParseStyle',
  severity: 'WARNING',
  text: '[1][1][2][0]: Unknown expression "slice". If you wanted a literal array, use ["literal", [...]].'
}
```

For 'index-of'
```
mlgl: {
  class: 'ParseStyle',
  severity: 'WARNING',
  text: '[1][0]: Unknown expression "index-of". If you wanted a literal array, use ["literal", [...]].'
}
```

For WEBP
```
[Error: unsupported image type]
GET /styles/PMTiles_Test/6/19/23.png 500 410.098 ms - 2
mlgl: {
  class: 'Style',
  severity: 'ERROR',
  text: 'Failed to load tile 5/9/11=>5 for source hillshade_source: unsupported image type'
```
