### PR TITLE
Android annotations: implement automatic grouping

### DIFF
--- a/design-proposals/2023-06-17-android-annotations.md
+++ b/design-proposals/2023-06-17-android-annotations.md
@@ -179,7 +179,7 @@ The following list shows concrete public properties or functions that should be 
     * `val rotate: Float` (default `0f` in degrees)
     * `val transform: Transform?` (`null` represents `NONE`)
     * `val offset: Offset?`
-    * `val opacity: Float` (default `1f`)
+    * `val opacity: Float` (default `1f`) (throws if not between `0f` and `1f`)
     * `val color: @ColorInt Int` (default `Color.BLACK`)
     * `val halo: Halo?`
     * `val pitchAlignment: Alignment?` (`null` represents `"auto"`) (NDD)
@@ -194,7 +194,7 @@ The following list shows concrete public properties or functions that should be 
 * `Line extends Annotation`
     * `var path: List<LatLng>`
     * `var join: Join` (default `MITER`)
-    * `var opacity: Float` (default `1f`)
+    * `var opacity: Float` (default `1f`) (throws if not between `0f` and `1f`)
     * `var color: @ColorInt Int` (default `Color.BLACK`)
     * `var width: Float` (default `1f`)
     * `var gap: Float?` (throws if <= 0)
@@ -211,7 +211,7 @@ The following list shows concrete public properties or functions that should be 
 * `enum Anchor` (inner class of `Translate`): `MAP`, `VIEWPORT`
 * `Fill extends Annotation`
     * `var paths: List<List<LatLng>>`
-    * `var opacity: Float` (default `1f`)
+    * `var opacity: Float` (default `1f`) (throws if not between `0f` and `1f`)
     * `var color: @ColorInt Int` (default `Color.BLACK`)
     * `var outlineColor: @ColorInt Int?`
     * `var pattern: Bitmap?` (note: if set, `outlineColor` is ignored)
@@ -222,7 +222,7 @@ The following list shows concrete public properties or functions that should be 
     * `var radius: Float` (default `5f`, in pixels)
     * `var color: @ColorInt Int` (default `Color.BLACK`)
     * `var blur: Float?` (throw if <= 0)
-    * `var opacity: Float` (default `1f`)
+    * `var opacity: Float` (default `1f`) (throws if not between `0f` and `1f`)
     * `var stroke: Stroke?`
     * `var translate: Translate?` (NDD)
     * `var pitchScale: Alignment` (default `MAP`) (NDD)
@@ -230,7 +230,7 @@ The following list shows concrete public properties or functions that should be 
 * `Stroke` (inner class of `Circle`)
     * `val width: Float` (throws if <= 0)
     * `val color: @ColorInt Int` (default `Color.BLACK`)
-    * `val opacity: Float` (default `1f`)
+    * `val opacity: Float` (default `1f`) (throws if not between `0f` and `1f`)
 * `enum PitchScale` (inner class of `Circle`): `MAP`, `VIEWPORT`
 * `ClusterGroup` (defaults match former `ClusterOptions`)
     * `val symbols: List<Symbol> by Delegates.observable(mutableListOf(), onChange = { _, _, new -> … })`

--- a/design-proposals/2023-06-17-android-annotations.md
+++ b/design-proposals/2023-06-17-android-annotations.md
@@ -201,12 +201,11 @@ The following list shows concrete public properties or functions that should be 
     * `var offset: Float` (default `0f`)
     * `var blur: Float?` (throws if <= 0)
     * `var pattern: Bitmap?`
-    * `var cap: Cap` (default `BUTT`) (NDD)
+    * `var cap: android.graphics.Paint.Cap` (default `BUTT`) (NDD)
     * `var translate: Translate?` (NDD)
-    * `var dashArray: Float[]?` (throws if `.length % 2 != 0`) (NDD)
+    * `var dashArray: Array<Float>?` (throws if `.size % 2 != 0`) (NDD)
 * `enum Join` (inner class of `Line`): `BEVEL`, `ROUND`, `MITER`
-* `enum Cap` (inner class of `Line`): `BUTT`, `ROUND`, `SQUARE`
-* `Translate` (inner class of `Line`, `Circle` and `Fill`)
+* `Translate`
     * `val offset: PointF` (maps to `line-translate`)
     * `val anchor: Translate.Anchor`
 * `enum Anchor` (inner class of `Translate`): `MAP`, `VIEWPORT`

--- a/design-proposals/2023-06-17-android-annotations.md
+++ b/design-proposals/2023-06-17-android-annotations.md
@@ -203,7 +203,7 @@ The following list shows concrete public properties or functions that should be 
     * `var pattern: Bitmap?`
     * `var cap: android.graphics.Paint.Cap` (default `BUTT`) (NDD)
     * `var translate: Translate?` (NDD)
-    * `var dashArray: Array<Float>?` (throws if `.size % 2 != 0`) (NDD)
+    * `var dashArray: List<Float>?` (throws if `.size % 2 != 0`) (NDD)
 * `enum Join` (inner class of `Line`): `BEVEL`, `ROUND`, `MITER`
 * `Translate`
     * `val offset: PointF` (maps to `line-translate`)

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainer.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainer.kt
@@ -10,6 +10,7 @@ import org.maplibre.android.annotations.data.toArray
 import org.maplibre.android.maps.MapLibreMap
 import org.maplibre.android.maps.MapView
 import org.maplibre.android.maps.Style
