### PR TITLE
Prevent deferred tile cleanup from sometimes happening on the main thread

### DIFF
--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -236,8 +236,11 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
 
                 if (tilesIt->second) {
                     tilesIt->second->cancel();
-                    Scheduler::GetBackground()->schedule(
-                        [tile_{std::shared_ptr<Tile>(std::move(tiles.extract((tilesIt++)->first).mapped()))}]() {});
+                    // See `TileCache::deferredRelease`
+                    std::unique_ptr<Tile> tile = std::move(tiles.extract(tilesIt++).mapped());
+                    std::function<void()> func{[tile_{std::shared_ptr<Tile>(std::move(tile))}] {
+                    }};
+                    Scheduler::GetBackground()->schedule(std::move(func));
                 } else {
                     tiles.erase(tilesIt++);
                 }


### PR DESCRIPTION
The temporary lambda holds a `shared_ptr` instance that can outlive the capture and lead to the destructor being called on the main thread.