### PR TITLE
Eliminate an extra vector allocation for many attributes

### DIFF
--- a/include/mbgl/gfx/vertex_attribute.hpp
+++ b/include/mbgl/gfx/vertex_attribute.hpp
@@ -33,7 +33,6 @@ class VertexAttributeArray;
 class VertexVectorBase;
 
 using UniqueVertexAttribute = std::unique_ptr<VertexAttribute>;
-using UniqueVertexAttributeArray = std::unique_ptr<VertexAttributeArray>;
 
 class VertexAttribute {
 public:
@@ -304,17 +303,18 @@ public:
     /// Add a new attribute element.
     /// Returns a pointer to the new element on success, or null if the attribute already exists.
     /// The result is valid only until the next non-const method call on this class.
+    /// @param count Number of items, zero for shared data
     const std::unique_ptr<VertexAttribute>& add(const StringIdentity id,
                                                 int index = -1,
-                                                AttributeDataType = AttributeDataType::Invalid,
-                                                std::size_t count = 1);
+                                                AttributeDataType type = AttributeDataType::Invalid,
+                                                std::size_t count = 0);
 
     /// Add a new attribute element if it doesn't already exist.
     /// Returns a pointer to the new element on success, or null if the type or count conflict with an existing entry.
     /// The result is valid only until the next non-const method call on this class.
     /// @param index index to match, or -1 for any
     /// @param type type to match, or `Invalid` for any
