### PR TITLE
Reduce memory use of `GridIndex`

### DIFF
--- a/src/mbgl/gfx/index_vector.hpp
+++ b/src/mbgl/gfx/index_vector.hpp
@@ -45,6 +45,8 @@ public:
 
     bool isReleased() const { return released; }
 
+    void reserve(std::size_t count) { v.reserve(count); }
+
     void extend(std::size_t n, const uint16_t val) {
         assert(!released);
         v.resize(v.size() + n, val);

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -178,7 +178,7 @@ public:
 
     void setPatternParameters(const std::optional<ImagePosition>&,
                               const std::optional<ImagePosition>&,
-                              const CrossfadeParameters&) override {};
+                              const CrossfadeParameters&) override {}
 
     std::tuple<float> interpolationFactor(float) const override { return std::tuple<float>{0.0f}; }
 
@@ -272,7 +272,7 @@ public:
 
     void setPatternParameters(const std::optional<ImagePosition>&,
                               const std::optional<ImagePosition>&,
-                              const CrossfadeParameters&) override {};
+                              const CrossfadeParameters&) override {}
     void populateVertexVector(const GeometryTileFeature& feature,
                               std::size_t length,
                               std::size_t index,
@@ -391,7 +391,7 @@ public:
 
     void setPatternParameters(const std::optional<ImagePosition>&,
                               const std::optional<ImagePosition>&,
-                              const CrossfadeParameters&) override {};
+                              const CrossfadeParameters&) override {}
     void populateVertexVector(const GeometryTileFeature& feature,
                               std::size_t length,
                               std::size_t index,
@@ -415,6 +415,9 @@ public:
         const AttributeValue value = zoomInterpolatedAttributeValue(attributeValue(range.min),
                                                                     attributeValue(range.max));
         const auto elements = vertexVector.elements();
+        if (vertexVector.empty()) {
+            vertexVector.reserve(length);
+        }
         for (std::size_t i = elements; i < length; ++i) {
             vertexVector.emplace_back(Vertex{value});
         }

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -13,14 +13,14 @@ TileLayerIndex::TileLayerIndex(OverscaledTileID coord_,
     : coord(coord_),
       bucketInstanceId(bucketInstanceId_),
       bucketLeaderId(std::move(bucketLeaderId_)) {
-    for (SymbolInstance& symbolInstance : symbolInstances) {
+    for (const SymbolInstance& symbolInstance : symbolInstances) {
         if (symbolInstance.crossTileID == SymbolInstance::invalidCrossTileID()) continue;
         indexedSymbolInstances[symbolInstance.key].emplace_back(symbolInstance.crossTileID,
                                                                 getScaledCoordinates(symbolInstance, coord));
     }
 }
 
-Point<int64_t> TileLayerIndex::getScaledCoordinates(SymbolInstance& symbolInstance,
+Point<int64_t> TileLayerIndex::getScaledCoordinates(const SymbolInstance& symbolInstance,
                                                     const OverscaledTileID& childTileCoord) const {
     // Round anchor positions to roughly 4 pixel grid
     const double roundingFactor = 512.0 / util::EXTENT / 2.0;

--- a/src/mbgl/text/cross_tile_symbol_index.hpp
+++ b/src/mbgl/text/cross_tile_symbol_index.hpp
@@ -36,7 +36,7 @@ public:
                    uint32_t bucketInstanceId,
                    std::string bucketLeaderId);
 
-    Point<int64_t> getScaledCoordinates(SymbolInstance&, const OverscaledTileID&) const;
+    Point<int64_t> getScaledCoordinates(const SymbolInstance&, const OverscaledTileID&) const;
     void findMatches(SymbolBucket&, const OverscaledTileID&, std::set<uint32_t>&) const;
 
     OverscaledTileID coord;

--- a/src/mbgl/util/grid_index.hpp
+++ b/src/mbgl/util/grid_index.hpp
@@ -4,14 +4,14 @@
 #include <mapbox/geometry/box.hpp>
 #include <mbgl/math/minmax.hpp>
 
-#include <unordered_set>
+#include <cassert>
 #include <cmath>
-#include <cstdint>
 #include <cstddef>
-#include <vector>
+#include <cstdint>
 #include <functional>
 #include <optional>
-#include <cassert>
+#include <unordered_set>
+#include <vector>
 
 namespace mbgl {
 
@@ -103,8 +103,9 @@ private:
     std::vector<std::pair<T, BBox>> boxElements;
     std::vector<std::pair<T, BCircle>> circleElements;
 
-    std::vector<std::vector<size_t>> boxCells;
-    std::vector<std::vector<size_t>> circleCells;
+    using uid_t = uint32_t;
+    std::vector<std::vector<uid_t>> boxCells;
+    std::vector<std::vector<uid_t>> circleCells;
 };
 
 template <class T>
@@ -123,7 +124,8 @@ GridIndex<T>::GridIndex(const float width_, const float height_, const uint32_t 
 
 template <class T>
 void GridIndex<T>::insert(T&& t, const BBox& bbox) {
-    const size_t uid = boxElements.size();
+    assert(boxElements.size() < std::numeric_limits<uid_t>::max());
+    const auto uid = static_cast<uid_t>(boxElements.size());
 
     const auto cx1 = convertToXCellCoord(bbox.min.x);
     const auto cy1 = convertToYCellCoord(bbox.min.y);
@@ -145,7 +147,8 @@ void GridIndex<T>::insert(T&& t, const BBox& bbox) {
 
 template <class T>
 void GridIndex<T>::insert(T&& t, const BCircle& bcircle) {
-    const size_t uid = circleElements.size();
+    assert(circleElements.size() < std::numeric_limits<uid_t>::max());
+    const auto uid = static_cast<uid_t>(circleElements.size());
 
     const auto cx1 = convertToXCellCoord(bcircle.center.x - bcircle.radius);
     const auto cy1 = convertToYCellCoord(bcircle.center.y - bcircle.radius);
@@ -231,8 +234,8 @@ typename GridIndex<T>::BBox GridIndex<T>::convertToBox(const BCircle& circle) co
 
 template <class T>
 void GridIndex<T>::query(const BBox& queryBBox, std::function<bool(const T&, const BBox&)> resultFn) const {
-    std::unordered_set<size_t> seenBoxes;
-    std::unordered_set<size_t> seenCircles;
+    std::unordered_set<uid_t> seenBoxes;
+    std::unordered_set<uid_t> seenCircles;
 
     if (noIntersection(queryBBox)) {
         return;

--- a/src/mbgl/util/grid_index.hpp
+++ b/src/mbgl/util/grid_index.hpp
@@ -103,9 +103,8 @@ private:
     std::vector<std::pair<T, BBox>> boxElements;
     std::vector<std::pair<T, BCircle>> circleElements;
 
-    using uid_t = uint32_t;
-    std::vector<std::vector<uid_t>> boxCells;
-    std::vector<std::vector<uid_t>> circleCells;
+    std::vector<std::vector<uint32_t>> boxCells;
+    std::vector<std::vector<uint32_t>> circleCells;
 };
 
 template <class T>
@@ -124,8 +123,8 @@ GridIndex<T>::GridIndex(const float width_, const float height_, const uint32_t 
 
 template <class T>
 void GridIndex<T>::insert(T&& t, const BBox& bbox) {
-    assert(boxElements.size() < std::numeric_limits<uid_t>::max());
-    const auto uid = static_cast<uid_t>(boxElements.size());
+    assert(boxElements.size() < std::numeric_limits<uint32_t>::max());
+    const auto uid = static_cast<uint32_t>(boxElements.size());
 
     const auto cx1 = convertToXCellCoord(bbox.min.x);
     const auto cy1 = convertToYCellCoord(bbox.min.y);
@@ -147,8 +146,8 @@ void GridIndex<T>::insert(T&& t, const BBox& bbox) {
 
 template <class T>
 void GridIndex<T>::insert(T&& t, const BCircle& bcircle) {
-    assert(circleElements.size() < std::numeric_limits<uid_t>::max());
-    const auto uid = static_cast<uid_t>(circleElements.size());
+    assert(circleElements.size() < std::numeric_limits<uint32_t>::max());
+    const auto uid = static_cast<uint32_t>(circleElements.size());
 
     const auto cx1 = convertToXCellCoord(bcircle.center.x - bcircle.radius);
     const auto cy1 = convertToYCellCoord(bcircle.center.y - bcircle.radius);
@@ -234,8 +233,8 @@ typename GridIndex<T>::BBox GridIndex<T>::convertToBox(const BCircle& circle) co
 
 template <class T>
 void GridIndex<T>::query(const BBox& queryBBox, std::function<bool(const T&, const BBox&)> resultFn) const {
-    std::unordered_set<uid_t> seenBoxes;
-    std::unordered_set<uid_t> seenCircles;
+    std::unordered_set<uint32_t> seenBoxes;
+    std::unordered_set<uint32_t> seenCircles;
 
     if (noIntersection(queryBBox)) {
         return;


### PR DESCRIPTION
The `GridIndex` class uses a 64-bit integer as the unique identifier for a feature within a grid, which is per-bucket or feature query.  I think we can safely assume that it's not necessary to support more than 2^32 features.

These are not huge, but are among the largest groups of persistent allocations, behind HTTP responses and the largest vertex buffers.  

<img width="600" alt="image" src="https://github.com/WetDogWeather/maplibre-gl-native/assets/71895881/99d4ca48-2670-44c4-a4b5-b2d5a78307fb">

Also adds some reserve calls based on observations of large numbers of allocations.