### PR TITLE
Synchronous rendering on Metal when annotation views are visible

### DIFF
--- a/platform/ios/src/MLNMapView+Impl.h
+++ b/platform/ios/src/MLNMapView+Impl.h
@@ -57,6 +57,10 @@ public:
     void render();
 
     virtual MLNBackendResource getObject() = 0;
+    
+    virtual void setSynchronous(bool value) {};
+    virtual bool getSynchronous() const { return false; };
+
 
     // mbgl::MapObserver implementation
     void onCameraWillChange(mbgl::MapObserver::CameraChangeMode) override;

--- a/platform/ios/src/MLNMapView+Metal.h
+++ b/platform/ios/src/MLNMapView+Metal.h
@@ -50,8 +50,8 @@ public:
     MLNBackendResource getObject() override;
     // End implementation of MLNMapViewImpl
 
-    virtual void setSynchronous(bool value) override { synchronousFrame = value; };
-    virtual bool getSynchronous() const override { return synchronousFrame; };
+    void setSynchronous(bool value) override { synchronousFrame = value; };
+    bool getSynchronous() const override { return synchronousFrame; };
 private:
     bool presentsWithTransaction = false;
     bool synchronousFrame = false;

--- a/platform/ios/src/MLNMapView+Metal.h
+++ b/platform/ios/src/MLNMapView+Metal.h
@@ -50,6 +50,9 @@ public:
     MLNBackendResource getObject() override;
     // End implementation of MLNMapViewImpl
 
+    virtual void setSynchronous(bool value) override { synchronousFrame = value; };
+    virtual bool getSynchronous() const override { return synchronousFrame; };
 private:
     bool presentsWithTransaction = false;
+    bool synchronousFrame = false;
 };

--- a/platform/ios/src/MLNMapView+Metal.mm
+++ b/platform/ios/src/MLNMapView+Metal.mm
@@ -84,9 +84,15 @@ public:
         }
         [commandBuffer commit];
 
-        // Un-comment for synchronous, which can help troubleshoot rendering problems,
+        // Synchronous rendering can help troubleshoot rendering problems,
         // particularly those related to resource tracking and multiple queued buffers.
-        //[commandBuffer waitUntilCompleted];
+        // The conditional logic for synchronous rendering is commanded from MLNMapView.updateAnnotationViews:
+        // `_mbglView->setSynchronous(haveVisibleAnnotationViews);`
+        // and fixes the desynchronization of UIView annotation when the map is rendered on the Metal backend
+        // Issue: https://github.com/maplibre/maplibre-native/issues/2053
+        if (backend.getSynchronous()) {
+            [commandBuffer waitUntilCompleted];
+        }
 
         commandBuffer = nil;
         commandBufferPtr.reset();


### PR DESCRIPTION
Implement conditional synchronous rendering on Metal backend when annotation views are visible, that is waiting for frames to fully complete by invoking `[commandBuffer waitUntilCompleted];` in the `swap` method of the `MLNMapViewMetalRenderableResource`.

This is needed because the map transformation is set as soon as the camera is mutated, and annotations are positioned on the screen according to that in `MLNMapView`::`renderSync` -> `updateAnnotationViews`, while the frame rendering is completing asynchronously on Metal - which causes desynchronization.

ref: #2082 
Fixes #2053 
