### PR TITLE
Remove incorrect @get: property annotation

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/sources/GeoJsonSource.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/sources/GeoJsonSource.kt
@@ -372,7 +372,7 @@ class GeoJsonSource : Source {
         /**
          * @return The url or null
          */
-        @get:Deprecated("use {@link #getUri()} instead")
+        @Deprecated("use {@link #getUri()} instead")
         get() {
             return getUrlInternal()
         }


### PR DESCRIPTION
This use of `@get` is incorrect and has become an error in the newer kotlin releases:
`'@get:' annotations could be applied only to property declarations. It will be an error in a future release. See https://youtrack.jetbrains.com/issue/KT-15470`