### PR TITLE
Android 10.x.x: Don't filter pull_request CI by branch

### DIFF
--- a/.github/workflows/android-ci-pull.yml
+++ b/.github/workflows/android-ci-pull.yml
@@ -3,8 +3,6 @@ name: android-ci-pull
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     paths:
       - 'platform/android/**'
       - ".github/workflows/android-ci.yml"

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -26,8 +26,6 @@ on:
       - "!**/*.md"
   
   pull_request:
-    branches:
-      - main
     paths:
       - 'platform/ios/**'
       - 'platform/darwin/**'

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -26,8 +26,6 @@ on:
       - "!**/*.md"
 
   pull_request:
-    branches:
-      - main
     paths:
       - 'platform/ios/**'
       - 'platform/darwin/**'

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -25,8 +25,6 @@ on:
       - "!**/*.md"
 
   pull_request:
-    branches:
-      - main
     paths:
       - 'platform/node/**'
       - ".github/workflows/node-ci.yml"

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -27,8 +27,6 @@ on:
       - "!**/*.md"
 
   pull_request:
-    branches:
-      - main
     paths:
       - ".github/actions/qt5-build/**"
       - ".github/actions/qt6-build/**"


### PR DESCRIPTION
For older branches CI only runs on PRs to the main branch. That makes no sense:

- Even if PR'ing into another PR this is probably wanted, for review to make sense
- Even when working on other version specific base branches (like android-10.x.x), you'll want to have CI

In main, this has been resolved as sideeffect of https://github.com/maplibre/maplibre-native/pull/1570 (changing the filter to "*", thereby effectively removing it).

As is, there's path filtering which is meant to catch all dependencies of a platform (probably to reduce the amount of CI time, at risk of not catching mistakes), which is probably enough (or even too much) filtering.

---

Once this is merged, I also plan to forwardport/backport this to:

- ~~main~~ 
- opengl-2
- android-10.2.x

Once the branches for other platforms are created (like ios-5 being renamed to ios-5.x.x) I'd suggest someone also backports to those.