### PR TITLE
Makes `setURL` method on MLNImageSource public

### DIFF
--- a/platform/darwin/src/MLNImageSource.h
+++ b/platform/darwin/src/MLNImageSource.h
@@ -82,6 +82,13 @@ MLN_EXPORT
 @property (nonatomic, copy, nullable)NSURL *URL;
 
 /**
+ Sets the URL for the image source, performing necessary validations.
+
+ @param url The URL to set for the image source.
+ */
+- (void)setURL:(NSURL *)url;
+
+/**
  The source image.
 
  If the receiver was initialized using `-initWithIdentifier:coordinateQuad:URL:` or if the `URL` property is set, this property is set to `nil`.

--- a/platform/darwin/test/MLNImageSourceTests.m
+++ b/platform/darwin/test/MLNImageSourceTests.m
@@ -39,7 +39,7 @@
     XCTAssertNil(source.URL);
 }
 
-- (void)testSetURL {
+- (void)testMLNImageSourceSetURL {
     // Create a test instance of MLNImageSource
     MLNCoordinateQuad quad = { { 80, 37}, { 81, 37}, { 81, 39}, { 80, 39}};
     MLNImageSource *source = [[MLNImageSource alloc] initWithIdentifier:@"source-id" coordinateQuad:quad URL:[NSURL URLWithString:@"http://host/image.png"]];

--- a/platform/darwin/test/MLNImageSourceTests.m
+++ b/platform/darwin/test/MLNImageSourceTests.m
@@ -39,4 +39,19 @@
     XCTAssertNil(source.URL);
 }
 
+- (void)testSetURL {
+    // Create a test instance of MLNImageSource
+    MLNCoordinateQuad quad = { { 80, 37}, { 81, 37}, { 81, 39}, { 80, 39}};
+    MLNImageSource *source = [[MLNImageSource alloc] initWithIdentifier:@"source-id" coordinateQuad:quad URL:[NSURL URLWithString:@"http://host/image.png"]];
+    
+    // Set the URL using setURL
+    NSURL *testURL = [NSURL URLWithString:@"http://host/image1.png"];
+    [source setURL:testURL];
+    
+    // Assert that the URL is set correctly
+    XCTAssertNotNil(source.URL);
+    XCTAssertEqualObjects(source.URL.absoluteString, @"http://host/image1.png");
+    XCTAssertNil(source.image);
+}
+
 @end


### PR DESCRIPTION
This PR makes the `setURL` method on the MLNImageSource public. This is required to be able to dynamically update the url of an existing image source. The Android SDK already provides such a method ([see setUri ](https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.style.sources/-image-source/index.html?query=class%20ImageSource%20:%20Source#-682102938%2FFunctions%2F2110661137)for more details). Until now this use case could only be addressed by creating a new source when ever the url changed and deleting the "old" source which resulted in bad performance of the app. The `setURL` method would greatly improve the implementation of this use case.

Please let me know if I can improve anything. I am not an Objective-C developer. Therefore any hints on improvements are greatly appreciated.