### PR TITLE
[node][main] Update latest release to node-v5.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Renders map tiles with MapLibre Native",
   "keywords": [
     "maplibre",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 ## main
 
+## 5.3.1
+
+* [Note] This is a OpenGL-2 release. It does not include metal support.
+* Add WebP decoding support to Linux and Windows. @mwilsnd @acalcutt https://github.com/maplibre/maplibre-native/pull/2044
+* Add support for slice and index-of expression @SiarheiFedartsou @acalcutt https://github.com/maplibre/maplibre-native/pull/2023
+
 ## 5.3.0
 
 * [Note] This is a OpenGL-2 release. It does not include metal support.


### PR DESCRIPTION
This is a cherry pick of the node-v5.3.1 release https://github.com/maplibre/maplibre-native/pull/2059 on the 'opengl-2' branch. This is mainly so main package.json reflects the latest version and the CHANGELOG includes the latest information.

In addition to updating the version, this will also make npm pull in the latest binaries when a user does 'npm install', since it uses the version in package.json to know which version to pull.

Note
This will not actually make a new release, since node-v5.3.1 is already published.