### PR TITLE
Dense image maps

### DIFF
--- a/src/mbgl/layout/layout.hpp
+++ b/src/mbgl/layout/layout.hpp
@@ -25,9 +25,9 @@ public:
                               bool,
                               const CanonicalTileID&) = 0;
 
-    virtual void prepareSymbols(const GlyphMap&, const GlyphPositions&, const ImageMap&, const ImagePositions&){};
+    virtual void prepareSymbols(const GlyphMap&, const GlyphPositions&, const ImageMap&, const ImagePositions&) {}
 
-    virtual bool hasSymbolInstances() const { return true; };
+    virtual bool hasSymbolInstances() const { return true; }
 
     virtual bool hasDependencies() const = 0;
 };

--- a/src/mbgl/renderer/image_atlas.cpp
+++ b/src/mbgl/renderer/image_atlas.cpp
@@ -46,15 +46,18 @@ namespace {
 void populateImagePatches(ImagePositions& imagePositions,
                           const ImageManager& imageManager,
                           std::vector<ImagePatch>& /*out*/ patches) {
+    if (imagePositions.empty()) {
+        imagePositions.reserve(imageManager.updatedImageVersions.size());
+    }
     for (auto& updatedImageVersion : imageManager.updatedImageVersions) {
         const std::string& name = updatedImageVersion.first;
         const uint32_t version = updatedImageVersion.second;
-        auto it = imagePositions.find(updatedImageVersion.first);
+        const auto it = imagePositions.find(updatedImageVersion.first);
         if (it != imagePositions.end()) {
             auto& position = it->second;
             if (position.version == version) continue;
 
-            auto updatedImage = imageManager.getSharedImage(name);
+            const auto updatedImage = imageManager.getSharedImage(name);
             if (updatedImage == nullptr) continue;
 
             patches.emplace_back(*updatedImage, position.paddedRect);

--- a/src/mbgl/renderer/image_atlas.cpp
+++ b/src/mbgl/renderer/image_atlas.cpp
@@ -72,28 +72,30 @@ std::vector<ImagePatch> ImageAtlas::getImagePatchesAndUpdateVersions(const Image
     return imagePatches;
 }
 
-ImageAtlas makeImageAtlas(const ImageMap& icons,
-                          const ImageMap& patterns,
-                          const std::unordered_map<std::string, uint32_t>& versionMap) {
+ImageAtlas makeImageAtlas(const ImageMap& icons, const ImageMap& patterns, const ImageVersionMap& versionMap) {
     ImageAtlas result;
 
     mapbox::ShelfPack::ShelfPackOptions options;
     options.autoResize = true;
     mapbox::ShelfPack pack(0, 0, options);
 
+    result.iconPositions.reserve(icons.size());
+
     for (const auto& entry : icons) {
         const style::Image::Impl& image = *entry.second;
         const mapbox::Bin& bin = _packImage(pack, image, result, ImageType::Icon);
-        auto it = versionMap.find(entry.first);
-        auto version = it != versionMap.end() ? it->second : 0;
+        const auto it = versionMap.find(entry.first);
+        const auto version = it != versionMap.end() ? it->second : 0;
         result.iconPositions.emplace(image.id, ImagePosition{bin, image, version});
     }
+
+    result.patternPositions.reserve(patterns.size());
 
     for (const auto& entry : patterns) {
         const style::Image::Impl& image = *entry.second;
         const mapbox::Bin& bin = _packImage(pack, image, result, ImageType::Pattern);
-        auto it = versionMap.find(entry.first);
-        auto version = it != versionMap.end() ? it->second : 0;
+        const auto it = versionMap.find(entry.first);
+        const auto version = it != versionMap.end() ? it->second : 0;
         result.patternPositions.emplace(image.id, ImagePosition{bin, image, version});
     }
 

--- a/src/mbgl/renderer/image_atlas.hpp
+++ b/src/mbgl/renderer/image_atlas.hpp
@@ -52,7 +52,7 @@ public:
     }
 };
 
-using ImagePositions = std::map<std::string, ImagePosition>;
+using ImagePositions = mbgl::unordered_map<std::string, ImagePosition>;
 
 class ImagePatch {
 public:
@@ -73,8 +73,6 @@ public:
     std::vector<ImagePatch> getImagePatchesAndUpdateVersions(const ImageManager&);
 };
 
-ImageAtlas makeImageAtlas(const ImageMap&,
-                          const ImageMap&,
-                          const std::unordered_map<std::string, uint32_t>& versionMap);
+ImageAtlas makeImageAtlas(const ImageMap&, const ImageMap&, const ImageVersionMap& versionMap);
 
 } // namespace mbgl

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -257,6 +257,10 @@ void ImageManager::notify(ImageRequestor& requestor, const ImageRequestPair& pai
     ImageMap patternMap;
     ImageVersionMap versionMap;
 
+    iconMap.reserve(pair.first.size());
+    patternMap.reserve(pair.first.size());
+    versionMap.reserve(pair.first.size());
+
     for (const auto& dependency : pair.first) {
         auto it = images.find(dependency.first);
         if (it != images.end()) {

--- a/src/mbgl/renderer/image_manager.hpp
+++ b/src/mbgl/renderer/image_manager.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/util/immutable.hpp>
 
 #include <map>
+#include <set>
 #include <string>
 
 namespace mbgl {

--- a/src/mbgl/style/image_impl.hpp
+++ b/src/mbgl/style/image_impl.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
 #include <mbgl/style/image.hpp>
+#include <mbgl/util/containers.hpp>
 
 #include <string>
-#include <unordered_map>
-#include <set>
 #include <optional>
 
 namespace mbgl {
@@ -45,10 +44,10 @@ enum class ImageType : bool {
     Pattern
 };
 
-using ImageMap = std::unordered_map<std::string, Immutable<style::Image::Impl>>;
-using ImageDependencies = std::unordered_map<std::string, ImageType>;
+using ImageMap = mbgl::unordered_map<std::string, Immutable<style::Image::Impl>>;
+using ImageDependencies = mbgl::unordered_map<std::string, ImageType>;
 using ImageRequestPair = std::pair<ImageDependencies, uint64_t>;
-using ImageVersionMap = std::unordered_map<std::string, uint32_t>;
+using ImageVersionMap = mbgl::unordered_map<std::string, uint32_t>;
 inline bool operator<(const Immutable<mbgl::style::Image::Impl>& a, const Immutable<mbgl::style::Image::Impl>& b) {
     return a->id < b->id;
 }

--- a/test/renderer/image_manager.test.cpp
+++ b/test/renderer/image_manager.test.cpp
@@ -83,12 +83,12 @@ public:
 
     void onImagesAvailable(ImageMap icons,
                            ImageMap patterns,
-                           std::unordered_map<std::string, uint32_t> versionMap,
+                           ImageVersionMap versionMap,
                            uint64_t imageCorrelationID_) final {
         if (imagesAvailable && imageCorrelationID == imageCorrelationID_) imagesAvailable(icons, patterns, versionMap);
     }
 
-    std::function<void(ImageMap, ImageMap, std::unordered_map<std::string, uint32_t>)> imagesAvailable;
+    std::function<void(ImageMap, ImageMap, ImageVersionMap)> imagesAvailable;
     uint64_t imageCorrelationID = 0;
 };
 
@@ -101,7 +101,7 @@ TEST(ImageManager, NotifiesRequestorWhenSpriteIsLoaded) {
     ImageManagerObserver observer;
     imageManager.setObserver(&observer);
 
-    requestor.imagesAvailable = [&](ImageMap, ImageMap, std::unordered_map<std::string, uint32_t>) {
+    requestor.imagesAvailable = [&](ImageMap, ImageMap, ImageVersionMap) {
         notified = true;
     };
 
@@ -126,7 +126,7 @@ TEST(ImageManager, NotifiesRequestorImmediatelyIfDependenciesAreSatisfied) {
     StubImageRequestor requestor(imageManager);
     bool notified = false;
 
-    requestor.imagesAvailable = [&](ImageMap, ImageMap, std::unordered_map<std::string, uint32_t>) {
+    requestor.imagesAvailable = [&](ImageMap, ImageMap, ImageVersionMap) {
         notified = true;
     };
 
@@ -167,7 +167,7 @@ TEST(ImageManager, OnStyleImageMissingBeforeSpriteLoaded) {
 
     bool notified = false;
 
-    requestor.imagesAvailable = [&](ImageMap, ImageMap, std::unordered_map<std::string, uint32_t>) {
+    requestor.imagesAvailable = [&](ImageMap, ImageMap, ImageVersionMap) {
         notified = true;
     };
 
@@ -222,7 +222,7 @@ TEST(ImageManager, OnStyleImageMissingAfterSpriteLoaded) {
 
     bool notified = false;
 
-    requestor.imagesAvailable = [&](ImageMap, ImageMap, std::unordered_map<std::string, uint32_t>) {
+    requestor.imagesAvailable = [&](ImageMap, ImageMap, ImageVersionMap) {
         notified = true;
     };
 


### PR DESCRIPTION
Is this still worthwhile for negligible performance effect, apparently within the margin of error?

before:

```
| SF zoom in   | 3.62 ms | 6.32 ms |
| SF zoom out  | 1.81 ms | 6.58 ms |
| DC zoom in   | 4.03 ms | 6.43 ms |
| DC zoom out  | 2.23 ms | 7.87 ms |
| AMS zoom in  | 3.40 ms | 5.35 ms |
| AMS zoom out | 1.98 ms | 7.82 ms |
| HEL zoom in  | 3.24 ms | 5.04 ms |
| HEL zoom out | 2.06 ms | 8.33 ms |
| AYA zoom in  | 2.83 ms | 4.62 ms |
| AYA zoom out | 1.78 ms | 5.89 ms |
| BER zoom in  | 3.05 ms | 4.83 ms |
| BER zoom out | 2.10 ms | 8.35 ms |
| BAN zoom in  | 3.18 ms | 5.61 ms |
| BAN zoom out | 2.09 ms | 6.76 ms |
| SHA zoom in  | 1.40 ms | 3.57 ms |
| SHA zoom out | 1.95 ms | 8.12 ms |
Average frame encoding time: 2.55 ms
Average frame rendering time: 6.34 ms
```

```
| SF zoom in   | 3.67 ms | 6.42 ms |
| SF zoom out  | 1.94 ms | 6.66 ms |
| DC zoom in   | 3.80 ms | 6.23 ms |
| DC zoom out  | 2.01 ms | 8.17 ms |
| AMS zoom in  | 3.26 ms | 5.13 ms |
| AMS zoom out | 1.93 ms | 8.14 ms |
| HEL zoom in  | 3.04 ms | 4.98 ms |
| HEL zoom out | 2.04 ms | 8.30 ms |
| AYA zoom in  | 2.73 ms | 4.79 ms |
| AYA zoom out | 1.65 ms | 5.84 ms |
| BER zoom in  | 3.83 ms | 5.52 ms |
| BER zoom out | 2.20 ms | 8.40 ms |
| BAN zoom in  | 3.25 ms | 5.68 ms |
| BAN zoom out | 2.08 ms | 6.89 ms |
| SHA zoom in  | 1.89 ms | 5.18 ms |
| SHA zoom out | 2.19 ms | 8.51 ms |
Average frame encoding time: 2.59 ms
Average frame rendering time: 6.55 ms
```

after:

```
| SF zoom in   | 3.64 ms | 6.26 ms |
| SF zoom out  | 1.90 ms | 6.62 ms |
| DC zoom in   | 3.91 ms | 6.38 ms |
| DC zoom out  | 2.31 ms | 8.14 ms |
| AMS zoom in  | 3.32 ms | 5.11 ms |
| AMS zoom out | 2.08 ms | 8.14 ms |
| HEL zoom in  | 3.29 ms | 5.01 ms |
| HEL zoom out | 2.01 ms | 8.24 ms |
| AYA zoom in  | 2.72 ms | 4.62 ms |
| AYA zoom out | 1.76 ms | 5.80 ms |
| BER zoom in  | 3.76 ms | 5.49 ms |
| BER zoom out | 2.19 ms | 8.31 ms |
| BAN zoom in  | 3.27 ms | 5.69 ms |
| BAN zoom out | 2.03 ms | 6.85 ms |
| SHA zoom in  | 1.43 ms | 4.14 ms |
| SHA zoom out | 1.91 ms | 8.28 ms |
Average frame encoding time: 2.59 ms
Average frame rendering time: 6.44 ms
```

```
| SF zoom in   | 3.61 ms | 6.37 ms |
| SF zoom out  | 1.89 ms | 6.68 ms |
| DC zoom in   | 4.00 ms | 6.47 ms |
| DC zoom out  | 2.36 ms | 8.09 ms |
| AMS zoom in  | 3.40 ms | 5.36 ms |
| AMS zoom out | 1.93 ms | 7.94 ms |
| HEL zoom in  | 3.10 ms | 5.02 ms |
| HEL zoom out | 1.98 ms | 8.32 ms |
| AYA zoom in  | 2.65 ms | 4.62 ms |
| AYA zoom out | 1.66 ms | 5.79 ms |
| BER zoom in  | 3.76 ms | 5.45 ms |
| BER zoom out | 2.13 ms | 8.32 ms |
| BAN zoom in  | 3.13 ms | 5.62 ms |
| BAN zoom out | 2.01 ms | 6.75 ms |
| SHA zoom in  | 1.65 ms | 4.31 ms |
| SHA zoom out | 2.02 ms | 8.28 ms |
Average frame encoding time: 2.58 ms
Average frame rendering time: 6.46 ms
```
