### PR TITLE
[qt/cpp-core:main] Fix Parser::parseLayers id access segfault

### DIFF
--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -218,7 +218,7 @@ void Parser::parseLayers(const JSValue& value) {
             continue;
         }
 
-        const JSValue& id = layerValue["id"];
+        const JSValue& id = layerValue.FindMember("id")->value;
         if (!id.IsString()) {
             Log::Warning(Event::ParseStyle, "layer id must be a string");
             continue;


### PR DESCRIPTION
Apply fix for #2218. `main` branch base.