+import org.maplibre.android.style.layers.Property
 import kotlin.reflect.KClass
 
 /**
@@ -136,10 +137,10 @@ class KAnnotationContainer(
                     // Apply NDD properties from key
 
                     iconTextFit = key.iconFitText.let { fitText ->
-                        if (fitText.width && fitText.height) "both"
-                        else if (fitText.width) "width"
-                        else if (fitText.height) "height"
-                        else "none"
+                        if (fitText.width && fitText.height) Property.ICON_TEXT_FIT_BOTH
+                        else if (fitText.width) Property.ICON_TEXT_FIT_WIDTH
+                        else if (fitText.height) Property.ICON_TEXT_FIT_HEIGHT
+                        else Property.ICON_TEXT_FIT_NONE
                     }
                     iconTextFitPadding = key.iconFitText.padding.let { padding ->
                         arrayOf(padding.top, padding.right, padding.bottom, padding.left)
@@ -147,15 +148,15 @@ class KAnnotationContainer(
 
                     iconKeepUpright = key.iconKeepUpright
                     iconPitchAlignment = when (key.iconPitchAlignment) {
-                        Alignment.MAP -> "map"
-                        Alignment.VIEWPORT -> "viewport"
-                        null -> "auto"
+                        Alignment.MAP -> Property.ICON_PITCH_ALIGNMENT_MAP
+                        Alignment.VIEWPORT -> Property.ICON_PITCH_ALIGNMENT_VIEWPORT
+                        null -> Property.ICON_PITCH_ALIGNMENT_AUTO
                     }
 
                     textPitchAlignment = when (key.textPitchAlignment) {
-                        Alignment.MAP -> "map"
-                        Alignment.VIEWPORT -> "viewport"
-                        null -> "auto"
+                        Alignment.MAP -> Property.TEXT_PITCH_ALIGNMENT_MAP
+                        Alignment.VIEWPORT -> Property.TEXT_PITCH_ALIGNMENT_VIEWPORT
+                        null -> Property.TEXT_PITCH_ALIGNMENT_AUTO
                     }
                     textLineHeight = key.textLineHeight
 
@@ -163,15 +164,15 @@ class KAnnotationContainer(
 
                 is LineKey -> LineManager(mapView, mapLibreMap, style, below).apply {
                     lineCap = when (key.cap) {
-                        Cap.BUTT -> "butt"
-                        Cap.ROUND -> "round"
-                        Cap.SQUARE -> "square"
+                        Cap.BUTT -> Property.LINE_CAP_BUTT
+                        Cap.ROUND -> Property.LINE_CAP_ROUND
+                        Cap.SQUARE -> Property.LINE_CAP_SQUARE
                     }
                     key.translate?.let { translate ->
                         lineTranslate = arrayOf(translate.offset.x, translate.offset.y)
                         lineTranslateAnchor = when (translate.anchor) {
-                            Translate.Anchor.MAP -> "map"
-                            Translate.Anchor.VIEWPORT -> "viewport"
+                            Translate.Anchor.MAP -> Property.LINE_TRANSLATE_ANCHOR_MAP
+                            Translate.Anchor.VIEWPORT -> Property.LINE_TRANSLATE_ANCHOR_VIEWPORT
                         }
                     }
                     key.dashArray?.let { dash ->
@@ -184,18 +185,18 @@ class KAnnotationContainer(
                     key.translate?.let { translate ->
                         circleTranslate = arrayOf(translate.offset.x, translate.offset.y)
                         circleTranslateAnchor = when (translate.anchor) {
-                            Translate.Anchor.MAP -> "map"
-                            Translate.Anchor.VIEWPORT -> "viewport"
+                            Translate.Anchor.MAP -> Property.CIRCLE_TRANSLATE_ANCHOR_MAP
+                            Translate.Anchor.VIEWPORT -> Property.CIRCLE_TRANSLATE_ANCHOR_VIEWPORT
                         }
                     }
 
                     circlePitchScale = when (key.pitchScale) {
-                        Alignment.MAP -> "map"
-                        Alignment.VIEWPORT -> "viewport"
+                        Alignment.MAP -> Property.CIRCLE_PITCH_SCALE_MAP
+                        Alignment.VIEWPORT -> Property.CIRCLE_PITCH_SCALE_VIEWPORT
                     }
                     circlePitchAlignment = when (key.pitchAlignment) {
-                        Alignment.MAP -> "map"
-                        Alignment.VIEWPORT -> "viewport"
+                        Alignment.MAP -> Property.CIRCLE_PITCH_ALIGNMENT_MAP
+                        Alignment.VIEWPORT -> Property.CIRCLE_PITCH_ALIGNMENT_VIEWPORT
                     }
                 }
 
@@ -205,8 +206,8 @@ class KAnnotationContainer(
                     key.translate?.let { translate ->
                         fillTranslate = arrayOf(translate.offset.x, translate.offset.y)
                         fillTranslateAnchor = when (translate.anchor) {
-                            Translate.Anchor.MAP -> "map"
-                            Translate.Anchor.VIEWPORT -> "viewport"
+                            Translate.Anchor.MAP -> Property.FILL_TRANSLATE_ANCHOR_MAP
+                            Translate.Anchor.VIEWPORT -> Property.FILL_TRANSLATE_ANCHOR_VIEWPORT
                         }
                     }
                 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainer.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainer.kt
@@ -102,9 +102,12 @@ class KAnnotationContainer(
         annotationList.groupBy { it.key() }
 
     private fun MutableMap<Key, AnnotationManager<*, *>>.getOrCreate(key: Key): AnnotationManager<*, *>? =
-        get(key) ?: style?.let {
+        get(key) ?: style?.let { style ->
+
+            val below = managers.keys.firstOrNull { it.z > key.z }?.let { managers[it] }?.layerId
+
             when (key) {
-                is SymbolKey -> SymbolManager(mapView, mapLibreMap, it).apply {
+                is SymbolKey -> SymbolManager(mapView, mapLibreMap, style, below).apply {
                     // Non-collision group symbols do not interfere with each other
                     textAllowOverlap = true
                     iconAllowOverlap = true
@@ -137,7 +140,7 @@ class KAnnotationContainer(
 
                 }
 
-                is LineKey -> LineManager(mapView, mapLibreMap, it).apply {
+                is LineKey -> LineManager(mapView, mapLibreMap, style, below).apply {
                     lineCap = when (key.cap) {
                         Cap.BUTT -> "butt"
                         Cap.ROUND -> "round"
@@ -156,7 +159,7 @@ class KAnnotationContainer(
 
                 }
 
-                is CircleKey -> CircleManager(mapView, mapLibreMap, it).apply {
+                is CircleKey -> CircleManager(mapView, mapLibreMap, style, below).apply {
                     key.translate?.let { translate ->
                         circleTranslate = arrayOf(translate.offset.x, translate.offset.y)
                         circleTranslateAnchor = when (translate.anchor) {
@@ -175,7 +178,7 @@ class KAnnotationContainer(
                     }
                 }
 
-                is FillKey -> FillManager(mapView, mapLibreMap, it).apply {
+                is FillKey -> FillManager(mapView, mapLibreMap, style, below).apply {
                     fillAntialias = key.antialias
 
                     key.translate?.let { translate ->

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainer.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainer.kt
@@ -176,7 +176,7 @@ class KAnnotationContainer(
                         }
                     }
                     key.dashArray?.let { dash ->
-                        lineDasharray = dash
+                        lineDasharray = dash.toTypedArray()
                     }
 
                 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
@@ -6,35 +6,37 @@ import org.maplibre.android.annotations.data.Defaults
 import org.maplibre.android.annotations.data.Icon
 import org.maplibre.android.annotations.data.Translate
 
-internal sealed class Key(val z: Int)
-internal class SymbolKey(
-    z: Int,
+internal sealed interface Key {
+    val z: Int
+}
+internal data class SymbolKey(
+    override val z: Int,
     val iconFitText: Icon.FitText,
     val iconKeepUpright: Boolean,
     val iconPitchAlignment: Alignment?,
     val textPitchAlignment: Alignment?,
     val textLineHeight: Float
-) : Key(z)
+) : Key
 
-internal class LineKey(
-    z: Int,
+internal data class LineKey(
+    override val z: Int,
     val cap: Paint.Cap,
     val translate: Translate?,
     val dashArray: Array<Float>?
-) : Key(z)
+) : Key
 
-internal class FillKey(
-    z: Int,
+internal data class FillKey(
+    override val z: Int,
     val antialias: Boolean,
     val translate: Translate?
-) : Key(z)
+) : Key
 
-internal class CircleKey(
-    z: Int,
+internal data class CircleKey(
+    override val z: Int,
     val translate: Translate?,
     val pitchScale: Alignment,
     val pitchAlignment: Alignment
-) : Key(z)
+) : Key
 
 internal fun KAnnotation<*>.key() = when (this) {
     is Symbol -> SymbolKey(

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
@@ -22,7 +22,7 @@ internal data class LineKey(
     override val z: Int,
     val cap: Paint.Cap,
     val translate: Translate?,
-    val dashArray: Array<Float>?
+    val dashArray: List<Float>?
 ) : Key
 
 internal data class FillKey(

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
@@ -1,0 +1,57 @@
+package org.maplibre.android.annotations
+
+import android.graphics.Paint
+import org.maplibre.android.annotations.data.Alignment
+import org.maplibre.android.annotations.data.Defaults
+import org.maplibre.android.annotations.data.Icon
+import org.maplibre.android.annotations.data.Translate
+
+internal sealed class Key(z: Int)
+internal class SymbolKey(
+    z: Int,
+    val iconFitText: Icon.FitText,
+    val iconKeepUpright: Boolean,
+    val iconPitchAlignment: Alignment?,
+    val textPitchAlignment: Alignment?,
+    val textLineHeight: Float
+) : Key(z)
+
+internal class LineKey(
+    z: Int,
+    val cap: Paint.Cap,
+    val translate: Translate?,
+    val dashArray: Array<Float>?
+) : Key(z)
+
+internal class FillKey(
+    z: Int,
+    val antialias: Boolean,
+    val translate: Translate?
+) : Key(z)
+
+internal class CircleKey(
+    z: Int,
+    val translate: Translate?,
+    val pitchScale: Alignment,
+    val pitchAlignment: Alignment
+) : Key(z)
+
+internal fun KAnnotation<*>.key() = when (this) {
+    is Symbol -> SymbolKey(
+        zLayer,
+        icon?.fitText ?: Defaults.ICON_FIT_TEXT,
+        icon?.keepUpright ?: Defaults.ICON_KEEP_UPRIGHT,
+        icon?.pitchAlignment ?: Defaults.ICON_PITCH_ALIGNMENT,
+        text?.pitchAlignment ?: Defaults.TEXT_PITCH_ALIGNMENT,
+        text?.lineHeight ?: Defaults.TEXT_LINE_HEIGHT
+    )
+    is Line -> LineKey(
+        zLayer, cap, translate, dashArray
+    )
+    is Fill -> FillKey(
+        zLayer, antialias, translate
+    )
+    is Circle -> CircleKey(
+        zLayer, translate, pitchScale, pitchAlignment
+    )
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
@@ -6,7 +6,7 @@ import org.maplibre.android.annotations.data.Defaults
 import org.maplibre.android.annotations.data.Icon
 import org.maplibre.android.annotations.data.Translate
 
-internal sealed class Key(z: Int)
+internal sealed class Key(val z: Int)
 internal class SymbolKey(
     z: Int,
     val iconFitText: Icon.FitText,

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Circle.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Circle.kt
@@ -45,6 +45,9 @@ class Circle @JvmOverloads constructor(
         }
     var opacity: Float = opacity
         set(value) {
+            if (value > 1f || value < 0f) {
+                throw IllegalArgumentException("Opacity must be between 0 and 1 (inclusive)")
+            }
             field = value
             updateThis()
         }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Circle.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Circle.kt
@@ -3,9 +3,10 @@ package org.maplibre.android.annotations
 import android.graphics.PointF
 import androidx.annotation.ColorInt
 import com.mapbox.android.gestures.MoveDistancesObject
-import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
+import org.maplibre.android.annotations.data.Alignment
 import org.maplibre.android.annotations.data.Defaults
+import org.maplibre.android.annotations.data.Translate
 import org.maplibre.android.constants.GeometryConstants
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.maps.Projection
@@ -17,7 +18,9 @@ class Circle @JvmOverloads constructor(
     blur: Float? = Defaults.CIRCLE_BLUR,
     opacity: Float = Defaults.CIRCLE_OPACITY,
     stroke: Stroke? = Defaults.CIRCLE_STROKE,
-    // TODO: NDD translate, pitchScale, pitchAlignment
+    translate: Translate? = Defaults.CIRCLE_TRANSLATE,
+    pitchScale: Alignment = Defaults.CIRCLE_PITCH_SCALE,
+    pitchAlignment: Alignment = Defaults.CIRCLE_PITCH_ALIGNMENT
 ) : KAnnotation<Point>() {
     var center: LatLng = center
         set(value) {
@@ -49,6 +52,21 @@ class Circle @JvmOverloads constructor(
         set(value) {
             field = value
             updateThis()
+        }
+    var translate: Translate? = translate
+        set(value) {
+            field = value
+            updateAll()
+        }
+    var pitchScale: Alignment = pitchScale
+        set(value) {
+            field = value
+            updateAll()
+        }
+    var pitchAlignment: Alignment = pitchAlignment
+        set(value) {
+            field = value
+            updateAll()
         }
 
     override var clickListener: OnAnnotationClickListener<Circle>? = null

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/CircleManager.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/CircleManager.kt
@@ -127,7 +127,7 @@ class CircleManager @UiThread internal constructor(
     /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
      */
