### PR TITLE
Android 10.x.x: Backport string expressions (`index-of` and `slice`)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,7 @@ target_sources(
     ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/image.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/image_expression.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/in.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/index_of.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/interpolate.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/interpolator.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/is_constant.hpp
@@ -604,6 +605,7 @@ target_sources(
     ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/image.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/image_expression.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/in.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/index_of.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/interpolate.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/is_constant.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/is_expression.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ target_sources(
     ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/match.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/number_format.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/parsing_context.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/slice.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/step.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/type.hpp
     ${PROJECT_SOURCE_DIR}/include/mbgl/style/expression/value.hpp
@@ -615,6 +616,7 @@ target_sources(
     ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/match.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/number_format.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/parsing_context.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/slice.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/step.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/util.cpp
     ${PROJECT_SOURCE_DIR}/src/mbgl/style/expression/util.hpp

--- a/include/mbgl/style/expression/expression.hpp
+++ b/include/mbgl/style/expression/expression.hpp
@@ -174,7 +174,8 @@ enum class Kind : int32_t {
     In,
     Within,
     Distance,
-    IndexOf
+    IndexOf,
+    Slice
 };
 
 class Expression {

--- a/include/mbgl/style/expression/expression.hpp
+++ b/include/mbgl/style/expression/expression.hpp
@@ -173,7 +173,8 @@ enum class Kind : int32_t {
     ImageExpression,
     In,
     Within,
-    Distance
+    Distance,
+    IndexOf
 };
 
 class Expression {

--- a/include/mbgl/style/expression/index_of.hpp
+++ b/include/mbgl/style/expression/index_of.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <mbgl/style/expression/expression.hpp>
+#include <mbgl/style/conversion.hpp>
+#include <memory>
+
+namespace mbgl {
+namespace style {
+namespace expression {
+
+class IndexOf : public Expression {
+public:
+    IndexOf(std::unique_ptr<Expression> keyword_,
+            std::unique_ptr<Expression> input_,
+            std::unique_ptr<Expression> fromIndex_);
+
+    static ParseResult parse(const mbgl::style::conversion::Convertible& value, ParsingContext& ctx);
+
+    EvaluationResult evaluate(const EvaluationContext& params) const override;
+    void eachChild(const std::function<void(const Expression&)>&) const override;
+
+    bool operator==(const Expression& e) const override;
+
+    std::vector<optional<Value>> possibleOutputs() const override;
+    std::string getOperator() const override;
+
+private:
+    EvaluationResult evaluateForArrayInput(const std::vector<Value>& array,
+                                           const Value& keyword,
+                                           size_t fromIndex) const;
+    EvaluationResult evaluateForStringInput(const std::string& string, const Value& keyword, size_t fromIndex) const;
+
+private:
+    std::unique_ptr<Expression> keyword;
+    std::unique_ptr<Expression> input;
+    std::unique_ptr<Expression> fromIndex;
+};
+
+} // namespace expression
+} // namespace style
+} // namespace mbgl

--- a/include/mbgl/style/expression/slice.hpp
+++ b/include/mbgl/style/expression/slice.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <mbgl/style/expression/expression.hpp>
+#include <mbgl/style/conversion.hpp>
+#include <memory>
+
+namespace mbgl {
+namespace style {
+namespace expression {
+
+class Slice : public Expression {
+public:
+    Slice(std::unique_ptr<Expression> input_,
+          std::unique_ptr<Expression> fromIndex_,
+          std::unique_ptr<Expression> toIndex_);
+
+    static ParseResult parse(const mbgl::style::conversion::Convertible& value, ParsingContext& ctx);
+
+    EvaluationResult evaluate(const EvaluationContext& params) const override;
+    void eachChild(const std::function<void(const Expression&)>&) const override;
+
+    bool operator==(const Expression& e) const override;
+
+    std::vector<optional<Value>> possibleOutputs() const override;
+    std::string getOperator() const override;
+
+private:
+    EvaluationResult evaluateForStringInput(const std::string& input, int fromIndexValue, int toIndexValue) const;
+    EvaluationResult evaluateForArrayInput(const std::vector<Value>& input, int fromIndexValue, int toIndexValue) const;
+
+private:
+    std::unique_ptr<Expression> input;
+    std::unique_ptr<Expression> fromIndex;
+    std::unique_ptr<Expression> toIndex;
+};
+
+} // namespace expression
+} // namespace style
+} // namespace mbgl

--- a/metrics/integration/expression-tests/index-of/assert-array/test.json
+++ b/metrics/integration/expression-tests/index-of/assert-array/test.json
@@ -1,0 +1,26 @@
+{
+    "expression": ["index-of", ["get", "i"], ["array", ["get", "arr"]]],
+    "inputs": [
+      [{}, {"properties": {"i": null, "arr": [9, 8, 7]}}],
+      [{}, {"properties": {"i": null, "arr": [9, 8, 7, null]}}],
+      [{}, {"properties": {"i": 1, "arr": [9, 8, 7]}}],
+      [{}, {"properties": {"i": 9, "arr": [9, 8, 7, 9]}}],
+      [{}, {"properties": {"i": 1, "arr": null}}]
+    ],
+    "expected": {
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "number"
+      },
+      "serialized": ["index-of", ["get", "i"], ["array", ["get", "arr"]]],
+      "outputs": [
+        -1,
+        3,
+        -1,
+        0,
+        {"error": "Expected value to be of type array, but found null instead."}
+      ]
+    }
+  }

--- a/metrics/integration/expression-tests/index-of/assert-string/test.json
+++ b/metrics/integration/expression-tests/index-of/assert-string/test.json
@@ -1,0 +1,24 @@
+{
+    "expression": ["index-of", ["get", "substr"], ["string", ["get", "str"]]],
+    "inputs": [
+      [{}, {"properties": {"substr": null, "str": "helloworld"}}],
+      [{}, {"properties": {"substr": "foo", "str": "helloworld"}}],
+      [{}, {"properties": {"substr": "low", "str": "helloworld"}}],
+      [{}, {"properties": {"substr": "low", "str": null}}]
+    ],
+    "expected": {
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "number"
+      },
+      "serialized": ["index-of", ["get", "substr"], ["string", ["get", "str"]]],
+      "outputs": [
+        -1,
+        -1,
+        3,
+        {"error": "Expected value to be of type string, but found null instead."}
+      ]
+    }
+  }

--- a/metrics/integration/expression-tests/index-of/basic-array/test.json
+++ b/metrics/integration/expression-tests/index-of/basic-array/test.json
@@ -1,0 +1,46 @@
+{
+  "expression": ["index-of", ["get", "i"], ["get", "arr"]],
+  "inputs": [
+    [{}, {"properties": {"i": null, "arr": [9, 8, 7]}}],
+    [{}, {"properties": {"i": 1, "arr": [9, 8, 7]}}],
+    [{}, {"properties": {"i": 9, "arr": [9, 8, 7]}}],
+    [
+      {},
+      {
+        "properties": {
+          "i": "foo",
+          "arr": ["baz", "bar", "hello", "foo", "world"]
+        }
+      }
+    ],
+    [
+      {},
+      {
+        "properties": {
+          "i": true,
+          "arr": ["foo", 123, null, 456, false, {}, true]
+        }
+      }
+    ],
+    [{}, {"properties": {"i": 1, "arr": null}}]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "number"
+    },
+    "serialized": ["index-of", ["get", "i"], ["get", "arr"]],
+    "outputs": [
+      -1,
+      -1,
+      0,
+      3,
+      6,
+      {
+        "error": "Expected second argument to be of type array or string, but found null instead."
+      }
+    ]
+  }
+}

--- a/metrics/integration/expression-tests/index-of/basic-string/test.json
+++ b/metrics/integration/expression-tests/index-of/basic-string/test.json
@@ -1,0 +1,32 @@
+{
+    "expression": ["index-of", ["get", "substr"], ["get", "str"]],
+    "inputs": [
+      [{}, {"properties": {"substr": null, "str": "helloworld"}}],
+      [{}, {"properties": {"substr": "foo", "str": "helloworld"}}],
+      [{}, {"properties": {"substr": "low", "str": "helloworld"}}],
+      [{}, {"properties": {"substr": true, "str": "falsetrue"}}],
+      [{}, {"properties": {"substr": false, "str": "falsetrue"}}],
+      [{}, {"properties": {"substr": 123, "str": "hello123world"}}],
+      [{}, {"properties": {"substr": "low", "str": null}}]
+    ],
+    "expected": {
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "number"
+      },
+      "serialized": ["index-of", ["get", "substr"], ["get", "str"]],
+      "outputs": [
+        -1,
+        -1,
+        3,
+        5,
+        0,
+        5,
+        {
+          "error": "Expected second argument to be of type array or string, but found null instead."
+        }
+      ]
+    }
+  }

--- a/metrics/integration/expression-tests/index-of/invalid-haystack/test.json
+++ b/metrics/integration/expression-tests/index-of/invalid-haystack/test.json
@@ -1,0 +1,28 @@
+{
+    "expression": ["index-of", ["get", "needle"], ["get", "haystack"]],
+    "inputs": [
+      [{}, {"properties": {"needle": 1, "haystack": 123}}],
+      [{}, {"properties": {"needle": "foo", "haystack": {}}}],
+      [{}, {"properties": {"needle": "foo", "haystack": null}}]
+    ],
+    "expected": {
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "number"
+      },
+      "serialized": ["index-of", ["get", "needle"], ["get", "haystack"]],
+      "outputs": [
+        {
+          "error": "Expected second argument to be of type array or string, but found number instead."
+        },
+        {
+          "error": "Expected second argument to be of type array or string, but found object instead."
+        },
+        {
+          "error": "Expected second argument to be of type array or string, but found null instead."
+        }
+      ]
+    }
+  }

--- a/metrics/integration/expression-tests/index-of/invalid-needle/test.json
+++ b/metrics/integration/expression-tests/index-of/invalid-needle/test.json
@@ -1,0 +1,25 @@
+{
+    "expression": ["index-of", ["get", "needle"], ["get", "haystack"]],
+    "inputs": [
+      [{}, {"properties": {"needle": {}, "haystack": [9, 8, 7]}}],
+      [{}, {"properties": {"needle": {}, "haystack": "helloworld"}}]
+    ],
+    "expected": {
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "number"
+      },
+      "serialized": ["index-of", ["get", "needle"], ["get", "haystack"]],
+      "outputs": [
+        {
+          "error": "Expected first argument to be of type boolean, string, number or null, but found object instead."
+        },
+        {
+          "error": "Expected first argument to be of type boolean, string, number or null, but found object instead."
+        }
+      ]
+    }
+  }
+  

