### PR TITLE
Remove references to Mapbox iOS examples

### DIFF
--- a/platform/darwin/src/MLNAnnotation.h
+++ b/platform/darwin/src/MLNAnnotation.h
@@ -18,10 +18,9 @@ NS_ASSUME_NONNULL_BEGIN
  The other methods of this protocol are optional.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/annotation-models/">
- Annotation models</a> and <a href="https://docs.mapbox.com/ios/maps/examples/annotation-views/">
- Annotation views</a> examples to learn how to add objects that follow the
- `MLNAnnotation` protocol.
+ TODO: Annotation models
+ TODO: Annotation views, learn how to add objects that follow the
+ `MLNAnnotation` protocol
  */
 @protocol MLNAnnotation <NSObject>
 

--- a/platform/darwin/src/MLNFeature.h
+++ b/platform/darwin/src/MLNFeature.h
@@ -185,8 +185,7 @@ MLN_EXPORT
  identifier and attributes.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/runtime-multiple-annotations/">
- Dynamically style interactive points</a> example to learn how to initialize
+ TODO: Dynamically style interactive points, learn how to initialize
  `MLNPointFeature` objects and add them to your map.
  */
 MLN_EXPORT
@@ -200,8 +199,7 @@ MLN_EXPORT
  @see `MLNCluster`
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/clustering/">
- Clustering point data</a> example to learn how to initialize
+ TODO: Clustering point data, learn how to initialize
  clusters and add them to your map.
  */
 MLN_EXPORT
@@ -217,8 +215,7 @@ MLN_EXPORT
  feature in GeoJSON.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/line-geojson/">
- Add a line annotation from GeoJSON</a> example to learn how to initialize an
+ TODO: Add a line annotation from GeoJSON, learn how to initialize an
  `MLNPolylineFeature` and add it to an `MLNMapView` object.
  */
 MLN_EXPORT
@@ -284,8 +281,7 @@ MLN_EXPORT
  in GeoJSON.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/shape-collection/">
- Add multiple shapes from a single shape source</a> example to learn how to
+ TODO: Add multiple shapes from a single shape source, learn how to
  add shape data to your map using an `MLNShapeCollectionFeature` object.
  */
 MLN_EXPORT

