### PR TITLE
[opengl-2][node] Release node-v5.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.3.1-pre.0",
+  "version": "5.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "5.3.1-pre.0",
+      "version": "5.3.1",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.3.1-pre.0",
+  "version": "5.3.1",
   "description": "Renders map tiles with Maplibre GL",
   "keywords": [
     "maplibre",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## main
 
-## 5.3.1-pre.0
+## 5.3.1
 
 * [Note] This is a OpenGL-2 release. It does not include metal support.
 * Add WebP decoding support to Linux and Windows. @mwilsnd @acalcutt https://github.com/maplibre/maplibre-native/pull/2044


### PR DESCRIPTION
This PR releases node-v5.3.1


I have tested the new features on Windows, Linux x64, and Linux Arm64 and everything worked as expected.

One note, on Linux x64 I did not have libwebp-dev installed, without it I got this error.  libwebp-dev was already added as a requirement in the docs, but I didn't realize I didn't have it installed on the machine I installed this on.
```
 Error: libwebp.so.7: cannot open shared object file: No such file or directory
     at Module._extensions..node (node:internal/modules/cjs/loader:1473:18)
     at Module.load (node:internal/modules/cjs/loader:1207:32)
     at Module._load (node:internal/modules/cjs/loader:1023:12)
     at Module.require (node:internal/modules/cjs/loader:1235:19)
     at require (node:internal/modules/helpers:176:18)
     at Object.<anonymous> (/opt/tileserver-gl/maptiler-tileserver/node_modules/@maplibre/maplibre-gl-native/platform/n>
     at Module._compile (node:internal/modules/cjs/loader:1376:14)
     at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
     at Module.load (node:internal/modules/cjs/loader:1207:32)
     at Module._load (node:internal/modules/cjs/loader:1023:12) {
   code: 'ERR_DLOPEN_FAILED'
 }
 Node.js v20.11.0
```