### PR TITLE
Line tweaker

### DIFF
--- a/src/mbgl/renderer/layers/background_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/background_layer_tweaker.cpp
@@ -51,6 +51,9 @@ void BackgroundLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintPara
     }
     layerGroup.setEnabled(true);
 
+    // properties are re-evaluated every time
+    propertiesUpdated = false;
+
     std::optional<uint32_t> samplerLocation{};
     visitLayerGroupDrawables(layerGroup, [&](gfx::Drawable& drawable) {
         assert(drawable.getTileID());

--- a/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.cpp
@@ -70,11 +70,8 @@ void FillExtrusionLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintP
         /* .pad = */ 0,
         0,
         0};
-    if (!propsBuffer) {
-        propsBuffer = context.createUniformBuffer(&paramsUBO, sizeof(paramsUBO));
-    } else {
-        propsBuffer->update(&paramsUBO, sizeof(paramsUBO));
-    }
+    context.emplaceOrUpdateUniformBuffer(propsBuffer, &paramsUBO);
+    propertiesUpdated = false;
 
     visitLayerGroupDrawables(layerGroup, [&](gfx::Drawable& drawable) {
         if (!drawable.getTileID() || !checkTweakDrawable(drawable)) {

--- a/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
@@ -25,6 +25,7 @@ static const StringIdentity idHeatmapEvaluatedPropsUBOName = stringIndexer().get
 
 void HeatmapLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters& parameters) {
     auto& context = parameters.context;
+    const auto zoom = parameters.state.getZoom();
     const auto& evaluated = static_cast<const HeatmapLayerProperties&>(*evaluatedProperties).evaluated;
 
     if (layerGroup.empty()) {
@@ -36,17 +37,17 @@ void HeatmapLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamet
     const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
 #endif
 
-    const auto zoom = parameters.state.getZoom();
-
-    if (!evaluatedPropsUniformBuffer) {
-        const HeatmapEvaluatedPropsUBO evaluatedPropsUBO = {
-            /* .weight = */ evaluated.get<HeatmapWeight>().constantOr(HeatmapWeight::defaultValue()),
-            /* .radius = */ evaluated.get<HeatmapRadius>().constantOr(HeatmapRadius::defaultValue()),
-            /* .intensity = */ evaluated.get<HeatmapIntensity>(),
-            /* .padding = */ 0};
-        evaluatedPropsUniformBuffer = parameters.context.createUniformBuffer(&evaluatedPropsUBO,
-                                                                             sizeof(evaluatedPropsUBO));
-    }
+    const auto getPropsBuffer = [&]() -> auto& {
+        if (!evaluatedPropsUniformBuffer || propertiesUpdated) {
+            const HeatmapEvaluatedPropsUBO evaluatedPropsUBO = {
+                /* .weight = */ evaluated.get<HeatmapWeight>().constantOr(HeatmapWeight::defaultValue()),
+                /* .radius = */ evaluated.get<HeatmapRadius>().constantOr(HeatmapRadius::defaultValue()),
+                /* .intensity = */ evaluated.get<HeatmapIntensity>(),
+                /* .padding = */ 0};
+            parameters.context.emplaceOrUpdateUniformBuffer(evaluatedPropsUniformBuffer, &evaluatedPropsUBO);
+        }
+        return evaluatedPropsUniformBuffer;
+    };
 
     visitLayerGroupDrawables(layerGroup, [&](gfx::Drawable& drawable) {
         if (!drawable.getTileID() || !checkTweakDrawable(drawable)) {
@@ -56,7 +57,7 @@ void HeatmapLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamet
         const UnwrappedTileID tileID = drawable.getTileID()->toUnwrapped();
 
         auto& uniforms = drawable.mutableUniformBuffers();
-        uniforms.addOrReplace(idHeatmapEvaluatedPropsUBOName, evaluatedPropsUniformBuffer);
+        uniforms.addOrReplace(idHeatmapEvaluatedPropsUBOName, getPropsBuffer());
 
         constexpr bool nearClipped = false;
         constexpr bool inViewportPixelUnits = false;
@@ -69,6 +70,8 @@ void HeatmapLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamet
 
         uniforms.createOrUpdate(idHeatmapDrawableUBOName, &drawableUBO, context);
     });
+
+    propertiesUpdated = false;
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.cpp
@@ -30,23 +30,27 @@ void HeatmapTextureLayerTweaker::execute(LayerGroupBase& layerGroup, const Paint
     const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
 #endif
 
+    const auto getDrawableUBO = [&]() -> auto& {
+        if (!drawableBuffer) {
+            const auto& size = parameters.staticData.backendSize;
+            mat4 viewportMat;
+            matrix::ortho(viewportMat, 0, size.width, size.height, 0, -1, 1);
+            const HeatmapTextureDrawableUBO drawableUBO = {
+                /* .matrix = */ util::cast<float>(viewportMat),
+                /* .world = */ {static_cast<float>(size.width), static_cast<float>(size.height)},
+                /* .opacity = */ evaluated.get<HeatmapOpacity>(),
+                /* .pad1 = */ 0,
+            };
+            parameters.context.emplaceOrUpdateUniformBuffer(drawableBuffer, &drawableUBO);
+        }
+        return drawableBuffer;
+    };
+
     visitLayerGroupDrawables(layerGroup, [&](gfx::Drawable& drawable) {
         if (!checkTweakDrawable(drawable)) {
             return;
         }
-
-        const auto& size = parameters.staticData.backendSize;
-        mat4 viewportMat;
-        matrix::ortho(viewportMat, 0, size.width, size.height, 0, -1, 1);
-        const HeatmapTextureDrawableUBO drawableUBO = {
-            /* .matrix = */ util::cast<float>(viewportMat),
-            /* .world = */ {static_cast<float>(size.width), static_cast<float>(size.height)},
-            /* .opacity = */ evaluated.get<HeatmapOpacity>(),
-            /* .pad1 = */ 0,
-        };
-
-        drawable.mutableUniformBuffers().createOrUpdate(
-            idHeatmapTextureDrawableUBOName, &drawableUBO, parameters.context);
+        drawable.mutableUniformBuffers().addOrReplace(idHeatmapTextureDrawableUBOName, getDrawableUBO());
     });
 }
 

--- a/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.hpp
@@ -18,6 +18,7 @@ public:
     void execute(LayerGroupBase&, const PaintParameters&) override;
 
 protected:
+    gfx::UniformBufferPtr drawableBuffer;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/hillshade_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/hillshade_layer_tweaker.cpp
@@ -15,8 +15,9 @@ namespace mbgl {
 using namespace style;
 using namespace shaders;
 
-static const StringIdentity idHillshadeDrawableUBOName = stringIndexer().get("HillshadeDrawableUBO");
-static const StringIdentity idHillshadeEvaluatedPropsUBOName = stringIndexer().get("HillshadeEvaluatedPropsUBO");
+namespace {
+const StringIdentity idHillshadeDrawableUBOName = stringIndexer().get("HillshadeDrawableUBO");
+const StringIdentity idHillshadeEvaluatedPropsUBOName = stringIndexer().get("HillshadeEvaluatedPropsUBO");
 
 std::array<float, 2> getLatRange(const UnwrappedTileID& id) {
     const LatLng latlng0 = LatLng(id);
@@ -27,10 +28,12 @@ std::array<float, 2> getLatRange(const UnwrappedTileID& id) {
 std::array<float, 2> getLight(const PaintParameters& parameters,
                               const HillshadePaintProperties::PossiblyEvaluated& evaluated) {
     float azimuthal = util::deg2radf(evaluated.get<HillshadeIlluminationDirection>());
-    if (evaluated.get<HillshadeIlluminationAnchor>() == HillshadeIlluminationAnchorType::Viewport)
+    if (evaluated.get<HillshadeIlluminationAnchor>() == HillshadeIlluminationAnchorType::Viewport) {
         azimuthal = azimuthal - static_cast<float>(parameters.state.getBearing());
+    }
     return {{evaluated.get<HillshadeExaggeration>(), azimuthal}};
 }
+} // namespace
 
 void HillshadeLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters& parameters) {
     const auto& evaluated = static_cast<const HillshadeLayerProperties&>(*evaluatedProperties).evaluated;
@@ -44,13 +47,16 @@ void HillshadeLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParam
     const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
 #endif
 
-    if (!evaluatedPropsUniformBuffer) {
-        HillshadeEvaluatedPropsUBO evaluatedPropsUBO = {/* .highlight = */ evaluated.get<HillshadeHighlightColor>(),
-                                                        /* .shadow = */ evaluated.get<HillshadeShadowColor>(),
-                                                        /* .accent = */ evaluated.get<HillshadeAccentColor>()};
-        evaluatedPropsUniformBuffer = parameters.context.createUniformBuffer(&evaluatedPropsUBO,
-                                                                             sizeof(evaluatedPropsUBO));
-    }
+    const auto getPropsBuffer = [&]() -> auto& {
+        if (!evaluatedPropsUniformBuffer || propertiesUpdated) {
+            const HillshadeEvaluatedPropsUBO evaluatedPropsUBO = {
+                /* .highlight = */ evaluated.get<HillshadeHighlightColor>(),
+                /* .shadow = */ evaluated.get<HillshadeShadowColor>(),
+                /* .accent = */ evaluated.get<HillshadeAccentColor>()};
+            parameters.context.emplaceOrUpdateUniformBuffer(evaluatedPropsUniformBuffer, &evaluatedPropsUBO);
+        }
+        return evaluatedPropsUniformBuffer;
+    };
 
     visitLayerGroupDrawables(layerGroup, [&](gfx::Drawable& drawable) {
         if (!drawable.getTileID() || !checkTweakDrawable(drawable)) {
@@ -59,16 +65,18 @@ void HillshadeLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParam
 
         const UnwrappedTileID tileID = drawable.getTileID()->toUnwrapped();
 
-        drawable.mutableUniformBuffers().addOrReplace(idHillshadeEvaluatedPropsUBOName, evaluatedPropsUniformBuffer);
+        auto& uniforms = drawable.mutableUniformBuffers();
+        uniforms.addOrReplace(idHillshadeEvaluatedPropsUBOName, getPropsBuffer());
 
         const auto matrix = getTileMatrix(
             tileID, parameters, {0.f, 0.f}, TranslateAnchorType::Viewport, false, false, drawable, true);
         HillshadeDrawableUBO drawableUBO = {/* .matrix = */ util::cast<float>(matrix),
                                             /* .latrange = */ getLatRange(tileID),
                                             /* .light = */ getLight(parameters, evaluated)};
-
-        drawable.mutableUniformBuffers().createOrUpdate(idHillshadeDrawableUBOName, &drawableUBO, parameters.context);
+        uniforms.createOrUpdate(idHillshadeDrawableUBOName, &drawableUBO, parameters.context);
     });
+
+    propertiesUpdated = false;
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.cpp
@@ -16,20 +16,21 @@ namespace mbgl {
 using namespace style;
 using namespace shaders;
 
-static const StringIdentity idHillshadePrepareDrawableUBOName = stringIndexer().get("HillshadePrepareDrawableUBO");
+namespace {
+const StringIdentity idHillshadePrepareDrawableUBOName = stringIndexer().get("HillshadePrepareDrawableUBO");
 
-const std::array<float, 4>& getUnpackVector(Tileset::DEMEncoding encoding) {
-    // https://www.mapbox.com/help/access-elevation-data/#mapbox-terrain-rgb
-    static const std::array<float, 4> unpackMapbox = {{6553.6f, 25.6f, 0.1f, 10000.0f}};
-    // https://aws.amazon.com/public-datasets/terrain/
-    static const std::array<float, 4> unpackTerrarium = {{256.0f, 1.0f, 1.0f / 256.0f, 32768.0f}};
+// https://www.mapbox.com/help/access-elevation-data/#mapbox-terrain-rgb
+constexpr std::array<float, 4> unpackMapbox = {{6553.6f, 25.6f, 0.1f, 10000.0f}};
 
-    return encoding == Tileset::DEMEncoding::Terrarium ? unpackTerrarium : unpackMapbox;
+// https://aws.amazon.com/public-datasets/terrain/
+constexpr std::array<float, 4> unpackTerrarium = {{256.0f, 1.0f, 1.0f / 256.0f, 32768.0f}};
+
+constexpr const std::array<float, 4>& getUnpackVector(const Tileset::DEMEncoding encoding) {
+    return (encoding == Tileset::DEMEncoding::Terrarium) ? unpackTerrarium : unpackMapbox;
 }
+} // namespace
 
 void HillshadePrepareLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters& parameters) {
-    // const auto& evaluated = static_cast<const HillshadeLayerProperties&>(*evaluatedProperties).evaluated;
-
     if (layerGroup.empty()) {
         return;
     }

--- a/src/mbgl/renderer/layers/line_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.cpp
@@ -43,11 +43,14 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
     const auto& crossfade = static_cast<const LineLayerProperties&>(*evaluatedProperties).crossfade;
 
     // Each property UBO is updated at most once if new evaluated properties were set
-    bool propUpdateFlags[4] = {propertiesUpdated, propertiesUpdated, propertiesUpdated, propertiesUpdated};
+    bool simplePropertiesUpdated = propertiesUpdated;
+    bool gradientPropertiesUpdated = propertiesUpdated;
+    bool patternPropertiesUpdated = propertiesUpdated;
+    bool sdfPropertiesUpdated = propertiesUpdated;
     propertiesUpdated = false;
 
     const auto getLinePropsBuffer = [&]() {
-        if (!linePropertiesBuffer || propUpdateFlags[0]) {
+        if (!linePropertiesBuffer || simplePropertiesUpdated) {
             const LinePropertiesUBO linePropertiesUBO{
                 /*color =*/evaluated.get<LineColor>().constantOr(LineColor::defaultValue()),
                 /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
@@ -59,12 +62,12 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
                 0,
                 0};
             context.emplaceOrUpdateUniformBuffer(linePropertiesBuffer, &linePropertiesUBO);
-            propUpdateFlags[0] = false;
+            simplePropertiesUpdated = false;
         }
         return linePropertiesBuffer;
     };
     const auto getLineGradientPropsBuffer = [&]() {
-        if (!lineGradientPropertiesBuffer || propUpdateFlags[1]) {
+        if (!lineGradientPropertiesBuffer || gradientPropertiesUpdated) {
             const LineGradientPropertiesUBO lineGradientPropertiesUBO{
                 /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
                 /*opacity =*/evaluated.get<LineOpacity>().constantOr(LineOpacity::defaultValue()),
@@ -75,12 +78,12 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
                 0,
                 0};
             context.emplaceOrUpdateUniformBuffer(lineGradientPropertiesBuffer, &lineGradientPropertiesUBO);
-            propUpdateFlags[1] = false;
+            gradientPropertiesUpdated = false;
         }
         return lineGradientPropertiesBuffer;
     };
     const auto getLinePatternPropsBuffer = [&]() {
-        if (!linePatternPropertiesBuffer || propUpdateFlags[2]) {
+        if (!linePatternPropertiesBuffer || patternPropertiesUpdated) {
             const LinePatternPropertiesUBO linePatternPropertiesUBO{
                 /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
                 /*opacity =*/evaluated.get<LineOpacity>().constantOr(LineOpacity::defaultValue()),
@@ -91,12 +94,12 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
                 0,
                 0};
             context.emplaceOrUpdateUniformBuffer(linePatternPropertiesBuffer, &linePatternPropertiesUBO);
-            propUpdateFlags[2] = false;
+            patternPropertiesUpdated = false;
         }
         return linePatternPropertiesBuffer;
     };
     const auto getLineSDFPropsBuffer = [&]() {
-        if (!lineSDFPropertiesBuffer || propUpdateFlags[3]) {
+        if (!lineSDFPropertiesBuffer || sdfPropertiesUpdated) {
             const LineSDFPropertiesUBO lineSDFPropertiesUBO{
                 /*color =*/evaluated.get<LineColor>().constantOr(LineColor::defaultValue()),
                 /*blur =*/evaluated.get<LineBlur>().constantOr(LineBlur::defaultValue()),
@@ -108,7 +111,7 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
                 0,
                 0};
             context.emplaceOrUpdateUniformBuffer(lineSDFPropertiesBuffer, &lineSDFPropertiesUBO);
-            propUpdateFlags[3] = false;
+            sdfPropertiesUpdated = false;
         }
         return lineSDFPropertiesBuffer;
     };

--- a/src/mbgl/renderer/layers/raster_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/raster_layer_tweaker.cpp
@@ -23,6 +23,8 @@ void RasterLayerTweaker::execute([[maybe_unused]] LayerGroupBase& layerGroup,
                                  [[maybe_unused]] const PaintParameters& parameters) {
     const auto& evaluated = static_cast<const RasterLayerProperties&>(*evaluatedProperties).evaluated;
 
+    propertiesUpdated = false;
+
     visitLayerGroupDrawables(layerGroup, [&](gfx::Drawable& drawable) {
         if (!checkTweakDrawable(drawable)) {
             return;

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -66,9 +66,8 @@ void RenderBackgroundLayer::evaluate(const PropertyEvaluationParameters& paramet
     evaluatedProperties = std::move(properties);
 
 #if MLN_DRAWABLE_RENDERER
-    if (layerGroup) {
-        auto newTweaker = std::make_shared<BackgroundLayerTweaker>(getID(), evaluatedProperties);
-        replaceTweaker(layerTweaker, std::move(newTweaker), {layerGroup});
+    if (layerTweaker) {
+        layerTweaker->updateProperties(evaluatedProperties);
     }
 #endif
 }

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -86,9 +86,8 @@ void RenderCircleLayer::evaluate(const PropertyEvaluationParameters& parameters)
     evaluatedProperties = std::move(properties);
 
 #if MLN_DRAWABLE_RENDERER
-    if (layerGroup) {
-        auto newTweaker = std::make_shared<CircleLayerTweaker>(getID(), evaluatedProperties);
-        replaceTweaker(layerTweaker, std::move(newTweaker), {layerGroup});
+    if (layerTweaker) {
+        layerTweaker->updateProperties(evaluatedProperties);
     }
 #endif // MLN_DRAWABLE_RENDERER
 }

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -75,9 +75,8 @@ void RenderFillExtrusionLayer::evaluate(const PropertyEvaluationParameters& para
     evaluatedProperties = std::move(properties);
 
 #if MLN_DRAWABLE_RENDERER
-    if (layerGroup) {
-        auto newTweaker = std::make_shared<FillExtrusionLayerTweaker>(getID(), evaluatedProperties);
-        replaceTweaker(layerTweaker, std::move(newTweaker), {layerGroup});
+    if (layerTweaker) {
+        layerTweaker->updateProperties(evaluatedProperties);
     }
 #endif // MLN_DRAWABLE_RENDERER
 }

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -53,6 +53,15 @@ void RenderHeatmapLayer::transition(const TransitionParameters& parameters) {
     updateColorRamp();
 }
 
+#if MLN_DRAWABLE_RENDERER
+void RenderHeatmapLayer::layerChanged(const TransitionParameters& parameters,
+                                      const Immutable<style::Layer::Impl>& impl,
+                                      UniqueChangeRequestVec& changes) {
+    RenderLayer::layerChanged(parameters, impl, changes);
+    textureTweaker.reset();
+}
+#endif
+
 void RenderHeatmapLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     auto properties = makeMutable<HeatmapLayerProperties>(staticImmutableCast<HeatmapLayer::Impl>(baseImpl),
                                                           unevaluated.evaluate(parameters));
@@ -63,16 +72,11 @@ void RenderHeatmapLayer::evaluate(const PropertyEvaluationParameters& parameters
     evaluatedProperties = std::move(properties);
 
 #if MLN_DRAWABLE_RENDERER
-    if (layerGroup) {
-        auto newTextureTweaker = std::make_shared<HeatmapTextureLayerTweaker>(getID(), evaluatedProperties);
-        replaceTweaker(textureTweaker, std::move(newTextureTweaker), {layerGroup});
+    if (layerTweaker) {
+        layerTweaker->updateProperties(evaluatedProperties);
     }
-
-    if (renderTarget) {
-        if (auto tileLayerGroup = renderTarget->getLayerGroup(0)) {
-            auto newTweaker = std::make_shared<HeatmapLayerTweaker>(getID(), evaluatedProperties);
-            replaceTweaker(layerTweaker, std::move(newTweaker), {std::move(tileLayerGroup)});
-        }
+    if (textureTweaker) {
+        textureTweaker->updateProperties(evaluatedProperties);
     }
 #endif
 }
@@ -499,8 +503,6 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
     // TODO: Don't rebuild drawables every time
     textureLayerGroup->clearDrawables();
 
-    std::unique_ptr<gfx::DrawableBuilder> heatmapTextureBuilder;
-
     if (!sharedTextureVertices) {
         sharedTextureVertices = std::make_shared<TextureVertexVector>(RenderStaticData::heatmapTextureVertices());
     }
@@ -515,7 +517,7 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
                                gfx::AttributeDataType::Short2);
     }
 
-    heatmapTextureBuilder = context.createDrawableBuilder("heatmapTexture");
+    auto heatmapTextureBuilder = context.createDrawableBuilder("heatmapTexture");
     heatmapTextureBuilder->setShader(heatmapTextureShader);
     heatmapTextureBuilder->setEnableDepth(false);
     heatmapTextureBuilder->setColorMode(gfx::ColorMode::alphaBlended());

--- a/src/mbgl/renderer/layers/render_heatmap_layer.hpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.hpp
@@ -56,6 +56,10 @@ private:
     void updateColorRamp();
 
 #if MLN_DRAWABLE_RENDERER
+    void layerChanged(const TransitionParameters& parameters,
+                      const Immutable<style::Layer::Impl>& impl,
+                      UniqueChangeRequestVec& changes);
+
     /// Remove all drawables for the tile from the layer group
     /// @return The number of drawables actually removed.
     std::size_t removeTile(RenderPass, const OverscaledTileID&) override;

--- a/src/mbgl/renderer/layers/render_heatmap_layer.hpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.hpp
@@ -58,7 +58,7 @@ private:
 #if MLN_DRAWABLE_RENDERER
     void layerChanged(const TransitionParameters& parameters,
                       const Immutable<style::Layer::Impl>& impl,
-                      UniqueChangeRequestVec& changes);
+                      UniqueChangeRequestVec& changes) override;
 
     /// Remove all drawables for the tile from the layer group
     /// @return The number of drawables actually removed.

--- a/src/mbgl/renderer/layers/render_hillshade_layer.hpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.hpp
@@ -45,6 +45,11 @@ private:
 
 #if MLN_DRAWABLE_RENDERER
     void updateLayerTweaker();
+
+    void layerChanged(const TransitionParameters& parameters,
+                      const Immutable<style::Layer::Impl>& impl,
+                      UniqueChangeRequestVec& changes);
+
 #endif // MLN_DRAWABLE_RENDERER
 
     void prepare(const LayerPrepareParameters&) override;

--- a/src/mbgl/renderer/layers/render_hillshade_layer.hpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.hpp
@@ -48,7 +48,7 @@ private:
 
     void layerChanged(const TransitionParameters& parameters,
                       const Immutable<style::Layer::Impl>& impl,
-                      UniqueChangeRequestVec& changes);
+                      UniqueChangeRequestVec& changes) override;
 
 #endif // MLN_DRAWABLE_RENDERER
 

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -81,9 +81,8 @@ void RenderLineLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     evaluatedProperties = std::move(properties);
 
 #if MLN_DRAWABLE_RENDERER
-    if (layerGroup) {
-        auto newTweaker = std::make_shared<LineLayerTweaker>(getID(), evaluatedProperties);
-        replaceTweaker(layerTweaker, std::move(newTweaker), {layerGroup});
+    if (layerTweaker) {
+        layerTweaker->updateProperties(evaluatedProperties);
     }
 #endif
 }

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -54,9 +54,8 @@ void RenderRasterLayer::evaluate(const PropertyEvaluationParameters& parameters)
     evaluatedProperties = std::move(properties);
 
 #if MLN_DRAWABLE_RENDERER
-    if (layerGroup) {
-        auto newTweaker = std::make_shared<RasterLayerTweaker>(getID(), evaluatedProperties);
-        replaceTweaker(layerTweaker, std::move(newTweaker), {layerGroup, imageLayerGroup});
+    if (layerTweaker) {
+        layerTweaker->updateProperties(evaluatedProperties);
     }
 #endif
 }

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -70,31 +70,6 @@ std::optional<Color> RenderLayer::getSolidBackground() const {
 }
 
 #if MLN_DRAWABLE_RENDERER
-void RenderLayer::replaceTweaker(LayerTweakerPtr& curTweaker,
-                                 LayerTweakerPtr newTweaker,
-                                 const std::vector<LayerGroupBasePtr>& layerGroups) {
-    const auto prevTweaker = curTweaker;
-
-    // We need to re-create the tweaker because it doesn't yet support modifying evaluated
-    // properties, but we don't want to stop updating drawables (as in the `layerChanged` case)
-    // so we need to update the tweaker reference on the outstanding drawables so that they
-    // pass the check in `updateExisting`.
-    // TODO: Once the tweaker doesn't need to be re-created on each property evaluation, this won't be needed.
-    for (const auto& group : layerGroups) {
-        if (group) {
-            group->addLayerTweaker(newTweaker);
-
-            visitLayerGroupDrawables(*group, [&](gfx::Drawable& drawable) {
-                if (drawable.getLayerTweaker() == prevTweaker) {
-                    drawable.setLayerTweaker(newTweaker);
-                }
-            });
-        }
-    }
-
-    curTweaker = std::move(newTweaker);
-}
-
 void RenderLayer::layerChanged(const TransitionParameters&,
                                const Immutable<style::Layer::Impl>&,
                                UniqueChangeRequestVec&) {

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -266,11 +266,6 @@ protected:
     /// unchanged
     bool setRenderTileBucketID(const OverscaledTileID&, util::SimpleIdentity bucketID);
 
-    /// Update the layer tweaker and drawables which reference it
-    static void replaceTweaker(LayerTweakerPtr& toReplace,
-                               LayerTweakerPtr newTweaker,
-                               const std::vector<LayerGroupBasePtr>&);
-
 #endif // MLN_DRAWABLE_RENDERER
 
     static bool applyColorRamp(const style::ColorRampPropertyValue&, PremultipliedImage&);


### PR DESCRIPTION
Eliminate the remaining examples of tweakers being re-created on each update, which reduced reuse of uniform buffers.