--- a/platform/darwin/src/MLNGeometry.h
+++ b/platform/darwin/src/MLNGeometry.h
@@ -150,8 +150,7 @@ NS_INLINE BOOL MLNCoordinateBoundsIntersectsCoordinateBounds(MLNCoordinateBounds
  Returns `YES` if the coordinate is within the coordinate bounds.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/constraining-gestures/">
- Restrict map panning to an area</a> example to learn how to use
+ TODO: Restrict map panning to an area, learn how to use
  `MLNCoordinateInCoordinateBounds` to determine if a point is within, or
  intersects, a given bounding box.
  */

--- a/platform/darwin/src/MLNImageSource.h
+++ b/platform/darwin/src/MLNImageSource.h
@@ -43,9 +43,7 @@ MLN_EXPORT
  ```
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/image-source/">
- Add an image</a> example to learn how to add an image to your map using
- `MLNImageSource`.
+ TODO: Add an image, learn how to add an image to your map using `MLNImageSource`.
  */
 MLN_EXPORT
 @interface MLNImageSource : MLNSource

--- a/platform/darwin/src/MLNMapCamera.h
+++ b/platform/darwin/src/MLNMapCamera.h
@@ -11,12 +11,10 @@ NS_ASSUME_NONNULL_BEGIN
  some point on an `MLNMapView`.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/camera-animation/">
- Camera animation</a> example to learn how to create a camera that rotates
- around a central point. See the <a href="https://docs.mapbox.com/ios/maps/examples/constraining-gestures/">
- Restrict map panning to an area</a> example to learn how to restrict map
- panning using `MLNMapViewDelegate`'s
-`-mapView:shouldChangeFromCamera:toCamera:` method.
+ TODO: Camera animation, learn how to create a camera that rotates
+ around a central point.
+ TODO: Restrict map panning to an area, learn how to restrict map
+ panning using `MLNMapViewDelegate`'s `-mapView:shouldChangeFromCamera:toCamera:` method.
  */
 MLN_EXPORT
 @interface MLNMapCamera : NSObject <NSSecureCoding, NSCopying>

--- a/platform/darwin/src/MLNMapSnapshotter.h
+++ b/platform/darwin/src/MLNMapSnapshotter.h
@@ -217,8 +217,7 @@ typedef void (^MLNMapSnapshotCompletionHandler)(MLNMapSnapshot* _Nullable snapsh
  ```
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/map-snapshotter/">
- Create a static map snapshot</a> example to learn how to use the
+ TODO: Create a static map snapshot, learn how to use the
  `MLNMapSnapshotter` to generate a static image based on an `MLNMapView`
  object's style, camera, and view bounds.
  */

--- a/platform/darwin/src/MLNOfflineStorage.h
+++ b/platform/darwin/src/MLNOfflineStorage.h
@@ -28,8 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  path.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/offline-pack/">
- Download an offline map</a> example to learn how to calculate the progress
+ TODO:Download an offline map, learn how to calculate the progress
  of an offline download.
  */
 FOUNDATION_EXTERN MLN_EXPORT const NSNotificationName MLNOfflinePackProgressChangedNotification;
@@ -189,8 +188,7 @@ typedef NS_ENUM(NSUInteger, MLNResourceKind) {
  information.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/offline-pack/">
- Download an offline map</a> example to learn how to create and register an
+ TODO: Download an offline map, learn how to create and register an
  offline pack for a defined region.
  */
 MLN_EXPORT

--- a/platform/darwin/src/MLNOfflineStorage.h
+++ b/platform/darwin/src/MLNOfflineStorage.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  path.
  
  #### Related examples
- TODO:Download an offline map, learn how to calculate the progress
+ TODO: Download an offline map, learn how to calculate the progress
  of an offline download.
  */
 FOUNDATION_EXTERN MLN_EXPORT const NSNotificationName MLNOfflinePackProgressChangedNotification;

--- a/platform/darwin/src/MLNPointAnnotation.h
+++ b/platform/darwin/src/MLNPointAnnotation.h
@@ -36,11 +36,10 @@ NS_ASSUME_NONNULL_BEGIN
  in GeoJSON.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/marker/">
- Mark a place on the map with an annotation</a>, <a href="https://docs.mapbox.com/ios/maps/examples/marker-image/">
- Mark a place on the map with an image</a>, and <a href="https://docs.mapbox.com/ios/maps/examples/default-callout/">
- Default callout usage</a> examples to learn how to add `MLNPointAnnotation`
- objects to your map.
+ TODO: Mark a place on the map with an annotation
+ TODO: Mark a place on the map with an image
+ TODO: Default callout usage
+ Learn how to add `MLNPointAnnotation` objects to your map.
  */
 MLN_EXPORT
 @interface MLNPointAnnotation : MLNShape

--- a/platform/darwin/src/MLNPolygon.h
+++ b/platform/darwin/src/MLNPolygon.h
@@ -46,8 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  than −180 degrees or greater than 180 degrees.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/polygon/">
- Add a polygon annotation</a> example to learn how to initialize an
+ TODO: Add a polygon annotation, learn how to initialize an
  `MLNPolygon` object from an array of coordinates.
  */
 MLN_EXPORT

--- a/platform/darwin/src/MLNPolyline.h
+++ b/platform/darwin/src/MLNPolyline.h
@@ -52,9 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  geometry in GeoJSON.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/annotation-models/">
- Annotation models</a> example to learn how to add an `MLNPolyine` object to
- your map.
+ TODO: Annotation models, learn how to add an `MLNPolyine` object to your map.
  */
 MLN_EXPORT
 @interface MLNPolyline : MLNMultiPoint <MLNOverlay>

--- a/platform/darwin/src/MLNRasterTileSource.h
+++ b/platform/darwin/src/MLNRasterTileSource.h
@@ -54,8 +54,7 @@ FOUNDATION_EXTERN MLN_EXPORT const MLNTileSourceOption MLNTileSourceOptionTileSi
  ```
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/source-custom-raster/">
- Add raster imagery</a> example to learn how to add a `MLNRasterStyleLayer`
+ TODO: Add raster imagery, learn how to add a `MLNRasterStyleLayer`
  to your map using an `MLNRasterTileSource`.
  */
 MLN_EXPORT

--- a/platform/darwin/src/MLNShapeSource.h
+++ b/platform/darwin/src/MLNShapeSource.h
@@ -27,7 +27,9 @@ typedef NSString *MLNShapeSourceOption NS_STRING_ENUM;
  is ignored when creating an `MLNComputedShapeSource` object.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/clustering/">Cluster point data</a> and <a href="https://docs.mapbox.com/ios/maps/examples/clustering-with-images/">Use images to cluster point data</a> examples to learn how to cluster point data with this `MLNShapeSourceOption`.
+ TODO: Cluster point data
+ TODO: Use images to cluster point data
+ Learn how to cluster point data with this `MLNShapeSourceOption`.
  */
 FOUNDATION_EXTERN MLN_EXPORT const MLNShapeSourceOption MLNShapeSourceOptionClustered;
 
@@ -181,7 +183,10 @@ FOUNDATION_EXTERN MLN_EXPORT const MLNShapeSourceOption MLNShapeSourceOptionLine
  ```
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/clustering/">Cluster point data</a>, <a href="https://docs.mapbox.com/ios/maps/examples/clustering-with-images/">Use images to cluster point data</a>, and <a href="https://docs.mapbox.com/ios/maps/examples/live-data/">Add live data</a> examples to learn how to add data to your map using this `MLNSource` object.
+ TODO: Cluster point data
+ TODO: Use images to cluster point data
+ TODO: Add live data
+ Learn how to add data to your map using this `MLNSource` object.
  */
 MLN_EXPORT
 @interface MLNShapeSource : MLNSource
@@ -207,8 +212,7 @@ MLN_EXPORT
  @return An initialized shape source.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/live-data/">
- Add live data</a> example to learn how to add live data to your map by
+ TODO: Add live data, learn how to add live data to your map by
  updating the an `MLNShapeSource` object's `URL` property.
  */
 - (instancetype)initWithIdentifier:(NSString *)identifier URL:(NSURL *)url options:(nullable NSDictionary<MLNShapeSourceOption, id> *)options NS_DESIGNATED_INITIALIZER;
@@ -241,8 +245,7 @@ MLN_EXPORT
  @return An initialized shape source.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/runtime-animate-line/">
- Animate a line</a> example to learn how to animate line data by continously
+ TODO: Animate a line, learn how to animate line data by continously
  updating an `MLNShapeSource`'s `shape` attribute.
  */
 - (instancetype)initWithIdentifier:(NSString *)identifier shape:(nullable MLNShape *)shape options:(nullable NSDictionary<MLNShapeSourceOption, id> *)options NS_DESIGNATED_INITIALIZER;

--- a/platform/darwin/src/MLNStyle.h
+++ b/platform/darwin/src/MLNStyle.h
@@ -23,9 +23,8 @@ FOUNDATION_EXTERN MLN_EXPORT MLNExceptionName const MLNRedundantSourceIdentifier
 /**
  The proxy object for the current map style.
 
- MLNStyle provides a set of convenience methods for changing Mapbox
- default styles using `MLNMapView.styleURL`.
- <a href="https://www.mapbox.com/maps/">Learn more about Mapbox default styles</a>.
+ MLNStyle provides a set of convenience methods for changing default styles included
+ with MapLibre.
 
  It is also possible to directly manipulate the current map style
  via `MLNMapView.style` by updating the style's data sources or layers.
@@ -35,11 +34,6 @@ FOUNDATION_EXTERN MLN_EXPORT MLNExceptionName const MLNRedundantSourceIdentifier
     `-[MLNMapViewDelegate mapView:didFinishLoadingStyle:]` or
     `-[MLNMapViewDelegate mapViewDidFinishLoadingMap:]` methods as indicators
     that it's safe to modify the map's style.
-
- #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/default-styles/">
- Default styles</a> example to learn how to initialize an `MLNMapView` object
- with a Mapbox default style using `MLNStyle`'s class methods.
  */
 MLN_EXPORT
 @interface MLNStyle : NSObject
@@ -245,8 +239,7 @@ MLN_EXPORT
  @param sibling An existing layer in the style.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/shape-collection/">
- Add multiple shapes from a single shape source</a> example to learn how to
+ TODO: Add multiple shapes from a single shape source, learn how to
  add a layer to your map below an existing layer.
  */
 - (void)insertLayer:(MLNStyleLayer *)layer belowLayer:(MLNStyleLayer *)sibling;
@@ -270,8 +263,7 @@ MLN_EXPORT
  @param sibling An existing layer in the style.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/image-source/">
- Add an image</a> example to learn how to add a layer to your map above an
+ TODO: Add an image, learn how to add a layer to your map above an
  existing layer.
  */
 - (void)insertLayer:(MLNStyleLayer *)layer aboveLayer:(MLNStyleLayer *)sibling;
@@ -322,10 +314,9 @@ MLN_EXPORT
  @param name The name of the image to set to the style.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/clustering-with-images/">
- Use images to cluster point data</a> and <a href="https://docs.mapbox.com/ios/maps/examples/clustering/">
- Cluster point data</a> examples to learn how to add images to your map using
- an `MLNStyle` object.
+ TODO: Use images to cluster point data
+ TODO: Cluster point data
+ Learn how to add images to your map using an `MLNStyle` object.
  */
 - (void)setImage:(MLNImage *)image forName:(NSString *)name;
 

--- a/platform/darwin/src/MLNStyleLayer.h
+++ b/platform/darwin/src/MLNStyleLayer.h
@@ -45,8 +45,7 @@ MLN_EXPORT
  Whether this layer is displayed. A value of `NO` hides the layer.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/runtime-toggle-layer/">
- Show and hide a layer</a> example to learn how to toggle an `MLNStyleLayer`
+ TODO: Show and hide a layer, learn how to toggle an `MLNStyleLayer`
  object's visibility.
  */
 @property (nonatomic, assign, getter=isVisible) BOOL visible;

--- a/platform/darwin/src/MLNTilePyramidOfflineRegion.h
+++ b/platform/darwin/src/MLNTilePyramidOfflineRegion.h
@@ -25,8 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  ```
   
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/offline-pack/">
- Download an offline map</a> example to learn how to define an offline region
+ TODO: Download an offline map, learn how to define an offline region
  to be downloaded to a user's device.
  */
 MLN_EXPORT

--- a/platform/darwin/src/MLNVectorTileSource.h
+++ b/platform/darwin/src/MLNVectorTileSource.h
@@ -55,8 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
  ```
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/dds-circle-layer/">
- Data-driven circles</a> example to learn how to add data to your map using
+ TODO: Data-driven circles, learn how to add data to your map using
  an `MLNVectorTileSource` object.
  */
 MLN_EXPORT

--- a/platform/darwin/src/NSExpression+MLNAdditions.h
+++ b/platform/darwin/src/NSExpression+MLNAdditions.h
@@ -123,11 +123,10 @@ FOUNDATION_EXTERN MLN_EXPORT const MLNExpressionInterpolationMode MLNExpressionI
  @param stops The stops must be an `NSDictionary` constant `NSExpression`.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/dds-circle-layer/">
- Data-driven circles</a>, <a href="https://docs.mapbox.com/ios/maps/examples/clustering/">
- Cluster point data</a>, and <a href="https://docs.mapbox.com/ios/maps/examples/clustering-with-images/">
- Use images to cluster point data</a> examples to learn how to use this
- expression to style a map layer based on an attribute value.
+ TODO: Data-driven circles
+ TODO: Cluster point data
+ TODO: Use images to cluster point data
+ Learn how to use this expression to style a map layer based on an attribute value.
  */
 + (instancetype)mgl_expressionForSteppingExpression:(nonnull NSExpression*)steppingExpression fromExpression:(nonnull NSExpression *)minimumExpression stops:(nonnull NSExpression*)stops NS_SWIFT_NAME(init(forMLNStepping:from:stops:));
 
@@ -143,8 +142,7 @@ FOUNDATION_EXTERN MLN_EXPORT const MLNExpressionInterpolationMode MLNExpressionI
  @param stops The stops expression.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/heatmap-example/">
- Create a heatmap layer</a> example to learn how to style an `MLNHeatmapStyleLayer`
+ TODO: Create a heatmap layer, learn how to style an `MLNHeatmapStyleLayer`
  based on zoom level and point density with this expression.
  */
 + (instancetype)mgl_expressionForInterpolatingExpression:(nonnull NSExpression*)inputExpression withCurveType:(nonnull MLNExpressionInterpolationMode)curveType parameters:(nullable NSExpression *)parameters stops:(nonnull NSExpression*)stops NS_SWIFT_NAME(init(forMLNInterpolating:curveType:parameters:stops:));

--- a/platform/ios/src/MLNAnnotationImage.h
+++ b/platform/ios/src/MLNAnnotationImage.h
@@ -11,8 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  by the map view.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/marker-image/">
- Mark a place on the map with an image</a> example to learn how use an image
+ TODO: Mark a place on the map with an image, learn how use an image
  as a marker using `MLNAnnotationImage`. 
  */
 MLN_EXPORT

--- a/platform/ios/src/MLNAnnotationView.h
+++ b/platform/ios/src/MLNAnnotationView.h
@@ -224,9 +224,7 @@ MLN_EXPORT
     change is immediate.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/annotation-vie
- ws/">Annotation views</a> example to learn how to modify an
- `MLNAnnotationView`'s behavior when it is selected.
+ TODO: modify an `MLNAnnotationView`'s behavior when it is selected.
  */
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated;
 
@@ -257,9 +255,7 @@ MLN_EXPORT
  continue to completion.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/draggable-views
- /">Draggable annotation views</a> to learn how to enable users to drag
- `MLNAnnotationView` objects on your map.
+ TODO: Enable users to drag `MLNAnnotationView` objects on your map.
  */
 @property (nonatomic, assign, getter=isDraggable) BOOL draggable;
 

--- a/platform/ios/src/MLNCalloutView.h
+++ b/platform/ios/src/MLNCalloutView.h
@@ -14,8 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
  use the optional methods available in the `MLNCalloutViewDelegate` protocol.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/custom-callout/">
- Display custom views as callouts</a> example to learn how to customize an
+ TODO: Display custom views as callouts by customizing an
  `MLNCalloutView`.
  */
 @protocol MLNCalloutView <NSObject>

--- a/platform/ios/src/MLNMapView.h
+++ b/platform/ios/src/MLNMapView.h
@@ -1932,8 +1932,7 @@ MLN_EXPORT
  which are unsupported by this SDK.
 
  The returned features are drawn by a style layer in the current style. For
- example, suppose the current style uses the
- <a href="https://www.mapbox.com/vector-tiles/mapbox-streets/">Mapbox Streets source</a>,
+ example, suppose the current style uses a particular source,
  but none of the specified style layers includes features that have the `maki`
  property set to `bus`. If you pass a rectangle containing the location of a bus
  stop into this method, the bus stop feature does not appear in the resulting

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -2862,7 +2862,7 @@ public:
         }
     }
 
