### PR TITLE
Updating local mbtiles file causes crash

### DIFF
--- a/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
@@ -252,6 +252,10 @@ private:
 
     // Multiple databases open simultaneoulsy, to effectively support multiple .mbtiles maps
     mapbox::sqlite::Database &get_db(const std::string &path) {
+        
+        // Close the DB path before using to prevent a crash that happens when you update the mbtiles file on the filesystem
+        close_db(path);
+
         auto ptr = db_cache.find(path);
         if (ptr != db_cache.end()) {
             return ptr->second;


### PR DESCRIPTION
This is a fix for issue #100 where updating a local `mbtiles` file with a new version will cause a crash.

The use case for this is for users that have `mbtiles` files on the filesystem an update that with a newer version of the file, such as downloading an updated map file. Previously this would crash.