### PR TITLE
Speculative crash detection and prevention

### DIFF
--- a/include/mbgl/util/logging.hpp
+++ b/include/mbgl/util/logging.hpp
@@ -40,6 +40,7 @@ public:
     Log();
     ~Log();
 
+    static bool useLogThread();
     static void useLogThread(bool enable);
 
     template <typename ...Args>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -1168,6 +1168,20 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity" />
         </activity>
+        <!-- Benchmark -->
+        <activity
+            android:name=".activity.benchmark.BenchmarkActivity"
+            android:description="@string/description_world_tour_benchmark"
+            android:exported="true"
+            android:label="@string/activity_benchmark_world_tour"
+            >
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_benchmark" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity" />
+        </activity>
         <!-- For Instrumentation tests -->
         <activity
             android:name=".activity.style.RuntimeStyleTimingTestActivity"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/benchmark/BenchmarkActivity.kt
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/benchmark/BenchmarkActivity.kt
@@ -1,0 +1,211 @@
+package com.mapbox.mapboxsdk.testapp.activity.benchmark
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.os.Handler
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.maps.MapView
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.testapp.R
+import java.util.*
+
+class FpsStore {
+    private val fpsValues = ArrayList<Double>(100000)
+
+    fun add(fps: Double) {
+        fpsValues.add(fps)
+    }
+
+    fun reset() {
+        fpsValues.clear()
+    }
+
+    fun low1p(): Double {
+        fpsValues.sort()
+        return fpsValues.slice(0..(fpsValues.size / 100)).average()
+    }
+
+    fun average(): Double {
+        return fpsValues.average()
+    }
+}
+
+data class Result(val average: Double, val low1p: Double)
+
+data class Results(
+    var map: MutableMap<String, List<Result>> = mutableMapOf<String, List<Result>>().withDefault { emptyList() })
+    {
+
+    fun addResult(styleName: String, fpsStore: FpsStore) {
+        val newResults = map.getValue(styleName).plus(Result(fpsStore.average(), fpsStore.low1p()))
+        map[styleName] = newResults
+    }
+}
+
+/**
+ * Benchmark using a [android.view.TextureView]
+ */
+class BenchmarkActivity : AppCompatActivity() {
+    private lateinit var mapView: MapView
+    private lateinit var maplibreMap: MapboxMap
+    private var handler: Handler? = null
+    private var delayed: Runnable? = null
+    private var fpsStore = FpsStore()
+    private var results = Results()
+    private var runsLeft = 5
+
+    // the styles used for the benchmark
+    // can be overridden adding with developer-config.xml
+    // ```xml
+    //  <array name="benchmark_style_names">
+    //    <item>Americana</item>
+    //  </array>
+    //  <array name="benchmark_style_urls">
+    //    <item>https://zelonewolf.github.io/openstreetmap-americana/style.json</item>
+    // </array>
+    // ```
+    private var styles = listOf(Pair("Demotiles", "https://demotiles.maplibre.org/style.json"))
+
+    @SuppressLint("DiscouragedApi")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_benchmark)
+        handler = Handler(mainLooper)
+        setupToolbar()
+        setupMapView(savedInstanceState)
+
+        val styleNames = resources.getStringArray(applicationContext.resources.getIdentifier(
+            "benchmark_style_names",
+            "array",
+            applicationContext.packageName))
+        val styleURLs = resources.getStringArray(applicationContext.resources.getIdentifier(
+            "benchmark_style_urls",
+            "array",
+            applicationContext.packageName))
+        if (styleNames.isNotEmpty() && styleNames.size == styleURLs.size) {
+            styles = styleNames.zip(styleURLs)
+        }
+    }
+
+    private fun setupToolbar() {
+        val actionBar = supportActionBar
+        if (actionBar != null) {
+            supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+            supportActionBar!!.setHomeButtonEnabled(true)
+        }
+    }
+
+    private fun setupMapView(savedInstanceState: Bundle?) {
+        mapView = findViewById<View>(R.id.mapView) as MapView
+        mapView.getMapAsync { maplibreMap: MapboxMap ->
+            this@BenchmarkActivity.maplibreMap = maplibreMap
+            maplibreMap.setStyle(styles[0].second)
+            setFpsView(maplibreMap)
+
+            // Start an animation on the map as well
+            flyTo(maplibreMap, 0, 0,14.0)
+        }
+    }
+
+    private fun flyTo(maplibreMap: MapboxMap, place: Int, style: Int, zoom: Double) {
+        maplibreMap.animateCamera(
+            CameraUpdateFactory.newLatLngZoom(PLACES[place], zoom),
+            10000,
+            object : MapboxMap.CancelableCallback {
+                override fun onCancel() {
+                    delayed = Runnable {
+                        delayed = null
+                        flyTo(maplibreMap, place, style, zoom)
+                    }
+                    delayed?.let {
+                        handler!!.postDelayed(it, 2000)
+                    }
+                }
+
+                override fun onFinish() {
+                    if (place == PLACES.size - 1) {  // done with tour
+                        results.addResult(styles[style].first, fpsStore)
+                        fpsStore.reset()
+
+                        println("FPS results $results")
+
+                        if (style < styles.size - 1) {  // continue with next style
+                            maplibreMap.setStyle(styles[style + 1].second)
+                            flyTo(maplibreMap, 0, style + 1, zoom)
+                        } else if (runsLeft > 0) {  // start over
+                            --runsLeft
+                            maplibreMap.setStyle(styles[0].second)
+                            flyTo(maplibreMap, 0, 0, zoom)
+                        } else {
+                            finish()
+                        }
+                        return
+                    }
+
+                    // continue with next place
+                    flyTo(maplibreMap, place + 1, style, zoom)
+                }
+            }
+        )
+    }
+
+    private fun setFpsView(maplibreMap: MapboxMap) {
+        maplibreMap.setOnFpsChangedListener { fps: Double ->
+            fpsStore.add(fps)
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapView.onStart()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        mapView.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        mapView.onPause()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapView.onStop()
+        if (handler != null && delayed != null) {
+            handler!!.removeCallbacks(delayed!!)
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mapView.onSaveInstanceState(outState)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView.onDestroy()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView.onLowMemory()
+    }
+
+    companion object {
+        private val PLACES = arrayOf(
+            LatLng(37.7749, -122.4194), // SF
+            LatLng(38.9072, -77.0369), // DC
+            LatLng(52.3702, 4.8952), // AMS
+            LatLng(60.1699, 24.9384), // HEL
+            LatLng(-13.1639, -74.2236), // AYA
+            LatLng(52.5200, 13.4050), // BER
+            LatLng(12.9716, 77.5946), // BAN
+            LatLng(31.2304, 121.4737) // SHA
+        )
+    }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_benchmark.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_benchmark.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activity.benchmark.BenchmarkActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:maplibre_renderTextureMode="true"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_marker_bulk.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_marker_bulk.xml
@@ -9,7 +9,6 @@
         android:id="@id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/toolbar"
         app:maplibre_cameraTargetLat="38.87031"
         app:maplibre_cameraTargetLng="-77.00897"
         app:maplibre_cameraZoom="10"/>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_press_for_marker.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_press_for_marker.xml
@@ -9,7 +9,6 @@
         android:id="@id/mapView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/toolbar"
         app:maplibre_cameraTargetLat="45.1855569"
         app:maplibre_cameraTargetLng="5.7215506"
         app:maplibre_cameraZoom="11"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_query_features_box.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_query_features_box.xml
@@ -9,7 +9,6 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/toolbar"
         app:maplibre_cameraTargetLat="52.0907"
         app:maplibre_cameraTargetLng="5.1214"
         app:maplibre_cameraZoom="16"/>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -4,4 +4,7 @@
     <string name="fps30">fps30</string>
     <string name="fps60">fps60</string>
     <string name="this_is_an_empty_fragment">This is an empty Fragment</string>
+    <string name="category_benchmark">Benchmark</string>
+    <string name="activity_benchmark_world_tour">World Tour Benchmark</string>
+    <string name="description_world_tour_benchmark">Writes out avg. fps and 1% fps after world tour with .flyTo()</string>
 </resources>

--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -1,5 +1,7 @@
 #include <mbgl/layout/symbol_instance.hpp>
 #include <mbgl/style/layers/symbol_layer_properties.hpp>
+#include <mbgl/util/logging.hpp>
+
 #include <utility>
 
 namespace mbgl {
@@ -199,4 +201,72 @@ optional<size_t> SymbolInstance::getDefaultHorizontalPlacedTextIndex() const {
     if (placedLeftTextIndex) return placedLeftTextIndex;
     return nullopt;
 }
+
+namespace {
+    void logFailure(std::string msg) {
+        // Log some info about where we found unexpected values, forcing it to happen
+        // in the current thread to avoid the entry being lost if we are about to crash.
+        const bool saveUseThread = Log::useLogThread();
+        Log::useLogThread(false);
+        Log::Error(Event::Crash, msg);
+        Log::useLogThread(saveUseThread);
+    }
+}
+bool SymbolInstance::check(std::size_t v, int n, std::string_view source) const {
+    if (!isFailed && v != checkVal) {
+        isFailed = true;
+        logFailure("SymbolInstance corrupted at " + util::toString(n) + " with value " + util::toString(v) + " from '" + std::string(source) + "'");
+    }
+    return !isFailed;
+}
+
+bool SymbolInstance::checkKey() const {
+    if (!isFailed && key.size() > 1000) {   // largest observed value=62
+        isFailed = true;
+        logFailure("SymbolInstance key corrupted with size=" + util::toString(key.size()));
+    }
+    return !isFailed;
+}
+
+bool SymbolInstance::checkIndex(const optional<std::size_t>& index, std::size_t size, std::string_view source) const {
+    if (index.has_value() && *index >= size) {
+        isFailed = true;
+        logFailure("SymbolInstance index corrupted with value=" + util::toString(*index) + " size=" + util::toString(size) + " from '" + std::string(source) + "'");
+    }
+    return !isFailed;
+}
+
+// this is just to avoid warnings about the values never being set
+void SymbolInstance::forceFail() {
+    check01 =
+    check02 =
+    check03 =
+    check04 =
+    check05 =
+    check06 =
+    check07 =
+    check08 =
+    check09 =
+    check10 =
+    check11 =
+    check12 =
+    check13 =
+    check14 =
+    check15 =
+    check16 =
+    check17 =
+    check18 =
+    check19 =
+    check20 =
+    check21 =
+    check22 =
+    check23 =
+    check24 =
+    check25 =
+    check26 =
+    check27 =
+    check28 =
+    check29 = 0;
+}
+
 } // namespace mbgl

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -85,42 +85,161 @@ public:
     const optional<SymbolQuads>& verticalIconQuads() const;
     void releaseSharedData();
 
+    bool check(std::string_view source = std::string_view()) const {
+        return !isFailed &&
+                check(check01, 1, source) &&
+                check(check02, 2, source) &&
+                check(check03, 3, source) &&
+                check(check04, 4, source) &&
+                check(check05, 5, source) &&
+                check(check06, 6, source) &&
+                check(check07, 7, source) &&
+                check(check08, 8, source) &&
+                check(check09, 9, source) &&
+                check(check10, 10, source) &&
+                check(check11, 11, source) &&
+                check(check12, 12, source) &&
+                check(check13, 13, source) &&
+                check(check14, 14, source) &&
+                check(check15, 15, source) &&
+                check(check16, 16, source) &&
+                check(check17, 17, source) &&
+                check(check18, 18, source) &&
+                check(check19, 19, source) &&
+                check(check20, 20, source) &&
+                check(check21, 21, source) &&
+                check(check22, 22, source) &&
+                check(check23, 23, source) &&
+                check(check24, 24, source) &&
+                check(check25, 25, source) &&
+                check(check26, 26, source) &&
+                check(check27, 27, source) &&
+                check(check28, 28, source) &&
+                check(check29, 29, source);
+    }
+    bool checkIndex(const optional<std::size_t>& index, std::size_t size, std::string_view source) const;
+    bool checkIndexes(std::size_t textCount, std::size_t iconSize, std::size_t sdfSize, std::string_view source) const {
+        return !isFailed &&
+            checkIndex(placedRightTextIndex, textCount, source) &&
+            checkIndex(placedCenterTextIndex, textCount, source) &&
+            checkIndex(placedLeftTextIndex, textCount, source) &&
+            checkIndex(placedVerticalTextIndex, textCount, source) &&
+            checkIndex(placedIconIndex, hasSdfIcon() ? sdfSize : iconSize, source) &&
+            checkIndex(placedVerticalIconIndex, hasSdfIcon() ? sdfSize : iconSize, source);
+    }
+
+    const Anchor& getAnchor() const { check(); return anchor; }
+    std::size_t getRightJustifiedGlyphQuadsSize() const { check(); return rightJustifiedGlyphQuadsSize; }
+    std::size_t getCenterJustifiedGlyphQuadsSize() const { check(); return centerJustifiedGlyphQuadsSize; }
+    std::size_t getLeftJustifiedGlyphQuadsSize() const { check(); return leftJustifiedGlyphQuadsSize; }
+    std::size_t getVerticalGlyphQuadsSize() const { check(); return verticalGlyphQuadsSize; }
+    std::size_t getIconQuadsSize() const { check(); return iconQuadsSize; }
+    const CollisionFeature& getTextCollisionFeature() const { check(); return textCollisionFeature; }
+    const CollisionFeature& getIconCollisionFeature() const { check(); return iconCollisionFeature; }
+    const optional<CollisionFeature>& getVerticalTextCollisionFeature() const { check(); return verticalTextCollisionFeature; }
+    const optional<CollisionFeature>& getVerticalIconCollisionFeature() const { check(); return verticalIconCollisionFeature; }
+    WritingModeType getWritingModes() const { check(); return writingModes; }
+    std::size_t getLayoutFeatureIndex() const { check(); return layoutFeatureIndex; }
+    std::size_t getDataFeatureIndex() const { check(); return dataFeatureIndex; }
+    std::array<float, 2> getTextOffset() const { check(); return textOffset; }
+    std::array<float, 2> getIconOffset() const { check(); return iconOffset; }
+    const std::u16string& getKey() const { check(); checkKey(); return key; }
+    optional<size_t> getPlacedRightTextIndex() const { check(); return placedRightTextIndex; }
+    optional<size_t> getPlacedCenterTextIndex() const { check(); return placedCenterTextIndex; }
+    optional<size_t> getPlacedLeftTextIndex() const { check(); return placedLeftTextIndex; }
+    optional<size_t> getPlacedVerticalTextIndex() const { check(); return placedVerticalTextIndex; }
+    optional<size_t> getPlacedIconIndex() const { check(); return placedIconIndex; }
+    optional<size_t> getPlacedVerticalIconIndex() const { check(); return placedVerticalIconIndex; }
+    float getTextBoxScale() const { check(); return textBoxScale; }
+    std::array<float, 2> getVariableTextOffset() const { check(); return variableTextOffset; }
+    bool getSingleLine() const { check(); return singleLine; }
+
+    uint32_t getCrossTileID() const { check(); return crossTileID; }
+    void setCrossTileID(uint32_t x) { check(); crossTileID = x; check(); }
+
+    optional<size_t>& refPlacedRightTextIndex() { check(); return placedRightTextIndex; }
+    optional<size_t>& refPlacedCenterTextIndex() { check(); return placedCenterTextIndex; }
+    optional<size_t>& refPlacedLeftTextIndex() { check(); return placedLeftTextIndex; }
+    optional<size_t>& refPlacedVerticalTextIndex() { check(); return placedVerticalTextIndex; }
+    optional<size_t>& refPlacedIconIndex() { check(); return placedIconIndex; }
+    optional<size_t>& refPlacedVerticalIconIndex() { check(); return placedVerticalIconIndex; }
+
+    void setPlacedRightTextIndex(optional<size_t> x) { check(); placedRightTextIndex = x; check(); }
+    void setPlacedCenterTextIndex(optional<size_t> x) { check(); placedCenterTextIndex = x; check(); }
+    void setPlacedLeftTextIndex(optional<size_t> x) { check(); placedLeftTextIndex = x; check(); }
+
+    static constexpr uint32_t invalidCrossTileID() { return std::numeric_limits<uint32_t>::max(); }
+
+protected:
+    bool check(std::size_t v, int n, std::string_view source) const;
+    bool checkKey() const;
+    void forceFail();  // this is just to avoid warnings about the values never being set
+
 private:
     std::shared_ptr<SymbolInstanceSharedData> sharedData;
 
-public:
+    static constexpr std::size_t checkVal = static_cast<std::size_t>(0x123456780ABCDEFFULL);
+
+    std::size_t check01 = checkVal;
     Anchor anchor;
+    std::size_t check02 = checkVal;
     SymbolContent symbolContent;
+    std::size_t check03 = checkVal;
 
     std::size_t rightJustifiedGlyphQuadsSize;
+    std::size_t check04 = checkVal;
     std::size_t centerJustifiedGlyphQuadsSize;
+    std::size_t check05 = checkVal;
     std::size_t leftJustifiedGlyphQuadsSize;
+    std::size_t check06 = checkVal;
     std::size_t verticalGlyphQuadsSize;
+    std::size_t check07 = checkVal;
     std::size_t iconQuadsSize;
+    std::size_t check08 = checkVal;
 
     CollisionFeature textCollisionFeature;
+    std::size_t check09 = checkVal;
     CollisionFeature iconCollisionFeature;
+    std::size_t check10 = checkVal;
     optional<CollisionFeature> verticalTextCollisionFeature = nullopt;
+    std::size_t check11 = checkVal;
     optional<CollisionFeature> verticalIconCollisionFeature = nullopt;
+    std::size_t check12 = checkVal;
     WritingModeType writingModes;
+    std::size_t check13 = checkVal;
     std::size_t layoutFeatureIndex; // Index into the set of features included at layout time
+    std::size_t check14 = checkVal;
     std::size_t dataFeatureIndex;   // Index into the underlying tile data feature set
+    std::size_t check15 = checkVal;
     std::array<float, 2> textOffset;
+    std::size_t check16 = checkVal;
     std::array<float, 2> iconOffset;
+    std::size_t check17 = checkVal;
     std::u16string key;
-    bool isDuplicate;
-    optional<size_t> placedRightTextIndex;
-    optional<size_t> placedCenterTextIndex;
-    optional<size_t> placedLeftTextIndex;
-    optional<size_t> placedVerticalTextIndex;
-    optional<size_t> placedIconIndex;
-    optional<size_t> placedVerticalIconIndex;
+    std::size_t check18 = checkVal;
+    //bool isDuplicate;
+    std::size_t check19 = checkVal;
+    optional<std::size_t> placedRightTextIndex;
+    std::size_t check20 = checkVal;
+    optional<std::size_t> placedCenterTextIndex;
+    std::size_t check21 = checkVal;
+    optional<std::size_t> placedLeftTextIndex;
+    std::size_t check22 = checkVal;
+    optional<std::size_t> placedVerticalTextIndex;
+    std::size_t check23 = checkVal;
+    optional<std::size_t> placedIconIndex;
+    std::size_t check24 = checkVal;
+    optional<std::size_t> placedVerticalIconIndex;
+    std::size_t check25 = checkVal;
     float textBoxScale;
+    std::size_t check26 = checkVal;
     std::array<float, 2> variableTextOffset;
+    std::size_t check27 = checkVal;
     bool singleLine;
+    std::size_t check28 = checkVal;
     uint32_t crossTileID = 0;
-
-    static constexpr uint32_t invalidCrossTileID() { return std::numeric_limits<uint32_t>::max(); }
+    std::size_t check29 = checkVal;
+    mutable bool isFailed;
 };
 
 using SymbolInstanceReferences = std::vector<std::reference_wrapper<const SymbolInstance>>;

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -246,31 +246,33 @@ void SymbolBucket::sortFeatures(const float angle) {
     // The index array buffer is rewritten to reference the (unchanged) vertices in the
     // sorted order.
     for (const SymbolInstance& symbolInstance : getSortedSymbols(angle)) {
-        symbolsSortOrder->push_back(symbolInstance.dataFeatureIndex);
+        if (!symbolInstance.check("sortFeatures")) continue;
+        if (!symbolInstance.checkIndexes(text.placedSymbols.size(), icon.placedSymbols.size(), sdfIcon.placedSymbols.size(), "sortFeatures")) continue;
+        symbolsSortOrder->push_back(symbolInstance.getDataFeatureIndex());
 
-        if (symbolInstance.placedRightTextIndex) {
-            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.placedRightTextIndex]);
+        if (symbolInstance.getPlacedRightTextIndex()) {
+            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.getPlacedRightTextIndex()]);
         }
 
