### PR TITLE
Remove Mapbox optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1392,7 +1392,6 @@ export(TARGETS
     mapbox-base-geojson.hpp
     mapbox-base-geometry.hpp
     mapbox-base-jni.hpp
-    mapbox-base-optional
     mapbox-base-pixelmatch-cpp
     mapbox-base-shelf-pack-cpp
     mapbox-base-supercluster.hpp

--- a/platform/android/android.cmake
+++ b/platform/android/android.cmake
@@ -110,7 +110,6 @@ target_link_libraries(
     PRIVATE
         GLESv3
         Mapbox::Base
-        Mapbox::Base::optional
         log
         mbgl-compiler-options
 )

--- a/vendor/BUILD.bazel
+++ b/vendor/BUILD.bazel
@@ -44,7 +44,6 @@ cc_library(
         "mapbox-base/include",
     ],
     visibility = ["//visibility:public"],
-    deps = ["optional"],
 )
 
 # vendor/parsedate
@@ -54,15 +53,6 @@ cc_library(
     hdrs = glob(["parsedate/**/*.hpp"]),
     copts = CPP_FLAGS,
     includes = ["parsedate"],
-    visibility = ["//visibility:public"],
-)
-
-# vendor/optional
-cc_library(
-    name = "optional",
-    hdrs = glob(["mapbox-base/deps/optional/*.hpp"]),
-    copts = CPP_FLAGS,
-    includes = ["mapbox-base/deps/optional"],
     visibility = ["//visibility:public"],
 )
 
@@ -78,7 +68,6 @@ cc_library(
     copts = CPP_FLAGS,
     includes = ["csscolorparser"],
     visibility = ["//visibility:public"],
-    deps = ["optional"],
 )
 
 # vendor/wagyu-files.json

--- a/vendor/csscolorparser.cmake
+++ b/vendor/csscolorparser.cmake
@@ -15,7 +15,7 @@ target_sources(
 
 target_link_libraries(
     mbgl-vendor-csscolorparser
-    PRIVATE Mapbox::Base::optional mbgl-compiler-options
+    PRIVATE mbgl-compiler-options
 )
 
 target_include_directories(

--- a/vendor/mapbox-base.cmake
+++ b/vendor/mapbox-base.cmake
@@ -77,15 +77,6 @@ set_target_properties(
 )
 
 set_target_properties(
-    mapbox-base-optional
-    PROPERTIES
-        INTERFACE_MAPBOX_NAME "Optional"
-        INTERFACE_MAPBOX_URL "https://github.com/akrzemi1/Optional"
-        INTERFACE_MAPBOX_AUTHOR "Andrzej Krzemienski"
-        INTERFACE_MAPBOX_LICENSE ${CMAKE_CURRENT_LIST_DIR}/mapbox-base/deps/optional/LICENSE
-)
-
-set_target_properties(
     mapbox-base
     PROPERTIES
         INTERFACE_MAPBOX_NAME "mapbox-base"


### PR DESCRIPTION
I removed Mapbox' optional implementation from https://github.com/maplibre/maplibre-native-base

Updating the submodule to remove it completely. We already switched to `std::optional`.

Maybe it will shave off some bytes.