### PR TITLE
Annotation view recycling re-enabled

### DIFF
--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -6974,14 +6974,18 @@ static void *windowScreenContext = &windowScreenContext;
 
         if (annotationView)
         {
-            annotationView.center = MLNPointRounded([self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self]);
+            CLLocationCoordinate2D coordinate = annotation.coordinate;
 
             // Every so often (1 out of 1000 frames?) the mbgl query mechanism fails. This logic spot checks the
             // offscreenAnnotations values -- if they are actually still on screen then the view center is
             // moved and the enqueue operation is avoided. This allows us to keep the performance benefit of
             // using the mbgl query result. It also forces views that have just gone offscreen to be cleared
             // fully from view.
-            if (!MLNCoordinateInCoordinateBounds(annotation.coordinate, coordinateBounds))
+            if (MLNCoordinateInCoordinateBounds(coordinate, coordinateBounds))
+            {
+                annotationView.center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
+            }
+            else
             {
                 if (annotationView.layer.animationKeys.count > 0) {
                     continue;
@@ -6991,12 +6995,8 @@ static void *windowScreenContext = &windowScreenContext;
                 CGPoint adjustedCenter = annotationView.center;
                 adjustedCenter.x = -CGRectGetWidth(self.frame) * 10.0;
                 annotationView.center = adjustedCenter;
-
-                // Disable the offscreen annotation view recycling on Metal because of issue https://github.com/maplibre/maplibre-native/issues/2117
-                // TLDR: Metal view rendering stutter / freeze
-#if !MLN_RENDER_BACKEND_METAL
-                 [self enqueueAnnotationViewForAnnotationContext:annotationContext];
-#endif
+                
+                [self enqueueAnnotationViewForAnnotationContext:annotationContext];
             }
         }
     }


### PR DESCRIPTION
Reverted code that disabled annotation view recycling, from this PR: https://github.com/maplibre/maplibre-native/pull/2148.
We don't need that workaround after fixing the `presentsWithTransaction` rendering in this PR: https://github.com/maplibre/maplibre-native/pull/2442.

Before `presentsWithTransaction` fix:

https://github.com/maplibre/maplibre-native/assets/19795769/e858aedc-520b-469b-9671-b5833faf7d6e

After `presentsWithTransaction` fix:

https://github.com/maplibre/maplibre-native/assets/19795769/0d6b8e9a-0a17-4b2d-967b-609a88c65b25
