### PR TITLE
Compile iOS Examples

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -77,6 +77,9 @@ jobs:
             ${{ runner.os }}-bazel-
           path: ~/.cache/bazel
 
+      - name: Build Example (Swift) App
+        run: bazel build //platform/ios/app-swift:MapLibreApp --//:renderer=metal
+
       - name: Check debug symbols
         run: bazel run //platform:check-public-symbols --//:renderer=metal
 

--- a/platform/ios/BUILD.bazel
+++ b/platform/ios/BUILD.bazel
@@ -268,6 +268,13 @@ xcodeproj(
             ],
         ),
         top_level_target(
+            "//platform/ios/app-swift:MapLibreApp",
+            target_environments = [
+                "simulator",
+                "device",
+            ],
+        ),
+        top_level_target(
             "BenchmarkApp",
             target_environments = [
                 "simulator",

--- a/platform/ios/CONTRIBUTING.md
+++ b/platform/ios/CONTRIBUTING.md
@@ -27,3 +27,33 @@ resources=(
   # add here
 )
 ```
+
+## Examples
+
+The code samples in the documentation should ideally be compiled on CI so they do not go out of date.
+
+Fence your example code with
+
+```swift
+// #-example-code(LineTapMapView)
+...
+// #-end-example-code
+```
+
+Prefix your documentation code block with
+
+````md
+<!-- include-example(LineTapMapView) -->
+
+```swift
+...
+```
+````
+
+Then the code block will be updated when you run:
+
+```sh
+node scripts/update-ios-examples.mjs
+```
+
+You need to add the relevant example paths and documentation paths to that file.

--- a/platform/ios/MapLibre.docc/GettingStarted.md
+++ b/platform/ios/MapLibre.docc/GettingStarted.md
@@ -30,25 +30,28 @@ import MapLibre
 
 To use MapLibre with SwiftUI we need to create a wrapper for the UIKit view that MapLibre provides (using UIViewRepresentable. The simplest way to implement this protocol is as follows:
 
-```swift
-struct MapLibreMapView: UIViewRepresentable {
+<!-- include-example(SimpleMapView) -->
 
-    func makeUIView(context: Context) -> MLNMapView {
+```swift
+struct SimpleMapView: UIViewRepresentable {
+    func makeUIView(context _: Context) -> MLNMapView {
         let mapView = MLNMapView()
         return mapView
     }
-    
-    func updateUIView(_ mapView: MLNMapView, context: Context) {
-    }
+
+    func updateUIView(_: MLNMapView, context _: Context) {}
 }
 ```
 
 You can use this view directly in a SwiftUI View hierarcy, for example:
 
 ```swift
-struct ContentView: View {
-    var body: some View {
-        MapLibreMapView()
+struct MyApp: App {
+
+    var body: some Scene {
+        WindowGroup {
+            MapLibreMapView().edgesIgnoringSafeArea(.all)
+        }
     }
 }
 ```

--- a/platform/ios/app-swift/BUILD.bazel
+++ b/platform/ios/app-swift/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+load("//platform/ios/bazel:provisioning.bzl", "configure_device_profiles")
+
+configure_device_profiles()
+
+swift_library(
+    name = "Sources",
+    srcs = glob(["Sources/*.swift"]),
+    module_name = "Sources",
+    tags = ["manual"],
+    deps = [
+        "//platform:ios-sdk",
+    ],
+)
+
+ios_application(
+    name = "MapLibreApp",
+    bundle_id = "org.maplibre.swiftapp",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [":Info.plist"],
+    minimum_os_version = "15.0",
+    provisioning_profile = "xcode_profile",
+    visibility = ["@rules_xcodeproj//xcodeproj:generated"],
+    deps = [":Sources"],
+)

--- a/platform/ios/app-swift/Info.plist
+++ b/platform/ios/app-swift/Info.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UILaunchScreen</key>
+		<dict/>
+	</dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/platform/ios/app-swift/Sources/LineTapMapView.swift
+++ b/platform/ios/app-swift/Sources/LineTapMapView.swift
@@ -1,14 +1,8 @@
-# Add Line on User Tap
+import MapLibre
+import SwiftUI
+import UIKit
 
-Demonstrating adding ``MLNPolyline`` annotations and responding to user input.
-
-## Overview
-
-This example draws a line from the tapped location to the center of the map. Handling the tap is done by the `Coordinator` class. It converts the location on the view to a geographic coordinate. It removes existing annotations before adding the new line.
-
-<!-- include-example(LineTapMapView) -->
-
-```swift
+// #-example-code(LineTapMapView)
 struct LineTapMapView: UIViewRepresentable {
     func makeUIView(context: Context) -> MLNMapView {
         let mapView = MLNMapView()
@@ -60,6 +54,5 @@ struct LineTapMapView: UIViewRepresentable {
         }
     }
 }
-```
 
-![](polyline.gif)
+// #-end-example-code

--- a/platform/ios/app-swift/Sources/MapLibreApp.swift
+++ b/platform/ios/app-swift/Sources/MapLibreApp.swift
@@ -1,0 +1,12 @@
+import MapLibre
+import SwiftUI
+import UIKit
+
+@main
+struct MapLibreApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/platform/ios/app-swift/Sources/SimpleMapView.swift
+++ b/platform/ios/app-swift/Sources/SimpleMapView.swift
@@ -1,0 +1,21 @@
+import MapLibre
+import SwiftUI
+import UIKit
+
+// #-example-code(SimpleMapView)
+struct SimpleMapView: UIViewRepresentable {
+    func makeUIView(context _: Context) -> MLNMapView {
+        let mapView = MLNMapView()
+        return mapView
+    }
+
+    func updateUIView(_: MLNMapView, context _: Context) {}
+}
+
+// #-end-example-code
+
+struct ContentView: View {
+    var body: some View {
+        SimpleMapView().edgesIgnoringSafeArea(.all)
+    }
+}

--- a/scripts/update-ios-examples.mjs
+++ b/scripts/update-ios-examples.mjs
@@ -1,18 +1,31 @@
+/**
+ * This script updates the iOS examples part of the DocC documentation.
+ * See platform/ios/CONTRIBUTING.md for the details.
+ */
+
 import fs from "fs/promises";
 
+/** documentation files that will be updated */
 const documentationPaths = [
   "platform/ios/MapLibre.docc/GettingStarted.md",
   "platform/ios/MapLibre.docc/LineOnUserTap.md",
 ];
 
-// source files that contain examples
+/** source files that contain examples */
 const examplePaths = [
   "platform/ios/app-swift/Sources/SimpleMapView.swift",
   "platform/ios/app-swift/Sources/LineTapMapView.swift"
 ];
 
 /**
+ * Parses a source file and looks for examples fenced in
+ * ```
+ * // #-example-code(ExampleId)
+ * ...
+ * // #-end-example-code
+ * ```
  * @param {string} examplePath
+ * @returns Mapping from example id to example, e.g. {"ExampleId": "..."}
  */
 async function parseExampleCode(examplePath) {
   const content = await fs.readFile(examplePath, "utf8");
@@ -45,6 +58,9 @@ async function parseExampleCode(examplePath) {
   return exampleCodeMap;
 }
 
+/**
+ * @returns Record of all example id to example code
+ */
 async function loadExamples() {
   /** @type {Record<string, string>} */
   let examples = {};
@@ -59,6 +75,7 @@ async function loadExamples() {
 }
 
 /**
+ * Replaces code block in examples with actual example in source code.
  * 
  * @param {string} documentationPath 
  * @param {Record<string, string>} examples 
@@ -67,21 +84,22 @@ async function updateDocumentation(documentationPath, examples) {
   const content = await fs.readFile(documentationPath, 'utf8');
   const lines = content.split('\n');
 
+  // This status implements little state machine.
   /** @type {{tag: 'find-example'} | {tag: 'find-codeblock', id: string} | {tag: 'skip-to-codeblock-end'}} */
   let status = {tag: 'find-example'};
   let currentId = '';
   let outputLines = [];
 
   for (const line of lines) {
-    if (status.tag === 'find-example') {
+    if (status.tag === 'find-example') {  // look for the start of an example
       const match = line.match(/<!-- include-example\(([^)]+)\) -->/);
-      if (match) {
+      if (match) { // found example
         currentId = match[1];
         status = {tag: 'find-codeblock', id: currentId};
       }
-      outputLines.push(line);
-    } else if (status.tag === 'find-codeblock') {
-      if (line === '```swift') {
+      outputLines.push(line); // otherwise include the line as-is
+    } else if (status.tag === 'find-codeblock') {  // look for a code block to replace
+      if (line === '```swift') {  // found it!
         outputLines.push(line);
         if (!examples[status.id]) throw Error(`Expected example with id='${status.id}'`);
         outputLines.push(examples[status.id].trim());
@@ -92,7 +110,7 @@ async function updateDocumentation(documentationPath, examples) {
     } else if (status.tag === 'skip-to-codeblock-end') {
       if (line === '```') {
         outputLines.push(line);
-        status = {tag: 'find-example'};
+        status = {tag: 'find-example'};  // look for the next example
       } else {
         continue;
       }

--- a/scripts/update-ios-examples.mjs
+++ b/scripts/update-ios-examples.mjs
@@ -1,0 +1,118 @@
+import fs from "fs/promises";
+
+const documentationPaths = [
+  "platform/ios/MapLibre.docc/GettingStarted.md",
+  "platform/ios/MapLibre.docc/LineOnUserTap.md",
+];
+
+// source files that contain examples
+const examplePaths = [
+  "platform/ios/app-swift/Sources/SimpleMapView.swift",
+  "platform/ios/app-swift/Sources/LineTapMapView.swift"
+];
+
+/**
+ * @param {string} examplePath
+ */
+async function parseExampleCode(examplePath) {
+  const content = await fs.readFile(examplePath, "utf8");
+  const lines = content.split("\n");
+  /** @type {Record<string, string>} */
+  const exampleCodeMap = {};
+
+  let capturing = false;
+  let currentId = "";
+
+  for (const line of lines) {
+    if (capturing) {
+      if (line.includes("// #-end-example-code")) {
+        capturing = false;
+      } else {
+        if (!exampleCodeMap[currentId]) {
+          exampleCodeMap[currentId] = "";
+        }
+        exampleCodeMap[currentId] += line + "\n";
+      }
+    } else {
+      const match = line.match(/\/\/ #\-example-code\(([^)]+)\)/);
+      if (match) {
+        currentId = match[1];
+        capturing = true;
+      }
+    }
+  }
+
+  return exampleCodeMap;
+}
+
+async function loadExamples() {
+  /** @type {Record<string, string>} */
+  let examples = {};
+  for (const examplePath of examplePaths) {
+    const newExamples = await parseExampleCode(examplePath);
+    if (Object.keys(newExamples).length === 0) {
+      throw new Error(`File '${examplePath}' does not contain any examples`);
+    }
+    examples = {...newExamples, ...examples};
+  }
+  return examples;
+}
+
+/**
+ * 
+ * @param {string} documentationPath 
+ * @param {Record<string, string>} examples 
+ */
+async function updateDocumentation(documentationPath, examples) {
+  const content = await fs.readFile(documentationPath, 'utf8');
+  const lines = content.split('\n');
+
+  /** @type {{tag: 'find-example'} | {tag: 'find-codeblock', id: string} | {tag: 'skip-to-codeblock-end'}} */
+  let status = {tag: 'find-example'};
+  let currentId = '';
+  let outputLines = [];
+
+  for (const line of lines) {
+    if (status.tag === 'find-example') {
+      const match = line.match(/<!-- include-example\(([^)]+)\) -->/);
+      if (match) {
+        currentId = match[1];
+        status = {tag: 'find-codeblock', id: currentId};
+      }
+      outputLines.push(line);
+    } else if (status.tag === 'find-codeblock') {
+      if (line === '```swift') {
+        outputLines.push(line);
+        if (!examples[status.id]) throw Error(`Expected example with id='${status.id}'`);
+        outputLines.push(examples[status.id].trim());
+        status = {tag: 'skip-to-codeblock-end'};
+      } else {
+        outputLines.push(line);
+      }
+    } else if (status.tag === 'skip-to-codeblock-end') {
+      if (line === '```') {
+        outputLines.push(line);
+        status = {tag: 'find-example'};
+      } else {
+        continue;
+      }
+    }
+  }
+
+  if (status.tag === 'find-codeblock') {
+    throw Error(`Ended evalution while looking for codeblock with id '${status.id}'`);
+  }
+
+  if (status.tag === 'skip-to-codeblock-end') {
+    throw Error("Could not find end of codeblock");
+  }
+
+  await fs.writeFile(documentationPath, outputLines.join('\n'));
+}
+
+const examples = await loadExamples();
+console.log(`Found examples: ${Object.keys(examples).join(", ")}`);
+
+for (const documentationPath of documentationPaths) {
+  await updateDocumentation(documentationPath, examples);
+}


### PR DESCRIPTION
The code samples in the documentation should be compiled on CI so they do not go out of date.

I wrote a script `scripts/update-ios-examples.mjs` that can update documentation based on examples in the codebase.

Examples need to be fenced with
```swift
// #-example-code(LineTapMapView)
...
// #-end-example-code
```

Documentation code blocks that are prefixed with

````md
<!-- include-example(LineTapMapView) -->

```swift
...
```
````

are pulled from actual code.

- Add sample (Swift) app and compile it on CI
- Update `CONTRIBUTING.md` with info how to add examples
- Add script for updating examples
- Run script (so current examples are updated)