### PR TITLE
Workaround for un-converted legacy layers

### DIFF
--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -132,10 +132,9 @@ public:
     bool supportsZoom(float zoom) const;
 
     virtual void upload(gfx::UploadPass&) {}
-    virtual void render(PaintParameters&) {};
+    virtual void render(PaintParameters&) {}
 
-    // Check wether the given geometry intersects
-    // with the feature
+    // Check whether the given geometry intersects with the feature
     virtual bool queryIntersectsFeature(const GeometryCoordinates&,
                                         const GeometryTileFeature&,
                                         const float,

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -369,6 +369,18 @@ void Renderer::Impl::render(const RenderTree& renderTree,
             parameters.currentLayer = maxLayerIndex - layerGroup.getLayerIndex();
             layerGroup.render(orchestrator, parameters);
         });
+
+        // Finally, render any legacy layers which have not been converted to drawables.
+        // Note that they may be out of order, this is just a temporary fix for `RenderLocationIndicatorLayer` (#2216)
+        parameters.depthRangeSize = 1 - (layerRenderItems.size() + 2) * PaintParameters::numSublayers *
+                                            PaintParameters::depthEpsilon;
+        int32_t i = static_cast<int32_t>(layerRenderItems.size()) - 1;
+        for (auto it = layerRenderItems.begin(); it != layerRenderItems.end() && i >= 0; ++it, --i) {
+            parameters.currentLayer = i;
+            if (it->hasRenderPass(parameters.pass)) {
+                it->render(parameters);
+            }
+        }
     };
 #endif
 


### PR DESCRIPTION
While `RenderLayer::render()` still exists, it is no longer called in drawable builds.  Layers which were never converted to drawables still compile and participate in `prepare()`, etc., but are never rendered.

As a workaround, call `render()` on each layer after rendering the drawable layer groups.

Longer-term, the location indicator layer should be updated to use drawables and the `render()` method should be made conditional so that layers using it do not compile in drawable builds.