### PR TITLE
Update vector-tile to MapLibre fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/mapbox/protozero.git
 [submodule "vendor/vector-tile"]
 	path = vendor/vector-tile
-	url = https://github.com/mapbox/vector-tile.git
+	url = https://github.com/maplibre/mvt-cpp.git
 [submodule "vendor/wagyu"]
 	path = vendor/wagyu
 	url = https://github.com/mapbox/wagyu.git

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🐞 Bug fixes
 
+- Fixes crash that happened with some PBF files ([Issue](https://github.com/maplibre/maplibre-native/issues/795), [PR](https://github.com/maplibre/maplibre-native/pull/2460)). 
+
 ## 11.0.0
 
 The rendering internals of MapLibre Native have undergone major changes. We've had an extensive period of [pre-releases](https://github.com/maplibre/maplibre-native/issues/1608) leading up to this official release. While we've worked hard to minimize potential issues, it's possible that there may still be regressions. Therefore, it's important to conduct your own testing and report any encountered issues on GitHub.

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,9 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 
 ## main
 
+- Fixes crash that happened with some PBF files ([Issue](https://github.com/maplibre/maplibre-native/issues/795), [PR](https://github.com/maplibre/maplibre-native/pull/2460)). 
+
+
 ## 6.4.2
 
 - Fix Metal frame glitch on older devices ([#2379](https://github.com/maplibre/maplibre-native/pull/2379)).


### PR DESCRIPTION
Updates the vector-tile vendored dependency to use the MapLibre fork hosted at https://github.com/maplibre/mvt-cpp

Includes a commit cherry-picked by @nathreed https://github.com/maplibre/mvt-cpp/pull/2 

Closes https://github.com/maplibre/maplibre-native/issues/795

| Style     | Metric                | mvt-cpp       | vector-tiles  |
|-----------|-----------------------|---------------|---------------|
| Americana | avgEncodingTime       | 13.0449364383 | 13.9205717752 |
| Americana | low1pEncodingTime     | 59.4919468571 | 63.3725865995 |
| Americana | avgRenderingTime      | 12.2574985444 | 12.8400150678 |
| Americana | low1pRenderingTime    | 37.3708819947 | 36.2964980954 |

Also some progress towards https://github.com/maplibre/maplibre-native/issues/2227