-    NSString *actionSheetTitle = NSLocalizedStringWithDefaultValue(@"SDK_NAME", nil, nil, @"Mapbox Maps SDK for iOS", @"Action sheet title");
+    NSString *actionSheetTitle = NSLocalizedStringWithDefaultValue(@"SDK_NAME", nil, nil, @"MapLibre Native for iOS", @"Action sheet title");
     UIAlertController *attributionController = [UIAlertController alertControllerWithTitle:actionSheetTitle
                                                                                    message:nil
                                                                             preferredStyle:UIAlertControllerStyleActionSheet];

--- a/platform/ios/src/MLNMapViewDelegate.h
+++ b/platform/ios/src/MLNMapViewDelegate.h
@@ -44,8 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
  `oldCamera` or change to `newCamera`.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/constraining-gestures/">
- Restrict map panning to an area</a> example to learn how to use this method
+ TODO: Restrict map panning to an area, learn how to use this method
  and `MLNMapCamera` objects to restrict a users ability to pan your map.
  */
 - (BOOL)mapView:(MLNMapView *)mapView shouldChangeFromCamera:(MLNMapCamera *)oldCamera toCamera:(MLNMapCamera *)newCamera;
@@ -117,8 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param mapView The map view whose viewpoint is changing.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/clustering/">
- Cluster point data</a> example to learn how to trigger an action whenever
+ TODO: Cluster point data, learn how to trigger an action whenever
  the map region changes.
  */
 - (void)mapViewRegionIsChanging:(MLNMapView *)mapView;
