### PR TITLE
Metal base vertex instance drawing disabled on GPUFamilyApple2 devices

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
   hooks:
     - id: buildifier
 - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
-  rev: v1.7.0.14
+  rev: v1.7.1.15
   hooks:
     - id: actionlint
       additional_dependencies: [shellcheck-py]

--- a/include/mbgl/mtl/renderer_backend.hpp
+++ b/include/mbgl/mtl/renderer_backend.hpp
@@ -32,7 +32,7 @@ public:
 
     const MTLDevicePtr& getDevice() const { return device; }
     const MTLCommandQueuePtr& getCommandQueue() const { return commandQueue; }
-    const bool isInstanceDrawingSupported() const { return instanceDrawingSupported; }
+    const bool isBaseVertexInstanceDrawingSupported() const { return baseVertexInstanceDrawingSupported; }
 
 protected:
     std::unique_ptr<gfx::Context> createContext() override;
@@ -62,7 +62,7 @@ public:
 protected:
     MTLDevicePtr device;
     MTLCommandQueuePtr commandQueue;
-    bool instanceDrawingSupported = false;
+    bool baseVertexInstanceDrawingSupported = false;
 };
 
 } // namespace mtl

--- a/include/mbgl/mtl/renderer_backend.hpp
+++ b/include/mbgl/mtl/renderer_backend.hpp
@@ -32,6 +32,7 @@ public:
 
     const MTLDevicePtr& getDevice() const { return device; }
     const MTLCommandQueuePtr& getCommandQueue() const { return commandQueue; }
+    const bool isInstanceDrawingSupported() const { return instanceDrawingSupported; }
 
 protected:
     std::unique_ptr<gfx::Context> createContext() override;
@@ -61,6 +62,7 @@ public:
 protected:
     MTLDevicePtr device;
     MTLCommandQueuePtr commandQueue;
+    bool instanceDrawingSupported = false;
 };
 
 } // namespace mtl

--- a/src/mbgl/mtl/context.cpp
+++ b/src/mbgl/mtl/context.cpp
@@ -416,9 +416,7 @@ bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,
                                    MTL::IndexType::IndexTypeUInt16,
                                    indexRes->getMetalBuffer().get(),
                                    /*indexOffset=*/0,
-                                   /*instanceCount=*/static_cast<NS::UInteger>(tileUBOs.size()),
-                                   /*baseVertex=*/0,
-                                   /*baseInstance=*/0);
+                                   /*instanceCount=*/static_cast<NS::UInteger>(tileUBOs.size()));
 #else
     const auto uboIndex = ShaderClass::uniforms[0].index;
     for (std::size_t ii = 0; ii < tileUBOs.size(); ++ii) {
@@ -428,7 +426,8 @@ bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,
                                        indexCount,
                                        MTL::IndexType::IndexTypeUInt16,
                                        indexRes->getMetalBuffer().get(),
-                                       /*indexOffset=*/0);
+                                       /*indexOffset=*/0,
+                                       /*instanceCount=*/1);
     }
 #endif
 

--- a/src/mbgl/mtl/context.cpp
+++ b/src/mbgl/mtl/context.cpp
@@ -428,10 +428,7 @@ bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,
                                        indexCount,
                                        MTL::IndexType::IndexTypeUInt16,
                                        indexRes->getMetalBuffer().get(),
-                                       /*indexOffset=*/0,
-                                       /*instanceCount=*/1,
-                                       /*baseVertex=*/0,
-                                       /*baseInstance=*/0);
+                                       /*indexOffset=*/0);
     }
 #endif
 

