### PR TITLE
Use optional values in place of zero placeholders

### DIFF
--- a/include/mbgl/gfx/drawable_atlases_tweaker.hpp
+++ b/include/mbgl/gfx/drawable_atlases_tweaker.hpp
@@ -23,8 +23,8 @@ class Drawable;
 class DrawableAtlasesTweaker : public gfx::DrawableTweaker {
 public:
     DrawableAtlasesTweaker(TileAtlasTexturesPtr atlases_,
-                           const StringIdentity iconNameId_,
-                           const StringIdentity glyphNameId_,
+                           const std::optional<StringIdentity> iconNameId_,
+                           const std::optional<StringIdentity> glyphNameId_,
                            bool isText_,
                            const bool sdfIcons_,
                            const style::AlignmentType rotationAlignment_,
@@ -37,7 +37,9 @@ public:
           sdfIcons(sdfIcons_),
           rotationAlignment(rotationAlignment_),
           iconScaled(iconScaled_),
-          textSizeIsZoomConstant(textSizeIsZoomConstant_) {}
+          textSizeIsZoomConstant(textSizeIsZoomConstant_) {
+        assert(iconNameId_ != glyphNameId_);
+    }
     ~DrawableAtlasesTweaker() override = default;
 
     void init(Drawable&) override;
@@ -48,8 +50,8 @@ protected:
     void setupTextures(Drawable&, const bool);
 
     TileAtlasTexturesPtr atlases;
-    StringIdentity iconNameId;
-    StringIdentity glyphNameId;
+    std::optional<StringIdentity> iconNameId;
+    std::optional<StringIdentity> glyphNameId;
     bool isText;
 
     const bool sdfIcons;

--- a/src/mbgl/gfx/drawable_atlases_tweaker.cpp
+++ b/src/mbgl/gfx/drawable_atlases_tweaker.cpp
@@ -8,9 +8,16 @@
 namespace mbgl {
 namespace gfx {
 
+namespace {
+std::optional<int> getSamplerLocation(const gfx::ShaderProgramBasePtr& shader,
+                                      const std::optional<StringIdentity>& nameId) {
+    return nameId ? shader->getSamplerLocation(*nameId) : std::nullopt;
+}
+} // namespace
+
 void DrawableAtlasesTweaker::setupTextures(gfx::Drawable& drawable, const bool linearFilterForIcons) {
     if (const auto& shader = drawable.getShader()) {
-        if (const auto samplerLocation = shader->getSamplerLocation(glyphNameId)) {
+        if (const auto samplerLocation = getSamplerLocation(shader, glyphNameId)) {
             if (atlases) {
                 atlases->glyph->setSamplerConfiguration(
                     {TextureFilterType::Linear, TextureWrapType::Clamp, TextureWrapType::Clamp});
@@ -19,7 +26,7 @@ void DrawableAtlasesTweaker::setupTextures(gfx::Drawable& drawable, const bool l
                      TextureWrapType::Clamp,
                      TextureWrapType::Clamp});
             }
-            if (const auto iconSamplerLocation = shader->getSamplerLocation(iconNameId)) {
+            if (const auto iconSamplerLocation = getSamplerLocation(shader, iconNameId)) {
                 assert(*samplerLocation != *iconSamplerLocation);
                 drawable.setTexture(atlases ? atlases->glyph : nullptr, *samplerLocation);
                 drawable.setTexture(atlases ? atlases->icon : nullptr, *iconSamplerLocation);

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -459,7 +459,7 @@ void RenderFillExtrusionLayer::update(gfx::ShaderRegistry& shaders,
         if (hasPattern && !tweaker) {
             if (const auto& atlases = tile.getAtlasTextures()) {
                 tweaker = std::make_shared<gfx::DrawableAtlasesTweaker>(atlases,
-                                                                        0,
+                                                                        std::nullopt,
                                                                         idIconTextureName,
                                                                         /*isText=*/false,
                                                                         false,

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -599,7 +599,7 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
                 if (const auto& atlases = tile.getAtlasTextures(); atlases && atlases->icon) {
                     atlasTweaker = std::make_shared<gfx::DrawableAtlasesTweaker>(
                         atlases,
-                        0,
+                        std::nullopt,
                         idIconTextureName,
                         /*isText*/ false,
                         /*sdfIcons*/ true, // to force linear filter

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -680,7 +680,7 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
                 if (!iconTweaker) {
                     iconTweaker = std::make_shared<gfx::DrawableAtlasesTweaker>(
                         atlases,
-                        0,
+                        std::nullopt,
                         idLineImageUniformName,
                         /*isText*/ false,
                         /*sdfIcons*/ true, // to force linear filter


### PR DESCRIPTION
Resolves random assertions when icon- or glyph-only atlases use names that end up at zero in the string indexer.  