### PR TITLE
Free GitHub runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,6 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
-    - MapLibre_Native_Linux_16_core
     - macos-14  # can be removed once actionlint is updated
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -217,6 +217,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
+
       - uses: actions/setup-java@v4
         with:
           distribution: "temurin"

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -33,7 +33,7 @@ jobs:
           files_yaml_from_source_file: .github/changed-files.yml
 
   android-build:
-    runs-on: ${{ github.event.pull_request && !github.event.pull_request.draft && 'MapLibre_Native_Linux_16_core' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     needs:
       - pre_job
     if: needs.pre_job.outputs.should_skip != 'true'

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -193,7 +193,35 @@ jobs:
           name: uploadsEnv
           path: uploads.env
 
-      # render test
+      - name: Store debug artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-artifacts
+          path: |
+            MapboxGLAndroidSDKTestApp/build/outputs/apk/debug
+            MapboxGLAndroidSDK/build/reports/lint-results.html
+            MapboxGLAndroidSDK/lint-baseline.xml
+            MapboxGLAndroidSDKTestApp/build/reports/lint-results.html
+            MapboxGLAndroidSDKTestApp/build/reports/lint-results.xml
+            MapboxGLAndroidSDKTestApp/lint-baseline.xml
+            MapboxGLAndroidSDK/build/intermediates/cmake/debug/obj
+
+  android-build-render-test:
+    runs-on: ubuntu-latest
+    needs:
+      - pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
       - name: Build Render Test App
         run: |
           ./gradlew assemble assembleAndroidTest
@@ -209,19 +237,6 @@ jobs:
           path: |
             ./render-test/android/RenderTestsApp.apk
             ./render-test/android/RenderTests.apk
-
-      - name: Store debug artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: debug-artifacts
-          path: |
-            MapboxGLAndroidSDKTestApp/build/outputs/apk/debug
-            MapboxGLAndroidSDK/build/reports/lint-results.html
-            MapboxGLAndroidSDK/lint-baseline.xml
-            MapboxGLAndroidSDKTestApp/build/reports/lint-results.html
-            MapboxGLAndroidSDKTestApp/build/reports/lint-results.xml
-            MapboxGLAndroidSDKTestApp/lint-baseline.xml
-            MapboxGLAndroidSDK/build/intermediates/cmake/debug/obj
 
   android-instrumentation-test:
     needs: android-build
@@ -265,6 +280,7 @@ jobs:
     needs:
       - pre_job
       - android-build
+      - android-build-render-test
     steps:
       - name: Mark result as failed
         if: needs.android-build.result != 'success'

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -210,7 +210,7 @@ jobs:
         if: github.event.inputs.release == 'full'
         run: |
           echo version="$(head VERSION)" >> "$GITHUB_ENV"
-          echo changelog_version_heading="## ${{ env.version }}" >> "$GITHUB_ENV"
+          echo changelog_version_heading="## $(head VERSION)" >> "$GITHUB_ENV"
 
       - name: Get version (pre-release)
         if: github.event.inputs.release == 'pre'
@@ -274,9 +274,9 @@ jobs:
             -H "Authorization: token ${{ steps.generate_token.outputs.token }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/maplibre/maplibre-gl-native-distribution/actions/workflows/$release_workflow_id/dispatches \
-            -d '{"ref":"main","inputs":{ \
-              "changelog_url": "https://maplibre-native.s3.eu-central-1.amazonaws.com/changelogs/ios-${{ env.version }}.md", \
-              "version":"${{ env.version }}", \
+            -d '{"ref":"main","inputs":{
+              "changelog_url": "https://maplibre-native.s3.eu-central-1.amazonaws.com/changelogs/ios-${{ env.version }}.md",
+              "version":"${{ env.version }}",
               "download_url":"${{ fromJSON(steps.github_release.outputs.assets)[0].browser_download_url }}"}}'
 
       - name: Release (CocoaPods)

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: true
       matrix:
         renderer: [legacy, drawable]
-    runs-on: ${{ github.event.pull_request && !github.event.pull_request.draft && 'MapLibre_Native_Linux_16_core' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The free GitHub runners got faster for open-source projects: https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/

So this PR disables the paid runners.

We go back from 16-core to 4-core, let's see if CI time is acceptable.