### PR TITLE
[opengl-2][node] Release node-v5.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.4.0-pre.0",
+  "version": "5.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "5.4.0-pre.0",
+      "version": "5.4.0",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.4.0-pre.0",
+  "version": "5.4.0",
   "description": "Renders map tiles with Maplibre GL",
   "keywords": [
     "maplibre",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## main
 
-## 5.4.0-pre.0
+## 5.4.0
 
 * [Note] This is a OpenGL-2 release. It does not include metal support.
 * Add support for [multi sprites](https://github.com/maplibre/maplibre-native/pull/1858). More information on this feature can be found in the [Style Spec Documentation](https://maplibre.org/maplibre-style-spec/sprite/#multiple-sprite-sources).

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## main
 
-## 5.4.0
+## 5.4.0-pre.0
 
 * [Note] This is a OpenGL-2 release. It does not include metal support.
 * Add support for [multi sprites](https://github.com/maplibre/maplibre-native/pull/1858). More information on this feature can be found in the [Style Spec Documentation](https://maplibre.org/maplibre-style-spec/sprite/#multiple-sprite-sources).


### PR DESCRIPTION
This PR releases [opengl-2][node] Release node-v5.4.0


**Testing**
I have tested the pre-release [v5.4.0-pre.0](https://www.npmjs.com/package/@maplibre/maplibre-gl-native/v/5.4.0-pre.0) in Ubuntu 22.04 (arm64/amd64) and Windows by Updating TileServer-GL to accept multi-sprites in https://github.com/maptiler/tileserver-gl/pull/1232 . @mnutt also tested the macos arm64 release and that seems to work as well

**Example**
I updated this ATV trail map to use two different sets of sprites, ['default' and 'colored'](https://github.com/maptiler/tileserver-gl/pull/1232#issue-2254686185). You can see the default icons and colored icons show as expected
https://tiles.wifidb.net/styles/WDB_GPSTRAILS/?raster#15/45.0491/-69.8739
![image](https://github.com/maplibre/maplibre-native/assets/3792408/6adacdd0-5e58-4d61-8113-1b29d5d6a10b)