--- a/src/mbgl/mtl/drawable.cpp
+++ b/src/mbgl/mtl/drawable.cpp
@@ -303,7 +303,8 @@ void Drawable::draw(PaintParameters& parameters) const {
                                                baseInstance);
             } else {
                 if (instanceCount == 1) {
-                    encoder->drawIndexedPrimitives(primitiveType, mlSegment.indexLength, indexType, indexBuffer, indexOffset);
+                    encoder->drawIndexedPrimitives(
+                        primitiveType, mlSegment.indexLength, indexType, indexBuffer, indexOffset);
                 } else {
                     assert(!"Base Vertex Instance Drawing is only supported on MTLGPUFamilyApple3 and later.");
                 }

--- a/src/mbgl/mtl/drawable.cpp
+++ b/src/mbgl/mtl/drawable.cpp
@@ -292,7 +292,7 @@ void Drawable::draw(PaintParameters& parameters) const {
             assert(static_cast<std::size_t>(maxIndex) < mlSegment.vertexLength);
 #endif
 
-            if (instanceCount > 1 ) {
+            if (instanceCount > 1) {
                 encoder->drawIndexedPrimitives(primitiveType,
                                                mlSegment.indexLength,
                                                indexType,
@@ -302,11 +302,8 @@ void Drawable::draw(PaintParameters& parameters) const {
                                                baseVertex,
                                                baseInstance);
             } else {
-                encoder->drawIndexedPrimitives(primitiveType,
-                                               mlSegment.indexLength,
-                                               indexType,
-                                               indexBuffer,
-                                               indexOffset);
+                encoder->drawIndexedPrimitives(
+                    primitiveType, mlSegment.indexLength, indexType, indexBuffer, indexOffset);
             }
 
             context.renderingStats().numDrawCalls++;

--- a/src/mbgl/mtl/drawable.cpp
+++ b/src/mbgl/mtl/drawable.cpp
@@ -292,14 +292,23 @@ void Drawable::draw(PaintParameters& parameters) const {
             assert(static_cast<std::size_t>(maxIndex) < mlSegment.vertexLength);
 #endif
 
-            encoder->drawIndexedPrimitives(primitiveType,
-                                           mlSegment.indexLength,
-                                           indexType,
-                                           indexBuffer,
-                                           indexOffset,
-                                           instanceCount,
-                                           baseVertex,
-                                           baseInstance);
+            if (instanceCount > 1 ) {
+                encoder->drawIndexedPrimitives(primitiveType,
+                                               mlSegment.indexLength,
+                                               indexType,
+                                               indexBuffer,
+                                               indexOffset,
+                                               instanceCount,
+                                               baseVertex,
+                                               baseInstance);
+            } else {
+                encoder->drawIndexedPrimitives(primitiveType,
+                                               mlSegment.indexLength,
+                                               indexType,
+                                               indexBuffer,
+                                               indexOffset);
+            }
+
             context.renderingStats().numDrawCalls++;
         }
     }

--- a/src/mbgl/mtl/drawable.cpp
+++ b/src/mbgl/mtl/drawable.cpp
@@ -292,7 +292,7 @@ void Drawable::draw(PaintParameters& parameters) const {
             assert(static_cast<std::size_t>(maxIndex) < mlSegment.vertexLength);
 #endif
 
-            if (context.getBackend().getDevice()->supportsFamily(MTL::GPUFamilyApple3)) {
+            if (context.getBackend().isInstanceDrawingSupported()) {
                 encoder->drawIndexedPrimitives(primitiveType,
                                                mlSegment.indexLength,
                                                indexType,

--- a/src/mbgl/mtl/drawable.cpp
+++ b/src/mbgl/mtl/drawable.cpp
@@ -302,13 +302,8 @@ void Drawable::draw(PaintParameters& parameters) const {
                                                baseVertex,
                                                baseInstance);
             } else {
-                encoder->drawIndexedPrimitives(primitiveType,
-                                               mlSegment.indexLength,
-                                               indexType,
-                                               indexBuffer,
-                                               indexOffset, 
-                                               instanceCount);
-
+                encoder->drawIndexedPrimitives(
+                    primitiveType, mlSegment.indexLength, indexType, indexBuffer, indexOffset, instanceCount);
             }
 
             context.renderingStats().numDrawCalls++;

--- a/src/mbgl/mtl/drawable.cpp
+++ b/src/mbgl/mtl/drawable.cpp
@@ -292,7 +292,7 @@ void Drawable::draw(PaintParameters& parameters) const {
             assert(static_cast<std::size_t>(maxIndex) < mlSegment.vertexLength);
 #endif
 
-            if (instanceCount > 1) {
+            if (context.getBackend().getDevice()->supportsFamily(MTL::GPUFamilyApple3)) {
                 encoder->drawIndexedPrimitives(primitiveType,
                                                mlSegment.indexLength,
                                                indexType,
@@ -302,8 +302,11 @@ void Drawable::draw(PaintParameters& parameters) const {
                                                baseVertex,
                                                baseInstance);
             } else {
-                encoder->drawIndexedPrimitives(
-                    primitiveType, mlSegment.indexLength, indexType, indexBuffer, indexOffset);
+                if (instanceCount == 1) {
+                    encoder->drawIndexedPrimitives(primitiveType, mlSegment.indexLength, indexType, indexBuffer, indexOffset);
+                } else {
+                    assert(!"Base Vertex Instance Drawing is only supported on MTLGPUFamilyApple3 and later.");
+                }
             }
 
             context.renderingStats().numDrawCalls++;

--- a/src/mbgl/mtl/drawable.cpp
+++ b/src/mbgl/mtl/drawable.cpp
@@ -292,7 +292,7 @@ void Drawable::draw(PaintParameters& parameters) const {
             assert(static_cast<std::size_t>(maxIndex) < mlSegment.vertexLength);
 #endif
 
-            if (context.getBackend().isInstanceDrawingSupported()) {
+            if (context.getBackend().isBaseVertexInstanceDrawingSupported()) {
                 encoder->drawIndexedPrimitives(primitiveType,
                                                mlSegment.indexLength,
                                                indexType,
@@ -302,12 +302,13 @@ void Drawable::draw(PaintParameters& parameters) const {
                                                baseVertex,
                                                baseInstance);
             } else {
-                if (instanceCount == 1) {
-                    encoder->drawIndexedPrimitives(
-                        primitiveType, mlSegment.indexLength, indexType, indexBuffer, indexOffset);
-                } else {
-                    assert(!"Base Vertex Instance Drawing is only supported on MTLGPUFamilyApple3 and later.");
-                }
+                encoder->drawIndexedPrimitives(primitiveType,
+                                               mlSegment.indexLength,
+                                               indexType,
+                                               indexBuffer,
+                                               indexOffset, 
+                                               instanceCount);
+
             }
 
             context.renderingStats().numDrawCalls++;

--- a/src/mbgl/mtl/renderer_backend.cpp
+++ b/src/mbgl/mtl/renderer_backend.cpp
@@ -46,6 +46,7 @@ RendererBackend::RendererBackend(const gfx::ContextMode contextMode_)
       commandQueue(NS::TransferPtr(device->newCommandQueue())) {
     assert(device);
     assert(commandQueue);
+    instanceDrawingSupported = device->supportsFamily(MTL::GPUFamilyApple3);
 }
 
 RendererBackend::~RendererBackend() = default;

--- a/src/mbgl/mtl/renderer_backend.cpp
+++ b/src/mbgl/mtl/renderer_backend.cpp
@@ -46,7 +46,7 @@ RendererBackend::RendererBackend(const gfx::ContextMode contextMode_)
       commandQueue(NS::TransferPtr(device->newCommandQueue())) {
     assert(device);
     assert(commandQueue);
-    instanceDrawingSupported = device->supportsFamily(MTL::GPUFamilyApple3);
+    baseVertexInstanceDrawingSupported = device->supportsFamily(MTL::GPUFamilyApple3);
 }
 
 RendererBackend::~RendererBackend() = default;


### PR DESCRIPTION
Disabled base vertex instance drawing on `GPUFamilyApple2` devices.

Note: `baseVertex` could be different than 0 for some styles, so we need to fix this use case in a future PR.