### PR TITLE
Use Drawable renderer for render test

### DIFF
--- a/render-test/android/app/build.gradle
+++ b/render-test/android/app/build.gradle
@@ -27,6 +27,7 @@ android {
             cmake {
                 arguments '-DANDROID_CCACHE=ccache'
                 arguments '-DANDROID_STL=c++_static'
+                arguments "-DMLN_LEGACY_RENDERER=OFF", "-DMLN_DRAWABLE_RENDERER=ON"
                 targets 'mbgl-render-test-runner'
             }
         }


### PR DESCRIPTION
Runs the render tests for Android with the Drawable renderer, in preparation for the release.