### PR TITLE
[node] Temporarily Exclude ABI 127

### DIFF
--- a/platform/node/CMakeLists.txt
+++ b/platform/node/CMakeLists.txt
@@ -12,6 +12,7 @@ add_node_module(
         47
         48
         51
+        127
 )
 
 if(WIN32)


### PR DESCRIPTION
Node 22 binaries are failing to build with the following error. This temporarily explode it from building until it can be fixed
![image](https://github.com/maplibre/maplibre-native/assets/3792408/1139ce75-10c5-4b85-8cac-e7e5367dd985)