--- a/metrics/integration/expression-tests/index-of/with-from-index/test.json
+++ b/metrics/integration/expression-tests/index-of/with-from-index/test.json
@@ -11,6 +11,9 @@
       [{}, {"properties": {"needle": 7, "hay": [9, 8, 7, 8, 7, 7], "i": 3}}],
       [{}, {"properties": {"needle": 9, "hay": [9, 8, 7, 8, 7, 7], "i": 1}}],
       [{}, {"properties": {"needle": 8, "hay": [9, 8, 7, 8, 7, 7], "i": 1}}],
+      [{}, {"properties": {"needle": 8, "hay": [9, 8, 7, 8, 7, 7], "i": -1}}],
+      [{}, {"properties": {"needle": "foo", "hay": ["foo", "foo"], "i": -100}}],
+      [{}, {"properties": {"needle": "foo", "hay": "__foo__foo", "i": -100}}],
       [{}, {"properties": {"needle": 8, "hay": [9, 8, 7, 8, 7, 7], "i": 10000}}],
       [{}, {"properties": {"needle": 8, "hay": [9, 8, 7, 8, 7, 7], "i": "wrong"}}]
     ],
@@ -35,6 +38,9 @@
         4,
         -1,
         1,
+        1,
+        0,
+        2,
         -1,
         {
           "error": "Expected third argument to be of type number, but found string instead."

--- a/metrics/integration/expression-tests/index-of/with-from-index/test.json
+++ b/metrics/integration/expression-tests/index-of/with-from-index/test.json
@@ -1,0 +1,45 @@
+{
+    "expression": ["index-of", ["get", "needle"], ["get", "hay"], ["get", "i"]],
+    "inputs": [
+      [{}, {"properties": {"needle": null, "hay": "helloworld", "i": 0}}],
+      [{}, {"properties": {"needle": "foo", "hay": "helloworld", "i": 0}}],
+      [{}, {"properties": {"needle": "low", "hay": "helloworldlow", "i": 4}}],
+      [{}, {"properties": {"needle": true, "hay": "falsetruetrue", "i": 6}}],
+      [{}, {"properties": {"needle": false, "hay": "falsetrue", "i": 0}}],
+      [{}, {"properties": {"needle": 123, "hay": "hello123world", "i": 6}}],
+      [{}, {"properties": {"needle": "low", "hay": null, "i": 0}}],
+      [{}, {"properties": {"needle": 7, "hay": [9, 8, 7, 8, 7, 7], "i": 3}}],
+      [{}, {"properties": {"needle": 9, "hay": [9, 8, 7, 8, 7, 7], "i": 1}}],
+      [{}, {"properties": {"needle": 8, "hay": [9, 8, 7, 8, 7, 7], "i": 1}}],
+      [{}, {"properties": {"needle": 8, "hay": [9, 8, 7, 8, 7, 7], "i": 10000}}],
+      [{}, {"properties": {"needle": 8, "hay": [9, 8, 7, 8, 7, 7], "i": "wrong"}}]
+    ],
+    "expected": {
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "number"
+      },
+      "serialized": ["index-of", ["get", "needle"], ["get", "hay"], ["get", "i"]],
+      "outputs": [
+        -1,
+        -1,
+        10,
+        9,
+        0,
+        -1,
+        {
+          "error": "Expected second argument to be of type array or string, but found null instead."
+        },
+        4,
+        -1,
+        1,
+        -1,
+        {
+          "error": "Expected third argument to be of type number, but found string instead."
+        }
+      ]
+    }
+  }
+  

