### PR TITLE
Android annotations: Implement `CollisionGroup`

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/AnnotationContainer.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/AnnotationContainer.kt
@@ -214,7 +214,7 @@ internal class KAnnotationContainer
                     }
 
                     // Apply NDD properties from symbol key
-                    val symbolKey = when (key) {
+                    when (key) {
                         is CollisionGroupKey -> {
                             if (key.collisionGroup.symbols.isEmpty()) return@apply
 
@@ -222,31 +222,8 @@ internal class KAnnotationContainer
                         }
                         is SymbolKey -> key
                         else -> throw IllegalStateException()
-                    }
+                    }.applyProperties(this)
 
-                    iconTextFit = symbolKey.iconFitText.let { fitText ->
-                        if (fitText.width && fitText.height) Property.ICON_TEXT_FIT_BOTH
-                        else if (fitText.width) Property.ICON_TEXT_FIT_WIDTH
-                        else if (fitText.height) Property.ICON_TEXT_FIT_HEIGHT
-                        else Property.ICON_TEXT_FIT_NONE
-                    }
-                    iconTextFitPadding = symbolKey.iconFitText.padding.let { padding ->
-                        arrayOf(padding.top, padding.right, padding.bottom, padding.left)
-                    }
-
-                    iconKeepUpright = symbolKey.iconKeepUpright
-                    iconPitchAlignment = when (symbolKey.iconPitchAlignment) {
-                        Alignment.MAP -> Property.ICON_PITCH_ALIGNMENT_MAP
-                        Alignment.VIEWPORT -> Property.ICON_PITCH_ALIGNMENT_VIEWPORT
-                        null -> Property.ICON_PITCH_ALIGNMENT_AUTO
-                    }
-
-                    textPitchAlignment = when (symbolKey.textPitchAlignment) {
-                        Alignment.MAP -> Property.TEXT_PITCH_ALIGNMENT_MAP
-                        Alignment.VIEWPORT -> Property.TEXT_PITCH_ALIGNMENT_VIEWPORT
-                        null -> Property.TEXT_PITCH_ALIGNMENT_AUTO
-                    }
-                    textLineHeight = symbolKey.textLineHeight
 
                 }
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
@@ -38,6 +38,11 @@ internal data class CircleKey(
     val pitchAlignment: Alignment
 ) : Key
 
