### PR TITLE
Use `EnvAttachingDeleter` for `LocalGlyphRasterizer` and `AssetManagerFileSource`

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/asset_manager_file_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/asset_manager_file_source.cpp
@@ -60,7 +60,7 @@ AssetManagerFileSource::AssetManagerFileSource(jni::JNIEnv& env,
                                                const jni::Object<android::AssetManager>& assetManager_,
                                                const ResourceOptions resourceOptions,
                                                const ClientOptions clientOptions)
-    : assetManager(jni::NewGlobal(env, assetManager_)),
+    : assetManager(jni::NewGlobal<jni::EnvAttachingDeleter>(env, assetManager_)),
       impl(std::make_unique<util::Thread<Impl>>(
           util::makeThreadPrioritySetter(platform::EXPERIMENTAL_THREAD_PRIORITY_FILE),
           "AssetManagerFileSource",

--- a/platform/android/MapLibreAndroid/src/cpp/asset_manager_file_source.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/asset_manager_file_source.hpp
@@ -35,7 +35,7 @@ public:
 private:
     class Impl;
 
-    jni::Global<jni::Object<android::AssetManager>> assetManager;
+    jni::Global<jni::Object<android::AssetManager>, jni::EnvAttachingDeleter> assetManager;
     std::unique_ptr<util::Thread<Impl>> impl;
 };
 

--- a/platform/android/MapLibreAndroid/src/cpp/text/local_glyph_rasterizer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/text/local_glyph_rasterizer.cpp
@@ -39,7 +39,7 @@ LocalGlyphRasterizer::LocalGlyphRasterizer() {
     static auto& javaClass = jni::Class<LocalGlyphRasterizer>::Singleton(*env);
     static auto constructor = javaClass.GetConstructor(*env);
 
-    javaObject = jni::NewGlobal(*env, javaClass.New(*env, constructor));
+    javaObject = jni::NewGlobal<jni::EnvAttachingDeleter>(*env, javaClass.New(*env, constructor));
 }
 
 PremultipliedImage LocalGlyphRasterizer::drawGlyphBitmap(const std::string& fontFamily,

--- a/platform/android/MapLibreAndroid/src/cpp/text/local_glyph_rasterizer_jni.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/text/local_glyph_rasterizer_jni.hpp
@@ -26,7 +26,7 @@ public:
     PremultipliedImage drawGlyphBitmap(const std::string& fontFamily, const bool bold, const char16_t glyphID);
 
 private:
-    jni::Global<jni::Object<LocalGlyphRasterizer>> javaObject;
+    jni::Global<jni::Object<LocalGlyphRasterizer>, jni::EnvAttachingDeleter> javaObject;
 };
 
 } // namespace android


### PR DESCRIPTION
The `DefaultRefDeleter` of these classes sometimes gets called on another thread than the one they were created on. This is because a class that composes them is held with a shared pointer that is shared between threads (e.g. std::shared_ptr<FileSource>`) and sometimes another thread holds to it longer. This causes problems because the env pointer of the creation thread is used, which cannot be used on another thread.

From the source code of jni.hpp:

> The default policy is to delete the reference using the same `JNIEnv` as was passed to the constructor, but in cases where the object may be deleted on a different thread (commonly, the Java finalizer thread), `EnvGettingDeleter` or `EnvAttachingDeleter` may be needed.

There are likely other cases where we need to make this change. But these are the places where a crash is either reported or observed.

Closes #2045