--- a/metrics/integration/expression-tests/slice/array-one-index/test.json
+++ b/metrics/integration/expression-tests/slice/array-one-index/test.json
@@ -1,0 +1,19 @@
+{
+    "expression": ["slice", ["array", ["get", "val"]], ["get", "index"]],
+    "inputs": [
+      [{}, {"properties": {"val": [1, 2, 3, 4, 5], "index": 2}}],
+      [{}, {"properties": {"val": [1, 2, 3, 4, 5], "index": 0}}],
+      [{}, {"properties": {"val": [1, 2, 3, 4, 5], "index": 99}}],
+      [{}, {"properties": {"val": [1, 2, 3, 4, 5], "index": -2}}]
+    ],
+    "expected": {
+    "serialized":  ["slice", ["array", ["get", "val"]], ["get", "index"]],
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "array"
+      },
+      "outputs": [[3, 4, 5], [1, 2, 3, 4, 5], [], [4, 5]]
+    }
+  }

--- a/metrics/integration/expression-tests/slice/array-two-indexes/test.json
+++ b/metrics/integration/expression-tests/slice/array-two-indexes/test.json
@@ -1,0 +1,31 @@
+{
+    "expression": [
+      "slice",
+      ["array", ["get", "val"]],
+      ["get", "i1"],
+      ["get", "i2"]
+    ],
+    "inputs": [
+      [{}, {"properties": {"val": [1, 2, 3, 4, 5], "i1": 2, "i2": 4}}],
+      [{}, {"properties": {"val": [1, 2, 3, 4, 5], "i1": 1, "i2": 5}}],
+      [{}, {"properties": {"val": [1, 2, 3, 4, 5], "i1": 1, "i2": 99}}],
+      [{}, {"properties": {"val": [1, 2, 3, 4, 5], "i1": -4, "i2": -2}}],
+      [{}, {"properties": {"val": [1, 2, 3, 4, 5], "i1": 0, "i2": -1}}],
+      [{}, {"properties": {"val": [1, 2, 3, 4, 5], "i1": 0, "i2": 0}}]
+    ],
+    "expected": {
+      "serialized": [
+            "slice",
+            ["array", ["get", "val"]],
+            ["get", "i1"],
+            ["get", "i2"]
+        ],
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "array"
+      },
+      "outputs": [[3, 4], [2, 3, 4, 5], [2, 3, 4, 5], [2, 3], [1, 2, 3, 4], []]
+    }
+  }

--- a/metrics/integration/expression-tests/slice/invalid-inputs/test.json
+++ b/metrics/integration/expression-tests/slice/invalid-inputs/test.json
@@ -1,0 +1,40 @@
+{
+    "expression": ["slice", ["get", "input"], ["get", "i1"]],
+    "inputs": [
+      [{}, {"properties": {"input": false, "i1": 1}}],
+      [{}, {"properties": {"input": null, "i1": 1}}],
+      [{}, {"properties": {"input": 12, "i1": 1}}],
+      [{}, {"properties": {"input": {}, "i1": 1}}],
+      [{}, {"properties": {"other": 1, "i1": 1}}],
+      [{}, {"properties": {"input": "correct", "i1": "one"}}]
+    ],
+    "expected": {
+      "serialized": ["slice", ["get", "input"], ["get", "i1"]],
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "value"
+      },
+      "outputs": [
+        {
+          "error": "Expected first argument to be of type array or string, but found boolean instead."
+        },
+        {
+          "error": "Expected first argument to be of type array or string, but found null instead."
+        },
+        {
+          "error": "Expected first argument to be of type array or string, but found number instead."
+        },
+        {
+          "error": "Expected first argument to be of type array or string, but found object instead."
+        },
+        {
+          "error": "Expected first argument to be of type array or string, but found null instead."
+        },
+        {
+          "error": "Expected value to be of type number, but found string instead."
+        }
+      ]
+    }
+  }

