### PR TITLE
Add line on user tap example to iOS Docs

### DIFF
--- a/platform/darwin/src/MLNPolyline.h
+++ b/platform/darwin/src/MLNPolyline.h
@@ -52,7 +52,10 @@ NS_ASSUME_NONNULL_BEGIN
  geometry in GeoJSON.
  
  #### Related examples
- TODO: Annotation models, learn how to add an `MLNPolyine` object to your map.
+
+ - <doc:LineOnUserTap>
+
+   TODO: Annotation models, learn how to add an `MLNPolyine` object to your map.
  */
 MLN_EXPORT
 @interface MLNPolyline : MLNMultiPoint <MLNOverlay>

--- a/platform/ios/MapLibre.docc/GettingStarted.md
+++ b/platform/ios/MapLibre.docc/GettingStarted.md
@@ -32,13 +32,13 @@ To use MapLibre with SwiftUI we need to create a wrapper for the UIKit view that
 
 ```swift
 struct MapLibreMapView: UIViewRepresentable {
-    private let mapView = MLNMapView()
-    
-    func makeUIView(context: Context) -> some UIView {
+
+    func makeUIView(context: Context) -> MLNMapView {
+        let mapView = MLNMapView()
         return mapView
     }
     
-    func updateUIView(_ uiView: UIViewType, context: Context) {
+    func updateUIView(_ mapView: MLNMapView, context: Context) {
     }
 }
 ```

--- a/platform/ios/MapLibre.docc/LineOnUserTap.md
+++ b/platform/ios/MapLibre.docc/LineOnUserTap.md
@@ -1,0 +1,64 @@
+# Add Line on User Tap
+
+Demonstrating adding ``MLNPolyline`` annotations and responding to user input.
+
+## Overview
+
+This example draws a line from the tapped location to the center of the map. Handling the tap is done by the `Coordinator` class. It converts the location on the view to a geographic coordinate. It removes existing annotations before adding the new line.
+
+```swift
+struct MapLibreMapView: UIViewRepresentable {
+    
+    func makeUIView(context: Context) -> MLNMapView {
+        let mapView = MLNMapView()
+        
+        // Add a single tap gesture recognizer
+        let singleTap = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleMapTap(sender:)))
+        for recognizer in mapView.gestureRecognizers! where recognizer is UITapGestureRecognizer {
+            singleTap.require(toFail: recognizer)
+        }
+        mapView.addGestureRecognizer(singleTap)
+        return mapView
+    }
+    
+    func updateUIView(_ mapView: MLNMapView, context: Context) {
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    class Coordinator: NSObject {
+        var parent: MapLibreMapView
+        
+        init(_ parent: MapLibreMapView) {
+            self.parent = parent
+        }
+        
+        @objc func handleMapTap(sender: UITapGestureRecognizer) {
+            guard let mapView = sender.view as? MLNMapView else { return }
+            
+            // Convert tap location (CGPoint) to geographic coordinate (CLLocationCoordinate2D).
+            let tapPoint: CGPoint = sender.location(in: mapView)
+            let tapCoordinate: CLLocationCoordinate2D = mapView.convert(tapPoint, toCoordinateFrom: nil)
+            print("You tapped at: \(tapCoordinate.latitude), \(tapCoordinate.longitude)")
+            
+            // Create an array of coordinates for our polyline, starting at the center of the map and ending at the tap coordinate.
+            var coordinates: [CLLocationCoordinate2D] = [mapView.centerCoordinate, tapCoordinate]
+            
+            // Remove any existing polyline(s) from the map.
+            if let existingAnnotations = mapView.annotations {
+                mapView.removeAnnotations(existingAnnotations)
+            }
+            
+            // Add a polyline with the new coordinates.
+            let polyline = MLNPolyline(coordinates: &coordinates, count: UInt(coordinates.count))
+            mapView.addAnnotation(polyline)
+        }
+    }
+}
+```
+
+![](polyline.gif)

--- a/platform/ios/MapLibre.docc/MapLibre.md
+++ b/platform/ios/MapLibre.docc/MapLibre.md
@@ -11,9 +11,10 @@ Powerful, free and open-source mapping toolkit with full control over data sourc
 [MapLibre Native](https://github.com/maplibre/maplibre-native) is a map rendering toolkit with support for iOS. It can be used as an alternative to MapKit. You have full control over the data sources used for rendering the map, as well as the styling. You can even participate in the development as MapLibre Native is free and open-source project.
 > Note: For information on creating and modifying map styles, see the [MapLibre Style Spec documentation](https://maplibre.org/maplibre-style-spec/).
 
-## Essentials
+## Guides
 
 - <doc:GettingStarted>
+- <doc:LineOnUserTap>
 
 ## Topics
 

--- a/platform/ios/scripts/docc.sh
+++ b/platform/ios/scripts/docc.sh
@@ -36,6 +36,7 @@ bazel build --//:renderer=metal //platform/darwin:generated_style_public_hdrs
 resources=(
   "AddPackageDependencies@2x.png"
   "DemotilesScreenshot@2x.png"
+  "polyline@2x.png"
 )
 
 destination_dir="platform/ios/MapLibre.docc/Resources"

--- a/platform/ios/scripts/docc.sh
+++ b/platform/ios/scripts/docc.sh
@@ -33,21 +33,7 @@ bazel build --//:renderer=metal //platform/darwin:generated_style_public_hdrs
 
 # download resources from S3
 
-resources=(
-  "AddPackageDependencies@2x.png"
-  "DemotilesScreenshot@2x.png"
-  "polyline@2x.png"
-)
-
-destination_dir="platform/ios/MapLibre.docc/Resources"
-
-for file in "${resources[@]}"; do
-  if [[ ! -f "$destination_dir/$file" ]]; then
-    aws s3 cp --no-sign-request "s3://maplibre-native/ios-documentation-resources/$file" "$destination_dir"
-  else
-    echo "Skipped: $file already exists in the destination directory"
-  fi
-done
+aws s3 sync --no-sign-request "s3://maplibre-native/ios-documentation-resources" "platform/ios/MapLibre.docc/Resources"
 
 public_headers=$(bazel query 'kind("source file", deps(//platform:ios-sdk, 2))' --output location | grep ".h$" | sed -r 's#.*/([^:]+).*#\1#')
 style_headers=$(bazel cquery --//:renderer=metal //platform/darwin:generated_style_public_hdrs --output=files)


### PR DESCRIPTION
- FIx Getting Started Guide.
- Add second example!

Adapted from https://github.com/mapbox/ios-sdk-examples/blob/0b1f3f0cd6acaebe7c8a03e69589d083c1c68c69/Examples/Swift/PointConversionExample.swift#L27 (CC-0) and updated to use SwiftUI (shamelessly used ChatGPT).

https://github.com/maplibre/maplibre-native/assets/649392/a7e4948d-641f-461c-8a34-7a16f998c99c