@@ -286,10 +284,9 @@ NS_ASSUME_NONNULL_BEGIN
  @param style The style that was loaded.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/runtime-multiple-annotations/">
- Dynamically style interactive points</a> and <a href="https://docs.mapbox.com/ios/maps/examples/shape-collection/">
- Add multiple shapes from a single shape source</a> examples to learn how to
- ensure a map's style has loaded before modifying it at runtime.
+ TODO: Dynamically style interactive points
+ TODO: Add multiple shapes from a single shape source examples, learn how to
+ ensure a map's style has loaded before modifying it at runtime
  */
 - (void)mapView:(MLNMapView *)mapView didFinishLoadingStyle:(MLNStyle *)style;
 
@@ -436,12 +433,11 @@ NS_ASSUME_NONNULL_BEGIN
     `nil` if you want to display the default marker image or an annotation view.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/annotation-models/">
- Annotation models</a>, <a href="https://docs.mapbox.com/ios/maps/examples/annotation-view-image/">
- Add annotation views and images</a>, and <a href="https://docs.mapbox.com/ios/maps/examples/marker-image/">
- Mark a place on the map with an image</a> examples to learn to specify which
+ TODO: Annotation models
+ TODO: Add annotation views and images
+ TODO: Mark a place on the map with an image, learn to specify which
  image should be used for `MLNAnnotation` objects that have been added to