-    var circleTranslate: Array<Float?>?
+    var circleTranslate: Array<Float>?
         get() = layer.circleTranslate.value
         set(value) {
             val propertyValue: PropertyValue<*> = PropertyFactory.circleTranslate(value)

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Fill.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Fill.kt
@@ -7,6 +7,7 @@ import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
 import com.mapbox.geojson.Polygon
 import org.maplibre.android.annotations.data.Defaults
+import org.maplibre.android.annotations.data.Translate
 import org.maplibre.android.constants.GeometryConstants.MAX_MERCATOR_LATITUDE
 import org.maplibre.android.constants.GeometryConstants.MIN_MERCATOR_LATITUDE
 import org.maplibre.android.geometry.LatLng
@@ -18,7 +19,14 @@ class Fill @JvmOverloads constructor(
     @ColorInt color: Int = Defaults.FILL_COLOR,
     @ColorInt outlineColor: Int? = Defaults.FILL_OUTLINE_COLOR,
     pattern: Bitmap? = Defaults.FILL_PATTERN,
-    // TODO: NDD properties antialias and translate
+    /**
+     * NDD
+     */
+    antialias: Boolean = Defaults.FILL_ANTIALIAS,
+    /**
+     * NDD
+     */
+    translate: Translate? = Defaults.FILL_TRANSLATE
 ) : KAnnotation<Polygon>() {
 
     var paths: List<List<LatLng>> = paths
@@ -46,6 +54,16 @@ class Fill @JvmOverloads constructor(
         set(value) {
             field = value
             updateThis()
+        }
+    var antialias: Boolean = antialias
+        set(value) {
+            field = value
+            updateAll()
+        }
+    var translate: Translate? = translate
+        set(value) {
+            field = value
+            updateAll()
         }
 
     override var clickListener: OnAnnotationClickListener<Fill>? = null

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/FillManager.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/FillManager.kt
@@ -125,7 +125,7 @@ class FillManager @UiThread internal constructor(
     /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
      */
-    var fillTranslate: Array<Float?>?
+    var fillTranslate: Array<Float>?
         get() = layer.fillTranslate.value
         set(value) {
             val propertyValue: PropertyValue<*> = PropertyFactory.fillTranslate(value)

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Line.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Line.kt
@@ -101,7 +101,7 @@ class Line @JvmOverloads constructor(
             field = value
             updateThis()
         }
-    var cap: Cap? = cap
+    var cap: Cap = cap
         set(value) {
             field = value
             updateAll()

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Line.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Line.kt
@@ -1,12 +1,14 @@
 package org.maplibre.android.annotations
 
 import android.graphics.Bitmap
+import android.graphics.Paint.Cap
 import androidx.annotation.ColorInt
 import com.mapbox.android.gestures.MoveDistancesObject
 import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import org.maplibre.android.annotations.data.Defaults
+import org.maplibre.android.annotations.data.Translate
 import org.maplibre.android.constants.GeometryConstants.MAX_MERCATOR_LATITUDE
 import org.maplibre.android.constants.GeometryConstants.MIN_MERCATOR_LATITUDE
 import org.maplibre.android.geometry.LatLng
@@ -22,7 +24,18 @@ class Line @JvmOverloads constructor(
     offset: Float = Defaults.LINE_OFFSET,
     blur: Float? = Defaults.LINE_BLUR,
     pattern: Bitmap? = Defaults.LINE_PATTERN,
-    // TODO: NDD properties cap, translate, dashArray
+    /**
+     * NDD
+     */
+    cap: Cap = Defaults.LINE_CAP,
+    /**
+     * NDD
+     */
+    translate: Translate? = Defaults.LINE_TRANSLATE,
+    /**
+     * NDD
+     */
+    dashArray: Array<Float>? = Defaults.LINE_DASH_ARRAY
 ) : KAnnotation<LineString>() {
 
     var path: List<LatLng> = path
@@ -72,6 +85,21 @@ class Line @JvmOverloads constructor(
         set(value) {
             field = value
             updateThis()
+        }
+    var cap: Cap? = cap
+        set(value) {
+            field = value
+            updateAll()
+        }
+    var translate: Translate? = translate
+        set(value) {
+            field = value
+            updateAll()
+        }
+    var dashArray: Array<Float>? = dashArray
+        set(value) {
+            field = value
+            updateAll()
         }
 
     override var clickListener: OnAnnotationClickListener<Line>? = null
@@ -130,7 +158,12 @@ class Line @JvmOverloads constructor(
         if (opacity > 1f || opacity < 0f) {
             throw IllegalArgumentException("Opacity must be between 0 and 1 (inclusive)")
         }
-
+        if (dashArray != null && dashArray.size % 2 != 0) {
+            throw IllegalArgumentException(
+                "A dash array of the uneven size ${dashArray.size} has been provided. Dash arrays need an even " +
+                        "amount of entries."
+            )
+        }
     }
 
     enum class Join {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Line.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Line.kt
@@ -68,16 +68,31 @@ class Line @JvmOverloads constructor(
         }
     var gap: Float? = gap
         set(value) {
+            if (value != null && value <= 0) {
+                throw IllegalArgumentException(
+                    "You tried setting a gap of $gap for a Line object. This means that no line gap is to be used. " +
+                            "Please use `null` to indicate that `gap` is not used."
+                )
+            }
             field = value
             updateThis()
         }
     var offset: Float = offset
         set(value) {
+            if (value > 1f || value < 0f) {
+                throw IllegalArgumentException("Opacity must be between 0 and 1 (inclusive)")
+            }
             field = value
             updateThis()
         }
     var blur: Float? = blur
         set(value) {
+            if (value != null && value <= 0) {
+                throw IllegalArgumentException(
+                    "You tried setting a blur of $blur for a Line object. This means that no blur is to be used. " +
+                            "Please use `null` to indicate that `blur` is not used."
+                )
+            }
             field = value
             updateThis()
         }
@@ -98,6 +113,12 @@ class Line @JvmOverloads constructor(
         }
     var dashArray: Array<Float>? = dashArray
         set(value) {
+            if (value != null && value.size % 2 != 0) {
+                throw IllegalArgumentException(
+                    "You attempted setting a dash array of the uneven size ${value.size}. Dash arrays " +
+                            "need an even amount of entries."
+                )
+            }
             field = value
             updateAll()
         }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Line.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/Line.kt
@@ -35,7 +35,7 @@ class Line @JvmOverloads constructor(
     /**
      * NDD
      */
-    dashArray: Array<Float>? = Defaults.LINE_DASH_ARRAY
+    dashArray: List<Float>? = Defaults.LINE_DASH_ARRAY
 ) : KAnnotation<LineString>() {
 
     var path: List<LatLng> = path
@@ -111,7 +111,7 @@ class Line @JvmOverloads constructor(
             field = value
             updateAll()
         }
-    var dashArray: Array<Float>? = dashArray
+    var dashArray: List<Float>? = dashArray
         set(value) {
             if (value != null && value.size % 2 != 0) {
                 throw IllegalArgumentException(

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/LineManager.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/LineManager.kt
@@ -160,7 +160,7 @@ class LineManager @UiThread internal constructor(
     /**
      * The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
      */
-    var lineTranslate: Array<Float?>?
+    var lineTranslate: Array<Float>?
         get() = layer.lineTranslate.value
         set(value) {
             val propertyValue: PropertyValue<*> = PropertyFactory.lineTranslate(value)
@@ -182,7 +182,7 @@ class LineManager @UiThread internal constructor(
     /**
      * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent expressions will be evaluated only at integer zoom levels.
      */
-    var lineDasharray: Array<Float?>?
+    var lineDasharray: Array<Float>?
         get() = layer.lineDasharray.value
         set(value) {
             val propertyValue: PropertyValue<*> = PropertyFactory.lineDasharray(value)

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/SymbolManager.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/SymbolManager.kt
@@ -330,7 +330,7 @@ class SymbolManager @UiThread internal constructor(
     /**
      * Size of the additional area added to dimensions determined by [Property.ICON_TEXT_FIT], in clockwise order: top, right, bottom, left.
      */
-    var iconTextFitPadding: Array<Float?>?
+    var iconTextFitPadding: Array<Float>?
         get() = layer.iconTextFitPadding.value
         set(value) {
             val propertyValue: PropertyValue<*> = PropertyFactory.iconTextFitPadding(value)
@@ -407,7 +407,7 @@ class SymbolManager @UiThread internal constructor(
     /**
      * To increase the chance of placing high-priority labels on the map, you can provide an array of [Property.TEXT_ANCHOR] locations: the render will attempt to place the label at each location, in order, before moving onto the next label. Use `text-justify: auto` to choose justification based on anchor position. To apply an offset, use the [PropertyFactory.textRadialOffset] instead of the two-dimensional [PropertyFactory.textOffset].
      */
-    var textVariableAnchor: Array<String?>?
+    var textVariableAnchor: Array<String>?
         get() = layer.textVariableAnchor.value
         set(value) {
             val propertyValue: PropertyValue<*> = PropertyFactory.textVariableAnchor(value)
@@ -484,7 +484,7 @@ class SymbolManager @UiThread internal constructor(
     /**
      * Distance that the icon's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
      */
-    var iconTranslate: Array<Float?>?
+    var iconTranslate: Array<Float>?
         get() = layer.iconTranslate.value
         set(value) {
             val propertyValue: PropertyValue<*> = PropertyFactory.iconTranslate(value)
@@ -508,7 +508,7 @@ class SymbolManager @UiThread internal constructor(
     /**
      * Distance that the text's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
      */
-    var textTranslate: Array<Float?>?
+    var textTranslate: Array<Float>?
         get() = layer.textTranslate.value
         set(value) {
             val propertyValue: PropertyValue<*> = PropertyFactory.textTranslate(value)

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Defaults.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Defaults.kt
@@ -79,7 +79,7 @@ class Defaults {
         val LINE_PATTERN: Bitmap? = null
         val LINE_CAP: Cap = Cap.BUTT
         val LINE_TRANSLATE: Translate? = null
-        val LINE_DASH_ARRAY: Array<Float>? = null
+        val LINE_DASH_ARRAY: List<Float>? = null
 
         val FILL_OPACITY: Float = 1f
         @ColorInt

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Defaults.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Defaults.kt
@@ -2,6 +2,7 @@ package org.maplibre.android.annotations.data
 
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.graphics.Paint.Cap
 import android.graphics.PointF
 import androidx.annotation.ColorInt
 import com.google.gson.JsonElement
@@ -32,6 +33,8 @@ class Defaults {
             height = FIT_TEXT_HEIGHT,
             padding = FIT_TEXT_PADDING
         )
+        val ICON_KEEP_UPRIGHT: Boolean = false
+        val ICON_PITCH_ALIGNMENT: Alignment? = null
         val ICON_HALO: Halo? = null
 
         val HALO_BLUR: Float? = null
@@ -49,6 +52,8 @@ class Defaults {
         @ColorInt
         val TEXT_COLOR: Int = Color.BLACK
         val TEXT_HALO: Halo? = null
+        val TEXT_PITCH_ALIGNMENT: Alignment? = null
+        val TEXT_LINE_HEIGHT: Float = 1.2f
 
         val CIRCLE_RADIUS: Float = 5f
         @ColorInt
@@ -56,6 +61,9 @@ class Defaults {
         val CIRCLE_BLUR: Float? = null
         val CIRCLE_OPACITY: Float = 1f
         val CIRCLE_STROKE: Circle.Stroke? = null
+        val CIRCLE_TRANSLATE: Translate? = null
+        val CIRCLE_PITCH_SCALE: Alignment = Alignment.MAP
+        val CIRCLE_PITCH_ALIGNMENT: Alignment = Alignment.VIEWPORT
 
         val CIRCLE_STROKE_COLOR: Int = Color.BLACK
         val CIRCLE_STROKE_OPACITY: Float = 1f
@@ -69,11 +77,16 @@ class Defaults {
         val LINE_OFFSET: Float = 0f
         val LINE_BLUR: Float? = null
         val LINE_PATTERN: Bitmap? = null
+        val LINE_CAP: Cap = Cap.BUTT
+        val LINE_TRANSLATE: Translate? = null
+        val LINE_DASH_ARRAY: Array<Float>? = null
 
         val FILL_OPACITY: Float = 1f
         @ColorInt
         val FILL_COLOR: Int = Color.BLACK
         val FILL_OUTLINE_COLOR: Int? = null
         val FILL_PATTERN: Bitmap? = null
+        val FILL_ANTIALIAS: Boolean = true
+        val FILL_TRANSLATE: Translate? = null
     }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Halo.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Halo.kt
@@ -3,7 +3,7 @@ package org.maplibre.android.annotations.data
 import androidx.annotation.ColorInt
 import androidx.annotation.FloatRange
 
-class Halo(
+data class Halo(
     @FloatRange(from = 0.0, fromInclusive = false)
     val width: Float,
     @ColorInt val color: Int,

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Icon.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Icon.kt
@@ -26,9 +26,18 @@ open class Icon(
     val anchor: Anchor = Defaults.ICON_ANCHOR,
     @FloatRange(from = 0.0, to = 1.0)
     val opacity: Float = Defaults.ICON_OPACITY,
-    // TODO val fitText: FitText = Defaults.ICON_FIT_TEXT, // NDD
-    // TODO val keepUpright: Boolean = false // (NDD)
-    // TODO val pitchAlignment: Alignment? (NDD)
+    /**
+     * NDD
+     */
+    val fitText: FitText = Defaults.ICON_FIT_TEXT,
+    /**
+     * NDD
+     */
+    val keepUpright: Boolean = Defaults.ICON_KEEP_UPRIGHT,
+    /**
+     * NDD
+     */
+    val pitchAlignment: Alignment? = Defaults.ICON_PITCH_ALIGNMENT
 ) {
 
     constructor(

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Icon.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Icon.kt
@@ -46,8 +46,11 @@ open class Icon(
         rotate: Float = Defaults.ICON_ROTATE,
         offset: PointF = Defaults.ICON_OFFSET,
         anchor: Anchor = Defaults.ICON_ANCHOR,
-        opacity: Float = Defaults.ICON_OPACITY
-    ) : this(image.toBitmap(), size, rotate, offset, anchor, opacity)
+        opacity: Float = Defaults.ICON_OPACITY,
+        fitText: FitText = Defaults.ICON_FIT_TEXT,
+        keepUpright: Boolean = Defaults.ICON_KEEP_UPRIGHT,
+        pitchAlignment: Alignment? = Defaults.ICON_PITCH_ALIGNMENT
+    ) : this(image.toBitmap(), size, rotate, offset, anchor, opacity, fitText, keepUpright, pitchAlignment)
 
     init {
         if (opacity > 1f || opacity < 0f) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Text.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Text.kt
@@ -9,7 +9,7 @@ import org.maplibre.android.annotations.asColorString
 import org.maplibre.android.annotations.default
 import org.maplibre.android.style.layers.Property
 
-data class Text(
+class Text(
     val string: String,
     val font: List<String>? = Defaults.TEXT_FONT,
     val size: Float = Defaults.TEXT_SIZE,

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Text.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Text.kt
@@ -9,7 +9,7 @@ import org.maplibre.android.annotations.asColorString
 import org.maplibre.android.annotations.default
 import org.maplibre.android.style.layers.Property
 
-class Text(
+data class Text(
     val string: String,
     val font: List<String>? = Defaults.TEXT_FONT,
     val size: Float = Defaults.TEXT_SIZE,
@@ -24,8 +24,14 @@ class Text(
     val opacity: Float = Defaults.TEXT_OPACITY,
     @ColorInt val color: Int = Defaults.TEXT_COLOR,
     val halo: Halo? = Defaults.TEXT_HALO,
-    // val pitchAlignment: Alignment?, (NDD)
-    // val lineHeight: Float = 1.2f (NDD)
+    /**
+     * NDD
+     */
+    val pitchAlignment: Alignment? = Defaults.TEXT_PITCH_ALIGNMENT,
+    /**
+     * NDD
+     */
+    val lineHeight: Float = Defaults.TEXT_LINE_HEIGHT
 ) {
 
     init {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Translate.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/annotations/data/Translate.kt
@@ -1,0 +1,12 @@
+package org.maplibre.android.annotations.data
+
+import android.graphics.PointF
+
+data class Translate(
+    val offset: PointF,
+    val anchor: Translate.Anchor
+) {
+    enum class Anchor {
+        MAP, VIEWPORT
+    }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/maps/MapLibreMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/maps/MapLibreMap.java
@@ -2194,8 +2194,12 @@ public final class MapLibreMap {
     this.locationComponent = locationComponent;
   }
 
-  void injectAnnotationManager(AnnotationManager annotationManager, MapView mapView) {
-    this.annotationContainer = new KAnnotationContainer(this, mapView, style);
+  void injectAnnotationManager(AnnotationManager annotationManager,
+                               KAnnotationContainer annotationContainer,
+                               MapView mapView) {
+    annotationContainer.setStyle(style);
+    this.annotationContainer = annotationContainer;
+
     this.annotationManager = annotationManager.bind(this);
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/org/maplibre/android/maps/MapView.java
@@ -26,6 +26,7 @@ import org.maplibre.android.MapLibre;
 import org.maplibre.android.R;
 import org.maplibre.android.WellKnownTileServer;
 import org.maplibre.android.annotations.Annotation;
+import org.maplibre.android.annotations.KAnnotationContainer;
 import org.maplibre.android.constants.MapLibreConstants;
 import org.maplibre.android.exceptions.MapLibreConfigurationException;
 import org.maplibre.android.location.LocationComponent;
@@ -169,11 +170,12 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
             annotations, markers, polygons, polylines, shapeAnnotations);
     Transform transform = new Transform(this, nativeMapView, cameraDispatcher);
 
-    // MapboxMap
+    // MapLibreMap
     List<MapLibreMap.OnDeveloperAnimationListener> developerAnimationListeners = new ArrayList<>();
     maplibreMap = new MapLibreMap(nativeMapView, transform, uiSettings, proj, registerTouchListener, cameraDispatcher,
             developerAnimationListeners);
-    maplibreMap.injectAnnotationManager(annotationManager, this);
+    KAnnotationContainer annotationContainer = new KAnnotationContainer(maplibreMap, this, null);
+    maplibreMap.injectAnnotationManager(annotationManager, annotationContainer, this);
 
     // user input
     mapGestureDetector = new MapGestureDetector(context, transform, proj, uiSettings,

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/org/maplibre/android/annotations/AnnotationContainerTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/org/maplibre/android/annotations/AnnotationContainerTest.kt
@@ -1,0 +1,4 @@
+package org.maplibre.android.annotations
+
+class AnnotationContainerTest {
+}

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/org/maplibre/android/annotations/AnnotationContainerTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/org/maplibre/android/annotations/AnnotationContainerTest.kt
@@ -1,4 +1,164 @@
 package org.maplibre.android.annotations
 
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.Style
+import org.maplibre.android.style.layers.CircleLayer
+import org.maplibre.android.style.layers.FillLayer
+import org.maplibre.android.style.layers.LineLayer
+import org.maplibre.android.style.layers.SymbolLayer
+import org.maplibre.android.style.sources.GeoJsonOptions
+import org.maplibre.android.style.sources.GeoJsonSource
+import org.mockito.InjectMocks
+import org.mockito.Mockito
+
 class AnnotationContainerTest {
+    @InjectMocks
+    private val maplibreMap = Mockito.mock(MapLibreMap::class.java)
+    @InjectMocks
+    private val mapView = Mockito.mock(MapView::class.java)
+    @InjectMocks
+    private val style = Mockito.mock(Style::class.java)
+    private val symbolElementProvider: CoreElementProvider<SymbolLayer> = Mockito.mock(
+        SymbolElementProvider::class.java
+    )
+    private val symbolLayer: SymbolLayer = Mockito.mock(SymbolLayer::class.java)
+
+    private val lineElementProvider: CoreElementProvider<LineLayer> = Mockito.mock(
+        LineElementProvider::class.java
+    )
+    private val lineLayer: LineLayer = Mockito.mock(LineLayer::class.java)
+
+    private val circleElementProvider: CoreElementProvider<CircleLayer> = Mockito.mock(
+        CircleElementProvider::class.java
+    )
+    private val circleLayer: CircleLayer = Mockito.mock(CircleLayer::class.java)
+
+    private val fillElementProvider: CoreElementProvider<FillLayer> = Mockito.mock(
+        FillElementProvider::class.java
+    )
+    private val fillLayer: FillLayer = Mockito.mock(FillLayer::class.java)
+
+    private val layerId = "annotation_layer"
+    private val geoJsonSource: GeoJsonSource = Mockito.mock(GeoJsonSource::class.java)
+    private val geoJsonOptions: GeoJsonOptions = Mockito.mock(GeoJsonOptions::class.java)
+
+    private val optionedGeoJsonSource: GeoJsonSource = Mockito.mock(GeoJsonSource::class.java)
+
+    @Before
+    fun beforeTest() {
+        Mockito.`when`(symbolLayer.id).thenReturn(layerId)
+        Mockito.`when`(symbolElementProvider.layer).thenReturn(symbolLayer)
+        Mockito.`when`(symbolElementProvider.getSource(null)).thenReturn(geoJsonSource)
+        Mockito.`when`(symbolElementProvider.getSource(geoJsonOptions))
+            .thenReturn(optionedGeoJsonSource)
+
+        Mockito.`when`(lineLayer.id).thenReturn(layerId)
+        Mockito.`when`(lineElementProvider.layer).thenReturn(lineLayer)
+        Mockito.`when`(lineElementProvider.getSource(null)).thenReturn(geoJsonSource)
+        Mockito.`when`(lineElementProvider.getSource(geoJsonOptions))
+            .thenReturn(optionedGeoJsonSource)
+
+
+        Mockito.`when`(circleLayer.id).thenReturn(layerId)
+        Mockito.`when`(circleElementProvider.layer).thenReturn(circleLayer)
+        Mockito.`when`(circleElementProvider.getSource(null)).thenReturn(geoJsonSource)
+        Mockito.`when`(circleElementProvider.getSource(geoJsonOptions))
+            .thenReturn(optionedGeoJsonSource)
+
+
+        Mockito.`when`(fillLayer.id).thenReturn(layerId)
+        Mockito.`when`(fillElementProvider.layer).thenReturn(fillLayer)
+        Mockito.`when`(fillElementProvider.getSource(null)).thenReturn(geoJsonSource)
+        Mockito.`when`(fillElementProvider.getSource(geoJsonOptions))
+            .thenReturn(optionedGeoJsonSource)
+
+
+
+        Mockito.`when`(style.isFullyLoaded).thenReturn(true)
+    }
+
+    @InjectMocks
+    private val draggableAnnotationController = Mockito.mock(
+        DraggableAnnotationController::class.java
+    )
+
+    private fun getMockContainer() = KAnnotationContainer(
+        maplibreMap,
+        mapView,
+        style,
+        draggableAnnotationController,
+        symbolElementProvider,
+        lineElementProvider,
+        circleElementProvider,
+        fillElementProvider
+    )
+
+    @Test
+    fun `add one of each type`() {
+        val container = getMockContainer()
+        container.add(
+            Symbol(LatLng(0.0, 0.0))
+        )
+        container.add(
+            Line(listOf(LatLng(2.0, -1.0), LatLng(1.0, -2.0)))
+        )
+        container.add(
+            Circle(LatLng(1.0, 2.0))
+        )
+        container.add(
+            Fill(listOf(listOf(LatLng(1.0, 0.0), LatLng(0.0, 1.0))))
+        )
+        assertEquals(4, container.size)
+        assertEquals(4, container.managerCount)
+    }
+
+    @Test
+    fun `add two of same type`() {
+        val container = getMockContainer()
+        container.add(
+            Symbol(LatLng(0.0, 0.0))
+        )
+        container.add(
+            Symbol(LatLng(1.0, 2.0))
+        )
+        assertEquals(2, container.size)
+        assertEquals(1, container.managerCount)
+    }
+
+    @Test
+    fun `add two of same with different z layers`() {
+        val container = getMockContainer()
+        container.add(
+            Symbol(LatLng(0.0, 0.0)).apply { zLayer = 1 }
+        )
+        container.add(
+            Symbol(LatLng(1.0, 2.0)).apply { zLayer = 2 }
+        )
+        assertEquals(2, container.size)
+        assertEquals(2, container.managerCount)
+    }
+
+    @Test
+    fun `add two of same kind with different NDD properties`() {
+        val container = getMockContainer()
+        container.add(
+            Fill(
+                paths = listOf(listOf(LatLng(1.0, 0.0), LatLng(0.0, 1.0))),
+                antialias = true
+            )
+        )
+        container.add(
+            Fill(
+                paths = listOf(listOf(LatLng(1.0, 0.0), LatLng(0.0, 1.0))),
+                antialias = false
+            )
+        )
+        assertEquals(2, container.size)
+        assertEquals(2, container.managerCount)
+    }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/org/maplibre/android/maps/MapLibreMapTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/org/maplibre/android/maps/MapLibreMapTest.kt
@@ -14,6 +14,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.maplibre.android.annotations.KAnnotationContainer
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
@@ -56,9 +57,11 @@ class MapLibreMapTest {
         )
         every { nativeMapView.isDestroyed } returns false
         every { nativeMapView.nativePtr } returns 5
+        val annotationContainer: KAnnotationContainer = mockk()
+        every { annotationContainer.setStyle(any()) } returns Unit
         maplibreMap.injectLocationComponent(spyk())
         maplibreMap.setStyle(Style.getPredefinedStyle("Streets"))
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.onFinishLoadingStyle()
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/test/java/org/maplibre/android/maps/StyleTest.kt
+++ b/platform/android/MapboxGLAndroidSDK/src/test/java/org/maplibre/android/maps/StyleTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.maplibre.android.annotations.KAnnotationContainer
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.robolectric.RobolectricTestRunner
@@ -36,6 +37,9 @@ class StyleTest {
     @Mock
     private lateinit var appContext: Context
 
+    @Mock
+    private lateinit var annotationContainer: KAnnotationContainer
+
     @Before
     fun setup() {
         MockitoAnnotations.initMocks(this)
@@ -52,6 +56,8 @@ class StyleTest {
         )
         every { nativeMapView.isDestroyed } returns false
         maplibreMap.injectLocationComponent(spyk())
+        annotationContainer = mockk()
+        every { annotationContainer.setStyle(any()) } returns Unit
     }
 
     @Test
@@ -81,7 +87,7 @@ class StyleTest {
         every { layer.id } returns "1"
         val builder = Style.Builder().withLayer(layer)
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.onFinishLoadingStyle()
         verify(exactly = 1) {
             nativeMapView.addLayerBelow(
@@ -97,7 +103,7 @@ class StyleTest {
         every { layer.id } returns "1"
         val builder = Style.Builder().withLayerAbove(layer, "id")
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.onFinishLoadingStyle()
         verify(exactly = 1) { nativeMapView.addLayerAbove(layer, "id") }
     }
@@ -108,7 +114,7 @@ class StyleTest {
         every { layer.id } returns "1"
         val builder = Style.Builder().withLayerBelow(layer, "id")
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.onFinishLoadingStyle()
         verify(exactly = 1) { nativeMapView.addLayerBelow(layer, "id") }
     }
@@ -119,7 +125,7 @@ class StyleTest {
         every { layer.id } returns "1"
         val builder = Style.Builder().withLayerAt(layer, 1)
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.onFinishLoadingStyle()
         verify(exactly = 1) { nativeMapView.addLayerAt(layer, 1) }
     }
@@ -130,7 +136,7 @@ class StyleTest {
         every { source.id } returns "1"
         val builder = Style.Builder().withSource(source)
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.onFinishLoadingStyle()
         verify(exactly = 1) { nativeMapView.addSource(source) }
     }
@@ -140,7 +146,7 @@ class StyleTest {
         val transitionOptions = TransitionOptions(100, 200)
         val builder = Style.Builder().withTransition(transitionOptions)
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.onFinishLoadingStyle()
         verify(exactly = 1) { nativeMapView.transitionOptions = transitionOptions }
     }
@@ -153,7 +159,7 @@ class StyleTest {
             Style.Builder().fromUrl(Style.getPredefinedStyle("Streets")).withSource(source)
         maplibreMap.setStyle(builder)
         verify(exactly = 1) { nativeMapView.styleUri = Style.getPredefinedStyle("Streets") }
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         verify(exactly = 1) { nativeMapView.addSource(source) }
     }
@@ -165,7 +171,7 @@ class StyleTest {
         val builder = Style.Builder().fromUrl(Style.getPredefinedStyle("Streets")).withLayer(layer)
         maplibreMap.setStyle(builder)
         verify(exactly = 1) { nativeMapView.styleUri = Style.getPredefinedStyle("Streets") }
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         verify(exactly = 1) {
             nativeMapView.addLayerBelow(
@@ -183,7 +189,7 @@ class StyleTest {
             Style.Builder().fromUrl(Style.getPredefinedStyle("Streets")).withLayerAt(layer, 1)
         maplibreMap.setStyle(builder)
         verify(exactly = 1) { nativeMapView.styleUri = Style.getPredefinedStyle("Streets") }
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         verify(exactly = 1) { nativeMapView.addLayerAt(layer, 1) }
     }
@@ -196,7 +202,7 @@ class StyleTest {
             .withLayerBelow(layer, "below")
         maplibreMap.setStyle(builder)
         verify(exactly = 1) { nativeMapView.styleUri = Style.getPredefinedStyle("Streets") }
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         verify(exactly = 1) { nativeMapView.addLayerBelow(layer, "below") }
     }
@@ -209,7 +215,7 @@ class StyleTest {
             .withLayerBelow(layer, "below")
         maplibreMap.setStyle(builder)
         verify(exactly = 1) { nativeMapView.styleUri = Style.getPredefinedStyle("Streets") }
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         verify(exactly = 1) { nativeMapView.addLayerBelow(layer, "below") }
     }
@@ -221,7 +227,7 @@ class StyleTest {
             .withTransition(transitionOptions)
         maplibreMap.setStyle(builder)
         verify(exactly = 1) { nativeMapView.styleUri = Style.getPredefinedStyle("Streets") }
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         verify(exactly = 1) { nativeMapView.transitionOptions = transitionOptions }
     }
@@ -233,7 +239,7 @@ class StyleTest {
         val builder = Style.Builder().fromUrl(Style.getPredefinedStyle("Streets"))
         maplibreMap.setStyle(builder, callback)
         verify(exactly = 1) { nativeMapView.styleUri = Style.getPredefinedStyle("Streets") }
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         verify(exactly = 1) { callback.onStyleLoaded(any()) }
     }
@@ -246,7 +252,7 @@ class StyleTest {
         every { source.id } returns "1"
         val builder = Style.Builder().withSource(source)
         maplibreMap.setStyle(builder, callback)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.onFinishLoadingStyle()
         verify(exactly = 1) { nativeMapView.addSource(source) }
         verify(exactly = 1) { callback.onStyleLoaded(any()) }
@@ -261,7 +267,7 @@ class StyleTest {
         every { source.id } returns "1"
         val builder = Style.Builder().withSource(source)
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.onFinishLoadingStyle()
         verify(exactly = 1) { nativeMapView.addSource(source) }
         verify(exactly = 1) { callback.onStyleLoaded(any()) }
@@ -277,7 +283,7 @@ class StyleTest {
         val builder = Style.Builder().fromJson("{}")
         maplibreMap.setStyle(builder)
         verify(exactly = 1) { nativeMapView.styleJson = "{}" }
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         verify(exactly = 1) { callback.onStyleLoaded(any()) }
     }
@@ -293,7 +299,7 @@ class StyleTest {
             Style.Builder().fromUrl(Style.getPredefinedStyle("Streets")).withSource(source)
         maplibreMap.setStyle(builder)
         verify(exactly = 1) { nativeMapView.styleUri = Style.getPredefinedStyle("Streets") }
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         verify(exactly = 1) { nativeMapView.addSource(source) }
         verify(exactly = 1) { callback.onStyleLoaded(any()) }
@@ -311,7 +317,7 @@ class StyleTest {
             .withTransition(transitionOptions)
         maplibreMap.setStyle(builder)
         Assert.assertNull(maplibreMap.style)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         Assert.assertNotNull(maplibreMap.style)
     }
@@ -326,7 +332,7 @@ class StyleTest {
         val builder = Style.Builder().fromJson("{}")
         maplibreMap.setStyle(builder)
         verify(exactly = 1) { nativeMapView.styleJson = "{}" }
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         maplibreMap.setStyle(Style.getPredefinedStyle("Streets"))
         verify(exactly = 1) { callback.onStyleLoaded(any()) }
@@ -336,7 +342,7 @@ class StyleTest {
     fun testIllegalStateExceptionWithStyleReload() {
         val builder = Style.Builder().fromUrl(Style.getPredefinedStyle("Streets"))
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         val style = maplibreMap.style
         maplibreMap.setStyle(Style.Builder().fromUrl(Style.getPredefinedStyle("Bright")))
@@ -351,7 +357,7 @@ class StyleTest {
         maplibreMap.setStyle(builder)
         verify(exactly = 1) { nativeMapView.styleUri = Style.getPredefinedStyle("Satellite Hybrid") }
         verify(exactly = 0) { nativeMapView.addImages(any()) }
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         verify(exactly = 1) { nativeMapView.addImages(any()) }
     }
@@ -366,7 +372,7 @@ class StyleTest {
         maplibreMap.setStyle(builder)
         verify(exactly = 1) { nativeMapView.styleUri = Style.getPredefinedStyle("Satellite Hybrid") }
         verify(exactly = 0) { nativeMapView.addImages(any()) }
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
         verify(exactly = 1) { nativeMapView.addImages(any()) }
     }
@@ -380,7 +386,7 @@ class StyleTest {
 
         val builder = Style.Builder().withSource(source1)
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
 
         every { nativeMapView.addSource(any()) } throws CannotAddSourceException("Duplicate ID")
@@ -405,7 +411,7 @@ class StyleTest {
 
         val builder = Style.Builder().withLayer(layer1)
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
 
         every { nativeMapView.addLayer(any()) } throws CannotAddLayerException("Duplicate ID")
@@ -430,7 +436,7 @@ class StyleTest {
 
         val builder = Style.Builder().withLayer(layer1)
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
 
         every {
@@ -460,7 +466,7 @@ class StyleTest {
 
         val builder = Style.Builder().withLayer(layer1)
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
 
         every {
@@ -490,7 +496,7 @@ class StyleTest {
 
         val builder = Style.Builder().withLayer(layer1)
         maplibreMap.setStyle(builder)
-        maplibreMap.injectAnnotationManager(mockk(relaxed = true), mockk())
+        maplibreMap.injectAnnotationManager(mockk(relaxed = true), annotationContainer, mockk())
         maplibreMap.notifyStyleLoaded()
 
         every { nativeMapView.addLayerAt(any(), 5) } throws CannotAddLayerException("Duplicate ID")

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/org/maplibre/android/testapp/activity/annotation/BulkMarkerActivity.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/org/maplibre/android/testapp/activity/annotation/BulkMarkerActivity.kt
@@ -116,6 +116,8 @@ class BulkMarkerActivity : AppCompatActivity(), OnItemSelectedListener {
                     if (i == 1) {
                         draggable = true
                     }
+
+                    zLayer = i % 10
                 }
             )
         }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/org/maplibre/android/testapp/activity/annotation/BulkMarkerActivity.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/org/maplibre/android/testapp/activity/annotation/BulkMarkerActivity.kt
@@ -13,8 +13,10 @@ import android.widget.Spinner
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.MenuItemCompat
 import org.maplibre.android.annotations.Symbol
+import org.maplibre.android.annotations.data.Alignment
 import org.maplibre.android.annotations.data.Icon
 import org.maplibre.android.annotations.data.Text
 import org.maplibre.android.geometry.LatLng
@@ -96,15 +98,17 @@ class BulkMarkerActivity : AppCompatActivity(), OnItemSelectedListener {
     private fun showGlMarkers(amount: Int) {
         val random = Random()
         var randomIndex: Int
-        val icon = Icon(AppCompatResources.getDrawable(this, R.drawable.ic_android)!!)
+        val bitmap = AppCompatResources.getDrawable(this, R.drawable.ic_android)!!.toBitmap()
         for (i in 0 until amount) {
             randomIndex = random.nextInt(locations!!.size)
             val latLng = locations!![randomIndex]
+
+            val pitchAlignment = if (i == 2) Alignment.VIEWPORT else Alignment.MAP
             maplibreMap.addAnnotation(
                 Symbol(
                     position = latLng,
-                    text = Text(i.toString(), color = Color.WHITE),
-                    icon = icon
+                    text = Text(i.toString(), color = Color.WHITE, pitchAlignment = pitchAlignment),
+                    icon = Icon(bitmap, pitchAlignment = pitchAlignment)
                 ).apply {
                     if (i == 0) {
                         clickListener = {


### PR DESCRIPTION
[Android annotations API proposal](https://github.com/maplibre/maplibre-native/blob/main/design-proposals/2023-06-17-android-annotations.md) implementation PR as a part of https://github.com/maplibre/maplibre-native/issues/1491. Closes #1494.

---

* NDD fields have been added.
* The "Add Markers in Bulk" activity in the test app has been modified to allow manual testing: the symbol number 2 always stands upright, and the last digit indicates the z layer (i.e. 89 comes above 98 comes above 7).
* Unchanges, to avoid conflicts, the following classes still have temporary names that differ from their intended names:
   * `Annotation` → `KAnnotation`
   * `AnnotationContainer` → `KAnnotationContainer`
* Grouping only uses default `.groupBy`; there's still lots of room for improvements to also support the use case where users might add lots of different z layers.
* Unused bitmaps should now be discarded.