### PR TITLE
Android 10.2.x: Don't filter pull_request CI by branch

### DIFF
--- a/.github/workflows/android-ci-pull.yml
+++ b/.github/workflows/android-ci-pull.yml
@@ -3,8 +3,6 @@ name: android-ci-pull
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     paths:
       - 'platform/android/**'
       - ".github/workflows/android-ci.yml"

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -26,8 +26,6 @@ on:
       - "!**/*.md"
   
   pull_request:
-    branches:
-      - main
     paths:
       - 'platform/ios/**'
       - 'platform/darwin/**'

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -26,8 +26,6 @@ on:
       - "!**/*.md"
 
   pull_request:
-    branches:
-      - main
     paths:
       - 'platform/ios/**'
       - 'platform/darwin/**'

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -25,8 +25,6 @@ on:
       - "!**/*.md"
 
   pull_request:
-    branches:
-      - main
     paths:
       - 'platform/node/**'
       - ".github/workflows/node-ci.yml"

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -27,8 +27,6 @@ on:
       - "!**/*.md"
 
   pull_request:
-    branches:
-      - main
     paths:
       - ".github/actions/qt5-build/**"
       - ".github/actions/qt6-build/**"


### PR DESCRIPTION
Backport of #2109

One of the problems that has shown in #2108 is that the changes from #2109 also trigger a lot of CI failures (for non-android platforms in the android branch).

It might be acceptable to only run android CI on the main and android branches (as also suggested in https://github.com/maplibre/maplibre-native/pull/2109#issuecomment-1941135144). Personally I think the android version should be a slim layer on top of the core version, so for future versions I'd always except all CI to work.

However, I can see that simple backports would still trigger a lot of CI we don't care about (even if android-11.x.x can be used to generate a working iOS build, that's probably not relevant).
We'd just have to document that branches for specific versions (like `platform-*.*.x`) are only guaranteed to work for the mentioned platform.

I'm expecting maintainers to make a decision here if I should reintroduce platform branch filtering for `pull_request` (for this PR, and follow-up for #2108 in android-10.x.x).