- your map.
+ your map
  */
 - (nullable MLNAnnotationImage *)mapView:(MLNMapView *)mapView imageForAnnotation:(id <MLNAnnotation>)annotation;
 
@@ -476,8 +472,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return A color to use for the shape outline.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/annotation-models/">
- Annotation models</a> example to learn how to modify the outline color of an
+ TODO: Annotation models, learn how to modify the outline color of an
  `MLNShape` object that has been added to your map as an annotation.
  */
 - (UIColor *)mapView:(MLNMapView *)mapView strokeColorForShapeAnnotation:(MLNShape *)annotation;
@@ -496,8 +491,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return The polygon’s interior fill color.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/polygon/">Add
- a polygon annotation</a> example to learn how to modify the color of a an
+ TODO: Add a polygon annotation, learn how to modify the color of a an
  `MLNPolygon` at runtime.
  */
 - (UIColor *)mapView:(MLNMapView *)mapView fillColorForPolygonAnnotation:(MLNPolygon *)annotation;
@@ -513,8 +507,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return A line width for the polyline, measured in points.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/line-geojson/">
- Add a line annotation from GeoJSON</a> example to learn how to modify the
+ TODO: Add a line annotation from GeoJSON, learn how to modify the
  line width of an `MLNPolylineFeature` on your map.
  */
 - (CGFloat)mapView:(MLNMapView *)mapView lineWidthForPolylineAnnotation:(MLNPolyline *)annotation;
