### PR TITLE
Fix deprecations in glyph_manager.cpp

### DIFF
--- a/src/mbgl/text/glyph_manager.cpp
+++ b/src/mbgl/text/glyph_manager.cpp
@@ -57,7 +57,7 @@ void GlyphManager::getGlyphs(GlyphRequestor& requestor, GlyphDependencies glyphD
 
     // If the shared dependencies pointer is already unique, then all dependent
     // glyph ranges have already been loaded. Send a notification immediately.
-    if (dependencies.unique()) {
+    if (dependencies.use_count() == 1) {
         notify(requestor, *dependencies);
     }
 }
@@ -121,7 +121,7 @@ void GlyphManager::processResponse(const Response& res, const FontStack& fontSta
         for (auto& pair : request.requestors) {
             GlyphRequestor& requestor = *pair.first;
             const std::shared_ptr<GlyphDependencies>& dependencies = pair.second;
-            if (dependencies.unique()) {
+            if (dependencies.use_count() == 1) {
                 notify(requestor, *dependencies);
             }
         }


### PR DESCRIPTION
`std::shared_ptr` `unique()` method is deprecated as it is not thread-safe. As the code seems to work fine for our use, change it to use directly `use_count() == 1`.

This fixes issues with newer compilers.