### PR TITLE
iOS CI Fixes - Release & Docs

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -210,7 +210,7 @@ jobs:
         if: github.event.inputs.release == 'full'
         run: |
           echo version="$(head VERSION)" >> "$GITHUB_ENV"
-          echo changelog_version_heading="## {{ env.version }}" >> "$GITHUB_ENV"
+          echo changelog_version_heading="## ${{ env.version }}" >> "$GITHUB_ENV"
 
       - name: Get version (pre-release)
         if: github.event.inputs.release == 'pre'
@@ -221,8 +221,12 @@ jobs:
       - name: Extract changelog for version
         if: env.make_release
         run: |
-          awk '/^##/ { p = 0 }; p == 1 { print }; $0 == "{{ env.changelog_version_heading }}" { p = 1 };' CHANGELOG.md > changelog_for_version.md
+          awk '/^##/ { p = 0 }; p == 1 { print }; $0 == "${{ env.changelog_version_heading }}" { p = 1 };' CHANGELOG.md > changelog_for_version.md
           cat changelog_for_version.md
+
+      - name: Upload changelog to S3
+        if: env.make_release
+        run: aws s3 cp changelog_for_version.md s3://maplibre-native/changelogs/ios-${{ env.version }}.md
 
       - name: Create tag
         if: env.make_release
@@ -271,7 +275,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/maplibre/maplibre-gl-native-distribution/actions/workflows/$release_workflow_id/dispatches \
             -d '{"ref":"main","inputs":{ \
-              "changelog": "'"$(cat changelog_for_version.md)"'", \
+              "changelog_url": "https://maplibre-native.s3.eu-central-1.amazonaws.com/changelogs/ios-${{ env.version }}.md", \
               "version":"${{ env.version }}", \
               "download_url":"${{ fromJSON(steps.github_release.outputs.assets)[0].browser_download_url }}"}}'
 

--- a/platform/ios/scripts/docc.sh
+++ b/platform/ios/scripts/docc.sh
@@ -24,7 +24,7 @@ rm -rf "$build_dir"/symbol-graphs
 rm -rf "$build_dir"/headers/MapLibre
 rm -rf "$build_dir"/MapLibre.xcframework
 
-mkdir "$build_dir"/symbol-graphs
+mkdir -p "$build_dir"/symbol-graphs
 mkdir -p "$build_dir"/headers/MapLibre
 
 # unzip built XCFramework in build dir


### PR DESCRIPTION
Uploads changelog to S3 so it can be send over to [this workflow](https://github.com/maplibre/maplibre-gl-native-distribution/blob/main/.github/workflows/release.yml).

Fix typo preventing correct changelog extraction.

Add `-p` flag to mkdir so documentation builds correctly.

