### PR TITLE
Add debug symbols to Android release

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -142,6 +142,16 @@ jobs:
           asset_name: MapLibreAndroid-release.aar
           asset_content_type: application/zip
 
+      - name: Upload debug symbols
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: platform/android/build/debug-symbols.tar.gz
+          asset_name: debug-symbols.tar.gz
+          asset_content_type: application/gzip
+
       - name: Clean release
         run: |
           rm -f ${{ steps.prepare_release.outputs.release_notes }}

--- a/platform/android/Makefile
+++ b/platform/android/Makefile
@@ -215,11 +215,12 @@ run-android-unit-test:
 run-android-unit-test-%:
 	$(MLN_ANDROID_GRADLE) -Pmapbox.abis=none :MapLibreAndroid:testLegacyDebugUnitTest --info --tests "$*"
 
-# Builds a release package of the Android SDK
+# Builds a release package and .tar.gz with debug symbols of the Android SDK
 .PHONY: apackage
 apackage: 
 	make android-lib-arm-v7 && make android-lib-arm-v8 && make android-lib-x86 && make android-lib-x86-64
-	$(MLN_ANDROID_GRADLE) -Pmapbox.abis=all assemble$(BUILDTYPE)
+	$(MLN_ANDROID_GRADLE) -Pmapbox.abis=all assembleDrawable$(BUILDTYPE)
+	tar -czvf build/debug-symbols.tar.gz -C MapLibreAndroid/build/intermediates/library_jni/drawableRelease/jni .
 
 # Build test app instrumentation tests apk and test app apk for all abi's
 .PHONY: android-ui-test

--- a/platform/android/MapLibreAndroid/gradle.properties
+++ b/platform/android/MapLibreAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=11.0.0-pre4
+VERSION_NAME=11.0.0-pre6
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20


### PR DESCRIPTION
Fixes #2282 (hopefully).

```
 % tar -tvf build/debug-symbols.tar.gz
drwxr-xr-x  0 bart   staff       0 Apr 18 17:24 ./
drwxr-xr-x  0 bart   staff       0 Apr 18 17:24 ./armeabi-v7a/
drwxr-xr-x  0 bart   staff       0 Apr 18 17:24 ./x86/
drwxr-xr-x  0 bart   staff       0 Apr 18 17:24 ./arm64-v8a/
drwxr-xr-x  0 bart   staff       0 Apr 18 17:24 ./x86_64/
-rw-r--r--  0 bart   staff 193393432 Apr 18 17:24 ./x86_64/libmaplibre.so
-rw-r--r--  0 bart   staff 200794312 Apr 18 17:24 ./arm64-v8a/libmaplibre.so
-rw-r--r--  0 bart   staff 171135888 Apr 18 17:24 ./x86/libmaplibre.so
-rw-r--r--  0 bart   staff 172496144 Apr 18 17:24 ./armeabi-v7a/libmaplibre.so
```