### PR TITLE
[qt] Use GCC 13 on Ubuntu 24.04 to fix the CI

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,6 +2,7 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
     - macos-14  # can be removed once actionlint is updated
+    - ubuntu-24.04  # can be removed once actionlint is updated
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -72,7 +72,7 @@ jobs:
             qt_target: desktop
             compiler: ""
           - name: Linux_GCC13
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             build_type: RelWithDebInfo
             qt_version: 6.5.3
             qt_target: desktop
@@ -156,7 +156,7 @@ jobs:
             libxcb-render-util0 \
             libxcb-xinerama0 \
             libxcb-xfixes0 \
-            libegl1-mesa \
+            libegl1 \
             fonts-noto-cjk
 
       - name: Install compiler


### PR DESCRIPTION
`gcc-13` somehow disappeared from the build notes/repos. Try to use `gcc-13` on Ubuntu 24.04.