### PR TITLE
Update iOS BAZEL.md

### DIFF
--- a/platform/ios/BAZEL.md
+++ b/platform/ios/BAZEL.md
@@ -10,25 +10,23 @@ From there you can use the script in platform/ios/platform/ios/scripts/package-b
 
 ## There are 4 options:
 
-`cd platform/ios/platform/ios/scripts`
-
 Static xcframework compiled for release (this is default if no parameters are provided):
-`./bazel-package.sh --static --release`
+`platform/ios/scripts/bazel-package.sh --static --release`
 
 Static xcframework compiled for debug:
-`./bazel-package.sh --static --debug`
+`platform/ios/scripts/bazel-package.sh --static --debug`
 
 Dynamic xcframework compiled for release:
-`./bazel-package.sh --dynamic --release`
+`platform/ios/scripts/bazel-package.sh --dynamic --release`
 
 Dynamic xcframework compiled for debug:
-`./bazel-package.sh --dynamic --debug`
+`platform/ios/scripts/bazel-package.sh --dynamic --debug`
 
 All compiled frameworks will end up in the `bazel-bin/platform/ios/` path from the root of the repo.
 
 Also you can use the link option to ensure that the framework is able to link.
 
-`./bazel-package.sh --link`
+`platform/ios/scripts/bazel-package.sh --link`
 
 #### Bazel build files are placed in a few places throughout the project:
 


### PR DESCRIPTION
If the commands are executed the way described in this file, the command fails as on `bazel-package.sh`

```
if [ ! -d platform/ios/build ]; then
   mkdir platform/ios/build
fi
```

as there is no `platform/ios` folder in `platform/ios/scripts` and mkdir only would create the top directory `build`, but not `platform` and `ios` and then `build`. I've changed the documentation so that it is in reference to the root of the repo, which appears to be the way the scripts are set up. By executing the commands from there they start successfully.


<img width="942" alt="Screenshot 2024-04-19 at 13 22 14" src="https://github.com/maplibre/maplibre-native/assets/645674/d5a57a3e-9871-4ccf-ab44-299dfd5ca5d5">

