### PR TITLE
[darwin] Tighten camera equality requirements

### DIFF
--- a/platform/darwin/src/MLNMapCamera.mm
+++ b/platform/darwin/src/MLNMapCamera.mm
@@ -180,11 +180,11 @@ BOOL MLNEqualFloatWithAccuracy(CGFloat left, CGFloat right, CGFloat accuracy)
         return YES;
     }
     
-    return (MLNEqualFloatWithAccuracy(_centerCoordinate.latitude, otherCamera.centerCoordinate.latitude, 1e-6)
-            && MLNEqualFloatWithAccuracy(_centerCoordinate.longitude, otherCamera.centerCoordinate.longitude, 1e-6)
+    return (MLNEqualFloatWithAccuracy(_centerCoordinate.latitude, otherCamera.centerCoordinate.latitude, 1e-8)
+            && MLNEqualFloatWithAccuracy(_centerCoordinate.longitude, otherCamera.centerCoordinate.longitude, 1e-8)
             && MLNEqualFloatWithAccuracy(_altitude, otherCamera.altitude, 1e-6)
-            && MLNEqualFloatWithAccuracy(_pitch, otherCamera.pitch, 1)
-            && MLNEqualFloatWithAccuracy(_heading, otherCamera.heading, 1));
+            && MLNEqualFloatWithAccuracy(_pitch, otherCamera.pitch, 1e-2)
+            && MLNEqualFloatWithAccuracy(_heading, otherCamera.heading, 1e-2));
 }
 
 - (NSUInteger)hash


### PR DESCRIPTION
When working at high zoom levels (22+) and especially when manually driving camera animations, we require high precision control over the camera state.

The setCamera function on MGLMapView will ignore camera updates if it thinks the current camera and the new one are "equal". This equality function performs a floating point delta calculation and compares it to some epsilon value to determine if the values are "equal". This can become an issue when we actually need higher than epsilon precision over the camera.

To illustrate the point, consider:

We can roughly estimate degrees per points: dpp = 360 / (512 * 2^z), for zoom level 22 that comes out to ~ 1.7e-7 dpp. This means that if my camera movement is < ~6 points, it will be ignored. Sub 6 point movements are common if manually interpolating the camera at 60 fps.

So instead of using 1e-6, I propose we use 1e-8, which would be in line with our dpp calculation for the max supported zoom (25.5), dpp = 1.5e-8

For pitch and heading, looking at linear interpolation with no easing function applied, we can come up a value/frame = (end - start) / (duration * 60 fps), so for a 1 deg change over 0.3 seconds (standard ios animation time) we get ~ 0.05 deg deltas on every camera update. So to be safe, I propose setting the pitch and heading accuracies to 1e-2 (to account for non linear easing functions).

I would even propose going one step further and getting rid of the equality check, as the core c++ does not do anything like this. Set Camera does not seem to be used internally and thus is there for developers to use, we should trust their intent when calling the function.