@@ -545,8 +538,7 @@ NS_ASSUME_NONNULL_BEGIN
     want to display an annotation image instead.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/annotation-view-image/">
- Add annotation views and images</a> example to learn how to specify what
+ TODO: Add annotation views and images, learn how to specify what
  `MLNViewAnnotation` to use for a given `MLNPointAnnotation` object on your
  map.
  */
@@ -592,8 +584,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param annotation The annotation that was selected.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/runtime-multiple-annotations/">
- Dynamically style interactive points</a> example to learn how to remove an
+ TODO: Dynamically style interactive points, learn how to remove an
  annotation view if it has already been selected.
  */
 - (void)mapView:(MLNMapView *)mapView didSelectAnnotation:(id <MLNAnnotation>)annotation;
@@ -671,10 +662,9 @@ NS_ASSUME_NONNULL_BEGIN
     callout.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/annotation-view-image/">
- Add annotation views and images</a>, <a href="https://docs.mapbox.com/ios/maps/examples/custom-callout/">
- Display custom views as callouts</a>, and <a href="https://docs.mapbox.com/ios/maps/examples/default-callout/">
- Default callout usage</a> examples to learn how to show callouts for
+ TODO: Add annotation views and images
+ TODO: Display custom views as callouts
+ TODO: Default callout usage, learn how to show callouts for
  `MLNAnnotation` objects.
  */
 - (BOOL)mapView:(MLNMapView *)mapView annotationCanShowCallout:(id <MLNAnnotation>)annotation;
