### PR TITLE
Present drawable null check

### DIFF
--- a/platform/ios/src/MLNMapView+Metal.mm
+++ b/platform/ios/src/MLNMapView+Metal.mm
@@ -79,7 +79,9 @@ public:
 
     void swap() override {
         id<CAMetalDrawable> currentDrawable = [mtlView currentDrawable];
-        [commandBuffer presentDrawable:currentDrawable];
+        if (currentDrawable) {
+            [commandBuffer presentDrawable:currentDrawable];
+        }
         [commandBuffer commit];
 
         // Un-comment for synchronous, which can help troubleshoot rendering problems,


### PR DESCRIPTION
In case `currentDrawable` is null we skip to present the drawable, but we commit the command buffer.
I tested this scenario and is not crashing.
The command buffer is renewed every frame.