### PR TITLE
Make `useLogThread` a per-severity option and default `Error` to false

### DIFF
--- a/include/mbgl/util/event.hpp
+++ b/include/mbgl/util/event.hpp
@@ -9,6 +9,7 @@ enum class EventSeverity : uint8_t {
     Info,
     Warning,
     Error,
+    SeverityCount
 };
 
 enum class Event : uint8_t {

--- a/include/mbgl/util/logging.hpp
+++ b/include/mbgl/util/logging.hpp
@@ -38,7 +38,6 @@ public:
     Log();
     ~Log();
 
-    static bool useLogThread(EventSeverity) noexcept;
     static void useLogThread(bool enable) noexcept;
     static void useLogThread(bool enable, EventSeverity) noexcept;
 

--- a/include/mbgl/util/logging.hpp
+++ b/include/mbgl/util/logging.hpp
@@ -38,7 +38,9 @@ public:
     Log();
     ~Log();
 
+    static bool useLogThread(EventSeverity) noexcept;
     static void useLogThread(bool enable) noexcept;
+    static void useLogThread(bool enable, EventSeverity) noexcept;
 
     template <typename... Args>
     static void Debug(Event event, Args&&... args) noexcept {

--- a/platform/darwin/src/MLNLoggingConfiguration.mm
+++ b/platform/darwin/src/MLNLoggingConfiguration.mm
@@ -29,6 +29,9 @@ public:
             case EventSeverity::Error:
                 MLNLogError(message);
                 break;
+            default:
+                assert(false);
+                return false;
         }
         return true;
     }

--- a/platform/darwin/src/MLNLoggingConfiguration.mm
+++ b/platform/darwin/src/MLNLoggingConfiguration.mm
@@ -31,7 +31,6 @@ public:
                 break;
             default:
                 assert(false);
-                return false;
         }
         return true;
     }

--- a/src/mbgl/util/logging.cpp
+++ b/src/mbgl/util/logging.cpp
@@ -65,7 +65,7 @@ void Log::useLogThread(bool enable) noexcept {
 
 void Log::useLogThread(bool enable, EventSeverity severity) noexcept {
     const auto index = underlying_type(severity);
-    if (0 <= index && index < SeverityCount) {
+    if (index < SeverityCount) {
         useThread[index] = enable;
     }
 }

--- a/src/mbgl/util/logging.cpp
+++ b/src/mbgl/util/logging.cpp
@@ -56,11 +56,6 @@ Log* Log::get() noexcept {
     return &instance;
 }
 
-bool Log::useLogThread(EventSeverity severity) noexcept {
-    const auto index = underlying_type(severity);
-    return 0 <= index && index < SeverityCount && useThread[index];
-}
-
 void Log::useLogThread(bool enable) noexcept {
     useLogThread(enable, EventSeverity::Debug);
     useLogThread(enable, EventSeverity::Info);

--- a/src/mbgl/util/logging.cpp
+++ b/src/mbgl/util/logging.cpp
@@ -15,7 +15,7 @@ namespace mbgl {
 namespace {
 
 std::unique_ptr<Log::Observer> currentObserver;
-static constexpr auto SeverityCount = underlying_type(EventSeverity::SeverityCount);
+constexpr auto SeverityCount = underlying_type(EventSeverity::SeverityCount);
 std::atomic<bool> useThread[SeverityCount] = {true, true, true, false};
 std::mutex mutex;
 


### PR DESCRIPTION
This should make any error events more likely to be written out before a crash.  Such events are rare, so there should be no significant effect on performance.