### PR TITLE
Build DocC documentation for iOS

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -183,6 +183,19 @@ jobs:
       - if: github.event_name == 'pull_request'
         uses: ./.github/actions/save-pr-number
 
+      - name: Build DocC documentation main branch
+        if: github.ref == 'refs/heads/main'
+        run: |
+          scripts/docc.sh
+
+      - name: Deploy DocC documentation (main) 🚀
+        if: github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          branch: gh-pages
+          folder: platform/ios/build/docs
+          target-folder: ios/latest/
+
       # Make Metal XCFramework release
       - name: Should make release?
         if: github.event.inputs.release == 'full' || github.event.inputs.release == 'pre'

--- a/platform/ios/.gitignore
+++ b/platform/ios/.gitignore
@@ -38,6 +38,7 @@ test/fixtures/storage/assets.zip
 buck-out
 .buckd
 MapLibre.xcodeproj
+.docc-build
 
 # Visual Studio Code
 .vscode

--- a/platform/ios/MapLibre.docc/MapLibre.md
+++ b/platform/ios/MapLibre.docc/MapLibre.md
@@ -1,0 +1,34 @@
+# ``MapLibre``
+
+@Metadata {
+    @DisplayName("MapLibre Native for iOS")
+}
+
+Powerful, free and open-source mapping toolkit with full control over data sources and styling.
+
+## Overview
+
+[MapLibre Native](https://github.com/maplibre/maplibre-native) is a map rendering toolkit with support for iOS. It can be used as an alternative to MapKit. You have full control over the data sources used for rendering the map, as well as the styling. You can even participate in the development as MapLibre Native is free and open-source project.
+> Note: For information on creating and modifying map styles, see the [MapLibre Style Spec documentation](https://maplibre.org/maplibre-style-spec/).
+
+## Topics
+
+### Map
+
+- ``MLNMapView``
+
+### Style Layers
+
+- ``MLNFillStyleLayer``
+- ``MLNHeatmapStyleLayer``
+- ``MLNRasterStyleLayer``
+- ``MLNHillshadeStyleLayer``
+
+### Snapshotter
+
+- ``MLNMapSnapshot``
+
+### Offline support
+
+- ``MLNOfflineStorage``
+- ``MLNOfflineRegion``

--- a/platform/ios/MapLibre.docc/MapLibre.md
+++ b/platform/ios/MapLibre.docc/MapLibre.md
@@ -1,7 +1,7 @@
 # ``MapLibre``
 
 @Metadata {
-    @DisplayName("MapLibre Native for iOS")
+    @Available(iOS, introduced: "12.0")
 }
 
 Powerful, free and open-source mapping toolkit with full control over data sources and styling.
@@ -19,16 +19,65 @@ Powerful, free and open-source mapping toolkit with full control over data sourc
 
 ### Style Layers
 
+- ``MLNBackgroundStyleLayer``
+- ``MLNCircleStyleLayer``
+- ``MLNFillExtrusionStyleLayer``
 - ``MLNFillStyleLayer``
+- ``MLNForegroundStyleLayer``
 - ``MLNHeatmapStyleLayer``
-- ``MLNRasterStyleLayer``
 - ``MLNHillshadeStyleLayer``
+- ``MLNLineStyleLayer``
+- ``MLNRasterStyleLayer``
+- ``MLNStyleLayer``
+- ``MLNSymbolStyleLayer``
+- ``MLNVectorStyleLayer``
+
+### Sources
+
+- ``MLNComputedShapeSource``
+- ``MLNImageSource``
+- ``MLNRasterDEMSource``
+- ``MLNRasterTileSource``
+- ``MLNShapeSource``
+- ``MLNSource``
+- ``MLNTileSource``
+
+### Shapes
+
+- ``MLNEmptyFeature``
+- ``MLNMultiPoint``
+- ``MLNMultiPolygon``
+- ``MLNMultiPolygonFeature``
+- ``MLNMultiPolyline``
+- ``MLNMultiPolylineFeature``
+- ``MLNMultiPolylineFeature``
+- ``MLNPointAnnotation``
+- ``MLNPointCollection``
+- ``MLNPointCollectionFeature``
+- ``MLNPolygon``
+- ``MLNPolyline``
+- ``MLNPolylineFeature``
+- ``MLNShape``
+- ``MLNShapeCollection``
+- ``MLNShapeCollectionFeature``
 
 ### Snapshotter
 
 - ``MLNMapSnapshot``
+- ``MLNMapSnapshotOptions``
+- ``MLNMapSnapshotter``
 
 ### Offline support
 
-- ``MLNOfflineStorage``
+- ``MLNOfflinePack``
 - ``MLNOfflineRegion``
+- ``MLNOfflineStorage``
+- ``MLNShapeOfflineRegion``
+- ``MLNTilePyramidOfflineRegion``
+
+### Annotations
+
+- ``MLNAnnotationImage``
+- ``MLNAnnotationView``
+- ``MLNPointFeature``
+- ``MLNPointFeatureCluster``

--- a/platform/ios/scripts/docc.sh
+++ b/platform/ios/scripts/docc.sh
@@ -1,8 +1,28 @@
 #!/bin/bash
 
+# This script is a bit of a hack to generate DocC documentation until Bazel has support for it.
+# https://github.com/bazelbuild/rules_apple/issues/2241
+# To use this script, make sure the XCFramework is built with Bazel (see ios-ci.yml).
+# Then to start a local preview, run:
+# $ scripts/docc.sh bazel
+# You can also build the documentation locally
+# $ scripts/docc.sh
+# Then go to build/ios and run
+# $ python3 -m http.server
+# Go to http://localhost:8000/documentation/maplibre/
+
+cmd="convert"
+if [[ "$1" == "preview" ]]; then
+  cmd="preview"
+fi
+
 SDK_PATH=$(xcrun -sdk iphoneos --show-sdk-path)
 
-build_dir="$(mktemp -d)"
+build_dir=build
+
+rm -rf "$build_dir"/symbol-graphs
+rm -rf "$build_dir"/headers/MapLibre
+rm -rf "$build_dir"/MapLibre.xcframework
 
 mkdir "$build_dir"/symbol-graphs
 mkdir -p "$build_dir"/headers/MapLibre
@@ -13,8 +33,8 @@ unzip ../../bazel-bin/platform/ios/MapLibre.dynamic.xcframework.zip -d "$build_d
 # copy all public headers from XCFramework
 cp "$build_dir"/MapLibre.xcframework/ios-arm64/MapLibre.framework/Headers/*.h "$build_dir"/headers/MapLibre
 
-xcrun --toolchain swift clang                        \
-     -extract-api                                    \
+xcrun --toolchain swift clang \
+     -extract-api \
      --product-name=MapLibre \
      -isysroot $SDK_PATH \
      -F "$SDK_PATH"/System/Library/Frameworks \
@@ -26,11 +46,14 @@ xcrun --toolchain swift clang                        \
      "$build_dir"/headers/MapLibre/*.h
 
 export DOCC_HTML_DIR=$(dirname $(xcrun --toolchain swift --find docc))/../share/docc/render
-$(xcrun --find docc) preview MapLibre.docc \
-    --fallback-display-name MapLibre \
+$(xcrun --find docc) "$cmd" MapLibre.docc \
+    --fallback-display-name "MapLibre Native for iOS" \
     --fallback-bundle-identifier org.swift.MyProject \
     --fallback-bundle-version 0.0.1  \
-    --additional-symbol-graph-dir .build/symbol-graphs \
+    --additional-symbol-graph-dir "$build_dir"/symbol-graphs \
     --output-path "$build_dir"/MapLibre.doccarchive
 
-$(xcrun --find docc) process-archive transform-for-static-hosting "$build_dir"/MapLibre.doccarchive --output-path docs
+if [[ "$cmd" == "convert" ]]; then
+  rm -rf build/docs
+  $(xcrun --find docc) process-archive transform-for-static-hosting "$build_dir"/MapLibre.doccarchive --output-path build/docs
+fi

--- a/platform/ios/scripts/docc.sh
+++ b/platform/ios/scripts/docc.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+SDK_PATH=$(xcrun -sdk iphoneos --show-sdk-path)
+
+build_dir="$(mktemp -d)"
+
+mkdir "$build_dir"/symbol-graphs
+mkdir -p "$build_dir"/headers/MapLibre
+
+# unzip built XCFramework in build dir
+unzip ../../bazel-bin/platform/ios/MapLibre.dynamic.xcframework.zip -d "$build_dir"
+
+# copy all public headers from XCFramework
+cp "$build_dir"/MapLibre.xcframework/ios-arm64/MapLibre.framework/Headers/*.h "$build_dir"/headers/MapLibre
+
+xcrun --toolchain swift clang                        \
+     -extract-api                                    \
+     --product-name=MapLibre \
+     -isysroot $SDK_PATH \
+     -F "$SDK_PATH"/System/Library/Frameworks \
+     -I "$PWD" \
+     -I "$(realpath ../darwin/src)" \
+     -I "$build_dir"/headers \
+     -x objective-c-header  \
+     -o "$build_dir"/symbol-graphs/MapLibre.symbols.json  \
+     "$build_dir"/headers/MapLibre/*.h
+
+export DOCC_HTML_DIR=$(dirname $(xcrun --toolchain swift --find docc))/../share/docc/render
+$(xcrun --find docc) preview MapLibre.docc \
+    --fallback-display-name MapLibre \
+    --fallback-bundle-identifier org.swift.MyProject \
+    --fallback-bundle-version 0.0.1  \
+    --additional-symbol-graph-dir .build/symbol-graphs \
+    --output-path "$build_dir"/MapLibre.doccarchive
+
+$(xcrun --find docc) process-archive transform-for-static-hosting "$build_dir"/MapLibre.doccarchive --output-path docs


### PR DESCRIPTION
Closes #2069 and #1158 to bring back iOS documentation!

I'll go over the documentation to clean it up a bit a separate PR, but this is already quite usable.

<img width="1443" alt="image" src="https://github.com/maplibre/maplibre-native/assets/649392/e1b2bf80-6427-460a-b8e6-dfcd5132f348">

Once [Bazel has DocC support for Objective-C](https://github.com/bazelbuild/rules_apple/issues/2241) we can remove this script. Maybe I'll have a look at it, but I don't think my Bazel-fu is strong enough.
