### PR TITLE
[opengl-2] Cherry pick 'Update vector-tile to MapLibre fork'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/mapbox/protozero.git
 [submodule "vendor/vector-tile"]
 	path = vendor/vector-tile
-	url = https://github.com/mapbox/vector-tile.git
+	url = https://github.com/maplibre/mvt-cpp.git
 [submodule "vendor/wagyu"]
 	path = vendor/wagyu
 	url = https://github.com/mapbox/wagyu.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [core] Fix memory access violation exception in vector_tile_data.cpp [#632](https://github.com/maplibre/maplibre-native/pull/632)
 - [iOS] Fix a bug where the compass was determined to be misplaced when hidden [#498](https://github.com/maplibre/maplibre-native/pull/498).
 - [core] `MaptilerFileSource` renamed to `MBTilesFileSource` [#198](https://github.com/maplibre/maplibre-native/pull/198).
+- [core] Fixes crash that happened with some PBF files ([Issue](https://github.com/maplibre/maplibre-native/issues/795), [PR](https://github.com/maplibre/maplibre-native/pull/2460)). 
 
 ## maps-v1.6.0
 

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -11,6 +11,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 * Add support for [index-of expression](https://maplibre.org/maplibre-style-spec/expressions/#index-of) ([#1113](https://github.com/maplibre/maplibre-native/pull/1113))
 
 ### 🐞 Bug fixes
+- Fixes crash that happened with some PBF files ([Issue](https://github.com/maplibre/maplibre-native/issues/795), [PR](https://github.com/maplibre/maplibre-native/pull/2460)).
 
 ### ⛵ Dependencies
 

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 ## main
+* Fixes crash that happened with some PBF files ([Issue](https://github.com/maplibre/maplibre-native/issues/795), [PR](https://github.com/maplibre/maplibre-native/pull/2460)).
 
 ## 5.4.0
 


### PR DESCRIPTION
This cherry picks https://github.com/maplibre/maplibre-native/pull/2460 to the opengl-2 branch

I have seen bugs in nodejs similar to the ones mentioned for ios/android. Some of them have been worked around in https://github.com/maplibre/maplibre-native/pull/632 , but I have seen other cases also which were not fixed by that PR


Note, I did not include the change to the iOS changelog, since it is pretty much empty in this branch. I did add to the root + node + android changelogs