### PR TITLE
Do not interpolate zoom during flyTo when start and end zoom are same

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### 🐞 Bug fixes
 
-- Fixes crash that happened with some PBF files ([Issue](https://github.com/maplibre/maplibre-native/issues/795), [PR](https://github.com/maplibre/maplibre-native/pull/2460)). 
+- Fixes crash that happened with some PBF files ([Issue](https://github.com/maplibre/maplibre-native/issues/795), [PR](https://github.com/maplibre/maplibre-native/pull/2460)).
+- Fix blinking issue caused by `flyTo` transition when start and end zoom are the same ([#2477](https://github.com/maplibre/maplibre-native/issues/2477)).
 
 ## 11.0.0
 

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -307,13 +307,13 @@ void Transform::flyTo(const CameraOptions& camera, const AnimationOptions& anima
 
             // Calculate the current point and zoom level along the flight path.
             Point<double> framePoint = util::interpolate(startPoint, endPoint, us);
-            double frameZoom = linearZoomInterpolation ? util::interpolate(startZoom, zoom, k)
-                                                       : startZoom + state.scaleZoom(1 / w(s));
 
             // Zoom can be NaN if size is empty.
-            if (std::isnan(frameZoom)) {
-                frameZoom = zoom;
-            }
+            // also do not interpolate if start and end zoom are the same
+            // (https://github.com/maplibre/maplibre-native/issues/2477)
+            double frameZoom = std::isnan(zoom) || zoom == startZoom ? zoom
+                               : linearZoomInterpolation             ? util::interpolate(startZoom, zoom, k)
+                                                                     : startZoom + state.scaleZoom(1 / w(s));
 
             // Convert to geographic coordinates and set the new viewpoint.
             LatLng frameLatLng = Projection::unproject(framePoint, startScale);


### PR DESCRIPTION
When using flyTo zoom should not be interpolated during the transition. This was causing flickering of labels. Fixes https://github.com/maplibre/maplibre-native/issues/2477

https://github.com/maplibre/maplibre-native/assets/649392/e8306a18-2da7-4dac-b546-66ee73bd30b3



