### PR TITLE
Tiles not loading outside of metadata bounds

### DIFF
--- a/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
@@ -201,6 +201,8 @@ public:
 
         Response response;
         response.noContent = true;
+        response.error = std::make_unique<Response::Error>(Response::Error::Reason::Connection,
+                                                           "Not found in mbtile database");
 
         for (mapbox::sqlite::Query q(stmt); q.run();) {
             std::optional<std::string> data = q.get<std::optional<std::string>>(0);
@@ -209,6 +211,7 @@ public:
                 response.noContent = false;
                 response.expires = Timestamp::max();
                 response.etag = resource.url;
+                response.error.reset();
 
                 if (is_compressed(*response.data)) {
                     response.data = std::make_shared<std::string>(util::decompress(*response.data));


### PR DESCRIPTION
Fixes issue #1318 where tiles outside of metadata bounds are not loading. This fix allows over zooming so that map features that are not on higher zoom levels will still show from their lower zoom level tiles.

For example, the offline mbtiles file might include world tiles in `z1` only, but when you zoom in farther those tiles are blank unless you move to the metadata bounds. With this fix, if you zoom into an area outside of the bounds you will get over zoom from `z1` which makes for a much nicer looking map without blank tiles.