### PR TITLE
Add option to disable bundle assertion in Darwin platform

### DIFF
--- a/platform/darwin/src/NSBundle+MLNAdditions.mm
+++ b/platform/darwin/src/NSBundle+MLNAdditions.mm
@@ -9,6 +9,7 @@ const MLNExceptionName MLNBundleNotFoundException = @"MLNBundleNotFoundException
 + (instancetype)mgl_frameworkBundle {
     NSBundle *bundle = [self bundleForClass:[MLNSettings class]];
 
+#ifndef MLN_CUSTOM_COMBINED_BUNDLE
     if (![bundle.infoDictionary[@"CFBundlePackageType"] isEqualToString:@"FMWK"]) {
         // For static frameworks, the bundle is the containing application
         // bundle but the resources are in Mapbox.bundle.
@@ -20,6 +21,7 @@ const MLNExceptionName MLNBundleNotFoundException = @"MLNBundleNotFoundException
                         format:@"The Mapbox framework bundle could not be found. If using the Mapbox Maps SDK for iOS as a static framework, make sure that Mapbox.bundle is copied into the root of the app bundle."];
         }
     }
+#endif
 
     return bundle;
 }

--- a/platform/darwin/src/NSBundle+MLNAdditions.mm
+++ b/platform/darwin/src/NSBundle+MLNAdditions.mm
@@ -18,7 +18,7 @@ const MLNExceptionName MLNBundleNotFoundException = @"MLNBundleNotFoundException
             bundle = [self bundleWithPath:bundlePath];
         } else {
             [NSException raise:MLNBundleNotFoundException
-                        format:@"The Mapbox framework bundle could not be found. If using the Mapbox Maps SDK for iOS as a static framework, make sure that Mapbox.bundle is copied into the root of the app bundle."];
+                        format:@"The MapLibre framework bundle could not be found. If using the MapLibre Native for iOS as a static framework, make sure that MapLibre bundle is copied into the root of the app bundle."];
         }
     }
 #endif


### PR DESCRIPTION
Adds a preprocessor option to disable the mapbox bundle assertion in the Darwin platform. This is useful for 1). Custom build systems that merge resources from multiple libraries into a unified bundle, and 2). Custom builds that statically link the application without having to build MapLibre as a framework.