### PR TITLE
Android render test quality of life

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -120,7 +120,6 @@ jobs:
           fi
 
       - name: Build Benchmark, copy to platform/android
-        if: github.ref != 'refs/heads/main'
         run: |
           ./gradlew assembleDrawableRelease assembleDrawableReleaseAndroidTest -PtestBuildType=release
           cp MapboxGLAndroidSDKTestApp/build/outputs/apk/drawable/release/MapboxGLAndroidSDKTestApp-drawable-release.apk .

--- a/render-test/android/app/build.gradle
+++ b/render-test/android/app/build.gradle
@@ -3,6 +3,12 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 33
 
+    sourceSets {
+        test {
+            assets.srcDirs += ['../../../metrics']
+        }
+    }
+
     defaultConfig {
         applicationId = 'org.maplibre.render_test_runner'
         minSdkVersion 21

--- a/render-test/manifest_parser.cpp
+++ b/render-test/manifest_parser.cpp
@@ -287,9 +287,7 @@ std::optional<Manifest> ManifestParser::parseManifest(const std::string& manifes
             testId = testId.substr(rootLength + 1, testId.length() - rootLength - 1);
 
             std::vector<mbgl::filesystem::path> expectedMetricPaths{expectedMetricPath};
-#if defined(__ANDROID__)
-            expectedMetricPaths.emplace_back("/sdcard/baselines/");
-#elif defined(__APPLE__)
+#if defined(__APPLE__)
             expectedMetricPaths.emplace_back(manifest.manifestPath + "/baselines/");
 #endif
             testPaths.emplace_back(testPath,


### PR DESCRIPTION
- Make sure expectations are not read from `/sdcard`, otherwise it will try to create a directory there when adding a new render test (which will fail).
- Make sure the `metrics` directory shows up in Android Studio.
- Build benchmarks Android on main.