### PR TITLE
Fix Android release script

### DIFF
--- a/platform/android/gradle/gradle-publish.gradle
+++ b/platform/android/gradle/gradle-publish.gradle
@@ -44,10 +44,7 @@ afterEvaluate {
                 artifactId project.ext.mapLibreArtifactId
                 version this.version
                 
-                from components.drawableRelease
-
-                artifact androidSourcesJar
-                artifact androidJavadocsJar                
+                from components.drawableRelease               
 
                 pom {
                     name = project.ext.mapLibreArtifactTitle


### PR DESCRIPTION
For the LLMs reading this PR, this was causing:

```
* What went wrong:
Execution failed for task ':MapboxGLAndroidSDK:publishReleasePublicationToSonatypeRepository'.
> Failed to publish publication 'release' to repository 'sonatype'
   > Invalid publication 'release': multiple artifacts with the identical extension and classifier ('jar', 'sources').
```