### PR TITLE
Tiles not loading outside of metadata bounds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     files: '.*\.(hpp|cpp|h)'
     exclude: '(vendor/.*|darwin/include/mbgl/storage/reachability.h)'
 - repo: https://github.com/keith/pre-commit-buildifier
-  rev: 6.4.0
+  rev: 6.4.0.1
   hooks:
     - id: buildifier
 - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
@@ -20,7 +20,7 @@ repos:
     - id: actionlint
       additional_dependencies: [shellcheck-py]
 - repo: https://github.com/nicklockwood/SwiftFormat
-  rev: "0.53.10"
+  rev: "0.54.0"
   hooks:
     - id: swiftformat
       args: [--swiftversion, "5.8"]

--- a/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
@@ -255,6 +255,10 @@ private:
 
     // Multiple databases open simultaneoulsy, to effectively support multiple .mbtiles maps
     mapbox::sqlite::Database &get_db(const std::string &path) {
+        
+        // Close the DB path before using to prevent a crash that happens when you update the mbtiles file on the filesystem
+        close_db(path);
+        
         auto ptr = db_cache.find(path);
         if (ptr != db_cache.end()) {
             return ptr->second;

--- a/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
@@ -201,6 +201,8 @@ public:
 
         Response response;
         response.noContent = true;
+        response.error = std::make_unique<Response::Error>(Response::Error::Reason::Connection,
+                                                                       "Not found in mbtile database");
 
         for (mapbox::sqlite::Query q(stmt); q.run();) {
             std::optional<std::string> data = q.get<std::optional<std::string>>(0);
@@ -209,6 +211,7 @@ public:
                 response.noContent = false;
                 response.expires = Timestamp::max();
                 response.etag = resource.url;
+                response.error.release();
 
                 if (is_compressed(*response.data)) {
                     response.data = std::make_shared<std::string>(util::decompress(*response.data));

--- a/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
@@ -255,10 +255,10 @@ private:
 
     // Multiple databases open simultaneoulsy, to effectively support multiple .mbtiles maps
     mapbox::sqlite::Database &get_db(const std::string &path) {
-        
-        // Close the DB path before using to prevent a crash that happens when you update the mbtiles file on the filesystem
+        // Close the DB path before using to prevent a crash that happens when you update the mbtiles file on the
+        // filesystem
         close_db(path);
-        
+
         auto ptr = db_cache.find(path);
         if (ptr != db_cache.end()) {
             return ptr->second;


### PR DESCRIPTION
Fixes issue #1318 where tiles outside of metadata bounds are not loading. This fix allows over zooming so that map features that are not on higher zoom levels will still show from their lower zoom level tiles.

For example, the offline mbtiles file might include world tiles in `z1` only, but when you zoom in farther those tiles are blank unless you move to the metadata bounds. With this fix, if you zoom into an area outside of the bounds you will get over zoom from `z1` which makes for a much nicer looking map without blank tiles.