### PR TITLE
Fix test app issues, add tests

### DIFF
--- a/platform/darwin/src/MLNComputedShapeSource.mm
+++ b/platform/darwin/src/MLNComputedShapeSource.mm
@@ -144,8 +144,12 @@ mbgl::style::CustomGeometrySource::Options MBGLCustomGeometrySourceOptionsFromDi
             featureCollection.push_back(geoJsonObject);
         }
         const auto geojson = mbgl::GeoJSON{featureCollection};
-        if(![self isCancelled] && self.rawSource) {
-            self.rawSource->setTileData(mbgl::CanonicalTileID(self.z, self.x, self.y), geojson);
+
+        // Note: potential race condition with `cancel`
+        if(![self isCancelled]) {
+            if (auto *rawSource = self.rawSource) {
+                rawSource->setTileData(mbgl::CanonicalTileID(self.z, self.x, self.y), geojson);
+            }
         }
     }
 }

--- a/platform/ios/app/MBXViewController.mm
+++ b/platform/ios/app/MBXViewController.mm
@@ -1144,34 +1144,59 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
 
 - (void)styleSymbolLayer
 {
-    MLNSymbolStyleLayer *stateLayer = (MLNSymbolStyleLayer *)[self.mapView.style layerWithIdentifier:@"state-label-lg"];
-    stateLayer.textColor = [NSExpression expressionForConstantValue:[UIColor redColor]];
+    if (auto *stateLayer = (MLNSymbolStyleLayer *)[self.mapView.style layerWithIdentifier:@"state-label-lg"])
+    {
+        stateLayer.textColor = [NSExpression expressionForConstantValue:[UIColor redColor]];
+    }
 }
 
 - (void)styleBuildingLayer
 {
     MLNTransition transition =  { 5,  1 };
     self.mapView.style.transition = transition;
-    MLNFillStyleLayer *buildingLayer = (MLNFillStyleLayer *)[self.mapView.style layerWithIdentifier:@"building"];
-    buildingLayer.fillColor = [NSExpression expressionForConstantValue:[UIColor purpleColor]];
+    if (auto *buildingLayer = (MLNFillStyleLayer *)[self.mapView.style layerWithIdentifier:@"building"])
+    {
+        buildingLayer.fillColor = [NSExpression expressionForConstantValue:[UIColor purpleColor]];
+    }
 }
 
 - (void)styleFerryLayer
 {
-    MLNLineStyleLayer *ferryLineLayer = (MLNLineStyleLayer *)[self.mapView.style layerWithIdentifier:@"ferry"];
-    ferryLineLayer.lineColor = [NSExpression expressionForConstantValue:[UIColor redColor]];
+    if (auto *ferryLineLayer = (MLNLineStyleLayer *)[self.mapView.style layerWithIdentifier:@"ferry"])
+    {
+        ferryLineLayer.lineColor = [NSExpression expressionForConstantValue:[UIColor redColor]];
+    }
 }
 
 - (void)removeParkLayer
 {
-    MLNFillStyleLayer *parkLayer = (MLNFillStyleLayer *)[self.mapView.style layerWithIdentifier:@"park"];
-    [self.mapView.style removeLayer:parkLayer];
+    if (auto *parkLayer = (MLNFillStyleLayer *)[self.mapView.style layerWithIdentifier:@"park"])
+    {
+        [self.mapView.style removeLayer:parkLayer];
+    }
+}
+
+- (BOOL)loadStyleFromBundle:(NSString*)path
+{
+    NSString *resourcePath = [[NSBundle mainBundle] pathForResource:path ofType:@"json"];
+    if (NSURL* url = resourcePath ? [NSURL fileURLWithPath:resourcePath] : nil) {
+        [self.mapView setStyleURL:url];
+        return TRUE;
+    } else {
+        NSString *msg = [NSString stringWithFormat:@"Missing Style %@", path];
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Style File" message:msg preferredStyle:UIAlertControllerStyleAlert];
+        [alertController addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleCancel handler:nil]];
+        [self presentViewController:alertController animated:YES completion:nil];
+        return FALSE;
+    }
 }
 
 - (void)styleFilteredFill
 {
     // set style and focus on Texas
-    [self.mapView setStyleURL:[NSURL fileURLWithPath:[[NSBundle mainBundle] pathForResource:@"fill_filter_style" ofType:@"json"]]];
+    if (![self loadStyleFromBundle:@"fill_filter_style"]) {
+        return;
+    }
     [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(31, -100) zoomLevel:3 animated:NO];
 
     // after slight delay, fill in Texas (atypical use; we want to clearly see the change for test purposes)
@@ -1191,7 +1216,9 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
 - (void)styleFilteredLines
 {
     // set style and focus on lower 48
-    [self.mapView setStyleURL:[NSURL fileURLWithPath:[[NSBundle mainBundle] pathForResource:@"line_filter_style" ofType:@"json"]]];
+    if (![self loadStyleFromBundle:@"line_filter_style"]) {
+        return;
+    }
     [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(40, -97) zoomLevel:5 animated:NO];
 
     // after slight delay, change styling for all Washington-named counties  (atypical use; we want to clearly see the change for test purposes)
@@ -1212,7 +1239,9 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
 - (void)styleNumericFilteredFills
 {
     // set style and focus on lower 48
-    [self.mapView setStyleURL:[NSURL fileURLWithPath:[[NSBundle mainBundle] pathForResource:@"numeric_filter_style" ofType:@"json"]]];
+    if (![self loadStyleFromBundle:@"numeric_filter_style"]) {
+        return;
+    }
     [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(40, -97) zoomLevel:5 animated:NO];
 
     // after slight delay, change styling for regions 200-299 (atypical use; we want to clearly see the change for test purposes)
@@ -1494,7 +1523,8 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
 }
 
 
-- (void)updateAnimatedImageSource:(NSTimer *)timer {
+- (void)updateAnimatedImageSource:(NSTimer *)timer
+{
     static int radarSuffix = 0;
     MLNImageSource *imageSource = (MLNImageSource *)timer.userInfo;
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://maplibre.org/maplibre-gl-js-docs/assets/radar%d.gif", radarSuffix++]];
@@ -1568,7 +1598,8 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
 }
 
 #if MLN_DRAWABLE_RENDERER
-- (void)addCustomDrawableLayer {
+- (void)addCustomDrawableLayer
+{
     // Create a CustomLayer that uses the Drawable/Builder toolkit to generate and render geometry
     ExampleCustomDrawableStyleLayer* layer = [[ExampleCustomDrawableStyleLayer alloc] initWithIdentifier:@"custom-drawable-layer"];
 
@@ -1578,14 +1609,18 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
 }
 #endif
 
-- (void)removeSource:(NSString*)ident {
-    if (MLNSource *source = [self.mapView.style sourceWithIdentifier:ident]) {
+- (void)removeSource:(NSString*)ident
+{
+    if (MLNSource *source = [self.mapView.style sourceWithIdentifier:ident])
+    {
         [self.mapView.style removeSource:source];
     }
 }
 
-- (void)removeLayer:(NSString*)ident {
-    if (MLNStyleLayer* layer = [self.mapView.style layerWithIdentifier:ident]) {
+- (void)removeLayer:(NSString*)ident
+{
+    if (MLNStyleLayer* layer = [self.mapView.style layerWithIdentifier:ident])
+    {
         [self.mapView.style removeLayer:layer];
     }
 }

--- a/platform/ios/app/MBXViewController.mm
+++ b/platform/ios/app/MBXViewController.mm
@@ -1997,8 +1997,6 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
                          completionHandler:moveComplete];
 
         secondMapView.accessibilityIdentifier = @"Second Map";
-        secondMapView.accessibilityHint = @"Second Map";
-        secondMapView.accessibilityLabel = @"Second Map";
     } else {
         MLNMapView *secondMapView = (MLNMapView *)[self.view viewWithTag:2];
 
@@ -2056,71 +2054,24 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
 {
     self.styleNames = [NSMutableArray array];
     self.styleURLs = [NSMutableArray array];
-
-//    [self.styleNames addObject:@"LM Light"];
-//    [self.styleURLs addObject:[NSURL URLWithString:@"http://192.168.1.132:8000/LM_light.json"]];
-//
-//    [self.styleNames addObject:@"LM Dark"];
-//    [self.styleURLs addObject:[NSURL URLWithString:@"http://192.168.1.132:8000/LM_dark.json"]];
-//    
-//    [self.styleNames addObject:@"FB Light"];
-//    [self.styleURLs addObject:[NSURL URLWithString:@"https://external.xx.fbcdn.net/maps/vt/style/canterbury_1_0/?locale=en_US"]];
-
-//    [self.styleNames addObject:@"test"];
-//    [self.styleURLs addObject:[NSURL URLWithString:@"http://192.168.1.132:8080/style.json"]];
-
-//    [self.styleNames addObject:@"trangle1"];
-//    [self.styleURLs addObject:[NSURL URLWithString:@"http://192.168.1.132:8002/style.json"]];
-//
-//    [self.styleNames addObject:@"stencil"];
-//    [self.styleURLs addObject:[NSURL URLWithString:@"https://api.maptiler.com/maps/pastel/style.json?key=DK07xna3FmyH5aqaObhc"]];
-
-    //[self.styleNames addObject:@"map-text-depthtest"];
-    //[self.styleURLs addObject:[NSURL URLWithString:@"http://192.168.1.132:8002/style.json"]];
-
-    //[self.styleNames addObject:@"BG"];
-    //[self.styleURLs addObject:[NSURL URLWithString:@"https://gist.github.com/TimSylvester/5c0afbb8b605863f4db590fc4876e495/raw/1638d3793078da1483913c78a276d9d85461b65b/basic-bg-interp.json"]];
-    //[self.styleURLs addObject:[NSURL URLWithString:@"https://gist.github.com/TimSylvester/5c0afbb8b605863f4db590fc4876e495/raw/597e91ffee90e14a6bb937f324c37d4befd8fc4a/basic-bg-interp.json"]];
-    //[self.styleURLs addObject:[NSURL URLWithString:@"https://gist.github.com/TimSylvester/7a9c9767e70137c5837a3b6ed9481940/raw/20dc36445d4c4a9cb27830217d08d9ec2ecee40c/style.json"]];
-
-//    [self.styleNames addObject:@"1"];
-//    [self.styleURLs addObject:[NSURL URLWithString:@"https://gist.github.com/TimSylvester/98bf8a415c3e29215a6f23f151606c3c/raw/9dde21a22cd7af7f6ba0247a5989f92237763695/gistfile1.txt"]];
-//    [self.styleNames addObject:@"2"];
-//    [self.styleURLs addObject:[NSURL URLWithString:@"https://gist.github.com/TimSylvester/4d66b19dd22784028502b973618f9a12/raw/01ec2f83e00b9b652fdb193b98e823b2d8c959b7/gistfile1.txt"]];
-
+    
     /// Style that does not require an `apiKey` nor any further configuration
     [self.styleNames addObject:@"MapLibre Basic"];
     [self.styleURLs addObject:[NSURL URLWithString:@"https://demotiles.maplibre.org/style.json"]];
 
-//    [self.styleNames addObject:@"Hillshade"];
-//    [self.styleURLs addObject:[NSURL URLWithString:@"https://api.maptiler.com/maps/b33abf35-1ba5-46cb-b172-fdf3a718a5a7/style.json?key=G4MQXsYbLiUxOu3SV4lh"]];
-//
-//    [self.styleNames addObject:@"Heatmap"];
-//    [self.styleURLs addObject:[NSURL URLWithString:@"https://api.maptiler.com/maps/efd813d5-c532-4157-8953-47899b373eae/style.json?key=G4MQXsYbLiUxOu3SV4lh"]];
-// 
-    [self.styleNames addObject:@"FB Dark"];
-    [self.styleURLs addObject:[NSURL URLWithString:@"https://external.xx.fbcdn.net/maps/vt/style/dark/?locale=en_US"]];
-
-    [self.styleNames addObject:@"FB 3D"];
-    [self.styleURLs addObject:[NSURL URLWithString:@"https://external.xx.fbcdn.net/maps/vt/style/default_3d/?locale=en_US"]];
-
-#if 1
     /// Add MapLibre Styles if an `apiKey` exists
     NSString* apiKey = [MLNSettings apiKey];
     if (apiKey.length)
     {
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
+            
             for (MLNDefaultStyle* predefinedStyle in [MLNStyle predefinedStyles]){
-//                if ([predefinedStyle.name isEqualToString:@"Bright"] ||
-//                    [predefinedStyle.name isEqualToString:@"Pastel"]) {
-                    [self.styleNames addObject:predefinedStyle.name];
-                    [self.styleURLs addObject:predefinedStyle.url];
-//                }
+                [self.styleNames addObject:predefinedStyle.name];
+                [self.styleURLs addObject:predefinedStyle.url];
             }
         });
     }
-#endif
     
     NSAssert(self.styleNames.count == self.styleURLs.count, @"Style names and URLs don’t match.");
 }

--- a/platform/ios/app/MBXViewController.mm
+++ b/platform/ios/app/MBXViewController.mm
@@ -1531,7 +1531,6 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
     NSDictionary *sourceOptions = @{ MLNShapeSourceOptionLineDistanceMetrics: @YES };
     
     MLNShapeSource *routeSource = [[MLNShapeSource alloc] initWithIdentifier:@"style-route-source" shape:routeLine options:sourceOptions];
-    [self.mapView.style addSource:routeSource];
 
     MLNLineStyleLayer *baseRouteLayer = [[MLNLineStyleLayer alloc] initWithIdentifier:@"style-base-route-layer" source:routeSource];
     baseRouteLayer.lineColor = [NSExpression expressionForConstantValue:[UIColor orangeColor]];
@@ -1539,7 +1538,6 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
     baseRouteLayer.lineOpacity = [NSExpression expressionForConstantValue:@0.95];
     baseRouteLayer.lineCap = [NSExpression expressionForConstantValue:@"round"];
     baseRouteLayer.lineJoin = [NSExpression expressionForConstantValue:@"round"];
-    [self.mapView.style addLayer:baseRouteLayer];
 
     MLNLineStyleLayer *routeLayer = [[MLNLineStyleLayer alloc] initWithIdentifier:@"style-route-layer" source:routeSource];
     routeLayer.lineColor = [NSExpression expressionForConstantValue:[UIColor whiteColor]];
@@ -1560,12 +1558,17 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
     // (mgl_interpolate:withCurveType:parameters:stops:($lineProgress, 'linear', nil, %@))
     NSExpression *lineGradientExpression = [NSExpression expressionWithFormat:@"mgl_interpolate:withCurveType:parameters:stops:($lineProgress, 'linear', nil, %@)", stops];
     routeLayer.lineGradient = lineGradientExpression;
+
+    [self removeLayer:baseRouteLayer.identifier];
+    [self removeLayer:routeLayer.identifier];
+    [self removeSource:routeSource.identifier];
+    [self.mapView.style addSource:routeSource];
+    [self.mapView.style addLayer:baseRouteLayer];
     [self.mapView.style addLayer:routeLayer];
 }
 
 #if MLN_DRAWABLE_RENDERER
-- (void)addCustomDrawableLayer
-{
+- (void)addCustomDrawableLayer {
     // Create a CustomLayer that uses the Drawable/Builder toolkit to generate and render geometry
     ExampleCustomDrawableStyleLayer* layer = [[ExampleCustomDrawableStyleLayer alloc] initWithIdentifier:@"custom-drawable-layer"];
 
@@ -1574,6 +1577,18 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
     }
 }
 #endif
+
+- (void)removeSource:(NSString*)ident {
+    if (MLNSource *source = [self.mapView.style sourceWithIdentifier:ident]) {
+        [self.mapView.style removeSource:source];
+    }
+}
+
+- (void)removeLayer:(NSString*)ident {
+    if (MLNStyleLayer* layer = [self.mapView.style layerWithIdentifier:ident]) {
+        [self.mapView.style removeLayer:layer];
+    }
+}
 
 - (void)styleRouteLine
 {
@@ -1594,7 +1609,6 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
     MLNPolylineFeature *routeLine = [MLNPolylineFeature polylineWithCoordinates:coords count:count];
 
     MLNShapeSource *routeSource = [[MLNShapeSource alloc] initWithIdentifier:@"style-route-source" shape:routeLine options:nil];
-    [self.mapView.style addSource:routeSource];
 
     MLNLineStyleLayer *baseRouteLayer = [[MLNLineStyleLayer alloc] initWithIdentifier:@"style-base-route-layer" source:routeSource];
     baseRouteLayer.lineColor = [NSExpression expressionForConstantValue:[UIColor orangeColor]];
@@ -1602,7 +1616,6 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
     baseRouteLayer.lineOpacity = [NSExpression expressionForConstantValue:@0.5];
     baseRouteLayer.lineCap = [NSExpression expressionForConstantValue:@"round"];
     baseRouteLayer.lineJoin = [NSExpression expressionForConstantValue:@"round"];
-    [self.mapView.style addLayer:baseRouteLayer];
 
     MLNLineStyleLayer *routeLayer = [[MLNLineStyleLayer alloc] initWithIdentifier:@"style-route-layer" source:routeSource];
     routeLayer.lineColor = [NSExpression expressionForConstantValue:[UIColor whiteColor]];
@@ -1610,11 +1623,16 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
     routeLayer.lineOpacity = [NSExpression expressionForConstantValue:@0.8];
     routeLayer.lineCap = [NSExpression expressionForConstantValue:@"round"];
     routeLayer.lineJoin = [NSExpression expressionForConstantValue:@"round"];
+    
+    [self removeLayer:baseRouteLayer.identifier];
+    [self removeLayer:routeLayer.identifier];
+    [self removeSource:routeSource.identifier];
+    [self.mapView.style addSource:routeSource];
+    [self.mapView.style addLayer:baseRouteLayer];
     [self.mapView.style addLayer:routeLayer];
 }
 
-- (void)styleAddCustomTriangleLayer
-{
+- (void)styleAddCustomTriangleLayer {
     CustomStyleLayerExample *layer = [[CustomStyleLayerExample alloc] initWithIdentifier:@"mbx-custom"];
     [self.mapView.style addLayer:layer];
 }

--- a/platform/ios/bazel/files.bzl
+++ b/platform/ios/bazel/files.bzl
@@ -92,7 +92,7 @@ MLN_PUBLIC_IOS_APP_SOPURCE = [
     "app/MBXState.m",
     "app/MBXStateManager.m",
     "app/MBXUserLocationAnnotationView.m",
-    "app/MBXViewController.m",
+    "app/MBXViewController.mm",
     "app/main.m",
     "app/MBXAnnotationView.h",
     "app/MBXAppDelegate.h",

--- a/platform/ios/iosapp-UITests/BUILD.bazel
+++ b/platform/ios/iosapp-UITests/BUILD.bazel
@@ -15,6 +15,7 @@ swift_library(
 
 ios_ui_test(
     name = "uitest",
+    size = "large",
     minimum_os_version = "12.0",
     provisioning_profile = "xcode_profile",
     test_host = "//platform/ios:App",

--- a/platform/ios/iosapp-UITests/iosapp_UITests.swift
+++ b/platform/ios/iosapp-UITests/iosapp_UITests.swift
@@ -175,9 +175,15 @@ class iosapp_UITests: XCTestCase {
         // Only one of these will show up, run whichever one is there
         mapSettingsButton.tap()
         if let customLayer = staticItemIfExists("Add Custom Triangle Layer (OpenGL)") ??
-                             staticItemIfExists("Add Custom Triangle Layer (Metal)") ??
-                             staticItemIfExists("Add Custom Drawable Layer") {
+                             staticItemIfExists("Add Custom Triangle Layer (Metal)") {
             customLayer.tap()
+            sleep(1)
+            mapSettingsButton.tap()
+        }
+
+        if let customLayer = staticItemIfExists("Add Custom Drawable Layer") {
+            customLayer.tap()
+            sleep(1)
             mapSettingsButton.tap()
         }
 
@@ -186,6 +192,7 @@ class iosapp_UITests: XCTestCase {
             if let name = NSLocale(localeIdentifier: loc).displayName(forKey: .identifier, value: loc) {
                 if let item = staticItemIfExists("Show Labels in " + name) {
                     item.tap()
+                    sleep(1)
                     mapSettingsButton.tap()
                 }
             }

--- a/platform/ios/iosapp-UITests/iosapp_UITests.swift
+++ b/platform/ios/iosapp-UITests/iosapp_UITests.swift
@@ -14,6 +14,7 @@ class iosapp_UITests: XCTestCase {
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
         // UI tests must launch the application that they test.
+        app.launchEnvironment.updateValue("YES", forKey: "UITesting")
         app.launch()
 
         // In UI tests it is usually best to stop immediately when a failure occurs.
@@ -65,7 +66,33 @@ class iosapp_UITests: XCTestCase {
         sleep(1)
         add(screenshot(name: "Null Island, Zoom=0"))
     }
-    
+
+    /// Open and close the secondary map view a few times to ensure that the dynamic layout adjustment doesn't crash
+    func testSecondMap() {
+        let mapSettingsButton = app.navigationBars["MapLibre Basic"].buttons["Map settings"]
+
+        let showTimeout = 1.0
+        let hideTimeout = 10.0
+        let iterations = 3
+
+        let secondMapQuery = app.otherElements["Second Map"]
+        XCTAssert(!secondMapQuery.exists)
+
+        for _ in 0..<iterations {
+            mapSettingsButton.tap()
+            app.tables.staticTexts["Show Second Map"].tap()
+            XCTAssert(secondMapQuery.waitForExistence(timeout: showTimeout))
+
+            sleep(1)
+
+            mapSettingsButton.tap()
+            app.tables.staticTexts["Hide Second Map"].tap()
+
+            expectation(for: NSPredicate(format: "exists == 0"), evaluatedWith: secondMapQuery)
+            waitForExpectations(timeout: hideTimeout, handler: nil)
+        }
+    }
+
     func testRecord() {
         /// Use recording to get started writing UI tests.
         ///   Use `Editor` > `Start Recording UI Test` while your cursor is in this `func`

--- a/platform/ios/iosapp-UITests/iosapp_UITests.swift
+++ b/platform/ios/iosapp-UITests/iosapp_UITests.swift
@@ -39,7 +39,6 @@ class iosapp_UITests: XCTestCase {
     /// Turn on Debug tile boundaries, tile info and FPS ornaments
     /// Demonstrates how the Tile Boundaries look when rendered
     func testDebugBoundaryTiles() {
-
         app.windows.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.doubleTap()
         
         let mapSettingsButton = app.navigationBars["MapLibre Basic"].buttons["Map settings"]
@@ -67,10 +66,10 @@ class iosapp_UITests: XCTestCase {
         add(screenshot(name: "Null Island, Zoom=0"))
     }
 
+    var mapSettingsButton: XCUIElement { get { app.navigationBars["MapLibre Basic"].buttons["Map settings"] } }
+
     /// Open and close the secondary map view a few times to ensure that the dynamic layout adjustment doesn't crash
     func testSecondMap() {
-        let mapSettingsButton = app.navigationBars["MapLibre Basic"].buttons["Map settings"]
-
         let showTimeout = 1.0
         let hideTimeout = 10.0
         let iterations = 3
@@ -91,6 +90,130 @@ class iosapp_UITests: XCTestCase {
             expectation(for: NSPredicate(format: "exists == 0"), evaluatedWith: secondMapQuery)
             waitForExpectations(timeout: hideTimeout, handler: nil)
         }
+    }
+
+    func testAll() {
+        let allItems = [
+        "Reset position",
+        "Show tile boundaries",
+        "Hide tile boundaries",
+        "Show tile info",
+        "Hide tile info",
+        "Show tile timestamps",
+        "Hide tile timestamps",
+        "Show collision boxes",
+        "Hide collision boxes",
+        "Show overdraw visualization",
+        "Hide overdraw visualization",
+        "Show zoom level ornament",
+        "Hide zoom level ornament",
+        "Show frame time graph",
+        "Hide frame time graph",
+        "Show reuse queue stats",
+        "Hide reuse queue stats",
+        "Add 100 Views",
+        // These seem to break the test, maybe just take too long
+//        "Add 1,000 Views",
+//        "Add 10,000 Views",
+        "Add 100 Sprites",
+//        "Add 1,000 Sprites",
+//        "Add 10,000 Sprites",
+        "Animate an Annotation View",
+        "Add Test Shapes",
+        "Add 10x Test Shapes",
+        "Add Point With Custom Callout",
+        "Query Annotations",
+        "Enable Custom User Dot",
+        "Disable Custom User Dot",
+        "Remove Annotations",
+        "Select an offscreen point annotation",
+        "Center selected annotation",
+        "Add visible area polyline",
+        "Add Building Extrusions",
+        "Style Water With Function",
+        "Style Roads With Function",
+        "Add Raster & Apply Function",
+        "Add Shapes & Apply Fill",
+        "Style Symbol Color",
+        "Style Building Fill Color",
+        "Style Ferry Line Color",
+        // TODO: crash, only works on styles with park layers?
+        //"Remove Parks",
+        "Style Fill With Filter",
+        // TODO: crash, ?
+        //"Style Lines With Filter",
+        "Style Fill With Numeric Filter",
+        "Query and Style Features",
+        "Style Feature",
+        "Style Dynamic Point Collection",
+        "Update Shape Source: Data",
+        "Update Shape Source: URL",
+        "Update Shape Source: Features",
+        "Style Vector Tile Source",
+        "Style Raster Tile Source",
+        "Style Image Source",
+        "Add Route Line",
+        "Dynamically Style Polygon",
+        "Add Custom Lat/Lon Grid",
+        "Style Route line with gradient",
+        "Start World Tour",
+        "Random Tour",
+        "Show Second Map",
+        "Hide Second Map",
+        "Missing Icon",
+        "Limit Camera Changes",
+        "Unlimit Camera Changes",
+        "Turn On Content Insets",
+        "Turn Off Content Insets",
+        "Lat Long bounds with padding",
+        "Show Labels in Default Language",
+        ]
+
+        for label in allItems {
+            mapSettingsButton.tap()
+            app.tables.staticTexts[label].tap()
+            sleep(1)
+        }
+
+        let customLayerGL = app.tables.staticTexts["Add Custom Triangle Layer (OpenGL)"]
+        let customLayerMetal = app.tables.staticTexts["Add Custom Triangle Layer (Metal)"]
+        let customLayerLegacy = app.tables.staticTexts["Add Custom Drawable Layer"]
+
+        mapSettingsButton.tap()
+        if customLayerGL.exists {
+            customLayerGL.tap()
+        } else if customLayerMetal.exists {
+            customLayerMetal.tap()
+        } else if customLayerLegacy.exists {
+            customLayerLegacy.tap()
+        }
+
+        mapSettingsButton.tap()
+        for loc in [ "ar", "de", "en", "es", "fr", "ja", "ko", "pt", "ru", "zh", "zh-Hans", "zh-Hant" ] {
+            if let name = NSLocale(localeIdentifier: loc).displayName(forKey: .identifier, value: loc) {
+                let item = app.tables.staticTexts["Show Labels in " + name]
+                if item.exists {
+                    item.tap()
+                    mapSettingsButton.tap()
+                }
+            }
+        }
+
+        mapSettingsButton.tap()
+        app.tables.staticTexts["View Route Simulation"].tap()
+        app.navigationBars["MBXCustomLocationView"].buttons["Back"].tap()
+
+        mapSettingsButton.tap()
+        app.tables.staticTexts["Ornaments Placement"].tap()
+        app.navigationBars["Ornaments"].buttons["Back"].tap()
+
+        mapSettingsButton.tap()
+        app.tables.staticTexts["Show Snapshots"].tap()
+        app.navigationBars["MBXSnapshotsView"].buttons["Back"].tap()
+
+        mapSettingsButton.tap()
+        app.tables.staticTexts["Embedded Map View"].tap()
+        app.navigationBars["MBXEmbeddedMapView"].buttons["Back"].tap()
     }
 
     func testRecord() {

--- a/platform/ios/iosapp-UITests/iosapp_UITests.swift
+++ b/platform/ios/iosapp-UITests/iosapp_UITests.swift
@@ -194,25 +194,38 @@ class iosapp_UITests: XCTestCase {
         // These open another view controller that then needs to be closed
 
         app.tables.staticTexts["View Route Simulation"].tap()
-        app.navigationBars["MBXCustomLocationView"].buttons["Back"].tap()
+        XCTAssert(tapBackButton("MBXCustomLocationView", timeout: 5))
 
         mapSettingsButton.tap()
         app.tables.staticTexts["Ornaments Placement"].tap()
-        app.navigationBars["Ornaments"].buttons["Back"].tap()
+        XCTAssert(tapBackButton("Ornaments", timeout: 5))
 
         mapSettingsButton.tap()
         app.tables.staticTexts["Show Snapshots"].tap()
-        app.navigationBars["MBXSnapshotsView"].buttons["Back"].tap()
+        XCTAssert(tapBackButton("MBXSnapshotsView", timeout: 5))
 
         mapSettingsButton.tap()
         app.tables.staticTexts["Embedded Map View"].tap()
-        app.navigationBars["MBXEmbeddedMapView"].buttons["Back"].tap()
+        XCTAssert(tapBackButton("MBXEmbeddedMapView", timeout: 5))
     }
 
     private func staticItemIfExists(_ ident: String) -> XCUIElement? {
-        let item = app.staticTexts["Add Custom Drawable Layer"]
+        let item = app.staticTexts[ident]
         return item.exists ? item : nil
     }
+
+    private func tapBackButton(_ label: String, timeout: TimeInterval) -> Bool {
+        let bar = app.navigationBars[label]
+        if (bar.waitForExistence(timeout: timeout)) {
+            let button = bar.buttons["Back"]
+            if (button.waitForExistence(timeout: 1)) {
+                button.tap()
+                return true
+            }
+        }
+        return false
+    }
+
     func testRecord() {
         /// Use recording to get started writing UI tests.
         ///   Use `Editor` > `Start Recording UI Test` while your cursor is in this `func`

--- a/platform/ios/iosapp-UITests/iosapp_UITests.swift
+++ b/platform/ios/iosapp-UITests/iosapp_UITests.swift
@@ -112,12 +112,11 @@ class iosapp_UITests: XCTestCase {
         "Show reuse queue stats",
         "Hide reuse queue stats",
         "Add 100 Views",
-        // These seem to break the test, maybe just take too long
-//        "Add 1,000 Views",
-//        "Add 10,000 Views",
+        //"Add 1,000 Views",    // These cause the test to time out
+        //"Add 10,000 Views",
         "Add 100 Sprites",
-//        "Add 1,000 Sprites",
-//        "Add 10,000 Sprites",
+        //"Add 1,000 Sprites",
+        //"Add 10,000 Sprites",
         "Animate an Annotation View",
         "Add Test Shapes",
         "Add 10x Test Shapes",
@@ -137,11 +136,9 @@ class iosapp_UITests: XCTestCase {
         "Style Symbol Color",
         "Style Building Fill Color",
         "Style Ferry Line Color",
-        // TODO: crash, only works on styles with park layers?
-        //"Remove Parks",
+        "Remove Parks",
         "Style Fill With Filter",
-        // TODO: crash, ?
-        //"Style Lines With Filter",
+        "Style Lines With Filter",
         "Style Fill With Numeric Filter",
         "Query and Style Features",
         "Style Feature",
@@ -175,31 +172,27 @@ class iosapp_UITests: XCTestCase {
             sleep(1)
         }
 
-        let customLayerGL = app.tables.staticTexts["Add Custom Triangle Layer (OpenGL)"]
-        let customLayerMetal = app.tables.staticTexts["Add Custom Triangle Layer (Metal)"]
-        let customLayerLegacy = app.tables.staticTexts["Add Custom Drawable Layer"]
-
+        // Only one of these will show up, run whichever one is there
         mapSettingsButton.tap()
-        if customLayerGL.exists {
-            customLayerGL.tap()
-        } else if customLayerMetal.exists {
-            customLayerMetal.tap()
-        } else if customLayerLegacy.exists {
-            customLayerLegacy.tap()
+        if let customLayer = staticItemIfExists("Add Custom Triangle Layer (OpenGL)") ??
+                             staticItemIfExists("Add Custom Triangle Layer (Metal)") ??
+                             staticItemIfExists("Add Custom Drawable Layer") {
+            customLayer.tap()
+            mapSettingsButton.tap()
         }
 
-        mapSettingsButton.tap()
+        // See `bestLanguageForUser`
         for loc in [ "ar", "de", "en", "es", "fr", "ja", "ko", "pt", "ru", "zh", "zh-Hans", "zh-Hant" ] {
             if let name = NSLocale(localeIdentifier: loc).displayName(forKey: .identifier, value: loc) {
-                let item = app.tables.staticTexts["Show Labels in " + name]
-                if item.exists {
+                if let item = staticItemIfExists("Show Labels in " + name) {
                     item.tap()
                     mapSettingsButton.tap()
                 }
             }
         }
 
-        mapSettingsButton.tap()
+        // These open another view controller that then needs to be closed
+
         app.tables.staticTexts["View Route Simulation"].tap()
         app.navigationBars["MBXCustomLocationView"].buttons["Back"].tap()
 
@@ -216,6 +209,10 @@ class iosapp_UITests: XCTestCase {
         app.navigationBars["MBXEmbeddedMapView"].buttons["Back"].tap()
     }
 
+    private func staticItemIfExists(_ ident: String) -> XCUIElement? {
+        let item = app.staticTexts["Add Custom Drawable Layer"]
+        return item.exists ? item : nil
+    }
     func testRecord() {
         /// Use recording to get started writing UI tests.
         ///   Use `Editor` > `Start Recording UI Test` while your cursor is in this `func`

--- a/platform/ios/src/MLNMapView_Private.h
+++ b/platform/ios/src/MLNMapView_Private.h
@@ -75,6 +75,8 @@ FOUNDATION_EXTERN MLN_EXPORT MLNExceptionName const _Nonnull MLNUnderlyingMapUna
 @property (nonatomic, readonly) BOOL enablePresentsWithTransaction;
 @property (nonatomic, assign) BOOL needsDisplayRefresh;
 
+- (MLNMapCamera *_Nullable)cameraByTiltingToPitch:(CGFloat)pitch;
+
 - (BOOL) _opaque;
 
 @end


### PR DESCRIPTION
In using the iOS app to investigate a bug report, I ran into a bug in the dynamic layout of the dynamically-created view in "Add Second Map."

Aside from resolving that minor issue and adding a test case, I also added a "smoke test" that just clicks on all the items in the menu to make sure they don't crash, but with no validation that they work correctly.

That turned up several problems, such as test cases which can only be run in isolation, and cases which break later cases.  For example, "Add Route Line" and "Style Route line with gradient" created sources with the same name, and the style would throw when the second was added.

Currently all the cases are run except for the ones which add 1,000 or 10,000 items, as these seem to take so long that the search for the tappable menu button times out.  But they use the same method as the 100 case.
