### PR TITLE
Use cache for install-qt-action

### DIFF
--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -219,6 +219,7 @@ jobs:
           arch: ${{ matrix.qt_arch }}
           tools: ${{ matrix.qt_tools }}
           extra: --base https://mirrors.ocf.berkeley.edu/qt/
+          cache: true
 
       - name: Update ccache
         if: runner.os == 'Windows'


### PR DESCRIPTION
The Qt workflows are sometimes failing due to temporary network failures.

Caching should help reduce this to a minimum.

https://github.com/maplibre/maplibre-native/actions/runs/9469806144/job/26089733188?pr=2398

https://github.com/maplibre/maplibre-native/actions/runs/9355654961/job/25751324953