### PR TITLE
Remove assert behavior when preparing a RenderSymbolLayer

### DIFF
--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -707,8 +707,11 @@ void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
                     BucketPlacementData layerData{*bucket, renderTile, featureIndex, baseImpl->source, sortKeyRange};
                     auto sortPosition = std::upper_bound(
                         placementData.cbegin(), placementData.cend(), layerData, [](const auto& lhs, const auto& rhs) {
-                            assert(lhs.sortKeyRange && rhs.sortKeyRange);
-                            return lhs.sortKeyRange->sortKey < rhs.sortKeyRange->sortKey;
+                            if (lhs.sortKeyRange && rhs.sortKeyRange) {
+                                return lhs.sortKeyRange->sortKey < rhs.sortKeyRange->sortKey;
+                            } else {
+                                return lhs.sortKeyRange || !rhs.sortKeyRange;
+                            }
                         });
                     placementData.insert(sortPosition, std::move(layerData));
                 }


### PR DESCRIPTION
Render tile buckets may have a mix of empty and non-empty sort key ranges. This causes the assert to fail when determining the insert position into the placement data list. Instead of an assert, this condition should be handled gracefully.

Specifically, I'm seeing this behavior occur after updating the style URL, on a subsequent render pass, using maplibre-native-qt (QMapLibre::Map).

Two (of many) URLs that give me this issue:
From: https://api.maptiler.com/maps/hybrid/style.json?key=<api-key>
To: https://api.maptiler.com/maps/streets-v2/style.json?key=<api-key>