### PR TITLE
Fix GL Fence signaling status

### DIFF
--- a/include/mbgl/gl/buffer_allocator.hpp
+++ b/include/mbgl/gl/buffer_allocator.hpp
@@ -54,7 +54,7 @@ public:
     virtual void release(BufferRef* ref) noexcept = 0;
 
     /// Defragment the allocator's underlying buffer pool.
-    virtual void defragment(const std::shared_ptr<gl::Fence>& fence) noexcept = 0;
+    virtual void defragment(const std::shared_ptr<gl::Fence>& fence) = 0;
 
     /// Return the buffer page size used by the allocator. This is the maximum size a
     /// single buffer can possible be.
@@ -164,7 +164,7 @@ public:
 
     bool write(const void* data, size_t size, BufferRef*& ref) noexcept override;
     void release(BufferRef* ref) noexcept override;
-    void defragment(const std::shared_ptr<gl::Fence>& fence) noexcept override;
+    void defragment(const std::shared_ptr<gl::Fence>& fence) override;
     size_t pageSize() const noexcept override;
     int32_t getBufferID(size_t bufferIndex) const noexcept override;
 

--- a/src/mbgl/gl/buffer_allocator.cpp
+++ b/src/mbgl/gl/buffer_allocator.cpp
@@ -297,7 +297,7 @@ public:
 
     // Look for buffers that either have zero living references or equal or under FragmentationThresh
     // references. In the latter case, attempt to relocate these allocations to more utilized buffers.
-    void defragment(const std::shared_ptr<gl::Fence>& fence) noexcept override {
+    void defragment(const std::shared_ptr<gl::Fence>& fence) override {
         if (buffers.size() == 0) {
             return;
         }
@@ -502,7 +502,7 @@ void UniformBufferAllocator::release(BufferRef* ref) noexcept {
     impl->release(ref);
 }
 
-void UniformBufferAllocator::defragment(const std::shared_ptr<gl::Fence>& fence) noexcept {
+void UniformBufferAllocator::defragment(const std::shared_ptr<gl::Fence>& fence) {
     impl->defragment(fence);
 }
 

--- a/src/mbgl/gl/fence.cpp
+++ b/src/mbgl/gl/fence.cpp
@@ -1,11 +1,26 @@
 #include <mbgl/gl/fence.hpp>
 #include <mbgl/gl/defines.hpp>
 #include <cassert>
+#include <stdexcept>
+#include <string>
 
 namespace mbgl {
 namespace gl {
 
 using namespace platform;
+
+namespace {
+std::string glErrors() {
+    std::string error_list = "";
+    for (auto error = glGetError(); error != GL_NO_ERROR; error = glGetError()) {
+        error_list += std::to_string(error) + " ";
+    }
+    if (error_list.empty()) {
+        return error_list;
+    }
+    return "GL error codes: " + error_list;
+}
+} // namespace
 
 Fence::Fence() {}
 
@@ -20,12 +35,27 @@ void Fence::insert() noexcept {
     fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
 }
 
-bool Fence::isSignaled() const noexcept {
+bool Fence::isSignaled() const {
     if (!fence) {
         return false;
     }
 
-    return glClientWaitSync(fence, GL_SYNC_FLUSH_COMMANDS_BIT, 0);
+    GLenum fenceStatus = glClientWaitSync(fence, GL_SYNC_FLUSH_COMMANDS_BIT, 0);
+
+    switch (fenceStatus) {
+        case GL_ALREADY_SIGNALED:
+            [[fallthrough]];
+        case GL_CONDITION_SATISFIED:
+            return true;
+        case GL_TIMEOUT_EXPIRED:
+            return false;
+        case GL_WAIT_FAILED:
+            throw std::runtime_error("glClientWaitSync failed. " + glErrors());
+            return false;
+        default:
+            assert(false); // unreachable
+            return false;
+    }
 }
 
 } // namespace gl

--- a/src/mbgl/gl/fence.hpp
+++ b/src/mbgl/gl/fence.hpp
@@ -12,7 +12,7 @@ public:
     ~Fence();
 
     void insert() noexcept;
-    bool isSignaled() const noexcept;
+    bool isSignaled() const;
 
 private:
     platform::GLsync fence{nullptr};


### PR DESCRIPTION
The OpenGL renderer function `Fence::isSignaled` always returns true (signaled) and this bug can overrun the uniform buffer allocator. `glClientWaitSync` is interpreted as if it returns true (signaled) or false (unsignaled) but the function actually returns the following 4 enums:
```
GL_ALREADY_SIGNALED 0x911A
GL_TIMEOUT_EXPIRED 0x911B
GL_CONDITION_SATISFIED 0x911C
GL_WAIT_FAILED 0x911D
```
This PR ensures the returned value is correctly checked
 