### PR TITLE
Remove `MBGL_UNUSED`

### DIFF
--- a/platform/default/src/mbgl/util/compression.cpp
+++ b/platform/default/src/mbgl/util/compression.cpp
@@ -10,14 +10,8 @@
 #include <cstring>
 #include <stdexcept>
 
-#if defined(__GNUC__)
-#define MBGL_UNUSED __attribute__((unused))
-#else
-#define MBGL_UNUSED
-#endif
-
 // Check zlib library version.
-const static bool zlibVersionCheck MBGL_UNUSED = []() {
+[[maybe_unused]] const static bool zlibVersionCheck = []() {
     const char *const version = zlibVersion();
     if (version[0] != ZLIB_VERSION[0]) {
         char message[96];

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -12,12 +12,6 @@
 #include <thread>
 #include <random>
 
-#if defined(__GNUC__)
-#define MBGL_UNUSED __attribute__((unused))
-#else
-#define MBGL_UNUSED
-#endif
-
 using namespace std::literals::string_literals;
 using namespace mbgl;
 using mapbox::sqlite::ResultCode;
@@ -50,7 +44,7 @@ static FixtureLog::Message error(ResultCode code, const char* message) {
     return {EventSeverity::Error, Event::Database, static_cast<int64_t>(code), message};
 }
 
-static MBGL_UNUSED FixtureLog::Message warning(ResultCode code, const char* message) {
+[[maybe_unused]] static FixtureLog::Message warning(ResultCode code, const char* message) {
     return {EventSeverity::Warning, Event::Database, static_cast<int64_t>(code), message};
 }
 


### PR DESCRIPTION
Replaces `MBGL_UNUSED` with `[[maybe_unused]]` which all compilers should support by now.