### PR TITLE
CURL_POLL_INOUT action handle added

### DIFF
--- a/platform/default/src/mbgl/storage/http_file_source.cpp
+++ b/platform/default/src/mbgl/storage/http_file_source.cpp
@@ -204,6 +204,12 @@ int HTTPFileSource::Impl::handleSocket(
                 static_cast<int>(s), util::RunLoop::Event::Write, std::bind(&Impl::perform, context, _1, _2));
             break;
         }
+        case CURL_POLL_INOUT: {
+            using namespace std::placeholders;
+            util::RunLoop::Get()->addWatch(
+                static_cast<int>(s), util::RunLoop::Event::ReadWrite, std::bind(&Impl::perform, context, _1, _2));
+            break;
+        }
         case CURL_POLL_REMOVE:
             util::RunLoop::Get()->removeWatch(static_cast<int>(s));
             break;


### PR DESCRIPTION
Now HTTPFileSource handles CURL_POLL_INOUT socket action with ReadWrite event.
Issue #2357 mbgl-glfw fails with curl 8.x.x
After this fix build succeeds and app does not fail with my setup.

Please beware of merging this without proper control: I am not a C++ developer and barely understand what exactly my proposal does.