### PR TITLE
[node][main] Update latest release to node-v5.4.0

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -3,5 +3,5 @@
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-592547263
 pnpm-lock.yaml=104874376
-package-lock.json=-583117742
-package.json=-370460401
+package-lock.json=-1109603374
+package.json=752745807

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -82,7 +82,7 @@ jobs:
           # A release for macOS can be made from the opengl-2 branch
           # - runs-on: macos-12
           #   arch: x86_64
-          # - runs-on: macos-13
+          # - runs-on: macos-13-xlarge
           #   arch: arm64
           - runs-on: windows-2022
             arch: x86_64

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -51,7 +51,7 @@ jobs:
           # A release for macOS can be made from the opengl-2 branch
           # - runs-on: macos-12
           #   arch: x86_64
-          # - runs-on: [self-hosted, macOS, ARM64]
+          # - runs-on: macos-13-xlarge
           #   arch: arm64
           - runs-on: windows-2022
             arch: x86_64
@@ -87,7 +87,6 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
-          brew list cmake || brew install cmake
           brew list ccache || brew install ccache
           brew list ninja || brew install ninja
           brew list pkg-config || brew install pkg-config
@@ -134,11 +133,15 @@ jobs:
           $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
           "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Setup cmake (Linux)
-        if: runner.os == 'Linux' && matrix.arch != 'arm64'
-        uses: jwlawson/actions-setup-cmake@v2.0
+      - name: Setup cmake
+        if: ${{contains(runner.name, 'GitHub Actions')}}
+        uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: "3.19.x"
+          cmake-version: '3.29.2'
+ 
+      - name: cmake version
+        run: |
+          cmake --version
 
       - name: Set up ccache (MacOS/Linux)
         if: runner.os == 'MacOS' || runner.os == 'Linux'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "5.3.1",
+      "version": "5.4.0",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.3.1",
+  "version": "5.4.0-pre.0",
   "description": "Renders map tiles with MapLibre Native",
   "keywords": [
     "maplibre",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.4.0-pre.0",
+  "version": "5.4.0",
   "description": "Renders map tiles with MapLibre Native",
   "keywords": [
     "maplibre",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 ## main
 
+## 5.4.0-pre.0
+
+* [Note] This is a OpenGL-2 release. It does not include metal support.
+* Add support for [multi sprites](https://github.com/maplibre/maplibre-native/pull/1858). More information on this feature can be found in the [Style Spec Documentation](https://maplibre.org/maplibre-style-spec/sprite/#multiple-sprite-sources).
+
 ## 5.3.1
 
 * [Note] This is a OpenGL-2 release. It does not include metal support.

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## main
 
-## 5.4.0-pre.0
+## 5.4.0
 
 * [Note] This is a OpenGL-2 release. It does not include metal support.
 * Add support for [multi sprites](https://github.com/maplibre/maplibre-native/pull/1858). More information on this feature can be found in the [Style Spec Documentation](https://maplibre.org/maplibre-style-spec/sprite/#multiple-sprite-sources).


### PR DESCRIPTION
This is a cherry pick of https://github.com/maplibre/maplibre-native/pull/2286 and https://github.com/maplibre/maplibre-native/pull/2303 from the 'opengl-2' branch into main. This is mainly so main package.json reflects the latest version and the CHANGELOG includes the latest information.

https://github.com/maplibre/maplibre-native/pull/2286 also included a few fixes to the node release workflow that were forgotten when I fixed the node ci. This also brings those fixes to main.
