### PR TITLE
Remove custom platforms setting

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Build dynamic library for size test (Bloaty)
         run: |
-          bazel build //platform/ios:MapLibre.dynamic --//:renderer=metal --//:maplibre_platform=ios --compilation_mode="opt" --copt -g --copt="-Oz" --strip never --output_groups=+dsyms --apple_generate_dsym
+          bazel build //platform/ios:MapLibre.dynamic --//:renderer=metal --compilation_mode="opt" --copt -g --copt="-Oz" --strip never --output_groups=+dsyms --apple_generate_dsym
           bazel_bin="$(bazel info --compilation_mode="opt" bazel-bin)"
           unzip "$bazel_bin"/platform/ios/MapLibre.dynamic.xcframework.zip
           cp "$bazel_bin"/platform/ios/MapLibre.dynamic_dsyms/MapLibre_ios_device.framework.dSYM/Contents/Resources/DWARF/MapLibre_ios_device MapLibre_DWARF
@@ -208,8 +208,8 @@ jobs:
 
       - name: Build XCFramework
         run: |
-          bazel build --compilation_mode=opt --//:renderer=metal --//:maplibre_platform=ios //platform/ios:MapLibre.dynamic --embed_label=maplibre_ios_"$(cat VERSION)"
-          echo xcframework="$(bazel info execution_root)"/"$(bazel cquery --output=files --compilation_mode=opt --//:renderer=metal --//:maplibre_platform=ios //platform/ios:MapLibre.dynamic)" >> "$GITHUB_ENV"
+          bazel build --compilation_mode=opt --//:renderer=metal //platform/ios:MapLibre.dynamic --embed_label=maplibre_ios_"$(cat VERSION)"
+          echo xcframework="$(bazel info execution_root)"/"$(bazel cquery --output=files --compilation_mode=opt --//:renderer=metal //platform/ios:MapLibre.dynamic)" >> "$GITHUB_ENV"
 
       - name: Get version (release)
         if: github.event.inputs.release == 'full'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Generate coverage report
         run: |
           xvfb-run -a \
