### PR TITLE
Fix node windows workflow

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -265,10 +265,10 @@ jobs:
         run: set -o pipefail && ./build/mbgl-render-test-runner --manifestPath metrics/macos-xcode11-release-style.json
 
       - name: Upload render test artifacts (MacOS)
-        if: runner.os == 'MacOS'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: render-query-test-results
+          name: render-query-test-results_${{ runner.os }}_${{ matrix.arch }}
           path: metrics/macos-xcode11-release-style.html
 
       - name: Test (Linux)

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -265,10 +265,10 @@ jobs:
         run: set -o pipefail && ./build/mbgl-render-test-runner --manifestPath metrics/macos-xcode11-release-style.json
 
       - name: Upload render test artifacts (MacOS)
-        if: always()
+        if: runner.os == 'MacOS'
         uses: actions/upload-artifact@v4
         with:
-          name: render-query-test-results_${{ runner.os }}_${{ matrix.arch }}
+          name: render-query-test-results
           path: metrics/macos-xcode11-release-style.html
 
       - name: Test (Linux)

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -82,7 +82,7 @@ jobs:
           # A release for macOS can be made from the opengl-2 branch
           # - runs-on: macos-12
           #   arch: x86_64
-          # - runs-on: [self-hosted, macOS, ARM64]
+          # - runs-on: macos-13
           #   arch: arm64
           - runs-on: windows-2022
             arch: x86_64
@@ -118,7 +118,6 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
-          brew list cmake || brew install cmake
           brew list ccache || brew install ccache
           brew list ninja || brew install ninja
           brew list pkg-config || brew install pkg-config
@@ -165,11 +164,15 @@ jobs:
           $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
           "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Setup cmake (Linux)
-        if: runner.os == 'Linux' && matrix.arch != 'arm64'
-        uses: jwlawson/actions-setup-cmake@v2.0
+      - name: Setup cmake
+        if: runner.environment == 'github-hosted'
+        uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: "3.19.x"
+          cmake-version: '3.29.2'
+ 
+      - name: cmake version
+        run: |
+          cmake --version
 
       - name: Set up ccache (MacOS/Linux)
         if: runner.os == 'MacOS' || runner.os == 'Linux'

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -165,7 +165,7 @@ jobs:
           "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Setup cmake
-        if: runner.environment == 'github-hosted'
+        if: ${{contains(runner.name, 'GitHub Actions')}}
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.29.2'


### PR DESCRIPTION
Fixes https://github.com/maplibre/maplibre-native/issues/2256

The github runners are using cmake 3.29.1, which has been causing issues in macos and windows ci.  This PR uses jwlawson/actions-setup-cmake to make the workflow use 3.29.2 like suggested in https://github.com/actions/runner-images/issues/9680#issuecomment-2052018532 , which seems to fix the build issues

It looks like 'jwlawson/actions-setup-cmake' was already being used in the linux runner, so this changes it to also be used in all github runners. It did not work in the self-hosted runner, so I have restricted it from running in those workers