+data class CollisionGroupKey(
+    override val z: Int,
+    val collisionGroup: CollisionGroup
+) : Key
+
 internal fun KAnnotation<*>.key() = when (this) {
     is Symbol -> SymbolKey(
         zLayer,
@@ -57,3 +62,7 @@ internal fun KAnnotation<*>.key() = when (this) {
         zLayer, translate, pitchScale, pitchAlignment
     )
 }
+
+internal fun CollisionGroup.key(): CollisionGroupKey = CollisionGroupKey(
+    if (this.symbols.isNotEmpty()) this.symbols[0].zLayer else Defaults.Z_LAYER, this
+)

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
@@ -5,6 +5,7 @@ import org.maplibre.android.annotations.data.Alignment
 import org.maplibre.android.annotations.data.Defaults
 import org.maplibre.android.annotations.data.Icon
 import org.maplibre.android.annotations.data.Translate
+import org.maplibre.android.style.layers.Property
 
 internal sealed interface Key {
     val z: Int
@@ -64,5 +65,33 @@ internal fun KAnnotation<*>.key() = when (this) {
 }
 
 internal fun CollisionGroup.key(): CollisionGroupKey = CollisionGroupKey(
-    if (this.symbols.isNotEmpty()) this.symbols[0].zLayer else Defaults.Z_LAYER, this
+    Defaults.Z_LAYER, // TODO: if (this.symbols.isNotEmpty()) this.symbols[0].zLayer else …,
+    this
 )
+
+internal fun SymbolKey.applyProperties(to: SymbolManager) {
+    to.iconTextFit = iconFitText.let { fitText ->
+        if (fitText.width && fitText.height) Property.ICON_TEXT_FIT_BOTH
+        else if (fitText.width) Property.ICON_TEXT_FIT_WIDTH
+        else if (fitText.height) Property.ICON_TEXT_FIT_HEIGHT
+        else Property.ICON_TEXT_FIT_NONE
+    }
+    to.iconTextFitPadding = iconFitText.padding.let { padding ->
+        arrayOf(padding.top, padding.right, padding.bottom, padding.left)
+    }
+
+    to.iconKeepUpright = iconKeepUpright
+    to.iconPitchAlignment = when (iconPitchAlignment) {
+        Alignment.MAP -> Property.ICON_PITCH_ALIGNMENT_MAP
+        Alignment.VIEWPORT -> Property.ICON_PITCH_ALIGNMENT_VIEWPORT
+        null -> Property.ICON_PITCH_ALIGNMENT_AUTO
+    }
+
+    to.textPitchAlignment = when (textPitchAlignment) {
+        Alignment.MAP -> Property.TEXT_PITCH_ALIGNMENT_MAP
+        Alignment.VIEWPORT -> Property.TEXT_PITCH_ALIGNMENT_VIEWPORT
+        null -> Property.TEXT_PITCH_ALIGNMENT_AUTO
+    }
+    to.textLineHeight = textLineHeight
+
+}

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/AnnotationContainerKeys.kt
@@ -65,7 +65,7 @@ internal fun KAnnotation<*>.key() = when (this) {
 }
 
 internal fun CollisionGroup.key(): CollisionGroupKey = CollisionGroupKey(
-    Defaults.Z_LAYER, // TODO: if (this.symbols.isNotEmpty()) this.symbols[0].zLayer else …,
+    this.zLayer,
     this
 )
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/AnnotationManager.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/AnnotationManager.kt
@@ -152,8 +152,9 @@ abstract class AnnotationManager<L : Layer, T : KAnnotation<*>> @UiThread intern
      */
     @UiThread
     fun deleteAll() {
-        annotations.forEach {
-            draggableAnnotationController.onAnnotationDeleted(it.value)
+        annotations.values.forEach {
+            draggableAnnotationController.onAnnotationDeleted(it)
+            it.detachFromManager()
         }
         annotations.clear()
         updateSource()

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/CollisionGroup.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/CollisionGroup.kt
@@ -7,6 +7,7 @@ import kotlin.properties.Delegates
 
 class CollisionGroup(
     symbols: List<Symbol> = emptyList(),
+    val zLayer: Int = Defaults.Z_LAYER,
     symbolSpacing: Float = Defaults.COLLISION_GROUP_SYMBOL_SPACING,
     symbolAvoidEdges: Boolean = Defaults.COLLISION_GROUP_SYMBOL_AVOID_EDGES,
     iconAllowOverlap: Boolean = Defaults.COLLISION_GROUP_ICON_ALLOW_OVERLAP,

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/CollisionGroup.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/CollisionGroup.kt
@@ -1,0 +1,110 @@
+package org.maplibre.android.annotations
+
+import okhttp3.internal.toImmutableList
+import org.maplibre.android.annotations.data.Anchor
+import org.maplibre.android.annotations.data.Defaults
+import kotlin.properties.Delegates
+
+class CollisionGroup(
+    symbols: List<Symbol> = emptyList(),
+    symbolSpacing: Float = Defaults.COLLISION_GROUP_SYMBOL_SPACING,
+    symbolAvoidEdges: Boolean = Defaults.COLLISION_GROUP_SYMBOL_AVOID_EDGES,
+    iconAllowOverlap: Boolean = Defaults.COLLISION_GROUP_ICON_ALLOW_OVERLAP,
+    iconIgnorePlacement: Boolean = Defaults.COLLISION_GROUP_ICON_IGNORE_PLACEMENT,
+    iconOptional: Boolean = Defaults.COLLISION_GROUP_ICON_OPTIONAL,
+    iconPadding: Float = Defaults.COLLISION_GROUP_ICON_PADDING,
+    textPadding: Float = Defaults.COLLISION_GROUP_TEXT_PADDING,
+    textAllowOverlap: Boolean = Defaults.COLLISION_GROUP_TEXT_ALLOW_OVERLAP,
+    textIgnorePlacement: Boolean = Defaults.COLLISION_GROUP_TEXT_IGNORE_PLACEMENT,
+    textOptional: Boolean = Defaults.COLLISION_GROUP_TEXT_OPTIONAL,
+    textVariableAnchor: Array<Anchor>? = Defaults.COLLISION_GROUP_TEXT_VARIABLE_ANCHOR
+) {
+
+    var symbols: List<Symbol> by Delegates.observable(
+        symbols.toImmutableList(),
+        onChange = { _, _, new ->
+            testDistinctSymbolKeys()
+            manager?.apply {
+                deleteAll()
+                addAll(new)
+            }
+        }
+    )
+
+    var symbolSpacing: Float = symbolSpacing
+        set(value) {
+            field = value
+            manager?.symbolSpacing = value
+        }
+    var symbolAvoidEdges: Boolean = symbolAvoidEdges
+        set(value) {
+            field = value
+            manager?.symbolAvoidEdges = value
+        }
+    var iconAllowOverlap: Boolean = iconAllowOverlap
+        set(value) {
+            field = value
+            manager?.iconAllowOverlap = value
+        }
+    var iconIgnorePlacement: Boolean = iconIgnorePlacement
+        set(value) {
+            field = value
+            manager?.iconIgnorePlacement = value
+        }
+    var iconOptional: Boolean = iconOptional
+        set(value) {
+            field = value
+            manager?.iconOptional = value
+        }
+    var iconPadding: Float = iconPadding
+        set(value) {
+            field = value
+            manager?.iconPadding = value
+        }
+    var textPadding: Float = textPadding
+        set(value) {
+            field = value
+            manager?.textPadding = value
+        }
+    var textAllowOverlap: Boolean = textAllowOverlap
+        set(value) {
+            field = value
+            manager?.textAllowOverlap = value
+        }
+    var textIgnorePlacement: Boolean = textIgnorePlacement
+        set(value) {
+            field = value
+            manager?.textIgnorePlacement = value
+        }
+    var textOptional: Boolean = textOptional
+        set(value) {
+            field = value
+            manager?.textOptional = value
+        }
+    var textVariableAnchor: Array<Anchor>? = textVariableAnchor
+        set(value) {
+            field = value
+            manager?.textVariableAnchor = value?.map { it.toString() }?.toTypedArray()
+        }
+
+    // Set by AnnotationContainerKeys
+    internal var manager: SymbolManager? = null
+
+    init {
+        testDistinctSymbolKeys()
+    }
+
+    private fun testDistinctSymbolKeys() {
+        symbols.distinctBy {
+            it.key()
+        }.let {
+            if (it.size > 1) {
+                throw IllegalArgumentException(
+                    "You have added symbols with conflicting Non-Data Driven (NDD) properties " +
+                            "to this cluster group. Namely, the following sets of properties" +
+                            "were found: ${it.joinToString("; ")}"
+                )
+            }
+        }
+    }
+}

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/CollisionGroup.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/CollisionGroup.kt
@@ -26,7 +26,10 @@ class CollisionGroup(
             testDistinctSymbolKeys()
             manager?.apply {
                 deleteAll()
-                addAll(new)
+                if (new.isNotEmpty()) {
+                    addAll(new)
+                    (new[0].key() as SymbolKey).applyProperties(this)
+                }
             }
         }
     )
@@ -92,17 +95,24 @@ class CollisionGroup(
 
     init {
         testDistinctSymbolKeys()
+
+        if (textVariableAnchor?.isEmpty() == true) {
+            throw IllegalArgumentException(
+                "An empty array has been provided as a text variable anchor. Please use `null` " +
+                        "instead of an empty array to indicate that no alternative anchors are provided."
+            )
+        }
     }
 
     private fun testDistinctSymbolKeys() {
-        symbols.distinctBy {
+        symbols.map {
             it.key()
-        }.let {
+        }.distinct().let {
             if (it.size > 1) {
                 throw IllegalArgumentException(
                     "You have added symbols with conflicting Non-Data Driven (NDD) properties " +
-                            "to this cluster group. Namely, the following sets of properties" +
-                            "were found: ${it.joinToString("; ")}"
+                            "to this cluster group. Namely, the following sets of properties " +
+                            "were found:\n${it.joinToString("; \n")}"
                 )
             }
         }

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/KAnnotation.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/KAnnotation.kt
@@ -93,6 +93,13 @@ sealed class KAnnotation<T : Geometry>(
         }
     }
 
+    internal fun detachFromManager() {
+        if (attachedToManager != null) {
+            attachedToManager = null
+            id = 0L
+        }
+    }
+
     /**
      * Applies the given offset to the internal geometry, and applies this new Geometry to the annotation
      * itself. Afterwards, the annotation updates.

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/LineManager.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/LineManager.kt
@@ -128,7 +128,7 @@ class LineManager @UiThread internal constructor(
      * The display of line endings.
      */
     var lineCap: String?
-        get() = layer.lineCap.value
+        get() = layer.lineCap?.value
         set(value) {
             val propertyValue: PropertyValue<*> = PropertyFactory.lineCap(value)
             constantPropertyUsageMap[PROPERTY_LINE_CAP] = propertyValue

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/data/Defaults.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/annotations/data/Defaults.kt
@@ -88,5 +88,17 @@ class Defaults {
         val FILL_PATTERN: Bitmap? = null
         val FILL_ANTIALIAS: Boolean = true
         val FILL_TRANSLATE: Translate? = null
+
+        val COLLISION_GROUP_SYMBOL_SPACING: Float = 250f
+        val COLLISION_GROUP_SYMBOL_AVOID_EDGES: Boolean = false
+        val COLLISION_GROUP_ICON_ALLOW_OVERLAP: Boolean = false
+        val COLLISION_GROUP_ICON_IGNORE_PLACEMENT: Boolean = false
+        val COLLISION_GROUP_ICON_OPTIONAL: Boolean = false
+        val COLLISION_GROUP_ICON_PADDING: Float = 2f
+        val COLLISION_GROUP_TEXT_PADDING: Float = 2f
+        val COLLISION_GROUP_TEXT_ALLOW_OVERLAP: Boolean = false
+        val COLLISION_GROUP_TEXT_IGNORE_PLACEMENT: Boolean = false
+        val COLLISION_GROUP_TEXT_OPTIONAL: Boolean = false
+        val COLLISION_GROUP_TEXT_VARIABLE_ANCHOR: Array<Anchor>? = null
     }
 }

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMap.java
@@ -20,6 +20,8 @@ import com.mapbox.android.gestures.MoveGestureDetector;
 import com.mapbox.android.gestures.RotateGestureDetector;
 import com.mapbox.android.gestures.ShoveGestureDetector;
 import com.mapbox.android.gestures.StandardScaleGestureDetector;
+
+import org.maplibre.android.annotations.CollisionGroup;
 import org.maplibre.geojson.Feature;
 import org.maplibre.geojson.Geometry;
 import org.maplibre.android.MapStrictMode;
@@ -1054,6 +1056,10 @@ public final class MapLibreMap {
     }
   }
 
+  public void addCollisionGroup(@NonNull CollisionGroup collisionGroup) {
+    annotationContainer.add(collisionGroup);
+  }
+
   /**
    * Forces redraw of annotations. Annotations are automatically redrawn if any of their properties
    * are changed, or if a new map style is applied.
@@ -1088,6 +1094,10 @@ public final class MapLibreMap {
     for (KAnnotation annotation : annotations) {
       annotationContainer.remove(annotation);
     }
+  }
+
+  public void removeCollisionGroup(@NonNull CollisionGroup collisionGroup) {
+    annotationContainer.remove(collisionGroup);
   }
 
   /**

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/annotations/CollisionGroupTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/annotations/CollisionGroupTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.maplibre.android.annotations.data.Alignment
 import org.maplibre.android.annotations.data.Text
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.maps.MapLibreMap
@@ -149,6 +150,24 @@ class CollisionGroupTest {
         collisionGroup.textOptional = true
 
         Mockito.verify(symbolLayer).setProperties(PropertyFactory.textOptional(true))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `throws on adding values with inconsistent NDD properties`() {
+        CollisionGroup(
+            listOf(
+                Symbol(LatLng(0.0, 0.0), text = Text("hello", pitchAlignment = Alignment.MAP)),
+                Symbol(LatLng(0.0, 0.0), text = Text("world", pitchAlignment = Alignment.VIEWPORT))
+            )
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `throws on adding empty text-variable-anchor array`() {
+        CollisionGroup(
+            emptyList(),
+            textVariableAnchor = emptyArray()
+        )
     }
 
 }

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/annotations/CollisionGroupTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/annotations/CollisionGroupTest.kt
@@ -107,7 +107,7 @@ class CollisionGroupTest {
         container.add(collisionGroup)
 
         collisionGroup.symbols = listOf(
-            Symbol(LatLng(0.0, 0.0))
+            Symbol(LatLng(0.0, 0.0), text = Text("test", lineHeight = 2f))
         )
 
         assertEquals(1, collisionGroup.symbols.size)
@@ -116,6 +116,7 @@ class CollisionGroupTest {
 
         assertTrue(collisionGroup.manager is SymbolManager)
         assertEquals(1, (collisionGroup.manager as SymbolManager).annotations.size)
+        Mockito.verify(symbolLayer).setProperties(PropertyFactory.textLineHeight(2f))
     }
 
     @Test

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/annotations/CollisionGroupTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/annotations/CollisionGroupTest.kt
@@ -1,0 +1,154 @@
+package org.maplibre.android.annotations
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.maplibre.android.annotations.data.Text
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.Style
+import org.maplibre.android.style.layers.PropertyFactory
+import org.maplibre.android.style.layers.SymbolLayer
+import org.maplibre.android.style.sources.GeoJsonOptions
+import org.maplibre.android.style.sources.GeoJsonSource
+import org.mockito.InjectMocks
+import org.mockito.Mockito
+
+class CollisionGroupTest {
+    @InjectMocks
+    private val maplibreMap = Mockito.mock(MapLibreMap::class.java)
+    @InjectMocks
+    private val mapView = Mockito.mock(MapView::class.java)
+    @InjectMocks
+    private val style = Mockito.mock(Style::class.java)
+    private val symbolElementProvider: CoreElementProvider<SymbolLayer> = Mockito.mock(
+        SymbolElementProvider::class.java
+    )
+    private val symbolLayer: SymbolLayer = Mockito.mock(SymbolLayer::class.java)
+
+    private val layerId = "annotation_layer"
+    private val geoJsonSource: GeoJsonSource = Mockito.mock(GeoJsonSource::class.java)
+    private val geoJsonOptions: GeoJsonOptions = Mockito.mock(GeoJsonOptions::class.java)
+
+    private val optionedGeoJsonSource: GeoJsonSource = Mockito.mock(GeoJsonSource::class.java)
+
+    @Before
+    fun beforeTest() {
+        Mockito.`when`(symbolLayer.id).thenReturn(layerId)
+        Mockito.`when`(symbolElementProvider.layer).thenReturn(symbolLayer)
+        Mockito.`when`(symbolElementProvider.getSource(null)).thenReturn(geoJsonSource)
+        Mockito.`when`(symbolElementProvider.getSource(geoJsonOptions))
+            .thenReturn(optionedGeoJsonSource)
+
+        Mockito.`when`(style.isFullyLoaded).thenReturn(true)
+    }
+
+    @InjectMocks
+    private val draggableAnnotationController = Mockito.mock(
+        DraggableAnnotationController::class.java
+    )
+
+    private fun getMockContainer() = KAnnotationContainer(
+        maplibreMap,
+        mapView,
+        style,
+        draggableAnnotationController,
+        { symbolElementProvider }
+    )
+
+    @Test
+    fun `add CollisionGroup`() {
+        val container = getMockContainer()
+        val collisionGroup = CollisionGroup()
+        container.add(collisionGroup)
+
+        assertEquals(0, container.size)
+        assertEquals(1, container.managerCount)
+    }
+
+    @Test
+    fun `add and remove CollisionGroup`() {
+        val container = getMockContainer()
+        val collisionGroup = CollisionGroup()
+
+        container.add(collisionGroup)
+        container.remove(collisionGroup)
+
+        assertEquals(0, container.size)
+        assertEquals(0, container.managerCount)
+    }
+
+    @Test
+    fun `add CollisionGroup with Symbols`() {
+        val container = getMockContainer()
+        val collisionGroup = CollisionGroup(
+            symbols = listOf(
+                Symbol(LatLng(0.0, 0.0), text = Text("custom", lineHeight = 2.0f))
+            )
+        )
+
+        container.add(collisionGroup)
+
+        assertEquals(1, container.size)
+        assertEquals(1, container.managerCount)
+
+        assertTrue(collisionGroup.manager is SymbolManager)
+        Mockito.verify(symbolLayer).setProperties(PropertyFactory.textLineHeight(2f))
+    }
+
+    @Test
+    fun `add CollisionGroup, then add Symbols`() {
+        val container = getMockContainer()
+        val collisionGroup = CollisionGroup()
+
+        container.add(collisionGroup)
+
+        collisionGroup.symbols = listOf(
+            Symbol(LatLng(0.0, 0.0))
+        )
+
+        assertEquals(1, collisionGroup.symbols.size)
+        assertEquals(1, container.size)
+        assertEquals(1, container.managerCount)
+
+        assertTrue(collisionGroup.manager is SymbolManager)
+        assertEquals(1, (collisionGroup.manager as SymbolManager).annotations.size)
+    }
+
+    @Test
+    fun `add CollisionGroup with properties`() {
+        val container = getMockContainer()
+        val collisionGroup = CollisionGroup(
+            textOptional = true
+        )
+
+        container.add(collisionGroup)
+
+        assertEquals(0, container.size)
+        assertEquals(1, container.managerCount)
+
+        assertTrue(collisionGroup.manager is SymbolManager)
+        Mockito.verify(symbolLayer).setProperties(PropertyFactory.textOptional(true))
+    }
+
+    @Test
+    fun `add CollisionGroup, then set properties`() {
+        val container = getMockContainer()
+        val collisionGroup = CollisionGroup()
+
+        container.add(collisionGroup)
+
+        assertTrue(collisionGroup.manager is SymbolManager)
+        Mockito.verify(symbolLayer, Mockito.never()).setProperties(PropertyFactory.textOptional(true))
+
+        assertEquals(0, container.size)
+        assertEquals(1, container.managerCount)
+
+        collisionGroup.textOptional = true
+
+        Mockito.verify(symbolLayer).setProperties(PropertyFactory.textOptional(true))
+    }
+
+}


### PR DESCRIPTION
[Android annotations API proposal](https://github.com/maplibre/maplibre-native/blob/main/design-proposals/2023-06-17-android-annotations.md) implementation PR as a part of https://github.com/maplibre/maplibre-native/issues/1491. Closes #1495.

---

* `CollisionGroup` is implemented per specification. In effect, it is somewhat of a wrapper around `SymbolManager`.
* The `CollisionGroupTest` contains some tests I found to be helpful.
* One annoyance is that I couldn't add an observable list as I hoped. Instead, the list of `symbols` is currently immutable, and can be set to a new value through assignment (which we listen to using `Delegates.observable`). We could decide to add `add(Symbol)`, `delete(Symbol)`, etc. instead.