--- a/metrics/integration/expression-tests/slice/string-one-index/test.json
+++ b/metrics/integration/expression-tests/slice/string-one-index/test.json
@@ -1,0 +1,19 @@
+{
+    "expression": ["slice", ["get", "val"], ["get", "index"]],
+    "inputs": [
+      [{}, {"properties": {"val": "0123456789", "index": 0}}],
+      [{}, {"properties": {"val": "0123456789", "index": 4}}],
+      [{}, {"properties": {"val": "0123456789", "index": 99}}],
+      [{}, {"properties": {"val": "0123456789", "index": -2}}]
+    ],
+    "expected": {
+      "serialized": ["slice", ["get", "val"], ["get", "index"]],
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "value"
+      },
+      "outputs": ["0123456789", "456789", "", "89"]
+    }
+  }

--- a/metrics/integration/expression-tests/slice/string-two-indexes/test.json
+++ b/metrics/integration/expression-tests/slice/string-two-indexes/test.json
@@ -1,0 +1,20 @@
+{
+    "expression": ["slice", ["get", "val"], ["get", "i1"], ["get", "i2"]],
+    "inputs": [
+      [{}, {"properties": {"val": "0123456789", "i1": 1, "i2": 8}}],
+      [{}, {"properties": {"val": "0123456789", "i1": 4, "i2": -2}}],
+      [{}, {"properties": {"val": "0123456789", "i1": -3, "i2": -1}}],
+      [{}, {"properties": {"val": "0123456789", "i1": 0, "i2": -1}}],
+      [{}, {"properties": {"val": "0123456789", "i1": 0, "i2": 99}}]
+    ],
+    "expected": {
+      "serialized": ["slice", ["get", "val"], ["get", "i1"], ["get", "i2"]],
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "value"
+      },
+      "outputs": ["1234567", "4567", "78", "012345678", "0123456789"]
+    }
+  }

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -5,8 +5,8 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 ## main
 
 ### ✨ Features and improvements
