### PR TITLE
Android build config maintenance

### DIFF
--- a/benchmark/android/build.gradle
+++ b/benchmark/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
        google()
-       jcenter()
+       mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
@@ -12,7 +12,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/platform/android/MapLibreAndroid/build.gradle
+++ b/platform/android/MapLibreAndroid/build.gradle
@@ -131,6 +131,9 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    buildFeatures {
+        buildConfig true
+    }
 }
 
 licenseReport {

--- a/platform/android/MapLibreAndroid/src/cpp/CMakeLists.txt
+++ b/platform/android/MapLibreAndroid/src/cpp/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
+project(MapLibreAndroid)
+
 add_subdirectory(../../../../../
                  ../../../../../${ANDROID_ABI})
 

--- a/platform/android/MapLibreAndroidTestApp/build.gradle
+++ b/platform/android/MapLibreAndroidTestApp/build.gradle
@@ -78,6 +78,7 @@ android {
 
     buildFeatures {
         viewBinding = true
+        buildConfig true
     }
 
     namespace 'org.maplibre.android.testapp'

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/feature/QueryRenderedFeaturesBoxSymbolCountActivity.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/feature/QueryRenderedFeaturesBoxSymbolCountActivity.kt
@@ -26,7 +26,7 @@ class QueryRenderedFeaturesBoxSymbolCountActivity : AppCompatActivity() {
     lateinit var mapView: MapView
     lateinit var maplibreMap: MapLibreMap
         private set
-    private lateinit var toast: Toast
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_query_features_box)
@@ -80,15 +80,11 @@ class QueryRenderedFeaturesBoxSymbolCountActivity : AppCompatActivity() {
                 val features = maplibreMap.queryRenderedFeatures(box, "symbols-layer")
 
                 // Show count
-                if (toast != null) {
-                    toast!!.cancel()
-                }
-                toast = Toast.makeText(
+                 Toast.makeText(
                     this@QueryRenderedFeaturesBoxSymbolCountActivity,
-                    String.format("%s features in box", features.size),
+                    "${features.size} feature${if (features.size == 1) "" else "s"} in box",
                     Toast.LENGTH_SHORT
-                )
-                toast.show()
+                ).show()
             }
         }
     }

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_espresso_test.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_espresso_test.xml
@@ -9,7 +9,6 @@
         android:id="@id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/toolbar"
         app:maplibre_cameraZoom="1"/>
 
 </RelativeLayout>

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_manual_zoom.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_manual_zoom.xml
@@ -9,7 +9,6 @@
         android:id="@id/mapView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/toolbar"
         app:maplibre_cameraBearing="220"
         app:maplibre_cameraTargetLat="50.871062"
         app:maplibre_cameraTargetLng="1.583210"

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_marker_bulk.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_marker_bulk.xml
@@ -9,7 +9,6 @@
         android:id="@id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/toolbar"
         app:maplibre_cameraTargetLat="38.87031"
         app:maplibre_cameraTargetLng="-77.00897"
         app:maplibre_cameraZoom="10"/>

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_press_for_marker.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_press_for_marker.xml
@@ -9,7 +9,6 @@
         android:id="@id/mapView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/toolbar"
         app:maplibre_cameraTargetLat="45.1855569"
         app:maplibre_cameraTargetLng="5.7215506"
         app:maplibre_cameraZoom="11"

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_query_features_box.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_query_features_box.xml
@@ -9,7 +9,6 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/toolbar"
         app:maplibre_cameraTargetLat="52.0907"
         app:maplibre_cameraTargetLng="5.1214"
         app:maplibre_cameraZoom="16"/>

--- a/platform/android/gradle.properties
+++ b/platform/android/gradle.properties
@@ -2,6 +2,5 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.http.connectionTimeout=360000
 systemProp.org.gradle.internal.http.socketTimeout=360000
 org.gradle.jvmargs=-Xmx4096M
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/platform/android/gradle/gradle-publish.gradle
+++ b/platform/android/gradle/gradle-publish.gradle
@@ -77,7 +77,7 @@ afterEvaluate {
 afterEvaluate { project ->
     android.libraryVariants.all { variant ->
         tasks.androidJavadocs.doFirst {
-            classpath += files(variant.javaCompile.classpath.files)
+            classpath += files(variant.javaCompileProvider.get().classpath.files)
         }
     }
 }

--- a/render-test/android/build.gradle
+++ b/render-test/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
        google()
-       jcenter()
+       mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.4.1'
@@ -11,6 +11,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/test/android/build.gradle
+++ b/test/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
        google()
-       jcenter()
+       mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.1'
@@ -12,7 +12,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Assorted Android maintenance (build config and test app)

- `variant.javaCompile` was scheduled to be deleted at the end of 2019, but it will be finally removed with Gradle 9.0 apparantly. Fixed.
- Replaced `jcenter()` with `mavenCentral()`
- Run Refactor > Migrate BuildConfig to Gradle Build Files this adds the `buildConfig` lines. More: https://stackoverflow.com/a/74692390/1929678
- Remove reference to non-existing `@id/toolbar`
- Fix crash in activity in demo app.
- Add `project(...)` to CMakeLists.txt to remove warning.
