### PR TITLE
Get unit and render tests running on iOS simulator

### DIFF
--- a/src/mbgl/mtl/offscreen_texture.cpp
+++ b/src/mbgl/mtl/offscreen_texture.cpp
@@ -35,6 +35,8 @@ public:
                 ->setUsage(MTL::TextureUsageShaderRead | MTL::TextureUsageShaderWrite | MTL::TextureUsageRenderTarget);
         }
 
+        // On iOS simulator, the depth target is PixelFormatDepth32Float_Stencil8
+#if !TARGET_OS_SIMULATOR
         if (stencil) {
             stencilTexture = context.createTexture2D();
             stencilTexture->setSize(size);
@@ -44,6 +46,8 @@ public:
             static_cast<Texture2D*>(stencilTexture.get())
                 ->setUsage(MTL::TextureUsageShaderRead | MTL::TextureUsageShaderWrite | MTL::TextureUsageRenderTarget);
         }
+#endif
+
         context.renderingStats().numFrameBuffers++;
     }
 

--- a/test/include/mbgl/test/util.hpp
+++ b/test/include/mbgl/test/util.hpp
@@ -6,7 +6,8 @@
 
 #define TEST_READ_ONLY 0
 
-#if !ANDROID
+// iOS simulator server can work
+#if !ANDROID && !TARGET_OS_SIMULATOR
 #ifndef TEST_HAS_SERVER
 #define TEST_HAS_SERVER 1
 #endif

--- a/test/include/mbgl/test/util.hpp
+++ b/test/include/mbgl/test/util.hpp
@@ -6,7 +6,7 @@
 
 #define TEST_READ_ONLY 0
 
-// iOS simulator server can work
+// iOS simulator server can work if port 3000 is available
 #if !ANDROID && !TARGET_OS_SIMULATOR
 #ifndef TEST_HAS_SERVER
 #define TEST_HAS_SERVER 1

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -8,7 +8,6 @@
 #include <mbgl/gfx/backend_scope.hpp>
 #include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/gfx/shader_registry.hpp>
-#include <mbgl/gl/context.hpp>
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/math/log2.hpp>
 #include <mbgl/renderer/renderer.hpp>


### PR DESCRIPTION
Fixes Metal errors on iOS simulator related to special requirements on textures.

Also disables HTTP tests, because listening on port 3000 fails, and it seems impractical to make the port dynamic since it appears in a bunch of `.json` files.

I'm curious whether this is specific to my system/configuration, though, so perhaps it can be left enabled.  I don't find anyone else having the same issue on, e.g., StackOverflow.

48 of the 1165 render tests fail on the simulator, which seems not so bad.  Interestingly, a lot of them seem to show the same pattern of a vertical and horizontal stripe of errors.

<img width="300" alt="image" src="https://github.com/maplibre/maplibre-native/assets/71895881/98a0c7ac-e6a7-4a91-9bca-2975234d9c65">
