### PR TITLE
Allow pre-releases from branches

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -11,6 +11,10 @@ on:
           - pre
           - no
         description: Whether to make a release, choose full release (uses platform/ios/VERSION) or pre-release
+      pre_release_version:
+        type: string
+        default: ''
+        description: Version (only for pre-releases)
   push:
     branches:
       - main
@@ -204,7 +208,7 @@ jobs:
   ios-release:
     runs-on: macos-14
     needs: ios-build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event.inputs.release == 'pre'
     defaults:
       run:
         working-directory: platform/ios
@@ -251,7 +255,11 @@ jobs:
       - name: Get version (pre-release)
         if: github.event.inputs.release == 'pre'
         run: |
-          echo version="$(head VERSION)"-pre${{ github.sha }} >> "$GITHUB_ENV"
+          version="${{ github.event.inputs.pre_release_version }}"
+          if [[ -z "$version" ]]; then
+            version="$(head VERSION)"-pre${{ github.sha }}
+          fi
+          echo version="$version" >> "$GITHUB_ENV"
           echo changelog_version_heading="## main" >> "$GITHUB_ENV"
 
       - name: Extract changelog for version


### PR DESCRIPTION
Sometimes we may want to cut a pre-release from another branch.

These workflow changes make it possible.

You have pass the version in the GitHub GUI, it won't read it from `platform/ios/VERSION` like normal releases, which should only be bumped for official releases.

![image](https://github.com/maplibre/maplibre-native/assets/649392/daaca6e6-ca06-4c6c-8919-df6e206cc8b2)
