### PR TITLE
Always create check for Android render test, Take into account cancelled workflows

### DIFF
--- a/.github/workflows/android-device-test.yml
+++ b/.github/workflows/android-device-test.yml
@@ -7,21 +7,7 @@ on:
       - completed
 
 jobs:
-  pre_job:
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.check_skip.outputs.should_skip }}
-    steps:
-      # if android-build in android-ci was skipped, the android-device-test job can be skipped entirely
-      - id: check_skip
-        run: |
-          conclusion=$(curl ${{ github.event.workflow_run.jobs_url }} | jq -r '.jobs[] | select(.name == "android-build").conclusion')
-          should_skip=$([ "$conclusion" = "skipped" ] && echo "true" || echo "false")
-          echo "should_skip=$should_skip" >> "$GITHUB_OUTPUT"
-
   android-device-test:
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip == 'false'
     strategy:
       max-parallel: 2
       matrix:
@@ -51,11 +37,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Sanity check, test files should exist
-        uses: andstor/file-existence-action@v2.0.0
-        with:
-          files: "${{ matrix.test.testFile }}, ${{ matrix.test.appFile }}"
-          fail: true
+      - id: parent_workflow
+        run: |
+          conclusion=$(curl ${{ github.event.workflow_run.jobs_url }} | jq -r '.jobs[] | select(.name == "android-build").conclusion')
+          was_skipped=$([[ "$conclusion" = "skipped" || "$conclusion" = "cancelled" ]] && echo "true" || echo "false")
+          echo "was_skipped=$was_skipped" >> "$GITHUB_OUTPUT"
 
       # get comment from PR
 
@@ -82,9 +68,10 @@ jobs:
         # always run when something was merged into main
         # run benchmark when comment with '!benchmark android' exists in PR
         if: |
-          (github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.event == 'push') ||
+          steps.parent_workflow.outputs.was_skipped == 'false' &&
+          ((github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.event == 'push') ||
           matrix.test.name == 'Android Benchmark' && steps.benchmark_comment.outputs.comment-id ||
-          matrix.test.name != 'Android Benchmark'
+          matrix.test.name != 'Android Benchmark')
         run: 
           echo "run_device_test=true" >> "$GITHUB_ENV"
 
@@ -102,6 +89,7 @@ jobs:
         if: env.run_device_test == 'true'
         with:
           artifact-name: ${{ matrix.test.artifactName }}
+          expect-files: "${{ matrix.test.testFile }}, ${{ matrix.test.appFile }}"
 
       - name: Configure AWS Credentials
         if: env.run_device_test == 'true' && matrix.test.name == 'Android Benchmark'

--- a/.github/workflows/android-device-test.yml
+++ b/.github/workflows/android-device-test.yml
@@ -76,7 +76,7 @@ jobs:
           echo "run_device_test=true" >> "$GITHUB_ENV"
 
       - uses: LouisBrunner/checks-action@v2.0.0
-        if: env.run_device_test == 'true'
+        if: env.run_device_test == 'true' || matrix.test.name == 'Android Render Tests'
         id: create_check
         with:
           token: ${{ steps.generate_token.outputs.token }}
@@ -129,7 +129,7 @@ jobs:
           testSpecArn: ${{ matrix.test.testSpecArn }}
 
       - uses: LouisBrunner/checks-action@v2.0.0
-        if: always() && env.run_device_test == 'true'
+        if: always() && (env.run_device_test == 'true' || matrix.test.name == 'Android Render Tests')
         with:
           token: ${{ steps.generate_token.outputs.token }}
           check_id: ${{ steps.create_check.outputs.check_id }}

--- a/.github/workflows/pr-bloaty-ios.yml
+++ b/.github/workflows/pr-bloaty-ios.yml
@@ -19,11 +19,10 @@ jobs:
     outputs:
       should_skip: ${{ steps.check_skip.outputs.should_skip }}
     steps:
-      # if ios-build in ios-ci was skipped, the rest of the workflow can be skipped
       - id: check_skip
         run: |
           conclusion=$(curl ${{ github.event.workflow_run.jobs_url }} | jq -r '.jobs[] | select(.name == "ios-build").conclusion')
-          should_skip=$([ "$conclusion" = "skipped" ] && echo "true" || echo "false")
+          should_skip=$([[ "$conclusion" = "skipped" || "$conclusion" = "cancelled" ]] && echo "true" || echo "false")
           echo "should_skip=$should_skip" >> "$GITHUB_OUTPUT"
 
   pr-bloaty-ios:

--- a/.github/workflows/pr-linux-tests.yml
+++ b/.github/workflows/pr-linux-tests.yml
@@ -22,11 +22,10 @@ jobs:
     outputs:
       should_skip: ${{ steps.check_skip.outputs.should_skip }}
     steps:
-      # if linux-build-and-test in linux-ci was skipped, the rest of the workflow can be skipped
       - id: check_skip
         run: |
           conclusion=$(curl ${{ github.event.workflow_run.jobs_url }} | jq -r '.jobs[] | select(.name == "linux-build-and-test").conclusion')
-          should_skip=$([ "$conclusion" = "skipped" ] && echo "true" || echo "false")
+          should_skip=$([[ "$conclusion" = "skipped" || "$conclusion" = "cancelled" ]] && echo "true" || echo "false")
           echo "should_skip=$should_skip" >> "$GITHUB_OUTPUT"
 
   pr-bloaty:

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -15,7 +15,7 @@ jobs:
       - id: check_skip
         run: |
           conclusion=$(curl ${{ github.event.workflow_run.jobs_url }} | jq -r '.jobs[] | select(.name == "linux-coverage").conclusion')
-          should_skip=$([ "$conclusion" = "skipped" ] && echo "true" || echo "false")
+          should_skip=$([[ "$conclusion" = "skipped" || "$conclusion" = "cancelled" ]] && echo "true" || echo "false")
           echo "should_skip=$should_skip" >> "$GITHUB_OUTPUT"
 
   upload-coverage:


### PR DESCRIPTION
- Makes sure that a check for Android render test is always created (so it can be made into a required check).
- When the parent workflow is cancelled (and not just skipped), some workflows need to be skipped