### PR TITLE
Move all `WeakPtrFactory` members to the end of the containing class

### DIFF
--- a/include/mbgl/style/layer.hpp
+++ b/include/mbgl/style/layer.hpp
@@ -165,6 +165,11 @@ public:
     /// Collect dependencies
     expression::Dependency getDependencies() const noexcept;
 
+private:
+    std::optional<conversion::Error> setVisibility(const conversion::Convertible& value);
+    std::optional<conversion::Error> setMinZoom(const conversion::Convertible& value);
+    std::optional<conversion::Error> setMaxZoom(const conversion::Convertible& value);
+
 protected:
     virtual Mutable<Impl> mutableBaseImpl() const = 0;
     void serializeProperty(Value&, const StyleProperty&, const char* propertyName, bool isPaint) const;
@@ -172,11 +177,7 @@ protected:
                                                                  const conversion::Convertible& value) = 0;
     LayerObserver* observer;
     mapbox::base::WeakPtrFactory<Layer> weakFactory{this};
-
-private:
-    std::optional<conversion::Error> setVisibility(const conversion::Convertible& value);
-    std::optional<conversion::Error> setMinZoom(const conversion::Convertible& value);
-    std::optional<conversion::Error> setMaxZoom(const conversion::Convertible& value);
+    // Do not add members here, see `WeakPtrFactory`
 };
 
 } // namespace style

--- a/include/mbgl/style/sources/custom_geometry_source.hpp
+++ b/include/mbgl/style/sources/custom_geometry_source.hpp
@@ -57,6 +57,7 @@ private:
     std::shared_ptr<ThreadPool> threadPool;
     std::unique_ptr<Actor<CustomTileLoader>> loader;
     mapbox::base::WeakPtrFactory<Source> weakFactory{this};
+    // Do not add members here, see `WeakPtrFactory`
 };
 
 template <>

--- a/include/mbgl/style/sources/geojson_source.hpp
+++ b/include/mbgl/style/sources/geojson_source.hpp
@@ -83,6 +83,7 @@ private:
     std::shared_ptr<Scheduler> threadPool;
     std::shared_ptr<Scheduler> sequencedScheduler;
     mapbox::base::WeakPtrFactory<Source> weakFactory{this};
+    // Do not add members here, see `WeakPtrFactory`
 };
 
 template <>

--- a/include/mbgl/style/sources/image_source.hpp
+++ b/include/mbgl/style/sources/image_source.hpp
@@ -40,6 +40,7 @@ private:
     std::optional<std::string> url;
     std::unique_ptr<AsyncRequest> req;
     mapbox::base::WeakPtrFactory<Source> weakFactory{this};
+    // Do not add members here, see `WeakPtrFactory`
 };
 
 template <>

--- a/include/mbgl/style/sources/raster_source.hpp
+++ b/include/mbgl/style/sources/raster_source.hpp
@@ -39,6 +39,7 @@ private:
     const variant<std::string, Tileset> urlOrTileset;
     std::unique_ptr<AsyncRequest> req;
     mapbox::base::WeakPtrFactory<Source> weakFactory{this};
+    // Do not add members here, see `WeakPtrFactory`
 };
 
 template <>

--- a/include/mbgl/style/sources/vector_source.hpp
+++ b/include/mbgl/style/sources/vector_source.hpp
@@ -44,9 +44,10 @@ protected:
 private:
     const variant<std::string, Tileset> urlOrTileset;
     std::unique_ptr<AsyncRequest> req;
-    mapbox::base::WeakPtrFactory<Source> weakFactory{this};
     std::optional<float> maxZoom;
     std::optional<float> minZoom;
+    mapbox::base::WeakPtrFactory<Source> weakFactory{this};
+    // Do not add members here, see `WeakPtrFactory`
 };
 
 template <>

--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -91,6 +91,7 @@ private:
 
     std::unordered_set<AnnotationTile*> tiles;
     mapbox::base::WeakPtrFactory<AnnotationManager> weakFactory{this};
+    // Do not add members here, see `WeakPtrFactory`
 };
 
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -20,6 +20,7 @@ private:
     bool supportsLayerType(const mbgl::style::LayerTypeInfo*) const override;
     mapbox::base::WeakPtr<Source> makeWeakPtr() override { return weakFactory.makeWeakPtr(); }
     mapbox::base::WeakPtrFactory<Source> weakFactory{this};
+    // Do not add members here, see `WeakPtrFactory`
 };
 
 class AnnotationSource::Impl : public style::Source::Impl {

--- a/src/mbgl/sprite/sprite_loader.hpp
+++ b/src/mbgl/sprite/sprite_loader.hpp
@@ -41,6 +41,7 @@ private:
     SpriteLoaderObserver* observer = nullptr;
     std::shared_ptr<Scheduler> threadPool;
     mapbox::base::WeakPtrFactory<SpriteLoader> weakFactory{this};
+    // Do not add members here, see `WeakPtrFactory`
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/geojson_tile.hpp
+++ b/src/mbgl/tile/geojson_tile.hpp
@@ -24,6 +24,7 @@ public:
 private:
     std::shared_ptr<style::GeoJSONData> data;
     mapbox::base::WeakPtrFactory<GeoJSONTile> weakFactory{this};
+    // Do not add members here, see `WeakPtrFactory`
 };
 
 } // namespace mbgl

--- a/src/mbgl/util/thread_pool.hpp
+++ b/src/mbgl/util/thread_pool.hpp
@@ -94,10 +94,12 @@ public:
 
 private:
     std::vector<std::thread> threads;
-    mapbox::base::WeakPtrFactory<Scheduler> weakFactory{this};
 
     std::queue<std::function<void()>> renderThreadQueue;
     std::mutex renderMutex;
+
+    mapbox::base::WeakPtrFactory<Scheduler> weakFactory{this};
+    // Do not add members here, see `WeakPtrFactory`
 };
 
 class SequencedScheduler : public ThreadedScheduler {

--- a/test/actor/actor.test.cpp
+++ b/test/actor/actor.test.cpp
@@ -82,7 +82,6 @@ TEST(Actor, DestructionBlocksOnSend) {
         std::promise<void> promise;
         std::future<void> future;
         std::atomic<bool> waited;
-        mapbox::base::WeakPtrFactory<Scheduler> weakFactory{this};
 
         TestScheduler(std::promise<void> promise_, std::future<void> future_)
             : promise(std::move(promise_)),
@@ -103,6 +102,9 @@ TEST(Actor, DestructionBlocksOnSend) {
             waited = true;
         }
         mapbox::base::WeakPtr<Scheduler> makeWeakPtr() override { return weakFactory.makeWeakPtr(); }
+
+        mapbox::base::WeakPtrFactory<Scheduler> weakFactory{this};
+        // Do not add members here, see `WeakPtrFactory`
     };
 
     struct TestActor {


### PR DESCRIPTION
The `mapbox::base::WeakPtrFactory` class requires that it's the last member of any class in which it's used, but two of those uses violated that requirement.

Also adds comments on each use to make it harder to repeat.