-            bazel coverage --combined_report=lcov  --instrumentation_filter="//:mbgl-core" --//:maplibre_platform=linux \
+            bazel coverage --combined_report=lcov  --instrumentation_filter="//:mbgl-core" \
             --test_output=errors --local_test_jobs=1 \
             --test_env=DISPLAY --test_env=XAUTHORITY --copt="-DCI_BUILD" \
             //test:core //render-test:render-test //expression-test:test

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -113,7 +113,7 @@ cc_library(
             "MLN_DRAWABLE_RENDERER=1",
         ],
     }) + select({
-        "//:ios": ["GLES_SILENCE_DEPRECATION=1"],
+        "@platforms//os:ios": ["GLES_SILENCE_DEPRECATION=1"],
         "//conditions:default": [],
     }),
     includes = [
@@ -145,7 +145,7 @@ cc_library(
         "//vendor:vector-tile",
         "//vendor:wagyu",
     ] + select({
-        "//:ios": [
+        "@platforms//os:ios": [
             "//vendor:icu",
         ],
         "//conditions:default": [],
@@ -165,38 +165,6 @@ genrule(
     """,
     local = True,
     visibility = ["//visibility:public"],
-)
-
-# The next three rules are a bit of a hack
-# they are needed until rules_apple has platforms support
-# https://github.com/bazelbuild/rules_apple/issues/1658
-# Allows passing a command line flag to set the Platform
-# bazel build [target] --//:maplibre_platform=ios
-
-string_flag(
-    name = "maplibre_platform",
-    build_setting_default = "ios",
-)
-
-config_setting(
-    name = "linux",
-    flag_values = {
-        ":maplibre_platform": "linux",
-    },
-)
-
-config_setting(
-    name = "ios",
-    flag_values = {
-        ":maplibre_platform": "ios",
-    },
-)
-
-config_setting(
-    name = "windows",
-    flag_values = {
-        ":maplibre_platform": "windows",
-    },
 )
 
 # Selects the rendering implementation to utilize in the core

--- a/bazel/flags.bzl
+++ b/bazel/flags.bzl
@@ -20,43 +20,43 @@ GCC_CLANG_COMMON_FLAGS = [
 MSVC_FLAGS = [
     "/Wall",
     "/WX",
-    "/wd4068", # Unknown pragma
-    "/wd4820", # Padding
-    "/wd5045", # Compiler will insert Spectre mitigation for memory load
-    "/wd4643", # Non-conformant forward decl
-    "/wd4623", # Default ctor implicitly deleted
-    "/wd5027", # Default move ctor implicitly deleted
-    "/wd4626", # Assignment operator implicitly deleted
-    "/wd4514", # Unreferenced inline function has been removed
-    "/wd4582", # Constructor is not implicitly called
-    "/wd4365", # Signed/unsigned mismatch
-    "/wd4388", # Signed/unsigned mismatch
-    "/wd4244", # Conversion, possible loss of data
-    "/wd4242", # Conversion, possible loss of data
-    "/wd4625", # Copy constructor was implicitly defined as deleted
-    "/wd5026", # Move constructor was implicitly defined as deleted
-    "/wd5219", # Implicit conversion, possible loss of data
-    "/wd5246", # Initialization of a subobject should be wrapped in braces
-    "/wd4201", # Nonstandard extension used: nameless struct/union
-    "/wd4868", # Compiler may not enforce left-to-right evaluation order in braced initializer list
-    "/wd4061", # Eenumerator in switch of enum is not explicitly handled by a case label
-    "/wd4464", # Relative include path contains '..'
-    "/wd4668", # <x> is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
-    "/wd4800", # Implicit conversion from 'unsigned __int64' to bool. Possible information loss
-    "/wd4355", # 'this': used in base member initializer list
-    "/wd5204", # Class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed
-    "/wd5220", # A non-static data member with a volatile qualified type no longer implies
-    "/wd4619", # (boost) #pragma warning: there is no warning number <x>
-    "/wd5031", # (boost) #pragma warning(pop): likely mismatch, popping warning state pushed in different file
-    "/wd5243", # (boost) using incomplete class <x> can cause potential one definition rule violation due to ABI limitation
-    "/wd4371", # (boost) layout of class may have changed from a previous version of the compiler due to better packing of member <x>
-    "/wd4435", # (boost) Object layout under /vd2 will change due to virtual base
-    "/wd4702", # Unreachable code
-    "/wd4710", # Function not inlined
-    "/wd5041", # out-of-line definition for constexpr static data member is not needed and is deprecated in C++17
-    "/wd4946", # reinterpret_cast used between related classes
-    "/wd4459", # declaration of 'x' hides global declaration
-    "/wd4373", # virtual function overrides 'x', previous versions of the compiler did not override when parameters only differed by const/volatile qualifiers
+    "/wd4068",  # Unknown pragma
+    "/wd4820",  # Padding
+    "/wd5045",  # Compiler will insert Spectre mitigation for memory load
+    "/wd4643",  # Non-conformant forward decl
+    "/wd4623",  # Default ctor implicitly deleted
+    "/wd5027",  # Default move ctor implicitly deleted
+    "/wd4626",  # Assignment operator implicitly deleted
+    "/wd4514",  # Unreferenced inline function has been removed
+    "/wd4582",  # Constructor is not implicitly called
+    "/wd4365",  # Signed/unsigned mismatch
+    "/wd4388",  # Signed/unsigned mismatch
+    "/wd4244",  # Conversion, possible loss of data
+    "/wd4242",  # Conversion, possible loss of data
+    "/wd4625",  # Copy constructor was implicitly defined as deleted
+    "/wd5026",  # Move constructor was implicitly defined as deleted
+    "/wd5219",  # Implicit conversion, possible loss of data
+    "/wd5246",  # Initialization of a subobject should be wrapped in braces
+    "/wd4201",  # Nonstandard extension used: nameless struct/union
+    "/wd4868",  # Compiler may not enforce left-to-right evaluation order in braced initializer list
+    "/wd4061",  # Eenumerator in switch of enum is not explicitly handled by a case label
+    "/wd4464",  # Relative include path contains '..'
+    "/wd4668",  # <x> is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
+    "/wd4800",  # Implicit conversion from 'unsigned __int64' to bool. Possible information loss
+    "/wd4355",  # 'this': used in base member initializer list
+    "/wd5204",  # Class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed
+    "/wd5220",  # A non-static data member with a volatile qualified type no longer implies
+    "/wd4619",  # (boost) #pragma warning: there is no warning number <x>
+    "/wd5031",  # (boost) #pragma warning(pop): likely mismatch, popping warning state pushed in different file
+    "/wd5243",  # (boost) using incomplete class <x> can cause potential one definition rule violation due to ABI limitation
+    "/wd4371",  # (boost) layout of class may have changed from a previous version of the compiler due to better packing of member <x>
+    "/wd4435",  # (boost) Object layout under /vd2 will change due to virtual base
+    "/wd4702",  # Unreachable code
+    "/wd4710",  # Function not inlined
+    "/wd5041",  # out-of-line definition for constexpr static data member is not needed and is deprecated in C++17
+    "/wd4946",  # reinterpret_cast used between related classes
+    "/wd4459",  # declaration of 'x' hides global declaration
+    "/wd4373",  # virtual function overrides 'x', previous versions of the compiler did not override when parameters only differed by const/volatile qualifiers
 ]
 
 WARNING_FLAGS = {
@@ -72,9 +72,7 @@ WARNING_FLAGS = {
     "windows": MSVC_FLAGS,
 }
 
-"""
-Compilation flags used for all .cpp and .mm targets.
-"""
+# Compilation flags used for all .cpp and .mm targets.
 
 GCC_CLANG_CPP_FLAGS = [
     "-fexceptions",
@@ -92,21 +90,19 @@ MSVC_CPP_FLAGS = [
 ]
 
 CPP_FLAGS = select({
-    "//:ios": GCC_CLANG_CPP_FLAGS + WARNING_FLAGS["ios"],
-    "//:linux": GCC_CLANG_CPP_FLAGS + WARNING_FLAGS["linux"],
-    "//:windows": MSVC_CPP_FLAGS + WARNING_FLAGS["windows"],
+    "//conditions:default": GCC_CLANG_CPP_FLAGS + WARNING_FLAGS["ios"],
+    "@platforms//os:linux": GCC_CLANG_CPP_FLAGS + WARNING_FLAGS["linux"],
+    "@platforms//os:windows": MSVC_CPP_FLAGS + WARNING_FLAGS["windows"],
 })
 
-"""
-Compilation flags related to the Maplibre codebase. Relevant for all .cpp .mm and .m code
- - src/*
- - include/*
- - platform/*
-Not important for any vendors that are imported.
-"""
+# Compilation flags related to the Maplibre codebase. Relevant for all .cpp .mm and .m code
+#  - src/*
+#  - include/*
+#  - platform/*
+# Not important for any vendors that are imported.
 
 MAPLIBRE_FLAGS = select({
-    "//:windows": [
+    "@platforms//os:windows": [
         "/DMBGL_USE_GLES2=1",
         "/DMBGL_RENDER_BACKEND_OPENGL=1",
         "/D_USE_MATH_DEFINES",
@@ -117,5 +113,5 @@ MAPLIBRE_FLAGS = select({
         "-DMBGL_RENDER_BACKEND_OPENGL=1",
         "-DGLES_SILENCE_DEPRECATION",
         "-DMLN_USE_UNORDERED_DENSE",
-    ]
+    ],
 })

--- a/platform/default/BUILD.bazel
+++ b/platform/default/BUILD.bazel
@@ -58,7 +58,7 @@ cc_library(
         "//:metal_renderer": ["src/mbgl/mtl/headless_backend.cpp"],
         "//conditions:default": ["src/mbgl/gl/headless_backend.cpp"],
     }) + select({
-        "//:linux": [
+        "@platforms//os:linux": [
             "src/mbgl/i18n/number_format.cpp",
             "src/mbgl/layermanager/layer_manager.cpp",
             "src/mbgl/storage/http_file_source.cpp",
@@ -74,7 +74,7 @@ cc_library(
             "src/mbgl/util/timer.cpp",
             "src/mbgl/util/webp_reader.cpp",
         ],
-        "//:ios": [],
+        "@platforms//os:ios": [],
     }),
     hdrs = [
         "include/mbgl/gfx/headless_backend.hpp",
@@ -106,10 +106,10 @@ cc_library(
     deps = [
         "//:mbgl-core",
     ] + select({
-        "//:ios": [
+        "@platforms//os:ios": [
             "//platform/darwin:darwin-loop",
         ],
-        "//:linux": [
+        "@platforms//os:linux": [
             "default-collator",
         ],
     }),

--- a/platform/ios/scripts/bazel-package.sh
+++ b/platform/ios/scripts/bazel-package.sh
@@ -76,8 +76,7 @@ bazel build //platform/ios:"$target" --apple_platform_type=ios \
    --copt=-Wall --copt=-Wextra --copt=-Wpedantic \
    --copt=-Werror \
    --jobs "$ncpu" \
-   --//:renderer=$flavor \
-   --//:maplibre_platform=ios
+   --//:renderer=$flavor
 
 echo "Done."
 echo "Package will be available in \"/bazel-bin/platform/ios/$target.xcframework.zip\""

--- a/platform/ios/scripts/bazel-xcodeproj.sh
+++ b/platform/ios/scripts/bazel-xcodeproj.sh
@@ -20,4 +20,4 @@ done
 
 # Generate the Xcode project
 # Example invocation: bazel-xcodeproj.sh flavor split
-bazel run //platform/ios:xcodeproj --@rules_xcodeproj//xcodeproj:extra_common_flags="--//:renderer=$flavor --//:maplibre_platform=ios"
+bazel run //platform/ios:xcodeproj --@rules_xcodeproj//xcodeproj:extra_common_flags="--//:renderer=$flavor"

--- a/render-test/BUILD.bazel
+++ b/render-test/BUILD.bazel
@@ -34,8 +34,8 @@ cc_library(
     deps = [
         "//expression-test:test_runner_common",
     ] + select({
-        "//:ios": ["//platform:ios-sdk"],
-        "//:linux": ["//platform/linux:impl"],
+        "@platforms//os:ios": ["//platform:ios-sdk"],
+        "@platforms//os:linux": ["//platform/linux:impl"],
     }),
 )
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -14,7 +14,7 @@ cc_library(
 cc_library(
     name = "testlib",
     srcs = select({
-        "//:ios": glob(["src/mbgl/test/*.cpp"]),
+        "@platforms//os:ios": glob(["src/mbgl/test/*.cpp"]),
         "//conditions:default": glob(
             ["src/mbgl/test/*.cpp"],
             exclude = ["src/mbgl/test/http_server.cpp"],
@@ -26,7 +26,7 @@ cc_library(
         "src/mbgl/test/*.hpp",
     ]),
     copts = CPP_FLAGS + MAPLIBRE_FLAGS + select({
-        "//:ios": ["-DUSE_CPP_TEST_SERVER"],
+        "@platforms//os:ios": ["-DUSE_CPP_TEST_SERVER"],
         "//conditions:default": [],
     }),
     includes = [
@@ -40,7 +40,7 @@ cc_library(
         "testutils",
         "//:mbgl-core",
     ] + select({
-        "//:ios": ["//vendor:httplib"],
+        "@platforms//os:ios": ["//vendor:httplib"],
         "//conditions:default": [],
     }),
 )


### PR DESCRIPTION
With bazel 7.x and rules changes we can use the native platforms instead