-    /// @param count type to match, or 0 for any
+    /// @param count Number of items, zero for shared data
     const std::unique_ptr<VertexAttribute>& getOrAdd(const StringIdentity id,
                                                      int index = -1,
                                                      AttributeDataType type = AttributeDataType::Invalid,
@@ -407,7 +407,9 @@ protected:
             // Apply the property, or add it to the uniforms collection if it's constant.
             if (!isConstant && binder->getVertexCount() > 0) {
                 using Attribute = typename DataDrivenPaintProperty::Attribute;
-                applyPaintProperty<Attribute>(attrIndex, getOrAdd(*attributeNameID), binder);
+                const auto& attr = getOrAdd(
+                    *attributeNameID, /*index=*/-1, /*type=*/gfx::AttributeDataType::Invalid, /*count=*/0);
+                applyPaintProperty<Attribute>(attrIndex, attr, binder);
             } else {
                 propertiesAsUniforms.emplace(*attributeNameID);
             }

--- a/include/mbgl/shaders/mtl/shader_program.hpp
+++ b/include/mbgl/shaders/mtl/shader_program.hpp
@@ -14,10 +14,9 @@
 namespace mbgl {
 namespace shaders {
 struct AttributeInfo {
-    AttributeInfo(std::size_t index, gfx::AttributeDataType dataType, std::size_t count, std::string_view name);
+    AttributeInfo(std::size_t index, gfx::AttributeDataType dataType, std::string_view name);
     std::size_t index;
     gfx::AttributeDataType dataType;
-    std::size_t count;
     std::string_view name;
     StringIdentity nameID;
 };

--- a/src/mbgl/gfx/vertex_attribute.cpp
+++ b/src/mbgl/gfx/vertex_attribute.cpp
@@ -116,13 +116,16 @@ const std::unique_ptr<VertexAttribute>& VertexAttributeArray::getOrAdd(const Str
                                                                        AttributeDataType dataType,
                                                                        std::size_t count) {
     const auto result = attrs.insert(std::make_pair(id, std::unique_ptr<VertexAttribute>()));
-    if (auto& attr = result.first->second; result.second) {
-        return attr = create(index, dataType, count);
-    } else if ((dataType == AttributeDataType::Invalid || attr->getDataType() == dataType) &&
-               (index < 0 || attr->getIndex() == index) && (count == 0 || attr->getCount() == count)) {
-        return attr;
+    auto& attr = result.first->second;
+    if (result.second) {
+        // inserted
+        attr = create(index, dataType, count);
+    } else {
+        // already present
+        assert(dataType == AttributeDataType::Invalid || attr->getDataType() == dataType);
+        assert((index < 0 || attr->getIndex() == index) && (count == 0 || attr->getCount() == count));
     }
-    return nullref;
+    return attr;
 }
 
 std::size_t VertexAttributeArray::getTotalSize() const {

--- a/src/mbgl/shaders/mtl/background.cpp
+++ b/src/mbgl/shaders/mtl/background.cpp
@@ -5,7 +5,7 @@ namespace mbgl {
 namespace shaders {
 
 const std::array<AttributeInfo, 1> ShaderSource<BuiltIn::BackgroundShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Float3, 1, "a_pos"},
+    AttributeInfo{0, gfx::AttributeDataType::Float3, "a_pos"},
 };
 const std::array<UniformBlockInfo, 2> ShaderSource<BuiltIn::BackgroundShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{1, true, false, sizeof(BackgroundDrawableUBO), "BackgroundDrawableUBO"},

--- a/src/mbgl/shaders/mtl/background_pattern.cpp
+++ b/src/mbgl/shaders/mtl/background_pattern.cpp
@@ -6,7 +6,7 @@ namespace shaders {
 
 const std::array<AttributeInfo, 1>
     ShaderSource<BuiltIn::BackgroundPatternShader, gfx::Backend::Type::Metal>::attributes = {
-        AttributeInfo{0, gfx::AttributeDataType::Float3, 1, "a_pos"},
+        AttributeInfo{0, gfx::AttributeDataType::Float3, "a_pos"},
 };
 const std::array<UniformBlockInfo, 2>
     ShaderSource<BuiltIn::BackgroundPatternShader, gfx::Backend::Type::Metal>::uniforms = {

--- a/src/mbgl/shaders/mtl/circle.cpp
+++ b/src/mbgl/shaders/mtl/circle.cpp
@@ -4,14 +4,14 @@ namespace mbgl {
 namespace shaders {
 
 const std::array<AttributeInfo, 8> ShaderSource<BuiltIn::CircleShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-    AttributeInfo{1, gfx::AttributeDataType::Float4, 1, "a_color"},
-    AttributeInfo{2, gfx::AttributeDataType::Float2, 1, "a_radius"},
-    AttributeInfo{3, gfx::AttributeDataType::Float2, 1, "a_blur"},
-    AttributeInfo{4, gfx::AttributeDataType::Float2, 1, "a_opacity"},
-    AttributeInfo{5, gfx::AttributeDataType::Float4, 1, "a_stroke_color"},
-    AttributeInfo{6, gfx::AttributeDataType::Float2, 1, "a_stroke_width"},
-    AttributeInfo{7, gfx::AttributeDataType::Float2, 1, "a_stroke_opacity"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+    AttributeInfo{1, gfx::AttributeDataType::Float4, "a_color"},
+    AttributeInfo{2, gfx::AttributeDataType::Float2, "a_radius"},
+    AttributeInfo{3, gfx::AttributeDataType::Float2, "a_blur"},
+    AttributeInfo{4, gfx::AttributeDataType::Float2, "a_opacity"},
+    AttributeInfo{5, gfx::AttributeDataType::Float4, "a_stroke_color"},
+    AttributeInfo{6, gfx::AttributeDataType::Float2, "a_stroke_width"},
+    AttributeInfo{7, gfx::AttributeDataType::Float2, "a_stroke_opacity"},
 };
 const std::array<UniformBlockInfo, 4> ShaderSource<BuiltIn::CircleShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{8, true, false, sizeof(CircleDrawableUBO), "CircleDrawableUBO"},

--- a/src/mbgl/shaders/mtl/clipping_mask.cpp
+++ b/src/mbgl/shaders/mtl/clipping_mask.cpp
@@ -6,7 +6,7 @@ namespace shaders {
 using ShaderType = ShaderSource<BuiltIn::ClippingMaskProgram, gfx::Backend::Type::Metal>;
 
 const std::array<AttributeInfo, 1> ShaderType::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Float3, 1, "a_pos"},
+    AttributeInfo{0, gfx::AttributeDataType::Float3, "a_pos"},
 };
 const std::array<UniformBlockInfo, 1> ShaderType::uniforms = {
     UniformBlockInfo{1, true, false, sizeof(ClipUBO), "ClipUBO"},

--- a/src/mbgl/shaders/mtl/collision_box.cpp
+++ b/src/mbgl/shaders/mtl/collision_box.cpp
@@ -4,11 +4,11 @@ namespace mbgl {
 namespace shaders {
 
 const std::array<AttributeInfo, 5> ShaderSource<BuiltIn::CollisionBoxShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-    AttributeInfo{1, gfx::AttributeDataType::Short2, 1, "a_anchor_pos"},
-    AttributeInfo{2, gfx::AttributeDataType::Short2, 1, "a_extrude"},
-    AttributeInfo{3, gfx::AttributeDataType::UShort2, 1, "a_placed"},
-    AttributeInfo{4, gfx::AttributeDataType::Float2, 1, "a_shift"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+    AttributeInfo{1, gfx::AttributeDataType::Short2, "a_anchor_pos"},
+    AttributeInfo{2, gfx::AttributeDataType::Short2, "a_extrude"},
+    AttributeInfo{3, gfx::AttributeDataType::UShort2, "a_placed"},
+    AttributeInfo{4, gfx::AttributeDataType::Float2, "a_shift"},
 };
 const std::array<UniformBlockInfo, 1> ShaderSource<BuiltIn::CollisionBoxShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{5, true, true, sizeof(CollisionUBO), "CollisionBoxUBO"},

--- a/src/mbgl/shaders/mtl/collision_circle.cpp
+++ b/src/mbgl/shaders/mtl/collision_circle.cpp
@@ -5,10 +5,10 @@ namespace shaders {
 
 const std::array<AttributeInfo, 4> ShaderSource<BuiltIn::CollisionCircleShader, gfx::Backend::Type::Metal>::attributes =
     {
-        AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-        AttributeInfo{1, gfx::AttributeDataType::Short2, 1, "a_anchor_pos"},
-        AttributeInfo{2, gfx::AttributeDataType::Short2, 1, "a_extrude"},
-        AttributeInfo{3, gfx::AttributeDataType::UShort2, 1, "a_placed"},
+        AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+        AttributeInfo{1, gfx::AttributeDataType::Short2, "a_anchor_pos"},
+        AttributeInfo{2, gfx::AttributeDataType::Short2, "a_extrude"},
+        AttributeInfo{3, gfx::AttributeDataType::UShort2, "a_placed"},
 };
 const std::array<UniformBlockInfo, 1>
     ShaderSource<BuiltIn::CollisionCircleShader, gfx::Backend::Type::Metal>::uniforms = {

--- a/src/mbgl/shaders/mtl/debug.cpp
+++ b/src/mbgl/shaders/mtl/debug.cpp
@@ -4,7 +4,7 @@ namespace mbgl {
 namespace shaders {
 
 const std::array<AttributeInfo, 1> ShaderSource<BuiltIn::DebugShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
 };
 const std::array<UniformBlockInfo, 1> ShaderSource<BuiltIn::DebugShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{1, true, true, sizeof(DebugUBO), "DebugUBO"},

--- a/src/mbgl/shaders/mtl/fill.cpp
+++ b/src/mbgl/shaders/mtl/fill.cpp
@@ -4,9 +4,9 @@ namespace mbgl {
 namespace shaders {
 
 const std::array<AttributeInfo, 3> ShaderSource<BuiltIn::FillShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-    AttributeInfo{1, gfx::AttributeDataType::Float4, 1, "a_color"},
-    AttributeInfo{2, gfx::AttributeDataType::Float2, 1, "a_opacity"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+    AttributeInfo{1, gfx::AttributeDataType::Float4, "a_color"},
+    AttributeInfo{2, gfx::AttributeDataType::Float2, "a_opacity"},
 };
 const std::array<UniformBlockInfo, 3> ShaderSource<BuiltIn::FillShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{3, true, false, sizeof(FillDrawableUBO), "FillDrawableUBO"},
@@ -16,9 +16,9 @@ const std::array<UniformBlockInfo, 3> ShaderSource<BuiltIn::FillShader, gfx::Bac
 const std::array<TextureInfo, 0> ShaderSource<BuiltIn::FillShader, gfx::Backend::Type::Metal>::textures = {};
 
 const std::array<AttributeInfo, 3> ShaderSource<BuiltIn::FillOutlineShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-    AttributeInfo{1, gfx::AttributeDataType::Float4, 1, "a_outline_color"},
-    AttributeInfo{2, gfx::AttributeDataType::Float2, 1, "a_opacity"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+    AttributeInfo{1, gfx::AttributeDataType::Float4, "a_outline_color"},
+    AttributeInfo{2, gfx::AttributeDataType::Float2, "a_opacity"},
 };
 const std::array<UniformBlockInfo, 3> ShaderSource<BuiltIn::FillOutlineShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{3, true, false, sizeof(FillOutlineDrawableUBO), "FillOutlineDrawableUBO"},
@@ -28,10 +28,10 @@ const std::array<UniformBlockInfo, 3> ShaderSource<BuiltIn::FillOutlineShader, g
 const std::array<TextureInfo, 0> ShaderSource<BuiltIn::FillOutlineShader, gfx::Backend::Type::Metal>::textures = {};
 
 const std::array<AttributeInfo, 4> ShaderSource<BuiltIn::FillPatternShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-    AttributeInfo{1, gfx::AttributeDataType::UShort4, 1, "a_pattern_from"},
-    AttributeInfo{2, gfx::AttributeDataType::UShort4, 1, "a_pattern_to"},
-    AttributeInfo{3, gfx::AttributeDataType::Float2, 1, "a_opacity"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+    AttributeInfo{1, gfx::AttributeDataType::UShort4, "a_pattern_from"},
+    AttributeInfo{2, gfx::AttributeDataType::UShort4, "a_pattern_to"},
+    AttributeInfo{3, gfx::AttributeDataType::Float2, "a_opacity"},
 };
 const std::array<UniformBlockInfo, 4> ShaderSource<BuiltIn::FillPatternShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{4, true, true, sizeof(FillPatternDrawableUBO), "FillPatternDrawableUBO"},
@@ -45,10 +45,10 @@ const std::array<TextureInfo, 1> ShaderSource<BuiltIn::FillPatternShader, gfx::B
 
 const std::array<AttributeInfo, 4>
     ShaderSource<BuiltIn::FillOutlinePatternShader, gfx::Backend::Type::Metal>::attributes = {
-        AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-        AttributeInfo{1, gfx::AttributeDataType::UShort4, 1, "a_pattern_from"},
-        AttributeInfo{2, gfx::AttributeDataType::UShort4, 1, "a_pattern_to"},
-        AttributeInfo{3, gfx::AttributeDataType::Float2, 1, "a_opacity"},
+        AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+        AttributeInfo{1, gfx::AttributeDataType::UShort4, "a_pattern_from"},
+        AttributeInfo{2, gfx::AttributeDataType::UShort4, "a_pattern_to"},
+        AttributeInfo{3, gfx::AttributeDataType::Float2, "a_opacity"},
 };
 const std::array<UniformBlockInfo, 4> ShaderSource<BuiltIn::FillOutlinePatternShader,
                                                    gfx::Backend::Type::Metal>::uniforms = {

--- a/src/mbgl/shaders/mtl/fill_extrusion.cpp
+++ b/src/mbgl/shaders/mtl/fill_extrusion.cpp
@@ -4,11 +4,11 @@ namespace mbgl {
 namespace shaders {
 
 const std::array<AttributeInfo, 5> ShaderSource<BuiltIn::FillExtrusionShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-    AttributeInfo{1, gfx::AttributeDataType::Short4, 1, "a_normal_ed"},
-    AttributeInfo{2, gfx::AttributeDataType::Float4, 1, "a_color"},
-    AttributeInfo{3, gfx::AttributeDataType::Float, 1, "a_base"},
-    AttributeInfo{4, gfx::AttributeDataType::Float, 1, "a_height"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+    AttributeInfo{1, gfx::AttributeDataType::Short4, "a_normal_ed"},
+    AttributeInfo{2, gfx::AttributeDataType::Float4, "a_color"},
+    AttributeInfo{3, gfx::AttributeDataType::Float, "a_base"},
+    AttributeInfo{4, gfx::AttributeDataType::Float, "a_height"},
 };
 const std::array<UniformBlockInfo, 3> ShaderSource<BuiltIn::FillExtrusionShader, gfx::Backend::Type::Metal>::uniforms =
     {

--- a/src/mbgl/shaders/mtl/fill_extrusion_pattern.cpp
+++ b/src/mbgl/shaders/mtl/fill_extrusion_pattern.cpp
@@ -6,12 +6,12 @@ namespace shaders {
 
 const std::array<AttributeInfo, 6>
     ShaderSource<BuiltIn::FillExtrusionPatternShader, gfx::Backend::Type::Metal>::attributes = {
-        AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-        AttributeInfo{1, gfx::AttributeDataType::Short4, 1, "a_normal_ed"},
-        AttributeInfo{2, gfx::AttributeDataType::Float, 1, "a_base"},
-        AttributeInfo{3, gfx::AttributeDataType::Float, 1, "a_height"},
-        AttributeInfo{4, gfx::AttributeDataType::UShort4, 1, "a_pattern_from"},
-        AttributeInfo{5, gfx::AttributeDataType::UShort4, 1, "a_pattern_to"},
+        AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+        AttributeInfo{1, gfx::AttributeDataType::Short4, "a_normal_ed"},
+        AttributeInfo{2, gfx::AttributeDataType::Float, "a_base"},
+        AttributeInfo{3, gfx::AttributeDataType::Float, "a_height"},
+        AttributeInfo{4, gfx::AttributeDataType::UShort4, "a_pattern_from"},
+        AttributeInfo{5, gfx::AttributeDataType::UShort4, "a_pattern_to"},
 };
 const std::array<UniformBlockInfo, 4>
     ShaderSource<BuiltIn::FillExtrusionPatternShader, gfx::Backend::Type::Metal>::uniforms = {

--- a/src/mbgl/shaders/mtl/heatmap.cpp
+++ b/src/mbgl/shaders/mtl/heatmap.cpp
@@ -4,9 +4,9 @@ namespace mbgl {
 namespace shaders {
 
 const std::array<AttributeInfo, 3> ShaderSource<BuiltIn::HeatmapShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-    AttributeInfo{1, gfx::AttributeDataType::Float2, 1, "a_weight"},
-    AttributeInfo{2, gfx::AttributeDataType::Float2, 1, "a_radius"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+    AttributeInfo{1, gfx::AttributeDataType::Float2, "a_weight"},
+    AttributeInfo{2, gfx::AttributeDataType::Float2, "a_radius"},
 };
 const std::array<UniformBlockInfo, 3> ShaderSource<BuiltIn::HeatmapShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{3, true, false, sizeof(HeatmapDrawableUBO), "HeatmapDrawableUBO"},

--- a/src/mbgl/shaders/mtl/heatmap_texture.cpp
+++ b/src/mbgl/shaders/mtl/heatmap_texture.cpp
@@ -5,7 +5,7 @@ namespace shaders {
 
 const std::array<AttributeInfo, 1> ShaderSource<BuiltIn::HeatmapTextureShader, gfx::Backend::Type::Metal>::attributes =
     {
-        AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
+        AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
 };
 const std::array<UniformBlockInfo, 1> ShaderSource<BuiltIn::HeatmapTextureShader, gfx::Backend::Type::Metal>::uniforms =
     {

--- a/src/mbgl/shaders/mtl/hillshade.cpp
+++ b/src/mbgl/shaders/mtl/hillshade.cpp
@@ -4,8 +4,8 @@ namespace mbgl {
 namespace shaders {
 
 const std::array<AttributeInfo, 2> ShaderSource<BuiltIn::HillshadeShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-    AttributeInfo{1, gfx::AttributeDataType::Short2, 1, "a_texture_pos"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+    AttributeInfo{1, gfx::AttributeDataType::Short2, "a_texture_pos"},
 };
 const std::array<UniformBlockInfo, 2> ShaderSource<BuiltIn::HillshadeShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{2, true, true, sizeof(HillshadeDrawableUBO), "HillshadeDrawableUBO"},

--- a/src/mbgl/shaders/mtl/hillshade_prepare.cpp
+++ b/src/mbgl/shaders/mtl/hillshade_prepare.cpp
@@ -5,8 +5,8 @@ namespace shaders {
 
 const std::array<AttributeInfo, 2>
     ShaderSource<BuiltIn::HillshadePrepareShader, gfx::Backend::Type::Metal>::attributes = {
-        AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-        AttributeInfo{1, gfx::AttributeDataType::Short2, 1, "a_texture_pos"},
+        AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+        AttributeInfo{1, gfx::AttributeDataType::Short2, "a_texture_pos"},
 };
 const std::array<UniformBlockInfo, 1>
     ShaderSource<BuiltIn::HillshadePrepareShader, gfx::Backend::Type::Metal>::uniforms = {

--- a/src/mbgl/shaders/mtl/line.cpp
+++ b/src/mbgl/shaders/mtl/line.cpp
@@ -4,14 +4,14 @@ namespace mbgl {
 namespace shaders {
 
 const std::array<AttributeInfo, 8> ShaderSource<BuiltIn::LineShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos_normal"},
-    AttributeInfo{1, gfx::AttributeDataType::UByte4, 1, "a_data"},
-    AttributeInfo{2, gfx::AttributeDataType::Float4, 1, "a_color"},
-    AttributeInfo{3, gfx::AttributeDataType::Float2, 1, "a_blur"},
-    AttributeInfo{4, gfx::AttributeDataType::Float2, 1, "a_opacity"},
-    AttributeInfo{5, gfx::AttributeDataType::Float2, 1, "a_gapwidth"},
-    AttributeInfo{6, gfx::AttributeDataType::Float2, 1, "a_offset"},
-    AttributeInfo{7, gfx::AttributeDataType::Float2, 1, "a_width"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos_normal"},
+    AttributeInfo{1, gfx::AttributeDataType::UByte4, "a_data"},
+    AttributeInfo{2, gfx::AttributeDataType::Float4, "a_color"},
+    AttributeInfo{3, gfx::AttributeDataType::Float2, "a_blur"},
+    AttributeInfo{4, gfx::AttributeDataType::Float2, "a_opacity"},
+    AttributeInfo{5, gfx::AttributeDataType::Float2, "a_gapwidth"},
+    AttributeInfo{6, gfx::AttributeDataType::Float2, "a_offset"},
+    AttributeInfo{7, gfx::AttributeDataType::Float2, "a_width"},
 };
 const std::array<UniformBlockInfo, 4> ShaderSource<BuiltIn::LineShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{8, true, false, sizeof(LineDynamicUBO), "LineDynamicUBO"},
@@ -22,15 +22,15 @@ const std::array<UniformBlockInfo, 4> ShaderSource<BuiltIn::LineShader, gfx::Bac
 const std::array<TextureInfo, 0> ShaderSource<BuiltIn::LineShader, gfx::Backend::Type::Metal>::textures = {};
 
 const std::array<AttributeInfo, 9> ShaderSource<BuiltIn::LinePatternShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos_normal"},
-    AttributeInfo{1, gfx::AttributeDataType::UByte4, 1, "a_data"},
-    AttributeInfo{2, gfx::AttributeDataType::Float2, 1, "a_blur"},
-    AttributeInfo{3, gfx::AttributeDataType::Float2, 1, "a_opacity"},
-    AttributeInfo{4, gfx::AttributeDataType::Float2, 1, "a_gapwidth"},
-    AttributeInfo{5, gfx::AttributeDataType::Float2, 1, "a_offset"},
-    AttributeInfo{6, gfx::AttributeDataType::Float2, 1, "a_width"},
-    AttributeInfo{7, gfx::AttributeDataType::UShort4, 1, "a_pattern_from"},
-    AttributeInfo{8, gfx::AttributeDataType::UShort4, 1, "a_pattern_to"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos_normal"},
+    AttributeInfo{1, gfx::AttributeDataType::UByte4, "a_data"},
+    AttributeInfo{2, gfx::AttributeDataType::Float2, "a_blur"},
+    AttributeInfo{3, gfx::AttributeDataType::Float2, "a_opacity"},
+    AttributeInfo{4, gfx::AttributeDataType::Float2, "a_gapwidth"},
+    AttributeInfo{5, gfx::AttributeDataType::Float2, "a_offset"},
+    AttributeInfo{6, gfx::AttributeDataType::Float2, "a_width"},
+    AttributeInfo{7, gfx::AttributeDataType::UShort4, "a_pattern_from"},
+    AttributeInfo{8, gfx::AttributeDataType::UShort4, "a_pattern_to"},
 };
 const std::array<UniformBlockInfo, 5> ShaderSource<BuiltIn::LinePatternShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{9, true, false, sizeof(LineDynamicUBO), "LineDynamicUBO"},
@@ -44,15 +44,15 @@ const std::array<TextureInfo, 1> ShaderSource<BuiltIn::LinePatternShader, gfx::B
 };
 
 const std::array<AttributeInfo, 9> ShaderSource<BuiltIn::LineSDFShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos_normal"},
-    AttributeInfo{1, gfx::AttributeDataType::UByte4, 1, "a_data"},
-    AttributeInfo{2, gfx::AttributeDataType::Float4, 1, "a_color"},
-    AttributeInfo{3, gfx::AttributeDataType::Float2, 1, "a_blur"},
-    AttributeInfo{4, gfx::AttributeDataType::Float2, 1, "a_opacity"},
-    AttributeInfo{5, gfx::AttributeDataType::Float2, 1, "a_gapwidth"},
-    AttributeInfo{6, gfx::AttributeDataType::Float2, 1, "a_offset"},
-    AttributeInfo{7, gfx::AttributeDataType::Float2, 1, "a_width"},
-    AttributeInfo{8, gfx::AttributeDataType::Float2, 1, "a_floorwidth"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos_normal"},
+    AttributeInfo{1, gfx::AttributeDataType::UByte4, "a_data"},
+    AttributeInfo{2, gfx::AttributeDataType::Float4, "a_color"},
+    AttributeInfo{3, gfx::AttributeDataType::Float2, "a_blur"},
+    AttributeInfo{4, gfx::AttributeDataType::Float2, "a_opacity"},
+    AttributeInfo{5, gfx::AttributeDataType::Float2, "a_gapwidth"},
+    AttributeInfo{6, gfx::AttributeDataType::Float2, "a_offset"},
+    AttributeInfo{7, gfx::AttributeDataType::Float2, "a_width"},
+    AttributeInfo{8, gfx::AttributeDataType::Float2, "a_floorwidth"},
 };
 const std::array<UniformBlockInfo, 4> ShaderSource<BuiltIn::LineSDFShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{9, true, false, sizeof(LineDynamicUBO), "LineDynamicUBO"},
@@ -65,8 +65,8 @@ const std::array<TextureInfo, 1> ShaderSource<BuiltIn::LineSDFShader, gfx::Backe
 };
 
 const std::array<AttributeInfo, 2> ShaderSource<BuiltIn::LineBasicShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos_normal"},
-    AttributeInfo{1, gfx::AttributeDataType::UByte4, 1, "a_data"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos_normal"},
+    AttributeInfo{1, gfx::AttributeDataType::UByte4, "a_data"},
 };
 const std::array<UniformBlockInfo, 2> ShaderSource<BuiltIn::LineBasicShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{2, true, true, sizeof(LineBasicUBO), "LineBasicUBO"},

--- a/src/mbgl/shaders/mtl/line_gradient.cpp
+++ b/src/mbgl/shaders/mtl/line_gradient.cpp
@@ -4,13 +4,13 @@ namespace mbgl {
 namespace shaders {
 
 const std::array<AttributeInfo, 7> ShaderSource<BuiltIn::LineGradientShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos_normal"},
-    AttributeInfo{1, gfx::AttributeDataType::UByte4, 1, "a_data"},
-    AttributeInfo{2, gfx::AttributeDataType::Float2, 1, "a_blur"},
-    AttributeInfo{3, gfx::AttributeDataType::Float2, 1, "a_opacity"},
-    AttributeInfo{4, gfx::AttributeDataType::Float2, 1, "a_gapwidth"},
-    AttributeInfo{5, gfx::AttributeDataType::Float2, 1, "a_offset"},
-    AttributeInfo{6, gfx::AttributeDataType::Float2, 1, "a_width"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos_normal"},
+    AttributeInfo{1, gfx::AttributeDataType::UByte4, "a_data"},
+    AttributeInfo{2, gfx::AttributeDataType::Float2, "a_blur"},
+    AttributeInfo{3, gfx::AttributeDataType::Float2, "a_opacity"},
+    AttributeInfo{4, gfx::AttributeDataType::Float2, "a_gapwidth"},
+    AttributeInfo{5, gfx::AttributeDataType::Float2, "a_offset"},
+    AttributeInfo{6, gfx::AttributeDataType::Float2, "a_width"},
 };
 const std::array<UniformBlockInfo, 4> ShaderSource<BuiltIn::LineGradientShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{7, true, false, sizeof(LineDynamicUBO), "LineDynamicUBO"},

--- a/src/mbgl/shaders/mtl/raster.cpp
+++ b/src/mbgl/shaders/mtl/raster.cpp
@@ -4,8 +4,8 @@ namespace mbgl {
 namespace shaders {
 
 const std::array<AttributeInfo, 2> ShaderSource<BuiltIn::RasterShader, gfx::Backend::Type::Metal>::attributes = {
-    AttributeInfo{0, gfx::AttributeDataType::Short2, 1, "a_pos"},
-    AttributeInfo{1, gfx::AttributeDataType::Short2, 1, "a_texture_pos"},
+    AttributeInfo{0, gfx::AttributeDataType::Short2, "a_pos"},
+    AttributeInfo{1, gfx::AttributeDataType::Short2, "a_texture_pos"},
 };
 const std::array<UniformBlockInfo, 1> ShaderSource<BuiltIn::RasterShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{2, true, true, sizeof(RasterDrawableUBO), "RasterDrawableUBO"},

--- a/src/mbgl/shaders/mtl/shader_program.cpp
+++ b/src/mbgl/shaders/mtl/shader_program.cpp
@@ -24,13 +24,9 @@ using namespace std::string_literals;
 
 namespace mbgl {
 
-shaders::AttributeInfo::AttributeInfo(std::size_t index_,
-                                      gfx::AttributeDataType dataType_,
-                                      std::size_t count_,
-                                      std::string_view name_)
+shaders::AttributeInfo::AttributeInfo(std::size_t index_, gfx::AttributeDataType dataType_, std::string_view name_)
     : index(index_),
       dataType(dataType_),
-      count(count_),
       name(name_),
       nameID(stringIndexer().get(name_)) {}
 
@@ -208,7 +204,7 @@ void ShaderProgram::initAttribute(const shaders::AttributeInfo& info) {
         [&](auto, const gfx::VertexAttribute& attrib) { assert(attrib.getIndex() != index); });
     uniformBlocks.visit([&](auto, const gfx::UniformBlock& block) { assert(block.getIndex() != index); });
 #endif
-    vertexAttributes.add(stringIndexer().get(info.name), index, info.dataType, info.count);
+    vertexAttributes.add(stringIndexer().get(info.name), index, info.dataType, 1);
 }
 
 void ShaderProgram::initUniformBlock(const shaders::UniformBlockInfo& info) {

--- a/src/mbgl/shaders/mtl/symbol_icon.cpp
+++ b/src/mbgl/shaders/mtl/symbol_icon.cpp
@@ -5,14 +5,14 @@ namespace shaders {
 
 const std::array<AttributeInfo, 6> ShaderSource<BuiltIn::SymbolIconShader, gfx::Backend::Type::Metal>::attributes = {
     // always attributes
-    AttributeInfo{0, gfx::AttributeDataType::Short4, 1, "a_pos_offset"},
-    AttributeInfo{1, gfx::AttributeDataType::UShort4, 1, "a_data"},
-    AttributeInfo{2, gfx::AttributeDataType::Short4, 1, "a_pixeloffset"},
-    AttributeInfo{3, gfx::AttributeDataType::Float3, 1, "a_projected_pos"},
-    AttributeInfo{4, gfx::AttributeDataType::Float, 1, "a_fade_opacity"},
+    AttributeInfo{0, gfx::AttributeDataType::Short4, "a_pos_offset"},
+    AttributeInfo{1, gfx::AttributeDataType::UShort4, "a_data"},
+    AttributeInfo{2, gfx::AttributeDataType::Short4, "a_pixeloffset"},
+    AttributeInfo{3, gfx::AttributeDataType::Float3, "a_projected_pos"},
+    AttributeInfo{4, gfx::AttributeDataType::Float, "a_fade_opacity"},
 
     // sometimes uniforms
-    AttributeInfo{5, gfx::AttributeDataType::Float, 1, "a_opacity"},
+    AttributeInfo{5, gfx::AttributeDataType::Float, "a_opacity"},
 };
 const std::array<UniformBlockInfo, 5> ShaderSource<BuiltIn::SymbolIconShader, gfx::Backend::Type::Metal>::uniforms = {
     UniformBlockInfo{8, true, true, sizeof(SymbolDrawableUBO), "SymbolDrawableUBO"},

--- a/src/mbgl/shaders/mtl/symbol_sdf.cpp
+++ b/src/mbgl/shaders/mtl/symbol_sdf.cpp
@@ -6,18 +6,18 @@ namespace shaders {
 const std::array<AttributeInfo, 10> ShaderSource<BuiltIn::SymbolSDFIconShader, gfx::Backend::Type::Metal>::attributes =
     {
         // always attributes
-        AttributeInfo{0, gfx::AttributeDataType::Short4, 1, "a_pos_offset"},
-        AttributeInfo{1, gfx::AttributeDataType::UShort4, 1, "a_data"},
-        AttributeInfo{2, gfx::AttributeDataType::Short4, 1, "a_pixeloffset"},
-        AttributeInfo{3, gfx::AttributeDataType::Float3, 1, "a_projected_pos"},
-        AttributeInfo{4, gfx::AttributeDataType::Float, 1, "a_fade_opacity"},
+        AttributeInfo{0, gfx::AttributeDataType::Short4, "a_pos_offset"},
+        AttributeInfo{1, gfx::AttributeDataType::UShort4, "a_data"},
+        AttributeInfo{2, gfx::AttributeDataType::Short4, "a_pixeloffset"},
+        AttributeInfo{3, gfx::AttributeDataType::Float3, "a_projected_pos"},
+        AttributeInfo{4, gfx::AttributeDataType::Float, "a_fade_opacity"},
 
         // sometimes uniforms
-        AttributeInfo{5, gfx::AttributeDataType::Float4, 1, "a_fill_color"},
-        AttributeInfo{6, gfx::AttributeDataType::Float4, 1, "a_halo_color"},
-        AttributeInfo{7, gfx::AttributeDataType::Float, 1, "a_opacity"},
-        AttributeInfo{8, gfx::AttributeDataType::Float, 1, "a_halo_width"},
-        AttributeInfo{9, gfx::AttributeDataType::Float, 1, "a_halo_blur"},
+        AttributeInfo{5, gfx::AttributeDataType::Float4, "a_fill_color"},
+        AttributeInfo{6, gfx::AttributeDataType::Float4, "a_halo_color"},
+        AttributeInfo{7, gfx::AttributeDataType::Float, "a_opacity"},
+        AttributeInfo{8, gfx::AttributeDataType::Float, "a_halo_width"},
+        AttributeInfo{9, gfx::AttributeDataType::Float, "a_halo_blur"},
 };
 const std::array<UniformBlockInfo, 5> ShaderSource<BuiltIn::SymbolSDFIconShader, gfx::Backend::Type::Metal>::uniforms =
     {

--- a/src/mbgl/shaders/mtl/symbol_text_and_icon.cpp
+++ b/src/mbgl/shaders/mtl/symbol_text_and_icon.cpp
@@ -6,17 +6,17 @@ namespace shaders {
 const std::array<AttributeInfo, 9>
     ShaderSource<BuiltIn::SymbolTextAndIconShader, gfx::Backend::Type::Metal>::attributes = {
         // always attributes
-        AttributeInfo{0, gfx::AttributeDataType::Short4, 1, "a_pos_offset"},
-        AttributeInfo{1, gfx::AttributeDataType::UShort4, 1, "a_data"},
-        AttributeInfo{2, gfx::AttributeDataType::Float3, 1, "a_projected_pos"},
-        AttributeInfo{3, gfx::AttributeDataType::Float, 1, "a_fade_opacity"},
+        AttributeInfo{0, gfx::AttributeDataType::Short4, "a_pos_offset"},
+        AttributeInfo{1, gfx::AttributeDataType::UShort4, "a_data"},
+        AttributeInfo{2, gfx::AttributeDataType::Float3, "a_projected_pos"},
+        AttributeInfo{3, gfx::AttributeDataType::Float, "a_fade_opacity"},
 
         // sometimes uniforms
-        AttributeInfo{4, gfx::AttributeDataType::Float4, 1, "a_fill_color"},
-        AttributeInfo{5, gfx::AttributeDataType::Float4, 1, "a_halo_color"},
-        AttributeInfo{6, gfx::AttributeDataType::Float, 1, "a_opacity"},
-        AttributeInfo{7, gfx::AttributeDataType::Float, 1, "a_halo_width"},
-        AttributeInfo{8, gfx::AttributeDataType::Float, 1, "a_halo_blur"},
+        AttributeInfo{4, gfx::AttributeDataType::Float4, "a_fill_color"},
+        AttributeInfo{5, gfx::AttributeDataType::Float4, "a_halo_color"},
+        AttributeInfo{6, gfx::AttributeDataType::Float, "a_opacity"},
+        AttributeInfo{7, gfx::AttributeDataType::Float, "a_halo_width"},
+        AttributeInfo{8, gfx::AttributeDataType::Float, "a_halo_blur"},
 };
 const std::array<UniformBlockInfo, 5>
     ShaderSource<BuiltIn::SymbolTextAndIconShader, gfx::Backend::Type::Metal>::uniforms = {


### PR DESCRIPTION
Eliminates a 1-element vector allocation on some attribute instances due to the default parameter value.

Remove the count parameter on static attribute declarations because they're always 1 and larger values aren't fully supported anyway.