### PR TITLE
Fix benchmarks on CI Linux

### DIFF
--- a/.github/workflows/pr-linux-tests.yml
+++ b/.github/workflows/pr-linux-tests.yml
@@ -124,7 +124,8 @@ jobs:
           path: message.md
 
   pr-benchmark:
-    if: github.event.workflow_run.event == 'pull_request'
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip == 'false'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -147,6 +148,19 @@ jobs:
       # needed for compare.py
       - name: Install scipy
         run: pip3 install scipy
+
+      # not sure which one of these are runtime dependencies
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcurl4-openssl-dev \
+            libuv1-dev \
+            libjpeg-dev \
+            libpng-dev \
+            libglfw3-dev \
+            libwebp-dev \
+            libopengl0
 
       - name: Run Benchmarks
         # excluding the API tests because they hang https://github.com/maplibre/maplibre-native/issues/1808


### PR DESCRIPTION
This has been broken since I added it because of missing runtime dependencies.

This PR also makes sure it doesn't if the parent workflow didn't.