### PR TITLE
[opengl-2][node] Release node-v5.4.0-pre.0

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -49,7 +49,7 @@ jobs:
             arch: arm64
           - runs-on: macos-12
             arch: x86_64
-          - runs-on: [self-hosted, macOS, ARM64]
+          - runs-on: macos-13-xlarge
             arch: arm64
           - runs-on: windows-2022
             arch: x86_64
@@ -85,7 +85,6 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
-          brew list cmake || brew install cmake
           brew list ccache || brew install ccache
           brew list ninja || brew install ninja
           brew list pkg-config || brew install pkg-config
@@ -132,11 +131,15 @@ jobs:
           $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
           "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Setup cmake (Linux)
-        if: runner.os == 'Linux' && matrix.arch != 'arm64'
-        uses: jwlawson/actions-setup-cmake@v1.14
+      - name: Setup cmake
+        if: ${{contains(runner.name, 'GitHub Actions')}}
+        uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: "3.19.x"
+          cmake-version: '3.29.2'
+ 
+      - name: cmake version
+        run: |
+          cmake --version
 
       - name: Set up ccache (MacOS/Linux)
         if: runner.os == 'MacOS' || runner.os == 'Linux'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.3.1",
+  "version": "5.4.0-pre.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "5.3.1",
+      "version": "5.4.0-pre.0",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.3.1",
+  "version": "5.4.0-pre.0",
   "description": "Renders map tiles with Maplibre GL",
   "keywords": [
     "maplibre",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 ## main
 
+## 5.4.0-pre.0
+
+* [Note] This is a OpenGL-2 release. It does not include metal support.
+* Add support for [multi sprites](https://github.com/maplibre/maplibre-native/pull/1858). More information on this feature can be found in the [Style Spec Documentation](https://maplibre.org/maplibre-style-spec/sprite/#multiple-sprite-sources).
+
 ## 5.3.1
 
 * [Note] This is a OpenGL-2 release. It does not include metal support.


### PR DESCRIPTION
This PR is to Release node-v5.4.0-pre.0

This release adds support for multi-sprites, which have been cherry picked from the main branch in https://github.com/maplibre/maplibre-native/pull/2151


I also updated the release workflow to match the ci, so this release will actually work. I can cherry pick this to main later when the version gets updated there. Note that this also changes the macos arm64 binary to be built on the github 'macos-13-xlarge' runner, so this is a slighly newer version of macos that could need testing for macos arm64 users, which this prerelease will be useful for. I do wonder though if we should change macos-12 to macos-13, for the AMD64 runner.
