### PR TITLE
Retain property update flags

### DIFF
--- a/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
@@ -43,17 +43,16 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
     const auto debugGroup = parameters.encoder->createDebugGroup(label.c_str());
 #endif
 
-    // Only run each update function once
-    bool fillUniformBufferUpdated = false;
-    bool fillOutlineUniformBufferUpdated = false;
-    bool fillPatternUniformBufferUpdated = false;
-    bool fillOutlinePatternUniformBufferUpdated = false;
+    if (propertiesUpdated) {
+        fillUniformBufferUpdated = true;
+        fillOutlineUniformBufferUpdated = true;
+        fillPatternUniformBufferUpdated = true;
+        fillOutlinePatternUniformBufferUpdated = true;
+        propertiesUpdated = false;
+    }
 
     const auto UpdateFillUniformBuffers = [&]() {
-        if (fillUniformBufferUpdated) return;
-        fillUniformBufferUpdated = true;
-
-        if (!fillPropsUniformBuffer || propertiesUpdated) {
+        if (!fillPropsUniformBuffer || fillUniformBufferUpdated) {
             const FillEvaluatedPropsUBO paramsUBO = {
                 /* .color = */ evaluated.get<FillColor>().constantOr(FillColor::defaultValue()),
                 /* .opacity = */ evaluated.get<FillOpacity>().constantOr(FillOpacity::defaultValue()),
@@ -62,14 +61,12 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
                 0,
             };
             context.emplaceOrUpdateUniformBuffer(fillPropsUniformBuffer, &paramsUBO);
+            fillUniformBufferUpdated = false;
         }
     };
 
     const auto UpdateFillOutlineUniformBuffers = [&]() {
-        if (fillOutlineUniformBufferUpdated) return;
-        fillOutlineUniformBufferUpdated = true;
-
-        if (!fillOutlinePropsUniformBuffer || propertiesUpdated) {
+        if (!fillOutlinePropsUniformBuffer || fillOutlineUniformBufferUpdated) {
             const FillOutlineEvaluatedPropsUBO paramsUBO = {
                 /* .outline_color = */ evaluated.get<FillOutlineColor>().constantOr(FillOutlineColor::defaultValue()),
                 /* .opacity = */ evaluated.get<FillOpacity>().constantOr(FillOpacity::defaultValue()),
@@ -78,14 +75,12 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
                 0,
             };
             context.emplaceOrUpdateUniformBuffer(fillOutlinePropsUniformBuffer, &paramsUBO);
+            fillOutlineUniformBufferUpdated = false;
         }
     };
 
     const auto UpdateFillPatternUniformBuffers = [&]() {
-        if (fillPatternUniformBufferUpdated) return;
-        fillPatternUniformBufferUpdated = true;
-
-        if (!fillPatternPropsUniformBuffer || propertiesUpdated) {
+        if (!fillPatternPropsUniformBuffer || fillPatternUniformBufferUpdated) {
             const FillPatternEvaluatedPropsUBO paramsUBO = {
                 /* .opacity = */ evaluated.get<FillOpacity>().constantOr(FillOpacity::defaultValue()),
                 /* .fade = */ crossfade.t,
@@ -93,14 +88,12 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
                 0,
             };
             context.emplaceOrUpdateUniformBuffer(fillPatternPropsUniformBuffer, &paramsUBO);
+            fillPatternUniformBufferUpdated = false;
         }
     };
 
     const auto UpdateFillOutlinePatternUniformBuffers = [&]() {
-        if (fillOutlinePatternUniformBufferUpdated) return;
-        fillOutlinePatternUniformBufferUpdated = true;
-
-        if (!fillOutlinePatternPropsUniformBuffer || propertiesUpdated) {
+        if (!fillOutlinePatternPropsUniformBuffer || fillOutlinePatternUniformBufferUpdated) {
             const FillOutlinePatternEvaluatedPropsUBO paramsUBO = {
                 /* .opacity = */ evaluated.get<FillOpacity>().constantOr(FillOpacity::defaultValue()),
                 /* .fade = */ crossfade.t,
@@ -108,6 +101,7 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
                 0,
             };
             context.emplaceOrUpdateUniformBuffer(fillOutlinePatternPropsUniformBuffer, &paramsUBO);
+            fillOutlinePatternUniformBufferUpdated = false;
         }
     };
 
@@ -214,8 +208,6 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
             }
         }
     });
