### PR TITLE
Android: Allow custom ModuleProvider implementations in the SDK

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### ✨ Features and improvements
 
+- Add support for custom `ModuleProvider` implementations (#[2231](https://github.com/maplibre/maplibre-native/pull/2231))
 - Allow setting padding when camera is tracking (#[2165](https://github.com/maplibre/maplibre-native/pull/2165)).
 - Add support for the [`slice` expression](https://maplibre.org/maplibre-style-spec/expressions/#slice) ([#1113](https://github.com/maplibre/maplibre-native/pull/1133))
 - Add support for the [`index-of` expression](https://maplibre.org/maplibre-style-spec/expressions/#index-of) ([#1113](https://github.com/maplibre/maplibre-native/pull/1113))

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/MapLibre.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/MapLibre.java
@@ -232,6 +232,14 @@ public final class MapLibre {
   }
 
   /**
+   * Set the module provider. Call this as soon as possible.
+   * @param  provider The ModuleProvider instance to set
+   */
+  public static void setModuleProvider(ModuleProvider provider) {
+    moduleProvider = provider;
+  }
+
+  /**
    * Runtime validation of MapLibre creation.
    */
   private static void validateMapbox() {

--- a/platform/android/MapLibreAndroidTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/AndroidManifest.xml
@@ -844,6 +844,18 @@
                 android:value=".activity.FeatureOverviewActivity" />
         </activity>
         <activity
+            android:name=".activity.storage.CustomHttpRequestImplActivity"
+            android:description="@string/description_custom_http_request_impl"
+            android:exported="true"
+            android:label="@string/activity_custom_http_request_impl">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_storage" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity" />
+        </activity>
+        <activity
             android:name=".activity.storage.CacheManagementActivity"
             android:description="@string/description_cache_management"
             android:exported="true"

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/storage/CustomHttpRequestImpl.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/storage/CustomHttpRequestImpl.kt
@@ -1,0 +1,81 @@
+package org.maplibre.android.testapp.activity.storage
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import org.maplibre.android.ModuleProvider
+import org.maplibre.android.ModuleProviderImpl
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.MapLibre
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.OnMapReadyCallback
+import org.maplibre.android.maps.Style
+import org.maplibre.android.storage.FileSource
+import org.maplibre.android.storage.FileSource.ResourceTransformCallback
+import org.maplibre.android.storage.Resource
+import org.maplibre.android.testapp.R
+import org.maplibre.android.testapp.utils.ApiKeyUtils
+import org.maplibre.android.testapp.utils.ExampleCustomModuleProviderImpl
+import timber.log.Timber
+
+/**
+ * This example activity shows how to provide your own HTTP request implementation.
+ */
+class CustomHttpRequestImplActivity : AppCompatActivity() {
+    private lateinit var mapView: MapView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_data_driven_style)
+
+        // Set a custom module provider that provides our custom HTTPRequestImpl
+        MapLibre.setModuleProvider(ExampleCustomModuleProviderImpl() as ModuleProvider)
+
+        // Initialize map with a style
+        mapView = findViewById<View>(R.id.mapView) as MapView
+        mapView.onCreate(savedInstanceState)
+        mapView.getMapAsync(
+            OnMapReadyCallback { maplibreMap: MapLibreMap ->
+                maplibreMap.setStyle(Style.Builder().fromUri("https://demotiles.maplibre.org/style.json"))
+            }
+        )
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapView.onStart()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        mapView.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        mapView.onPause()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapView.onStop()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mapView.onSaveInstanceState(outState)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+
+        // Example of how to reset the module provider
+        MapLibre.setModuleProvider(ModuleProviderImpl())
+        mapView.onDestroy()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView.onLowMemory()
+    }
+}

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/utils/ExampleCustomModuleProviderImpl.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/utils/ExampleCustomModuleProviderImpl.kt
@@ -1,0 +1,21 @@
+package org.maplibre.android.testapp.utils
+
+import org.maplibre.android.LibraryLoaderProvider
+import org.maplibre.android.ModuleProvider
+import org.maplibre.android.http.HttpRequest
+import org.maplibre.android.module.loader.LibraryLoaderProviderImpl
+import org.maplibre.android.testapp.utils.ExampleHttpRequestImpl
+
+/*
+ * An example implementation of the ModuleProvider. This is useful primarily for providing
+ * a custom implementation of HttpRequest used by the core.
+ */
+class ExampleCustomModuleProviderImpl : ModuleProvider {
+    override fun createHttpRequest(): HttpRequest {
+        return ExampleHttpRequestImpl()
+    }
+
+    override fun createLibraryLoaderProvider(): LibraryLoaderProvider {
+        return LibraryLoaderProviderImpl()
+    }
+}

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/utils/ExampleHttpRequestImpl.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/utils/ExampleHttpRequestImpl.kt
@@ -1,0 +1,40 @@
+package org.maplibre.android.testapp.utils
+
+import org.maplibre.android.http.HttpResponder
+import org.maplibre.android.http.HttpRequest
+import org.maplibre.android.module.http.HttpRequestImpl
+
+/*
+ * An example implementation of HttpRequest for use with a custom implementation of
+ * the ModuleProvider. This allows you to provide your own transport mechanism for HTTP
+ * requests made by the library.
+ */
+class ExampleHttpRequestImpl : HttpRequest {
+    override fun executeRequest(httpRequest: HttpResponder, nativePtr: Long, resourceUrl: String,
+                                etag: String, modified: String, offlineUsage: Boolean)
+    {
+        // Load all json documents and any pbf ending with a 0.
+        if (resourceUrl.endsWith(".json") || resourceUrl.endsWith("0.pbf")) {
+            impl.executeRequest(httpRequest, nativePtr, resourceUrl, etag, modified, offlineUsage)
+        } else {
+            // All other requests get an instant 404!
+            httpRequest.onResponse(
+                    /* responseCode */ 404,
+                    /* eTag */ etag,
+                    /* lastModified */ "",
+                    /* cacheControl */ "",
+                    /* expires */ "",
+                    /* retryAfter */ "",
+                    /* xRateLimitReset */ "",
+                    /* body */ byteArrayOf(0x0)
+            )
+        }
+    }
+
+    override fun cancelRequest() {
+        impl.cancelRequest()
+    }
+
+    // The default implementation using okhttp
+    private var impl: HttpRequestImpl = HttpRequestImpl()
+}

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/values/descriptions.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/values/descriptions.xml
@@ -58,6 +58,7 @@
     <string name="description_circle_layer">Show bus stops and route in Singapore</string>
     <string name="description_collection_style_change">Verify that updating the GeoJsonSource across style changes allows for smooth transitions</string>
     <string name="description_url_transform">Transform urls on the fly</string>
+    <string name="description_custom_http_request_impl">Provides a custom HTTP implementation for fetching network resources</string>
     <string name="description_cache_management">Control the cache management with FileSource API</string>
     <string name="description_restricted_bounds">Limit viewport to Iceland</string>
     <string name="description_fill_extrusion_layer">Shows how to add 3D extruded shapes</string>

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/values/titles.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/values/titles.xml
@@ -54,6 +54,7 @@
     <string name="activity_map_visibility">Visibility Map</string>
     <string name="activity_map_in_dialog">Dialog with map</string>
     <string name="activity_url_transform">Url transform</string>
+    <string name="activity_custom_http_request_impl">Custom HTTPRequestImpl</string>
     <string name="activity_cache_management">Cache management</string>
     <string name="activity_restricted_bounds">Restrict camera to a bounds</string>
     <string name="activity_fill_extrusion_layer">Fill extrusions</string>


### PR DESCRIPTION
The primary feature added by this PR is a single function, `setModuleProvider`. The `ModuleProvider` in the Android SDK has two functions: Provide an `so` loader for the core, and: Provide a concrete implementation of `HTTPRequest` to facilitate all network activity.

By allowing a custom implementation of `ModuleProvider`, these features can be customized for more advanced use cases, ie: a custom network transport layer.

I've added a new example activity to the demo application showcasing how to create and use your own `ModuleProvider` and a custom `HTTPRequest` implementation which it constructs.