### PR TITLE
Add privacy manifest iOS

### DIFF
--- a/platform/ios/BUILD.bazel
+++ b/platform/ios/BUILD.bazel
@@ -124,7 +124,7 @@ apple_xcframework(
         "resources/*.lproj/**",
         "resources/*.xcassets/**",
         "resources/metal-cpp-ignores.txt",
-    ]),
+    ]) + ["PrivacyInfo.xcprivacy"],
     infoplists = ["info_plist"],
     ios = {
         "simulator": [
@@ -245,6 +245,7 @@ filegroup(
     srcs = [
         "BAZEL.md",
         "MapLibre.podspec",
+        "PrivacyInfo.xcprivacy",
         "README.md",
         "RELEASE.md",
         "VERSION",

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,8 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 
 ## main
 
+- Add [Privacy Manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files). MapLibre Native iOS has no built-in tracking, but it does use some system APIs for functional purposes that are marked by Apple as privacy sensitive. ([#1866](https://github.com/maplibre/maplibre-native/issues/1866)).
+
 ## 6.5.0
 
 - Allow uses to handle authorization for location services ([#2453](https://github.com/maplibre/maplibre-native/pull/2453)). See [`MLNMapview.shouldRequestAuthorizationToUseLocationServices`](https://maplibre.org/maplibre-native/ios/latest/documentation/maplibre/mlnmapview/shouldrequestauthorizationtouselocationservices).

--- a/platform/ios/MapLibre.podspec
+++ b/platform/ios/MapLibre.podspec
@@ -15,5 +15,7 @@ Pod::Spec.new do |s|
     s.social_media_url  = 'https://mastodon.social/@maplibre'
     s.ios.deployment_target = '12.0'
     s.ios.vendored_frameworks = "MapLibre.xcframework"
+    s.resource_bundle = {
+        "MapLibre_Privacy" => "PrivacyInfo.xcprivacy"
+    }
 end
-

--- a/platform/ios/PrivacyInfo.xcprivacy
+++ b/platform/ios/PrivacyInfo.xcprivacy
@@ -15,7 +15,7 @@
       <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
       <key>NSPrivacyAccessedAPITypeReasons</key>
       <array>
-        <string>0A2A.1</string>
+        <string>C617.1</string>
       </array>
     </dict>
     <dict>
@@ -31,7 +31,7 @@
       <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
       <key>NSPrivacyAccessedAPITypeReasons</key>
       <array>
-        <string>C56D.1</string>
+        <string>CA92.1</string>
       </array>
     </dict>
   </array>

--- a/platform/ios/PrivacyInfo.xcprivacy
+++ b/platform/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>0A2A.1</string>
+      </array>
+    </dict>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>35F9.1</string>
+      </array>
+    </dict>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>C56D.1</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds a [Privacy Manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files). Such a manifest may become a requirement from Apple all third-party SDKs in the future.

**Note for reviewer**:

See the APIs here: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api

#### File timestamps

> Declare this reason to access the timestamps, size, or other metadata of files inside the app container, app group container, or the app’s CloudKit container.

#### Boot time

> Declare this reason to access the system boot time in order to measure the amount of time that has elapsed between events that occurred within the app or to perform calculations to enable timers.
> Information accessed for this reason, or any derived information, may not be sent off-device. There is an exception for information about the amount of time that has elapsed between events that occurred within the app, which may be sent off-device.

#### Disk space

Not used as far as I know

#### User Defaults

> Declare this reason to access user defaults to read and write information that is only accessible to the app itself.

> This reason does not permit reading information that was written by other apps or the system, or writing information that can be accessed by other apps.

<img width="837" alt="image" src="https://github.com/maplibre/maplibre-native/assets/649392/c37042ac-ce91-4321-bd13-ec3af657d860">


Closes #1866