### PR TITLE
[node] Update nan to 2.19.0

### DIFF
--- a/platform/node/CMakeLists.txt
+++ b/platform/node/CMakeLists.txt
@@ -6,7 +6,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/module.cmake)
 add_node_module(
     mbgl-node
     INSTALL_PATH ${PROJECT_SOURCE_DIR}/lib/{node_abi}/mbgl.node
-    NAN_VERSION 2.18.0
+    NAN_VERSION 2.19.0
     EXCLUDE_NODE_ABIS
         46
         47


### PR DESCRIPTION
Fixes the node build error caused by SetAccessor. I think this was fixed by https://github.com/nodejs/nan/pull/966
![image](https://github.com/maplibre/maplibre-native/assets/3792408/812e565d-9b6c-465e-8bd3-5456b6fe1d03)
