### PR TITLE
Makes `setCoordinates` method on MLNImageSource public

### DIFF
--- a/platform/darwin/src/MLNImageSource.h
+++ b/platform/darwin/src/MLNImageSource.h
@@ -82,6 +82,13 @@ MLN_EXPORT
 @property (nonatomic, copy, nullable)NSURL *URL;
 
 /**
+ Sets the URL for the image source, performing necessary validations.
+
+ @param url The URL to set for the image source.
+ */
+- (void)setURL:(NSURL *)url;
+
+/**
  The source image.
 
  If the receiver was initialized using `-initWithIdentifier:coordinateQuad:URL:` or if the `URL` property is set, this property is set to `nil`.

--- a/platform/darwin/src/MLNImageSource.h
+++ b/platform/darwin/src/MLNImageSource.h
@@ -99,6 +99,14 @@ MLN_EXPORT
  The coordinates at which the corners of the source image will be placed.
  */
 @property (nonatomic) MLNCoordinateQuad coordinates;
+
+/**
+ Sets the coordinates for the image source.
+
+ @param coordinateQuad The coordinates to set for the image source.
+ */
+- (void)setCoordinates:(MLNCoordinateQuad)coordinateQuad;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MLNImageSource.h
+++ b/platform/darwin/src/MLNImageSource.h
@@ -82,13 +82,6 @@ MLN_EXPORT
 @property (nonatomic, copy, nullable)NSURL *URL;
 
 /**
- Sets the URL for the image source, performing necessary validations.
-
- @param url The URL to set for the image source.
- */
-- (void)setURL:(NSURL *)url;
-
-/**
  The source image.
 
  If the receiver was initialized using `-initWithIdentifier:coordinateQuad:URL:` or if the `URL` property is set, this property is set to `nil`.

--- a/platform/darwin/test/MLNImageSourceTests.m
+++ b/platform/darwin/test/MLNImageSourceTests.m
@@ -70,7 +70,7 @@
 
     // Assert that the coordinates are set correctly
     XCTAssertEqual(retrievedQuad.bottomLeft.latitude, newQuad.bottomLeft.latitude);
-    XCTAssertEqual(retrievedQuad.bottomLeft.longitude, newQuad.bottomLeft.latitude);
+    XCTAssertEqual(retrievedQuad.bottomLeft.longitude, newQuad.bottomLeft.longitude);
 }
 
 @end

--- a/platform/darwin/test/MLNImageSourceTests.m
+++ b/platform/darwin/test/MLNImageSourceTests.m
@@ -41,7 +41,7 @@
 
 - (void)testSetCoordinates {
     // Create a test instance of MLNImageSource
-    MLNCoordinateQuad originalQuad = { { 80, 37}, { 81, 37}, { 81, 39}, { 80, 39}};
+    MLNCoordinateQuad quad = { { 80, 37}, { 81, 37}, { 81, 39}, { 80, 39}};
     MLNImageSource *source = [[MLNImageSource alloc] initWithIdentifier:@"source-id" coordinateQuad:quad URL:[NSURL URLWithString:@"http://host/image.png"]];
 
     // Define a new set of coordinates

--- a/platform/darwin/test/MLNImageSourceTests.m
+++ b/platform/darwin/test/MLNImageSourceTests.m
@@ -39,21 +39,6 @@
     XCTAssertNil(source.URL);
 }
 
-- (void)testSetURL {
-    // Create a test instance of MLNImageSource
-    MLNCoordinateQuad quad = { { 80, 37}, { 81, 37}, { 81, 39}, { 80, 39}};
-    MLNImageSource *source = [[MLNImageSource alloc] initWithIdentifier:@"source-id" coordinateQuad:quad URL:[NSURL URLWithString:@"http://host/image.png"]];
-    
-    // Set the URL using setURL
-    NSURL *testURL = [NSURL URLWithString:@"http://host/image1.png"];
-    [source setURL:testURL];
-    
-    // Assert that the URL is set correctly
-    XCTAssertNotNil(source.URL);
-    XCTAssertEqualObjects(source.URL.absoluteString, @"http://host/image1.png");
-    XCTAssertNil(source.image);
-}
-
 - (void)testSetCoordinates {
     // Create a test instance of MLNImageSource
     MLNCoordinateQuad originalQuad = { { 80, 37}, { 81, 37}, { 81, 39}, { 80, 39}};

--- a/platform/darwin/test/MLNImageSourceTests.m
+++ b/platform/darwin/test/MLNImageSourceTests.m
@@ -54,8 +54,8 @@
     MLNCoordinateQuad retrievedQuad = source.coordinates;
 
     // Assert that the coordinates are set correctly
-    XCTAssertEqual(retrievedQuad.bottomLeft.latitude, 40);
-    XCTAssertEqual(retrievedQuad.bottomLeft.longitude, 50);
+    XCTAssertEqual(retrievedQuad.bottomLeft.latitude, newQuad.bottomLeft.latitude);
+    XCTAssertEqual(retrievedQuad.bottomLeft.longitude, newQuad.bottomLeft.latitude);
 }
 
 @end

--- a/platform/darwin/test/MLNImageSourceTests.m
+++ b/platform/darwin/test/MLNImageSourceTests.m
@@ -39,6 +39,21 @@
     XCTAssertNil(source.URL);
 }
 
+- (void)testMLNImageSourceSetURL {
+    // Create a test instance of MLNImageSource
+    MLNCoordinateQuad quad = { { 80, 37}, { 81, 37}, { 81, 39}, { 80, 39}};
+    MLNImageSource *source = [[MLNImageSource alloc] initWithIdentifier:@"source-id" coordinateQuad:quad URL:[NSURL URLWithString:@"http://host/image.png"]];
+
+    // Set the URL using setURL
+    NSURL *testURL = [NSURL URLWithString:@"http://host/image1.png"];
+    [source setURL:testURL];
+
+    // Assert that the URL is set correctly
+    XCTAssertNotNil(source.URL);
+    XCTAssertEqualObjects(source.URL.absoluteString, @"http://host/image1.png");
+    XCTAssertNil(source.image);
+}
+
 - (void)testMLNImageSourceSetCoordinates {
     // Create a test instance of MLNImageSource
     MLNCoordinateQuad quad = { { 80, 37}, { 81, 37}, { 81, 39}, { 80, 39}};

--- a/platform/darwin/test/MLNImageSourceTests.m
+++ b/platform/darwin/test/MLNImageSourceTests.m
@@ -39,4 +39,19 @@
     XCTAssertNil(source.URL);
 }
 
+- (void)testSetURL {
+    // Create a test instance of MLNImageSource
+    MLNCoordinateQuad quad = { { 80, 37}, { 81, 37}, { 81, 39}, { 80, 39}};
+    MLNImageSource *source = [[MLNImageSource alloc] initWithIdentifier:@"source-id" coordinateQuad:quad URL:[NSURL URLWithString:@"http://host/image.png"]];
+    
+    // Set the URL using setURL
+    NSURL *testURL = [NSURL URLWithString:@"http://host/image1.png"];
+    [source setURL:testURL];
+    
+    // Assert that the URL is set correctly
+    XCTAssertNotNil(source.URL);
+    XCTAssertEqualObjects(source.URL.absoluteString, @"http://host/image1.png");
+    XCTAssertNil(source.image);
+}
+
 @end

--- a/platform/darwin/test/MLNImageSourceTests.m
+++ b/platform/darwin/test/MLNImageSourceTests.m
@@ -54,4 +54,23 @@
     XCTAssertNil(source.image);
 }
 
+- (void)testSetCoordinates {
+    // Create a test instance of MLNImageSource
+    MLNCoordinateQuad originalQuad = { { 80, 37}, { 81, 37}, { 81, 39}, { 80, 39}};
+    MLNImageSource *source = [[MLNImageSource alloc] initWithIdentifier:@"source-id" coordinateQuad:originalQuad URL:nil];
+
+    // Define a new set of coordinates
+    MLNCoordinateQuad newQuad = { { 40, 50}, { 41, 50}, { 41, 52}, { 40, 52} };
+
+    // Set the coordinates using the setCoordinates method
+    [source setCoordinates:newQuad];
+
+    // Get the current coordinates from the source
+    MLNCoordinateQuad retrievedQuad = source.coordinates;
+
+    // Assert that the coordinates are set correctly
+    XCTAssertEqual(retrievedQuad[0].latitude, 40);
+    XCTAssertEqual(retrievedQuad[0].longitude, 50);
+}
+
 @end

--- a/platform/darwin/test/MLNImageSourceTests.m
+++ b/platform/darwin/test/MLNImageSourceTests.m
@@ -42,7 +42,7 @@
 - (void)testSetCoordinates {
     // Create a test instance of MLNImageSource
     MLNCoordinateQuad originalQuad = { { 80, 37}, { 81, 37}, { 81, 39}, { 80, 39}};
-    MLNImageSource *source = [[MLNImageSource alloc] initWithIdentifier:@"source-id" coordinateQuad:originalQuad URL:nil];
+    MLNImageSource *source = [[MLNImageSource alloc] initWithIdentifier:@"source-id" coordinateQuad:quad URL:[NSURL URLWithString:@"http://host/image.png"]];
 
     // Define a new set of coordinates
     MLNCoordinateQuad newQuad = { { 40, 50}, { 41, 50}, { 41, 52}, { 40, 52} };
@@ -54,8 +54,8 @@
     MLNCoordinateQuad retrievedQuad = source.coordinates;
 
     // Assert that the coordinates are set correctly
-    XCTAssertEqual(retrievedQuad[0].latitude, 40);
-    XCTAssertEqual(retrievedQuad[0].longitude, 50);
+    XCTAssertEqual(retrievedQuad.bottomLeft.latitude, 40);
+    XCTAssertEqual(retrievedQuad.bottomLeft.longitude, 50);
 }
 
 @end


### PR DESCRIPTION
This PR makes the `setCoordinates` method on the MLNImageSource public. The Android SDK already provides such a method ([see setCoordinates ](https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.style.sources/-image-source/index.html?query=class%20ImageSource%20:%20Source#1839451061%2FFunctions%2F2110661137)for more details). 

Please let me know if I can improve anything. I am not an Objective-C developer. Therefore any hints on improvements are greatly appreciated.