### PR TITLE
[cmake] Rename targets output folder to MapLibre

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 project("Mapbox GL Native" LANGUAGES CXX C)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER Core)
+set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER MapLibre)
 
 set(
     MEMORYCHECK_COMMAND_OPTIONS
@@ -1112,7 +1112,7 @@ set_target_properties(
         INTERFACE_MAPBOX_LICENSE ${PROJECT_SOURCE_DIR}/LICENSE.md
 )
 
-set_property(TARGET mbgl-core PROPERTY FOLDER Core)
+set_property(TARGET mbgl-core PROPERTY FOLDER MapLibre)
 
 add_library(
     Mapbox::Map ALIAS mbgl-core

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -60,4 +60,4 @@ target_link_libraries(
     PUBLIC mbgl-core
 )
 
-set_property(TARGET mbgl-benchmark PROPERTY FOLDER Core)
+set_property(TARGET mbgl-benchmark PROPERTY FOLDER MapLibre)

--- a/expression-test/CMakeLists.txt
+++ b/expression-test/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(
         mbgl-compiler-options
 )
 
-set_property(TARGET mbgl-expression-test PROPERTY FOLDER Executables)
+set_property(TARGET mbgl-expression-test PROPERTY FOLDER MapLibre)
 
 string(RANDOM LENGTH 5 ALPHABET 0123456789 MLN_EXPRESSION_TEST_SEED)
 

--- a/platform/glfw/CMakeLists.txt
+++ b/platform/glfw/CMakeLists.txt
@@ -101,6 +101,6 @@ if(NOT WIN32 AND MLN_WITH_OPENGL)
     )
 endif()
 
-set_property(TARGET mbgl-glfw PROPERTY FOLDER Executables)
+set_property(TARGET mbgl-glfw PROPERTY FOLDER MapLibre)
 
 install(TARGETS mbgl-glfw RUNTIME DESTINATION bin)

--- a/render-test/CMakeLists.txt
+++ b/render-test/CMakeLists.txt
@@ -59,4 +59,4 @@ target_link_libraries(
     PUBLIC mbgl-core
 )
 
-set_property(TARGET mbgl-render-test PROPERTY FOLDER Core)
+set_property(TARGET mbgl-render-test PROPERTY FOLDER MapLibre)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -237,7 +237,7 @@ if(WIN32)
     )
 endif()
 
-set_property(TARGET mbgl-test PROPERTY FOLDER Core)
+set_property(TARGET mbgl-test PROPERTY FOLDER MapLibre)
 
 if (MLN_WITH_CLANG_TIDY)
     set_target_properties(mbgl-test PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")


### PR DESCRIPTION
Manual cherry-pick of #2399 to the OpenGL 2 branch.