### PR TITLE
remove unused member variable

### DIFF
--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -113,7 +113,6 @@ public:
     std::array<float, 2> textOffset;
     std::array<float, 2> iconOffset;
     std::u16string key;
-    bool isDuplicate;
     std::optional<size_t> placedRightTextIndex;
     std::optional<size_t> placedCenterTextIndex;
     std::optional<size_t> placedLeftTextIndex;


### PR DESCRIPTION
Hi, found this via UBSAN:
`src/mbgl/layout/symbol_instance.hpp:55:7: runtime error: load of value 190, which is not a valid value for type 'bool'`
As grep doesn't show any usage of this member variable I suggest the removal.