-* Add support for the [`slice` expression](https://maplibre.org/maplibre-style-spec/expressions/#slice) ([#1113](https://github.com/maplibre/maplibre-native/pull/1133))
 
+* Add support for the [`slice` expression](https://maplibre.org/maplibre-style-spec/expressions/#slice) ([#1133](https://github.com/maplibre/maplibre-native/pull/1133))
 * Add support for [index-of expression](https://maplibre.org/maplibre-style-spec/expressions/#index-of) ([#1113](https://github.com/maplibre/maplibre-native/pull/1113))
 
 ### 🐞 Bug fixes

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -5,6 +5,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 ## main
 
 ### ✨ Features and improvements
+* Add support for the [`slice` expression](https://maplibre.org/maplibre-style-spec/expressions/#slice) ([#1113](https://github.com/maplibre/maplibre-native/pull/1133))
 
 * Add support for [index-of expression](https://maplibre.org/maplibre-style-spec/expressions/#index-of) ([#1113](https://github.com/maplibre/maplibre-native/pull/1113))
 
@@ -23,7 +24,6 @@ This version is identical to 10.0.2.
 ### ✨ Features and improvements
 
 * Change to a more natural fling animation and allow setting `flingThreshold` and `flingAnimationBaseTime` in `UiSettings` ([#963](https://github.com/maplibre/maplibre-native/pull/963))
-
 * Add support for [index-of expression](https://maplibre.org/maplibre-style-spec/expressions/#index-of) ([#1113](https://github.com/maplibre/maplibre-native/pull/1113))
 
 ### 🐞 Bug fixes

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -6,6 +6,8 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 
 ### ✨ Features and improvements
 
+* Add support for [index-of expression](https://maplibre.org/maplibre-style-spec/expressions/#index-of) ([#1113](https://github.com/maplibre/maplibre-native/pull/1113))
+
 ### 🐞 Bug fixes
 
 ### ⛵ Dependencies
@@ -21,7 +23,8 @@ This version is identical to 10.0.2.
 ### ✨ Features and improvements
 
 * Change to a more natural fling animation and allow setting `flingThreshold` and `flingAnimationBaseTime` in `UiSettings` ([#963](https://github.com/maplibre/maplibre-native/pull/963))
-* Add support for the [`index-of` expression](https://maplibre.org/maplibre-style-spec/expressions/#index-of) ([#1113](https://github.com/maplibre/maplibre-native/pull/1113))
+
+* Add support for [index-of expression](https://maplibre.org/maplibre-style-spec/expressions/#index-of) ([#1113](https://github.com/maplibre/maplibre-native/pull/1113))
 
 ### 🐞 Bug fixes
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -1565,7 +1565,7 @@ public class Expression {
   }
 
   /**
-   * Returns the first position at which a `needle` can be found in a `haystack`. 
+   * Returns the first position at which a `needle` can be found in a `haystack`.
    *
    * @param needle   the item expression
    * @param haystack the array or string expression
@@ -1575,6 +1575,33 @@ public class Expression {
    */
   public static Expression indexOf(@NonNull Expression keyword, @NonNull Expression input, @NonNull Expression fromIndex) {
     return new Expression("index-of", keyword, input, fromIndex);
+  }
+
+  /**
+   * Returns items from an array or a substring from a string from a specified start index. 
+   * The return value is inclusive of the start index.
+   *
+   * @param input the array or string expression
+   * @param fromIndex the index to start slice from
+   * @return array or string
+   * @see <a href="https://maplibre.org/maplibre-style-spec/expressions/#slice">Style specification</a>
+   */
+  public static Expression slice(@NonNull Expression input, @NonNull Expression fromIndex) {
+    return new Expression("slice", input, fromIndex);
+  }
+
+  /**
+   * Returns items from an array or a substring from a string between a start index and an end index if set. 
+   * The return value is inclusive of the start index, but not of the end index.
+   *
+   * @param input the array or string expression
+   * @param fromIndex the index to start slice from
+   * @param toIndex the index to end slice at
+   * @return array or string
+   * @see <a href="https://maplibre.org/maplibre-style-spec/expressions/#slice">Style specification</a>
+   */
+  public static Expression slice(@NonNull Expression input, @NonNull Expression fromIndex, @NonNull Expression toIndex) {
+    return new Expression("slice", input, fromIndex, toIndex);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -1553,6 +1553,31 @@ public class Expression {
   }
 
   /**
+   * Returns the first position at which a `needle` can be found in a `haystack`. 
+   *
+   * @param needle   the item expression
+   * @param haystack the array or string expression
+   * @return position in the array or string or -1 if not found.
+   * @see <a href="https://maplibre.org/maplibre-gl-js-docs/style-spec/#index-of">Style specification</a>
+   */
+  public static Expression indexOf(@NonNull Expression keyword, @NonNull Expression input) {
+    return new Expression("index-of", keyword, input);
+  }
+
+  /**
+   * Returns the first position at which a `needle` can be found in a `haystack`. 
+   *
+   * @param needle   the item expression
+   * @param haystack the array or string expression
+   * @param fromIndex the index to start searching from
+   * @return position in the array or string or -1 if not found.
+   * @see <a href="https://maplibre.org/maplibre-gl-js-docs/style-spec/#index-of">Style specification</a>
+   */
+  public static Expression indexOf(@NonNull Expression keyword, @NonNull Expression input, @NonNull Expression fromIndex) {
+    return new Expression("index-of", keyword, input, fromIndex);
+  }
+
+  /**
    * Retrieves whether an item exists in an array or a substring exists in a string.
    *
    * @param needle   the item expression

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.kt
@@ -478,6 +478,26 @@ class ExpressionTest {
 
     @Test
     @Throws(Exception::class)
+    fun testSlice() {
+        val expected = arrayOf<Any>("slice", arrayOf<Any>("literal", arrayOf<Any>(1f, 2f, 3f)), 1f)
+        val actual =
+            Expression.slice(Expression.literal(arrayOf<Any>(1f, 2f, 3f)), Expression.literal(1f))
+                .toArray()
+        Assert.assertTrue("expression should match", Arrays.deepEquals(expected, actual))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testSliceWithToIndex() {
+        val expected = arrayOf<Any>("slice", arrayOf<Any>("literal", arrayOf<Any>(1f, 2f, 3f)), 1f, 3f)
+        val actual =
+            Expression.slice(Expression.literal(arrayOf<Any>(1f, 2f, 3f)), Expression.literal(1f), Expression.literal(3f))
+                .toArray()
+        Assert.assertTrue("expression should match", Arrays.deepEquals(expected, actual))
+    }
+
+    @Test
+    @Throws(Exception::class)
     fun testInNumber() {
         val expected = arrayOf<Any>("in", 1f, arrayOf<Any>("literal", arrayOf<Any>(1f, 2f)))
         val actual =

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.kt
@@ -457,6 +457,27 @@ class ExpressionTest {
 
     @Test
     @Throws(Exception::class)
+    fun testIndexOf() {
+        val expected = arrayOf<Any>("index-of", 2f, arrayOf<Any>("literal", arrayOf<Any>(1f, 2f, 3f)))
+        val actual =
+            Expression.indexOf(Expression.literal(2f), Expression.literal(arrayOf<Any>(1f, 2f, 3f)))
+                .toArray()
+        Assert.assertTrue("expression should match", Arrays.deepEquals(expected, actual))
+    }
+
+
+    @Test
+    @Throws(Exception::class)
+    fun testIndexOfWithFromIndex() {
+        val expected = arrayOf<Any>("index-of", 2f, arrayOf<Any>("literal", arrayOf<Any>(1f, 2f, 3f)), 1f)
+        val actual =
+            Expression.indexOf(Expression.literal(2f), Expression.literal(arrayOf<Any>(1f, 2f, 3f)), Expression.literal(1f))
+                .toArray()
+        Assert.assertTrue("expression should match", Arrays.deepEquals(expected, actual))
+    }
+
+    @Test
+    @Throws(Exception::class)
     fun testInNumber() {
         val expected = arrayOf<Any>("in", 1f, arrayOf<Any>("literal", arrayOf<Any>(1f, 2f)))
         val actual =

--- a/src/mbgl/style/expression/index_of.cpp
+++ b/src/mbgl/style/expression/index_of.cpp
@@ -1,0 +1,138 @@
+#include "mbgl/style/expression/expression.hpp"
+#include <mbgl/style/conversion_impl.hpp>
+#include <mbgl/style/expression/index_of.hpp>
+#include <mbgl/util/string.hpp>
+#include <iostream>
+namespace mbgl {
+namespace style {
+namespace expression {
+
+IndexOf::IndexOf(std::unique_ptr<Expression> keyword_,
+                 std::unique_ptr<Expression> input_,
+                 std::unique_ptr<Expression> fromIndex_)
+    : Expression(Kind::IndexOf, type::Number),
+      keyword(std::move(keyword_)),
+      input(std::move(input_)),
+      fromIndex(std::move(fromIndex_)) {}
+
+EvaluationResult IndexOf::evaluate(const EvaluationContext &params) const {
+    const EvaluationResult evaluatedKeyword = keyword->evaluate(params);
+    const EvaluationResult evaluatedInput = input->evaluate(params);
+    if (!evaluatedKeyword) {
+        return evaluatedKeyword.error();
+    }
+    if (!evaluatedInput) {
+        return evaluatedInput.error();
+    }
+
+    if (!(evaluatedKeyword->is<double>() || evaluatedKeyword->is<std::string>() || evaluatedKeyword->is<bool>() ||
+          evaluatedKeyword->is<NullValue>())) {
+        return EvaluationError{"Expected first argument to be of type boolean, string, number or null, but found " +
+                               toString(typeOf(*evaluatedKeyword)) + " instead."};
+    }
+
+    size_t fromIndexValue = 0;
+    if (fromIndex) {
+        const EvaluationResult evaluatedFromIndex = fromIndex->evaluate(params);
+        if (!evaluatedFromIndex) {
+            return evaluatedFromIndex.error();
+        }
+        if (!evaluatedFromIndex->is<double>()) {
+            return EvaluationError{"Expected third argument to be of type number, but found " +
+                                   toString(typeOf(*evaluatedFromIndex)) + " instead."};
+        }
+        fromIndexValue = static_cast<size_t>(evaluatedFromIndex->get<double>());
+    }
+
+    return evaluatedInput->match(
+        [&](const std::string &s) { return evaluateForStringInput(s, *evaluatedKeyword, fromIndexValue); },
+        [&](const std::vector<Value> &v) { return evaluateForArrayInput(v, *evaluatedKeyword, fromIndexValue); },
+        [&](const auto &) -> EvaluationResult {
+            return EvaluationError{"Expected second argument to be of type array or string, but found " +
+                                   toString(typeOf(*evaluatedInput)) + " instead."};
+        });
+}
+
+EvaluationResult IndexOf::evaluateForArrayInput(const std::vector<Value> &array,
+                                                const Value &keywordValue,
+                                                size_t fromIndexValue) const {
+    for (size_t index = fromIndexValue; index < array.size(); ++index) {
+        if (array[index] == keywordValue) {
+            return static_cast<double>(index);
+        }
+    }
+    return static_cast<double>(-1);
+}
+
+EvaluationResult IndexOf::evaluateForStringInput(const std::string &string,
+                                                 const Value &keywordValue,
+                                                 size_t fromIndexValue) const {
+    std::string keywordString = keywordValue.match(
+        [](const std::string &s) { return s; },
+        [](bool b) { return b ? std::string{"true"} : std::string{"false"}; },
+        [](NullValue) { return std::string{"null"}; },
+        [](double n) { return util::toString(n); },
+        [](const auto &) -> std::string {
+            // it should be impossible to get here - we do validation in evaluate()
+            assert(false);
+            return "";
+        });
+    size_t index = string.find(keywordString, fromIndexValue);
+    if (index == std::string::npos) {
+        return static_cast<double>(-1);
+    }
+    return static_cast<double>(index);
+}
+
+void IndexOf::eachChild(const std::function<void(const Expression &)> &visit) const {
+    visit(*keyword);
+    visit(*input);
+    if (fromIndex) {
+        visit(*fromIndex);
+    }
+}
+
+using namespace mbgl::style::conversion;
+ParseResult IndexOf::parse(const Convertible &value, ParsingContext &ctx) {
+    assert(isArray(value));
+
+    std::size_t length = arrayLength(value);
+    if (length != 3 && length != 4) {
+        ctx.error("Expected 2 or 3 arguments, but found " + util::toString(length - 1) + " instead.");
+        return ParseResult();
+    }
+
+    ParseResult keyword = ctx.parse(arrayMember(value, 1), 1);
+    ParseResult input = ctx.parse(arrayMember(value, 2), 2);
+
+    ParseResult fromIndex = length == 4 ? ctx.parse(arrayMember(value, 3), 3) : ParseResult();
+
+    if (!keyword || !input) {
+        return ParseResult();
+    }
+
+    return ParseResult(
+        std::make_unique<IndexOf>(std::move(*keyword), std::move(*input), fromIndex ? std::move(*fromIndex) : nullptr));
+}
+
+bool IndexOf::operator==(const Expression &e) const {
+    if (e.getKind() == Kind::IndexOf) {
+        auto rhs = static_cast<const IndexOf *>(&e);
+        const auto fromIndexEqual = (fromIndex && rhs->fromIndex && *fromIndex == *(rhs->fromIndex)) ||
+                                    (!fromIndex && !rhs->fromIndex);
+        return *keyword == *(rhs->keyword) && *input == *(rhs->input) && fromIndexEqual;
+    }
+    return false;
+}
+
+std::vector<optional<Value>> IndexOf::possibleOutputs() const {
+    return {nullopt};
+}
+
+std::string IndexOf::getOperator() const {
+    return "index-of";
+}
+
+} // namespace expression
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/expression/index_of.cpp
+++ b/src/mbgl/style/expression/index_of.cpp
@@ -2,7 +2,7 @@
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/style/expression/index_of.hpp>
 #include <mbgl/util/string.hpp>
-#include <iostream>
+
 namespace mbgl {
 namespace style {
 namespace expression {

--- a/src/mbgl/style/expression/index_of.cpp
+++ b/src/mbgl/style/expression/index_of.cpp
@@ -41,7 +41,7 @@ EvaluationResult IndexOf::evaluate(const EvaluationContext &params) const {
             return EvaluationError{"Expected third argument to be of type number, but found " +
                                    toString(typeOf(*evaluatedFromIndex)) + " instead."};
         }
-        fromIndexValue = static_cast<size_t>(evaluatedFromIndex->get<double>());
+        fromIndexValue = static_cast<size_t>(std::max(evaluatedFromIndex->get<double>(), 0.0));
     }
 
     return evaluatedInput->match(

--- a/src/mbgl/style/expression/parsing_context.cpp
+++ b/src/mbgl/style/expression/parsing_context.cpp
@@ -26,6 +26,7 @@
 #include <mbgl/style/expression/step.hpp>
 #include <mbgl/style/expression/within.hpp>
 #include <mbgl/style/expression/index_of.hpp>
+#include <mbgl/style/expression/slice.hpp>
 
 #include <mbgl/style/expression/find_zoom_curve.hpp>
 #include <mbgl/style/expression/dsl.hpp>
@@ -107,43 +108,42 @@ ParseResult ParsingContext::parse(const Convertible& value, std::size_t index_, 
 
 using ParseFunction = ParseResult (*)(const conversion::Convertible&, ParsingContext&);
 MAPBOX_ETERNAL_CONSTEXPR const auto expressionRegistry =
-    mapbox::eternal::hash_map<mapbox::eternal::string, ParseFunction>({
-        {"==", parseComparison},
-        {"!=", parseComparison},
-        {">", parseComparison},
-        {"<", parseComparison},
-        {">=", parseComparison},
-        {"<=", parseComparison},
-        {"all", All::parse},
-        {"any", Any::parse},
-        {"array", Assertion::parse},
-        {"at", At::parse},
-        {"in", In::parse},
-        {"boolean", Assertion::parse},
-        {"case", Case::parse},
-        {"coalesce", Coalesce::parse},
-        {"collator", CollatorExpression::parse},
-        {"distance", Distance::parse},
-        {"format", FormatExpression::parse},
-        {"image", ImageExpression::parse},
-        {"interpolate", parseInterpolate},
-        {"length", Length::parse},
-        {"let", Let::parse},
-        {"literal", Literal::parse},
-        {"match", parseMatch},
-        {"number", Assertion::parse},
-        {"number-format", NumberFormat::parse},
-        {"object", Assertion::parse},
-        {"step", Step::parse},
-        {"string", Assertion::parse},
-        {"to-boolean", Coercion::parse},
-        {"to-color", Coercion::parse},
-        {"to-number", Coercion::parse},
-        {"to-string", Coercion::parse},
-        {"var", Var::parse},
-        {"within", Within::parse},
-        {"index-of", IndexOf::parse},
-    });
+    mapbox::eternal::hash_map<mapbox::eternal::string, ParseFunction>({{"==", parseComparison},
+                                                                       {"!=", parseComparison},
+                                                                       {">", parseComparison},
+                                                                       {"<", parseComparison},
+                                                                       {">=", parseComparison},
+                                                                       {"<=", parseComparison},
+                                                                       {"all", All::parse},
+                                                                       {"any", Any::parse},
+                                                                       {"array", Assertion::parse},
+                                                                       {"at", At::parse},
+                                                                       {"in", In::parse},
+                                                                       {"boolean", Assertion::parse},
+                                                                       {"case", Case::parse},
+                                                                       {"coalesce", Coalesce::parse},
+                                                                       {"collator", CollatorExpression::parse},
+                                                                       {"distance", Distance::parse},
+                                                                       {"format", FormatExpression::parse},
+                                                                       {"image", ImageExpression::parse},
+                                                                       {"interpolate", parseInterpolate},
+                                                                       {"length", Length::parse},
+                                                                       {"let", Let::parse},
+                                                                       {"literal", Literal::parse},
+                                                                       {"match", parseMatch},
+                                                                       {"number", Assertion::parse},
+                                                                       {"number-format", NumberFormat::parse},
+                                                                       {"object", Assertion::parse},
+                                                                       {"step", Step::parse},
+                                                                       {"string", Assertion::parse},
+                                                                       {"to-boolean", Coercion::parse},
+                                                                       {"to-color", Coercion::parse},
+                                                                       {"to-number", Coercion::parse},
+                                                                       {"to-string", Coercion::parse},
+                                                                       {"var", Var::parse},
+                                                                       {"within", Within::parse},
+                                                                       {"index-of", IndexOf::parse},
+                                                                       {"slice", Slice::parse}});
 
 bool isExpression(const std::string& name) {
     return expressionRegistry.contains(name.c_str());

--- a/src/mbgl/style/expression/parsing_context.cpp
+++ b/src/mbgl/style/expression/parsing_context.cpp
@@ -25,6 +25,7 @@
 #include <mbgl/style/expression/number_format.hpp>
 #include <mbgl/style/expression/step.hpp>
 #include <mbgl/style/expression/within.hpp>
+#include <mbgl/style/expression/index_of.hpp>
 
 #include <mbgl/style/expression/find_zoom_curve.hpp>
 #include <mbgl/style/expression/dsl.hpp>
@@ -141,6 +142,7 @@ MAPBOX_ETERNAL_CONSTEXPR const auto expressionRegistry =
         {"to-string", Coercion::parse},
         {"var", Var::parse},
         {"within", Within::parse},
+        {"index-of", IndexOf::parse},
     });
 
 bool isExpression(const std::string& name) {

--- a/src/mbgl/style/expression/slice.cpp
+++ b/src/mbgl/style/expression/slice.cpp
@@ -1,0 +1,156 @@
+#include "mbgl/style/expression/expression.hpp"
+#include <limits>
+#include <mbgl/style/conversion_impl.hpp>
+#include <mbgl/style/expression/slice.hpp>
+#include <mbgl/util/string.hpp>
+
+namespace mbgl {
+namespace style {
+namespace expression {
+
+namespace {
+
+int normalizeIndex(int index, int length) {
+    if (index < 0) {
+        index += length;
+    }
+    return index;
+}
+
+} // namespace
+
+Slice::Slice(std::unique_ptr<Expression> input_,
+             std::unique_ptr<Expression> fromIndex_,
+             std::unique_ptr<Expression> toIndex_)
+    : Expression(Kind::Slice, input_->getType()),
+      input(std::move(input_)),
+      fromIndex(std::move(fromIndex_)),
+      toIndex(std::move(toIndex_)) {}
+
+EvaluationResult Slice::evaluate(const EvaluationContext &params) const {
+    const EvaluationResult evaluatedInput = input->evaluate(params);
+    if (!evaluatedInput) {
+        return evaluatedInput.error();
+    }
+    const EvaluationResult evaluatedFromIndex = fromIndex->evaluate(params);
+    if (!fromIndex) {
+        return evaluatedFromIndex.error();
+    }
+    if (!evaluatedFromIndex->is<double>()) {
+        return EvaluationError{"Expected value to be of type number, but found " +
+                               toString(typeOf(*evaluatedFromIndex)) + " instead."};
+    }
+
+    int fromIndexValue = static_cast<int>(evaluatedFromIndex->get<double>());
+    int toIndexValue = std::numeric_limits<int>::max();
+
+    if (toIndex) {
+        const EvaluationResult evaluatedToIndex = toIndex->evaluate(params);
+        if (!evaluatedToIndex) {
+            return evaluatedToIndex.error();
+        }
+        if (!evaluatedToIndex->is<double>()) {
+            return EvaluationError{"Expected value to be of type number, but found " +
+                                   toString(typeOf(*evaluatedFromIndex)) + " instead."};
+        }
+        toIndexValue = static_cast<int>(evaluatedToIndex->get<double>());
+    }
+
+    return evaluatedInput->match(
+        [&](const std::string &s) { return evaluateForStringInput(s, fromIndexValue, toIndexValue); },
+        [&](const std::vector<Value> &v) { return evaluateForArrayInput(v, fromIndexValue, toIndexValue); },
+        [&](const auto &) -> EvaluationResult {
+            return EvaluationError{"Expected first argument to be of type array or string, but found " +
+                                   toString(typeOf(*evaluatedInput)) + " instead."};
+        });
+}
+
+EvaluationResult Slice::evaluateForArrayInput(const std::vector<Value> &array,
+                                              int fromIndexValue,
+                                              int toIndexValue) const {
+    int length = static_cast<int>(array.size());
+    if (toIndexValue == std::numeric_limits<int>::max()) {
+        toIndexValue = length;
+    }
+    fromIndexValue = normalizeIndex(fromIndexValue, length);
+    toIndexValue = normalizeIndex(toIndexValue, length);
+
+    if (fromIndexValue >= toIndexValue) {
+        return std::vector<Value>{};
+    }
+    toIndexValue = std::min(toIndexValue, length);
+
+    std::vector<Value> result;
+    result.reserve(toIndexValue - fromIndexValue);
+    for (int index = fromIndexValue; index < toIndexValue; ++index) {
+        result.push_back(array[index]);
+    }
+    return result;
+}
+
+EvaluationResult Slice::evaluateForStringInput(const std::string &string, int fromIndexValue, int toIndexValue) const {
+    int length = static_cast<int>(string.size());
+    if (toIndexValue == std::numeric_limits<int>::max()) {
+        toIndexValue = length;
+    }
+    fromIndexValue = normalizeIndex(fromIndexValue, length);
+    toIndexValue = normalizeIndex(toIndexValue, length);
+    if (fromIndexValue >= length) {
+        return std::string{};
+    }
+
+    return string.substr(fromIndexValue, toIndexValue - fromIndexValue);
+}
+
+void Slice::eachChild(const std::function<void(const Expression &)> &visit) const {
+    visit(*input);
+    visit(*fromIndex);
+    if (toIndex) {
+        visit(*toIndex);
+    }
+}
+
+using namespace mbgl::style::conversion;
+ParseResult Slice::parse(const Convertible &value, ParsingContext &ctx) {
+    assert(isArray(value));
+
+    std::size_t length = arrayLength(value);
+    if (length != 3 && length != 4) {
+        ctx.error("Expected 2 or 3 arguments, but found " + util::toString(length - 1) + " instead.");
+        return ParseResult();
+    }
+
+    ParseResult input = ctx.parse(arrayMember(value, 1), 1);
+    ParseResult fromIndex = ctx.parse(arrayMember(value, 2), 2);
+
+    ParseResult toIndex = length == 4 ? ctx.parse(arrayMember(value, 3), 3) : ParseResult();
+
+    if (!input || !fromIndex) {
+        return ParseResult();
+    }
+
+    return ParseResult(
+        std::make_unique<Slice>(std::move(*input), std::move(*fromIndex), toIndex ? std::move(*toIndex) : nullptr));
+}
+
+bool Slice::operator==(const Expression &e) const {
+    if (e.getKind() == Kind::Slice) {
+        auto rhs = static_cast<const Slice *>(&e);
+        const auto toIndexEqual = (toIndex && rhs->toIndex && *toIndex == *(rhs->toIndex)) ||
+                                  (!toIndex && !rhs->toIndex);
+        return *input == *(rhs->input) && *fromIndex == *(rhs->fromIndex) && toIndexEqual;
+    }
+    return false;
+}
+
+std::vector<optional<Value>> Slice::possibleOutputs() const {
+    return {nullopt};
+}
+
+std::string Slice::getOperator() const {
+    return "slice";
+}
+
+} // namespace expression
+} // namespace style
+} // namespace mbgl


### PR DESCRIPTION
Continuation of #2094

---

Changes in this PR were mostly automated:

I checked https://github.com/maplibre/maplibre-native/commits/main/src/mbgl/style/expression to find relevant changes (as there's apparently no shared CHANGELOG section, as each branch has its own and the original PRs also modified the android changelog)

- git checkout origin/android-10    
- git checkout -b android-10/backport-string-expressions
- git cherry-pick 379b1fc606ef79396abedee689941f95419646fc
    - Moved platform/android/CHANGELOG.md to main
    - Replaced `std::optional` by `optional` and `std::nullopt` by `nullopt` (undo missing https://github.com/maplibre/maplibre-native/pull/911)
- git cherry-pick 5990efbb12ddf7718a668012ba9d0ee549dd8a67
- git cherry-pick 09f17c0fc42453edd274392d528266a6b6130abf   
    - Removed bazel/core.bzl because it didn't exist in android-10
    - Replaced `std::optional` by `optional` and `std::nullopt` by `nullopt` (undo missing https://github.com/maplibre/maplibre-native/pull/911)
- Added a new commit to cleanup CHANGELOG

CI fails because pre-commit.ci did not exist in android-10.x.x.

Tested on CI in https://github.com/JannikGM/maplibre-native/actions/runs/7830617258.