-        if (symbolInstance.placedCenterTextIndex && !symbolInstance.singleLine) {
-            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.placedCenterTextIndex]);
+        if (symbolInstance.getPlacedCenterTextIndex() && !symbolInstance.getSingleLine()) {
+            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.getPlacedCenterTextIndex()]);
         }
 
-        if (symbolInstance.placedLeftTextIndex && !symbolInstance.singleLine) {
-            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.placedLeftTextIndex]);
+        if (symbolInstance.getPlacedLeftTextIndex() && !symbolInstance.getSingleLine()) {
+            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.getPlacedLeftTextIndex()]);
         }
 
-        if (symbolInstance.placedVerticalTextIndex) {
-            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.placedVerticalTextIndex]);
+        if (symbolInstance.getPlacedVerticalTextIndex()) {
+            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.getPlacedVerticalTextIndex()]);
         }
 
         auto& iconBuffer = symbolInstance.hasSdfIcon() ? sdfIcon : icon;
-        if (symbolInstance.placedIconIndex) {
-            addPlacedSymbol(iconBuffer.triangles, iconBuffer.placedSymbols[*symbolInstance.placedIconIndex]);
+        if (symbolInstance.getPlacedIconIndex()) {
+            addPlacedSymbol(iconBuffer.triangles, iconBuffer.placedSymbols[*symbolInstance.getPlacedIconIndex()]);
         }
 
-        if (symbolInstance.placedVerticalIconIndex) {
-            addPlacedSymbol(iconBuffer.triangles, iconBuffer.placedSymbols[*symbolInstance.placedVerticalIconIndex]);
+        if (symbolInstance.getPlacedVerticalIconIndex()) {
+            addPlacedSymbol(iconBuffer.triangles, iconBuffer.placedSymbols[*symbolInstance.getPlacedVerticalIconIndex()]);
         }
     }
 
@@ -283,12 +285,12 @@ SymbolInstanceReferences SymbolBucket::getSortedSymbols(const float angle) const
     const float cos = std::cos(angle);
 
     std::sort(result.begin(), result.end(), [sin, cos](const SymbolInstance& a, const SymbolInstance& b) {
-        const auto aRotated = std::lround(sin * a.anchor.point.x + cos * a.anchor.point.y);
-        const auto bRotated = std::lround(sin * b.anchor.point.x + cos * b.anchor.point.y);
+        const auto aRotated = std::lround(sin * a.getAnchor().point.x + cos * a.getAnchor().point.y);
+        const auto bRotated = std::lround(sin * b.getAnchor().point.x + cos * b.getAnchor().point.y);
         if (aRotated != bRotated) {
             return aRotated < bRotated;
         }
-        return a.dataFeatureIndex > b.dataFeatureIndex;  // aRotated == bRotated
+        return a.getDataFeatureIndex() > b.getDataFeatureIndex();  // aRotated == bRotated
     });
 
     return result;

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -12,8 +12,8 @@ TileLayerIndex::TileLayerIndex(OverscaledTileID coord_,
                                std::string bucketLeaderId_)
     : coord(coord_), bucketInstanceId(bucketInstanceId_), bucketLeaderId(std::move(bucketLeaderId_)) {
     for (SymbolInstance& symbolInstance : symbolInstances) {
-        if (symbolInstance.crossTileID == SymbolInstance::invalidCrossTileID()) continue;
-        indexedSymbolInstances[symbolInstance.key].emplace_back(symbolInstance.crossTileID,
+        if (symbolInstance.getCrossTileID() == SymbolInstance::invalidCrossTileID()) continue;
+        indexedSymbolInstances[symbolInstance.getKey()].emplace_back(symbolInstance.getCrossTileID(),
                                                                 getScaledCoordinates(symbolInstance, coord));
     }
 }
@@ -24,8 +24,8 @@ Point<int64_t> TileLayerIndex::getScaledCoordinates(SymbolInstance& symbolInstan
     const double roundingFactor = 512.0 / util::EXTENT / 2.0;
     const double scale = roundingFactor / std::pow(2, childTileCoord.canonical.z - coord.canonical.z);
     return {
-        static_cast<int64_t>(std::floor((childTileCoord.canonical.x * util::EXTENT + symbolInstance.anchor.point.x) * scale)),
-        static_cast<int64_t>(std::floor((childTileCoord.canonical.y * util::EXTENT + symbolInstance.anchor.point.y) * scale))
+        static_cast<int64_t>(std::floor((childTileCoord.canonical.x * util::EXTENT + symbolInstance.getAnchor().point.x) * scale)),
+        static_cast<int64_t>(std::floor((childTileCoord.canonical.y * util::EXTENT + symbolInstance.getAnchor().point.y) * scale))
     };
 }
 
@@ -38,12 +38,12 @@ void TileLayerIndex::findMatches(SymbolBucket& bucket,
     if (bucket.bucketLeaderID != bucketLeaderId) return;
 
     for (auto& symbolInstance : symbolInstances) {
-        if (symbolInstance.crossTileID) {
+        if (symbolInstance.getCrossTileID()) {
             // already has a match, skip
             continue;
         }
 
-        auto it = indexedSymbolInstances.find(symbolInstance.key);
+        auto it = indexedSymbolInstances.find(symbolInstance.getKey());
         if (it == indexedSymbolInstances.end()) {
             // No symbol with this key in this bucket
             continue;
@@ -61,7 +61,7 @@ void TileLayerIndex::findMatches(SymbolBucket& bucket,
                 // don't let any other symbols at the same zoom level duplicate against
                 // the same parent (see issue #10844)
                 zoomCrossTileIDs.insert(thisTileSymbol.crossTileID);
-                symbolInstance.crossTileID = thisTileSymbol.crossTileID;
+                symbolInstance.setCrossTileID(thisTileSymbol.crossTileID);
                 break;
             }
         }
@@ -134,16 +134,16 @@ bool CrossTileSymbolLayerIndex::addBucket(const OverscaledTileID& tileID,
         // For overscaled tiles the viewport might be showing only a small part of the tile,
         // so we filter out the off-screen symbols to improve the performance.
         for (auto& symbolInstance : bucket.symbolInstances) {
-            if (isInVewport(tileMatrix, symbolInstance.anchor.point)) {
-                symbolInstance.crossTileID = 0u;
+            if (isInVewport(tileMatrix, symbolInstance.getAnchor().point)) {
+                symbolInstance.setCrossTileID(0u);
             } else {
-                symbolInstance.crossTileID = SymbolInstance::invalidCrossTileID();
+                symbolInstance.setCrossTileID(SymbolInstance::invalidCrossTileID());
                 bucket.hasUninitializedSymbols = true;
             }
         }
     } else {
         for (auto& symbolInstance : bucket.symbolInstances) {
-            symbolInstance.crossTileID = 0u;
+            symbolInstance.setCrossTileID(0u);
         }
     }
 
@@ -168,10 +168,10 @@ bool CrossTileSymbolLayerIndex::addBucket(const OverscaledTileID& tileID,
     }
 
     for (auto& symbolInstance : bucket.symbolInstances) {
-        if (!symbolInstance.crossTileID) {
+        if (!symbolInstance.getCrossTileID()) {
             // symbol did not match any known symbol, assign a new id
-            symbolInstance.crossTileID = ++maxCrossTileID;
-            thisZoomUsedCrossTileIDs.insert(symbolInstance.crossTileID);
+            symbolInstance.setCrossTileID(++maxCrossTileID);
+            thisZoomUsedCrossTileIDs.insert(symbolInstance.getCrossTileID());
         }
     }
 

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -151,7 +151,7 @@ protected:
                                  style::SymbolPlacementType,
                                  const std::vector<ProjectedCollisionBox>& /*textBoxes*/,
                                  const std::vector<ProjectedCollisionBox>& /*iconBoxes*/) {}
-    // Implentation specific hooks, which get called during a symbol bucket placement.
+    // Implementation specific hooks, which get called during a symbol bucket placement.
     virtual optional<CollisionBoundaries> getAvoidEdges(const SymbolBucket&, const mat4& /*posMatrix*/) {
         return nullopt;
     }

--- a/src/mbgl/util/logging.cpp
+++ b/src/mbgl/util/logging.cpp
@@ -44,6 +44,10 @@ Log* Log::get() noexcept {
     return &instance;
 }
 
+bool Log::useLogThread() {
+    return useThread;
+}
+
 void Log::useLogThread(bool enable) {
     useThread = enable;
 }


### PR DESCRIPTION
External call stacks indicate several crashes that seem like they must be caused by members from the pointer portion of `key` to `placedVerticalIconIndex` becoming unexpectedly invalid.

We insert fixed values between each member and check them on each access in hopes of narrowing down the range of potential places from which this could be caused and skip further processing of the symbol instance once any invalid value has been detected.

Also includes the benchmarking activity from #1850 to confirm that there's no major effect on performance.


```
10.3.1

Result(average=1137.1406652094868, low1p=206.20395674648492),
Result(average=972.6569705258048, low1p=195.68381800358537),
Result(average=1006.3422475857232, low1p=196.21148643908523),
Result(average=979.1130397712535, low1p=195.33316971831644),
Result(average=999.3013716059238, low1p=192.15926101090554),
Result(average=967.7307632612294, low1p=191.03237983679773)]})

10.3.1.1

Result(average=1102.1602248079416, low1p=203.00198974531042),
Result(average=997.9265047694663, low1p=189.26893108387634),
Result(average=1043.7275178877694, low1p=194.42137487148483),
Result(average=1049.3060329936836, low1p=198.54736418525866),
Result(average=1036.1822841437606, low1p=192.19624842621522),
Result(average=1043.3555232138212, low1p=196.9277046632644)]})
```

`clang-format` modifies almost the entire contents of every file, so I'll do that after people have had a chance to look at the meaningful differences.
