### PR TITLE
Prepare for Android 11.0.0-pre0 release

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -141,7 +141,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: platform/android/MapboxGLAndroidSDK/build/outputs/aar/MapboxGLAndroidSDK-release.aar
+          asset_path: platform/android/MapboxGLAndroidSDK/build/outputs/aar/MapboxGLAndroidSDK-drawable-release.aar
           asset_name: MapboxGLAndroidSDK-release.aar
           asset_content_type: application/zip
 

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -1,11 +1,18 @@
-# Changelog for the MapLibre Maps SDK for Android
-
-MapLibre welcomes participation and contributions from everyone. Please read [`Contributing Guide`](https://github.com/maplibre/maplibre-native/blob/main/CONTRIBUTING.md) to get started.
+# Changelog MapLibre Native for Android
 
 ## main
 
 ### ✨ Features and improvements
-* Add support for the [`slice` expression](https://maplibre.org/maplibre-style-spec/expressions/#slice) ([#1113](https://github.com/maplibre/maplibre-native/pull/1133))
+
+### 🐞 Bug fixes
+
+## 11.0.0
+
+### ✨ Features and improvements
+
+- Add support for the [`slice` expression](https://maplibre.org/maplibre-style-spec/expressions/#slice) ([#1113](https://github.com/maplibre/maplibre-native/pull/1133))
+- Add support for the [`index-of` expression](https://maplibre.org/maplibre-style-spec/expressions/#index-of) ([#1113](https://github.com/maplibre/maplibre-native/pull/1113))
+- Change to a more natural fling animation and allow setting `flingThreshold` and `flingAnimationBaseTime` in `UiSettings` ([#963](https://github.com/maplibre/maplibre-native/pull/963))
 
 - 💥 Breaking: Change package of all classes from `com.mapbox.mapboxsdk` to `org.maplibre.android` ([#1201](https://github.com/maplibre/maplibre-native/pull/1201)). This means you will need to fix your imports.
 
@@ -29,7 +36,11 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 
 - Fix "... has unresolved theme attributes" error in BitMapUtils ([#1274](https://github.com/maplibre/maplibre-native/issues/1274)).
 
-### ⛵ Dependencies
+## 10.2.0
+
+Revert changes of 10.1.0, which was a breaking release by accident.
+
+This version is identical to 10.0.2.
 
 ## 10.1.0 - May 9, 2023
 


### PR DESCRIPTION
I want to push out the first pre-release for Android. This PR:

- Makes sure the release uses the Drawable renderer (as it needs to be tested).
- Updates the changelog.

I made as little changes to the release workflow as possible. In the future the iOS and Android release workflows should be made more similar. For example: make use of the same scripts to extract the changelog, read `VERSION` from file and create a tag (for Android this is a manual process at the moment), intergrate `android-release` workflow into `android-ci`.