@@ -695,8 +685,7 @@ NS_ASSUME_NONNULL_BEGIN
     default callout view.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/custom-callout/">
- Display custom views as callouts</a> example to learn how to customize an
+ TODO: Display custom views as callouts, learn how to customize an
  `MLNAnnotation` object's `MLNCalloutView`.
  */
 - (nullable id <MLNCalloutView>)mapView:(MLNMapView *)mapView calloutViewForAnnotation:(id <MLNAnnotation>)annotation;
@@ -726,8 +715,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return The accessory view to display.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/default-callout/">
- Default callout usage</a> example to learn how to modify the view that is
+ TODO: Default callout usage, learn how to modify the view that is
  displayed on the left side of the standard callout bubble.
  */
 - (nullable UIView *)mapView:(MLNMapView *)mapView leftCalloutAccessoryViewForAnnotation:(id <MLNAnnotation>)annotation;
@@ -757,8 +745,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return The accessory view to display.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/default-callout/">
- Default callout usage</a> example to learn how to modify the view that is
+ TODO: Default callout usage, learn how to modify the view that is
  displayed on the right side of the standard callout bubble.
  */
 - (nullable UIView *)mapView:(MLNMapView *)mapView rightCalloutAccessoryViewForAnnotation:(id <MLNAnnotation>)annotation;
@@ -787,8 +774,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param control The control that was tapped.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/default-callout/">
- Default callout usage</a> example to learn how to trigger an action when the
+ TODO: Default callout usage, learn how to trigger an action when the
  standard callout bubble's accessory control is tapped.
  */
 - (void)mapView:(MLNMapView *)mapView annotation:(id <MLNAnnotation>)annotation calloutAccessoryControlTapped:(UIControl *)control;
@@ -810,8 +796,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param annotation The annotation whose callout was tapped.
 
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/custom-callout/">
- Display custom views as callouts</a> example to learn how to trigger an
+ TODO: Display custom views as callouts, learn how to trigger an
  action when an `MLNAnnotation`s `MLNCalloutView` is tapped.
  */
 - (void)mapView:(MLNMapView *)mapView tapOnCalloutForAnnotation:(id <MLNAnnotation>)annotation;

--- a/platform/ios/src/MLNUserLocation.h
+++ b/platform/ios/src/MLNUserLocation.h
@@ -13,8 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
  `userLocation` property of the map view displayed in your application.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/user-location-annotation/">
- Customize the user location annotation</a> example to learn how to overide the
+ TODO: Customize the user location annotation,learn how to overide the
  default user location annotation.
  */
 MLN_EXPORT

--- a/platform/ios/src/MLNUserLocationAnnotationView.h
+++ b/platform/ios/src/MLNUserLocationAnnotationView.h
@@ -27,8 +27,7 @@ MLN_EXPORT
  is inactive.
  
  #### Related examples
- See the <a href="https://docs.mapbox.com/ios/maps/examples/user-location-annotation/">
- Customize the user location annotation</a> example to learn how to customize
+ TODO: Customize the user location annotation, learn how to customize
  the default user location annotation object.
  */
 @property (nonatomic, readonly, weak, nullable) MLNUserLocation *userLocation;


### PR DESCRIPTION
That's a lot of examples.