### PR TITLE
Bring back removed script, make sure CI runs on deleted files

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -21,7 +21,7 @@ jobs:
   pre_job:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ github.event_name != 'workflow_dispatch' && steps.changed-files.outputs.android_any_changed != 'true' }}
+      should_skip: ${{ github.event_name != 'workflow_dispatch' && steps.changed-files.outputs.android_any_modified != 'true' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -30,7 +30,7 @@ jobs:
   pre_job:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ github.event_name != 'workflow_dispatch' && steps.changed-files-yaml.outputs.ios_any_changed != 'true' }}
+      should_skip: ${{ github.event_name != 'workflow_dispatch' && steps.changed-files-yaml.outputs.ios_any_modified != 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -42,7 +42,7 @@ jobs:
           files_yaml_from_source_file: .github/changed-files.yml
 
       - name: Run step if test file(s) change
-        if: steps.changed-files-yaml.outputs.ios_any_changed == 'true'  
+        if: steps.changed-files-yaml.outputs.ios_any_modified == 'true'  
         run: |
           echo "One or more iOS file(s) has changed."
           echo "List of changes: ${{ steps.changed-files-yaml.outputs.ios_all_changed_files }}"

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -28,7 +28,7 @@ jobs:
   pre_job:
     runs-on: ubuntu-22.04
     outputs:
-      should_skip: ${{ github.event_name != 'workflow_dispatch' && steps.changed-files.outputs.linux_any_changed != 'true' }}
+      should_skip: ${{ github.event_name != 'workflow_dispatch' && steps.changed-files.outputs.linux_any_modified != 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -40,7 +40,7 @@ jobs:
           files_yaml_from_source_file: .github/changed-files.yml
 
       - name: List changed files
-        if: steps.changed-files.outputs.linux_any_changed == 'true'  
+        if: steps.changed-files.outputs.linux_any_modified == 'true'  
         run: |
           echo "Changed file(s): ${{ steps.changed-files.outputs.linux_all_changed_files }}"
 

--- a/.github/workflows/pr-linux-tests.yml
+++ b/.github/workflows/pr-linux-tests.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Run Benchmarks
         # excluding the API tests because they hang https://github.com/maplibre/maplibre-native/issues/1808
-        run: python3 vendor/benchmark/tools/compare.py --no-color benchmarks ./mbgl-benchmark-runner-main mbgl-benchmark-runner --benchmark_filter='^[^A][^P][^I].*' > benchmark_out.txt
+        run: python3 vendor/benchmark/tools/compare.py --no-color benchmarks ./mbgl-benchmark-runner-main ./mbgl-benchmark-runner --benchmark_filter='^[^A][^P][^I].*' > benchmark_out.txt
 
       - name: Configure AWS Credentials
         if: github.ref == 'refs/heads/main' && vars.OIDC_AWS_ROLE_TO_ASSUME 

--- a/platform/ios/framework/Info-static.plist
+++ b/platform/ios/framework/Info-static.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>5.9.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>15256</string>
+	<key>MLNCommitHash</key>
+	<string>$(CURRENT_COMMIT_HASH)</string>
+	<key>MLNSemanticVersionString</key>
+	<string>$(CURRENT_SEMANTIC_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/platform/ios/framework/Info.plist
+++ b/platform/ios/framework/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>5.9.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>15256</string>
+	<key>MLNCommitHash</key>
+	<string>$(CURRENT_COMMIT_HASH)</string>
+	<key>MLNSemanticVersionString</key>
+	<string>$(CURRENT_SEMANTIC_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/platform/ios/scripts/lint-plists.sh
+++ b/platform/ios/scripts/lint-plists.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo Linting...
+
+plutil -lint platform/ios/app/Info.plist
+plutil -lint platform/ios/bench_UITests/Info.plist
+plutil -lint platform/ios/benchmark/Info.plist
+plutil -lint platform/ios/framework/Info.plist
+plutil -lint platform/ios/framework/Info-static.plist
+plutil -lint platform/ios/Integration_Test_Harness/Info.plist
+plutil -lint platform/ios/Integration_Tests/Info.plist
+plutil -lint platform/ios/iosapp-UITests/Info.plist
+plutil -lint platform/ios/test/Info.plist


### PR DESCRIPTION
#2168 removed one script too many, but CI didn't run so we didn't notice.

So this PR brings back the script.

It also uses `any_modified` instead of `any_changed` so that deleted files are detected.