-
-    propertiesUpdated = false;
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/fill_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/fill_layer_tweaker.hpp
@@ -25,6 +25,12 @@ private:
     gfx::UniformBufferPtr fillOutlinePropsUniformBuffer;
     gfx::UniformBufferPtr fillPatternPropsUniformBuffer;
     gfx::UniformBufferPtr fillOutlinePatternPropsUniformBuffer;
+
+    // Only run each update function once per property update
+    bool fillUniformBufferUpdated = true;
+    bool fillOutlineUniformBufferUpdated = true;
+    bool fillPatternUniformBufferUpdated = true;
+    bool fillOutlinePatternUniformBufferUpdated = true;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
@@ -42,6 +42,7 @@ void HeatmapLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamet
                 /* .intensity = */ evaluated.get<HeatmapIntensity>(),
                 /* .padding = */ 0};
             parameters.context.emplaceOrUpdateUniformBuffer(evaluatedPropsUniformBuffer, &evaluatedPropsUBO);
+            propertiesUpdated = false;
         }
         return evaluatedPropsUniformBuffer;
     };
@@ -67,8 +68,6 @@ void HeatmapLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamet
 
         uniforms.createOrUpdate(idHeatmapDrawableUBO, &drawableUBO, context);
     });
-
-    propertiesUpdated = false;
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/hillshade_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/hillshade_layer_tweaker.cpp
@@ -51,6 +51,7 @@ void HillshadeLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParam
                 /* .shadow = */ evaluated.get<HillshadeShadowColor>(),
                 /* .accent = */ evaluated.get<HillshadeAccentColor>()};
             parameters.context.emplaceOrUpdateUniformBuffer(evaluatedPropsUniformBuffer, &evaluatedPropsUBO);
+            propertiesUpdated = false;
         }
         return evaluatedPropsUniformBuffer;
     };
@@ -72,8 +73,6 @@ void HillshadeLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParam
                                             /* .light = */ getLight(parameters, evaluated)};
         uniforms.createOrUpdate(idHillshadeDrawableUBO, &drawableUBO, parameters.context);
     });
-
-    propertiesUpdated = false;
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/line_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.cpp
@@ -34,11 +34,13 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
     const auto& crossfade = static_cast<const LineLayerProperties&>(*evaluatedProperties).crossfade;
 
     // Each property UBO is updated at most once if new evaluated properties were set
-    bool simplePropertiesUpdated = propertiesUpdated;
-    bool gradientPropertiesUpdated = propertiesUpdated;
-    bool patternPropertiesUpdated = propertiesUpdated;
-    bool sdfPropertiesUpdated = propertiesUpdated;
-    propertiesUpdated = false;
+    if (propertiesUpdated) {
+        simplePropertiesUpdated = true;
+        gradientPropertiesUpdated = true;
+        patternPropertiesUpdated = true;
+        sdfPropertiesUpdated = true;
+        propertiesUpdated = false;
+    }
 
     const auto getLinePropsBuffer = [&]() {
         if (!linePropertiesBuffer || simplePropertiesUpdated) {

--- a/src/mbgl/renderer/layers/line_layer_tweaker.hpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.hpp
@@ -41,6 +41,11 @@ protected:
     gfx::UniformBufferPtr permutationUniformBuffer;
     gfx::UniformBufferPtr expressionUniformBuffer;
 #endif // MLN_RENDER_BACKEND_METAL
+
+    bool simplePropertiesUpdated = true;
+    bool gradientPropertiesUpdated = true;
+    bool patternPropertiesUpdated = true;
+    bool sdfPropertiesUpdated = true;
 };
 
 } // namespace mbgl


### PR DESCRIPTION
The property-update flag set from the layer `evaluate` method must be retained until it's actually used.  It would sometimes be reset when no drawables of a given category were present, leaving the UBO in the wrong state when one was later added.

Resolves #2074