### PR TITLE
More context

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -6,6 +6,13 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 
 ### ✨ Features and improvements
 
+## 10.3.2-pre3
+
+- Additional symbol instance checks building on previous success in detecting corruption and avoiding crashes
+- More context from check calls to help narrow down the origin of corruption
+
+Note: CI checks are not maintained for backporting releases, so only manual testing is done.
+
 ## 10.3.2-pre2
 
 A minor fix for a bug introduced in 10.3.2-pre1 which caused symbols to disappear randomly.

--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -203,7 +203,7 @@ optional<size_t> SymbolInstance::getDefaultHorizontalPlacedTextIndex() const {
 }
 
 bool SymbolInstance::check(std::size_t v, int n, std::string_view source) const {
-    if (!isFailed && v != checkVal) {
+    if (v != checkVal) {
         isFailed = true;
         Log::Error(Event::Crash, "SymbolInstance corrupted at " + util::toString(n) + " with value " + util::toString(v) + " from '" + std::string(source) + "'");
     }
@@ -211,7 +211,7 @@ bool SymbolInstance::check(std::size_t v, int n, std::string_view source) const 
 }
 
 bool SymbolInstance::checkKey() const {
-    if (!isFailed && key.size() > 1000) {   // largest observed value=62
+    if (key.size() > 1000) {   // largest observed value=62
         isFailed = true;
         Log::Error(Event::Crash, "SymbolInstance key corrupted with size=" + util::toString(key.size()));
     }

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -6,6 +6,10 @@
 #include <mbgl/style/layers/symbol_layer_properties.hpp>
 #include <mbgl/util/bitmask_operations.hpp>
 
+#define STRINGIZE(x) STRINGIZE2(x)
+#define STRINGIZE2(x) #x
+#define __LINE_STRING__ STRINGIZE(__LINE__)
+
 namespace mbgl {
 
 class Anchor;

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -9,6 +9,7 @@
 #define STRINGIZE(x) STRINGIZE2(x)
 #define STRINGIZE2(x) #x
 #define __LINE_STRING__ STRINGIZE(__LINE__)
+#define __SOURCE_LOCATION__ __FILE__ ":" __LINE_STRING__
 
 namespace mbgl {
 
@@ -89,37 +90,39 @@ public:
     const optional<SymbolQuads>& verticalIconQuads() const;
     void releaseSharedData();
 
-    bool check(std::string_view source = std::string_view()) const {
-        return !isFailed &&
-                check(check01, 1, source) &&
-                check(check02, 2, source) &&
-                check(check03, 3, source) &&
-                check(check04, 4, source) &&
-                check(check05, 5, source) &&
-                check(check06, 6, source) &&
-                check(check07, 7, source) &&
-                check(check08, 8, source) &&
-                check(check09, 9, source) &&
-                check(check10, 10, source) &&
-                check(check11, 11, source) &&
-                check(check12, 12, source) &&
-                check(check13, 13, source) &&
-                check(check14, 14, source) &&
-                check(check15, 15, source) &&
-                check(check16, 16, source) &&
-                check(check17, 17, source) &&
-                check(check18, 18, source) &&
-                check(check19, 19, source) &&
-                check(check20, 20, source) &&
-                check(check21, 21, source) &&
-                check(check22, 22, source) &&
-                check(check23, 23, source) &&
-                check(check24, 24, source) &&
-                check(check25, 25, source) &&
-                check(check26, 26, source) &&
-                check(check27, 27, source) &&
-                check(check28, 28, source) &&
-                check(check29, 29, source);
+    bool check(std::string_view source) const {
+        if (isFailed)
+            return false;
+        check(check01, 1, source);
+        check(check02, 2, source);
+        check(check03, 3, source);
+        check(check04, 4, source);
+        check(check05, 5, source);
+        check(check06, 6, source);
+        check(check07, 7, source);
+        check(check08, 8, source);
+        check(check09, 9, source);
+        check(check10, 10, source);
+        check(check11, 11, source);
+        check(check12, 12, source);
+        check(check13, 13, source);
+        check(check14, 14, source);
+        check(check15, 15, source);
+        check(check16, 16, source);
+        check(check17, 17, source);
+        check(check18, 18, source);
+        check(check19, 19, source);
+        check(check20, 20, source);
+        check(check21, 21, source);
+        check(check22, 22, source);
+        check(check23, 23, source);
+        check(check24, 24, source);
+        check(check25, 25, source);
+        check(check26, 26, source);
+        check(check27, 27, source);
+        check(check28, 28, source);
+        check(check29, 29, source);
+        return !isFailed;
     }
     bool checkIndex(const optional<std::size_t>& index, std::size_t size, std::string_view source) const;
     bool checkIndexes(std::size_t textCount, std::size_t iconSize, std::size_t sdfSize, std::string_view source) const {
@@ -132,45 +135,45 @@ public:
             checkIndex(placedVerticalIconIndex, hasSdfIcon() ? sdfSize : iconSize, source);
     }
 
-    const Anchor& getAnchor() const { check(); return anchor; }
-    std::size_t getRightJustifiedGlyphQuadsSize() const { check(); return rightJustifiedGlyphQuadsSize; }
-    std::size_t getCenterJustifiedGlyphQuadsSize() const { check(); return centerJustifiedGlyphQuadsSize; }
-    std::size_t getLeftJustifiedGlyphQuadsSize() const { check(); return leftJustifiedGlyphQuadsSize; }
-    std::size_t getVerticalGlyphQuadsSize() const { check(); return verticalGlyphQuadsSize; }
-    std::size_t getIconQuadsSize() const { check(); return iconQuadsSize; }
-    const CollisionFeature& getTextCollisionFeature() const { check(); return textCollisionFeature; }
-    const CollisionFeature& getIconCollisionFeature() const { check(); return iconCollisionFeature; }
-    const optional<CollisionFeature>& getVerticalTextCollisionFeature() const { check(); return verticalTextCollisionFeature; }
-    const optional<CollisionFeature>& getVerticalIconCollisionFeature() const { check(); return verticalIconCollisionFeature; }
-    WritingModeType getWritingModes() const { check(); return writingModes; }
-    std::size_t getLayoutFeatureIndex() const { check(); return layoutFeatureIndex; }
-    std::size_t getDataFeatureIndex() const { check(); return dataFeatureIndex; }
-    std::array<float, 2> getTextOffset() const { check(); return textOffset; }
-    std::array<float, 2> getIconOffset() const { check(); return iconOffset; }
-    const std::u16string& getKey() const { check(); checkKey(); return key; }
-    optional<size_t> getPlacedRightTextIndex() const { check(); return placedRightTextIndex; }
-    optional<size_t> getPlacedCenterTextIndex() const { check(); return placedCenterTextIndex; }
-    optional<size_t> getPlacedLeftTextIndex() const { check(); return placedLeftTextIndex; }
-    optional<size_t> getPlacedVerticalTextIndex() const { check(); return placedVerticalTextIndex; }
-    optional<size_t> getPlacedIconIndex() const { check(); return placedIconIndex; }
-    optional<size_t> getPlacedVerticalIconIndex() const { check(); return placedVerticalIconIndex; }
-    float getTextBoxScale() const { check(); return textBoxScale; }
-    std::array<float, 2> getVariableTextOffset() const { check(); return variableTextOffset; }
-    bool getSingleLine() const { check(); return singleLine; }
+    const Anchor& getAnchor(std::string_view source) const { check(source); return anchor; }
+    std::size_t getRightJustifiedGlyphQuadsSize(std::string_view source) const { check(source); return rightJustifiedGlyphQuadsSize; }
+    std::size_t getCenterJustifiedGlyphQuadsSize(std::string_view source) const { check(source); return centerJustifiedGlyphQuadsSize; }
+    std::size_t getLeftJustifiedGlyphQuadsSize(std::string_view source) const { check(source); return leftJustifiedGlyphQuadsSize; }
+    std::size_t getVerticalGlyphQuadsSize(std::string_view source) const { check(source); return verticalGlyphQuadsSize; }
+    std::size_t getIconQuadsSize(std::string_view source) const { check(source); return iconQuadsSize; }
+    const CollisionFeature& getTextCollisionFeature(std::string_view source) const { check(source); return textCollisionFeature; }
+    const CollisionFeature& getIconCollisionFeature(std::string_view source) const { check(source); return iconCollisionFeature; }
+    const optional<CollisionFeature>& getVerticalTextCollisionFeature(std::string_view source) const { check(source); return verticalTextCollisionFeature; }
+    const optional<CollisionFeature>& getVerticalIconCollisionFeature(std::string_view source) const { check(source); return verticalIconCollisionFeature; }
+    WritingModeType getWritingModes(std::string_view source) const { check(source); return writingModes; }
+    std::size_t getLayoutFeatureIndex(std::string_view source) const { check(source); return layoutFeatureIndex; }
+    std::size_t getDataFeatureIndex(std::string_view source) const { check(source); return dataFeatureIndex; }
+    std::array<float, 2> getTextOffset(std::string_view source) const { check(source); return textOffset; }
+    std::array<float, 2> getIconOffset(std::string_view source) const { check(source); return iconOffset; }
+    const std::u16string& getKey(std::string_view source) const { check(source); checkKey(); return key; }
+    optional<size_t> getPlacedRightTextIndex(std::string_view source) const { check(source); return placedRightTextIndex; }
+    optional<size_t> getPlacedCenterTextIndex(std::string_view source) const { check(source); return placedCenterTextIndex; }
+    optional<size_t> getPlacedLeftTextIndex(std::string_view source) const { check(source); return placedLeftTextIndex; }
+    optional<size_t> getPlacedVerticalTextIndex(std::string_view source) const { check(source); return placedVerticalTextIndex; }
+    optional<size_t> getPlacedIconIndex(std::string_view source) const { check(source); return placedIconIndex; }
+    optional<size_t> getPlacedVerticalIconIndex(std::string_view source) const { check(source); return placedVerticalIconIndex; }
+    float getTextBoxScale(std::string_view source) const { check(source); return textBoxScale; }
+    std::array<float, 2> getVariableTextOffset(std::string_view source) const { check(source); return variableTextOffset; }
+    bool getSingleLine(std::string_view source) const { check(source); return singleLine; }
 
-    uint32_t getCrossTileID() const { check(); return crossTileID; }
-    void setCrossTileID(uint32_t x) { check(); crossTileID = x; check(); }
+    uint32_t getCrossTileID(std::string_view source) const { check(source); return crossTileID; }
+    void setCrossTileID(uint32_t x, std::string_view source) { check(source); crossTileID = x; }
 
-    optional<size_t>& refPlacedRightTextIndex() { check(); return placedRightTextIndex; }
-    optional<size_t>& refPlacedCenterTextIndex() { check(); return placedCenterTextIndex; }
-    optional<size_t>& refPlacedLeftTextIndex() { check(); return placedLeftTextIndex; }
-    optional<size_t>& refPlacedVerticalTextIndex() { check(); return placedVerticalTextIndex; }
-    optional<size_t>& refPlacedIconIndex() { check(); return placedIconIndex; }
-    optional<size_t>& refPlacedVerticalIconIndex() { check(); return placedVerticalIconIndex; }
+    optional<size_t>& refPlacedRightTextIndex(std::string_view source) { check(source); return placedRightTextIndex; }
+    optional<size_t>& refPlacedCenterTextIndex(std::string_view source) { check(source); return placedCenterTextIndex; }
+    optional<size_t>& refPlacedLeftTextIndex(std::string_view source) { check(source); return placedLeftTextIndex; }
+    optional<size_t>& refPlacedVerticalTextIndex(std::string_view source) { check(source); return placedVerticalTextIndex; }
+    optional<size_t>& refPlacedIconIndex(std::string_view source) { check(source); return placedIconIndex; }
+    optional<size_t>& refPlacedVerticalIconIndex(std::string_view source) { check(source); return placedVerticalIconIndex; }
 
-    void setPlacedRightTextIndex(optional<size_t> x) { check(); placedRightTextIndex = x; check(); }
-    void setPlacedCenterTextIndex(optional<size_t> x) { check(); placedCenterTextIndex = x; check(); }
-    void setPlacedLeftTextIndex(optional<size_t> x) { check(); placedLeftTextIndex = x; check(); }
+    void setPlacedRightTextIndex(optional<size_t> x, std::string_view source) { check(source); placedRightTextIndex = x; }
+    void setPlacedCenterTextIndex(optional<size_t> x, std::string_view source) { check(source); placedCenterTextIndex = x; }
+    void setPlacedLeftTextIndex(optional<size_t> x, std::string_view source) { check(source); placedLeftTextIndex = x; }
 
     static constexpr uint32_t invalidCrossTileID() { return std::numeric_limits<uint32_t>::max(); }
 

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -896,6 +896,7 @@ void SymbolLayout::createBucket(const ImagePositions&,
             }
             renderData.emplace(pair.first, LayerRenderData{bucket, pair.second});
         }
+        bucket->check("SymbolLayout::createBucket");
     }
 }
 

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -775,13 +775,13 @@ void SymbolLayout::createBucket(const ImagePositions&,
                                                  iconsInText);
 
     for (SymbolInstance &symbolInstance : bucket->symbolInstances) {
-        if (!symbolInstance.check("createBucket 1")) continue;
+        if (!symbolInstance.check(__SOURCE_LOCATION__)) continue;
 
         const bool hasText = symbolInstance.hasText();
         const bool hasIcon = symbolInstance.hasIcon();
-        const bool singleLine = symbolInstance.getSingleLine();
+        const bool singleLine = symbolInstance.getSingleLine(__SOURCE_LOCATION__);
 
-        const auto& feature = features.at(symbolInstance.getLayoutFeatureIndex());
+        const auto& feature = features.at(symbolInstance.getLayoutFeatureIndex(__SOURCE_LOCATION__));
 
         // Insert final placement into collision tree and add glyphs/icons to buffers
 
@@ -791,11 +791,11 @@ void SymbolLayout::createBucket(const ImagePositions&,
             const Range<float> sizeData = bucket->iconSizeBinder->getVertexSizeData(feature);
             auto& iconBuffer = symbolInstance.hasSdfIcon() ? bucket->sdfIcon : bucket->icon;
             const auto placeIcon = [&](const SymbolQuads& iconQuads, auto& index, const WritingModeType writingMode) {
-                iconBuffer.placedSymbols.emplace_back(symbolInstance.getAnchor().point,
-                                                      symbolInstance.getAnchor().segment.value_or(0u),
+                iconBuffer.placedSymbols.emplace_back(symbolInstance.getAnchor(__SOURCE_LOCATION__).point,
+                                                      symbolInstance.getAnchor(__SOURCE_LOCATION__).segment.value_or(0u),
                                                       sizeData.min,
                                                       sizeData.max,
-                                                      symbolInstance.getIconOffset(),
+                                                      symbolInstance.getIconOffset(__SOURCE_LOCATION__),
                                                       writingMode,
                                                       symbolInstance.line(),
                                                       std::vector<float>());
@@ -803,21 +803,21 @@ void SymbolLayout::createBucket(const ImagePositions&,
                 PlacedSymbol& iconSymbol = iconBuffer.placedSymbols.back();
                 iconSymbol.angle = (allowVerticalPlacement && writingMode == WritingModeType::Vertical) ? static_cast<float>(M_PI_2) : 0.0f;
                 iconSymbol.vertexStartIndex =
-                    addSymbols(iconBuffer, sizeData, iconQuads, symbolInstance.getAnchor(), iconSymbol, feature.sortKey);
+                    addSymbols(iconBuffer, sizeData, iconQuads, symbolInstance.getAnchor(__SOURCE_LOCATION__), iconSymbol, feature.sortKey);
             };
 
-            placeIcon(*symbolInstance.iconQuads(), symbolInstance.refPlacedIconIndex(), WritingModeType::None);
-            symbolInstance.check();
+            placeIcon(*symbolInstance.iconQuads(), symbolInstance.refPlacedIconIndex(__SOURCE_LOCATION__), WritingModeType::None);
+            symbolInstance.check(__SOURCE_LOCATION__);
             if (symbolInstance.verticalIconQuads()) {
                 placeIcon(*symbolInstance.verticalIconQuads(),
-                          symbolInstance.refPlacedVerticalIconIndex(),
+                          symbolInstance.refPlacedVerticalIconIndex(__SOURCE_LOCATION__),
                           WritingModeType::Vertical);
-                symbolInstance.check();
+                symbolInstance.check(__SOURCE_LOCATION__);
             }
 
             for (auto& pair : bucket->paintProperties) {
                 pair.second.iconBinders.populateVertexVectors(
-                    feature, iconBuffer.vertices.elements(), symbolInstance.getDataFeatureIndex(), {}, {}, canonical);
+                    feature, iconBuffer.vertices.elements(), symbolInstance.getDataFeatureIndex(__SOURCE_LOCATION__), {}, {}, canonical);
             }
         }
 
@@ -828,57 +828,57 @@ void SymbolLayout::createBucket(const ImagePositions&,
                 lastAddedSection = addSymbolGlyphQuads(*bucket,
                                                        symbolInstance,
                                                        feature,
-                                                       symbolInstance.getWritingModes(),
+                                                       symbolInstance.getWritingModes(__SOURCE_LOCATION__),
                                                        placedTextIndex,
                                                        symbolInstance.rightJustifiedGlyphQuads(),
                                                        canonical,
                                                        lastAddedSection);
-                symbolInstance.setPlacedRightTextIndex(placedTextIndex);
-                symbolInstance.setPlacedCenterTextIndex(placedTextIndex);
-                symbolInstance.setPlacedLeftTextIndex(placedTextIndex);
+                symbolInstance.setPlacedRightTextIndex(placedTextIndex, __SOURCE_LOCATION__);
+                symbolInstance.setPlacedCenterTextIndex(placedTextIndex, __SOURCE_LOCATION__);
+                symbolInstance.setPlacedLeftTextIndex(placedTextIndex, __SOURCE_LOCATION__);
             } else {
-                if (symbolInstance.getRightJustifiedGlyphQuadsSize()) {
+                if (symbolInstance.getRightJustifiedGlyphQuadsSize(__SOURCE_LOCATION__)) {
                     lastAddedSection = addSymbolGlyphQuads(*bucket,
                                                            symbolInstance,
                                                            feature,
-                                                           symbolInstance.getWritingModes(),
-                                                           symbolInstance.refPlacedRightTextIndex(),
+                                                           symbolInstance.getWritingModes(__SOURCE_LOCATION__),
+                                                           symbolInstance.refPlacedRightTextIndex(__SOURCE_LOCATION__),
                                                            symbolInstance.rightJustifiedGlyphQuads(),
                                                            canonical,
                                                            lastAddedSection);
                 }
-                if (symbolInstance.getCenterJustifiedGlyphQuadsSize()) {
+                if (symbolInstance.getCenterJustifiedGlyphQuadsSize(__SOURCE_LOCATION__)) {
                     lastAddedSection = addSymbolGlyphQuads(*bucket,
                                                            symbolInstance,
                                                            feature,
-                                                           symbolInstance.getWritingModes(),
-                                                           symbolInstance.refPlacedCenterTextIndex(),
+                                                           symbolInstance.getWritingModes(__SOURCE_LOCATION__),
+                                                           symbolInstance.refPlacedCenterTextIndex(__SOURCE_LOCATION__),
                                                            symbolInstance.centerJustifiedGlyphQuads(),
                                                            canonical,
                                                            lastAddedSection);
                 }
-                if (symbolInstance.getLeftJustifiedGlyphQuadsSize()) {
+                if (symbolInstance.getLeftJustifiedGlyphQuadsSize(__SOURCE_LOCATION__)) {
                     lastAddedSection = addSymbolGlyphQuads(*bucket,
                                                            symbolInstance,
                                                            feature,
-                                                           symbolInstance.getWritingModes(),
-                                                           symbolInstance.refPlacedLeftTextIndex(),
+                                                           symbolInstance.getWritingModes(__SOURCE_LOCATION__),
+                                                           symbolInstance.refPlacedLeftTextIndex(__SOURCE_LOCATION__),
                                                            symbolInstance.leftJustifiedGlyphQuads(),
                                                            canonical,
                                                            lastAddedSection);
                 }
             }
-            if ((symbolInstance.getWritingModes() & WritingModeType::Vertical) && symbolInstance.getVerticalGlyphQuadsSize()) {
+            if ((symbolInstance.getWritingModes(__SOURCE_LOCATION__) & WritingModeType::Vertical) && symbolInstance.getVerticalGlyphQuadsSize(__SOURCE_LOCATION__)) {
                 lastAddedSection = addSymbolGlyphQuads(*bucket,
                                                        symbolInstance,
                                                        feature,
                                                        WritingModeType::Vertical,
-                                                       symbolInstance.refPlacedVerticalTextIndex(),
+                                                       symbolInstance.refPlacedVerticalTextIndex(__SOURCE_LOCATION__),
                                                        symbolInstance.verticalGlyphQuads(),
                                                        canonical,
                                                        lastAddedSection);
             }
-            symbolInstance.check("createBucket loop");
+            symbolInstance.check(__SOURCE_LOCATION__);
             assert(lastAddedSection); // True, as hasText == true;
             updatePaintPropertiesForSection(*bucket, feature, *lastAddedSection, canonical);
         }
@@ -896,7 +896,7 @@ void SymbolLayout::createBucket(const ImagePositions&,
             }
             renderData.emplace(pair.first, LayerRenderData{bucket, pair.second});
         }
-        bucket->check("SymbolLayout::createBucket");
+        bucket->check(__SOURCE_LOCATION__);
     }
 }
 
@@ -921,15 +921,15 @@ std::size_t SymbolLayout::addSymbolGlyphQuads(SymbolBucket& bucket,
                                               optional<std::size_t> lastAddedSection) {
     const Range<float> sizeData = bucket.textSizeBinder->getVertexSizeData(feature);
     const bool hasFormatSectionOverrides = bucket.hasFormatSectionOverrides();
-    const auto& placedIconIndex = writingMode == WritingModeType::Vertical ? symbolInstance.getPlacedVerticalIconIndex() : symbolInstance.getPlacedIconIndex();
-    bucket.text.placedSymbols.emplace_back(symbolInstance.getAnchor().point,
-                                           symbolInstance.getAnchor().segment.value_or(0u),
+    const auto& placedIconIndex = writingMode == WritingModeType::Vertical ? symbolInstance.getPlacedVerticalIconIndex(__SOURCE_LOCATION__) : symbolInstance.getPlacedIconIndex(__SOURCE_LOCATION__);
+    bucket.text.placedSymbols.emplace_back(symbolInstance.getAnchor(__SOURCE_LOCATION__).point,
+                                           symbolInstance.getAnchor(__SOURCE_LOCATION__).segment.value_or(0u),
                                            sizeData.min,
                                            sizeData.max,
-                                           symbolInstance.getTextOffset(),
+                                           symbolInstance.getTextOffset(__SOURCE_LOCATION__),
                                            writingMode,
                                            symbolInstance.line(),
-                                           calculateTileDistances(symbolInstance.line(), symbolInstance.getAnchor()),
+                                           calculateTileDistances(symbolInstance.line(), symbolInstance.getAnchor(__SOURCE_LOCATION__)),
                                            placedIconIndex);
     placedIndex = bucket.text.placedSymbols.size() - 1;
     PlacedSymbol& placedSymbol = bucket.text.placedSymbols.back();
@@ -943,7 +943,7 @@ std::size_t SymbolLayout::addSymbolGlyphQuads(SymbolBucket& bucket,
             }
             lastAddedSection = symbolQuad.sectionIndex;
         }
-        size_t index = addSymbol(bucket.text, sizeData, symbolQuad, symbolInstance.getAnchor(), placedSymbol, feature.sortKey);
+        size_t index = addSymbol(bucket.text, sizeData, symbolQuad, symbolInstance.getAnchor(__SOURCE_LOCATION__), placedSymbol, feature.sortKey);
         if (firstSymbol) {
             placedSymbol.vertexStartIndex = index;
             firstSymbol = false;
@@ -1100,10 +1100,10 @@ void SymbolLayout::addToDebugBuffers(SymbolBucket& bucket) {
                 auto& segment = collisionBuffer.segments.back();
                 auto index = static_cast<uint16_t>(segment.vertexLength);
 
-                collisionBuffer.vertices.emplace_back(CollisionBoxProgram::layoutVertex(anchor, symbolInstance.getAnchor().point, tl));
-                collisionBuffer.vertices.emplace_back(CollisionBoxProgram::layoutVertex(anchor, symbolInstance.getAnchor().point, tr));
-                collisionBuffer.vertices.emplace_back(CollisionBoxProgram::layoutVertex(anchor, symbolInstance.getAnchor().point, br));
-                collisionBuffer.vertices.emplace_back(CollisionBoxProgram::layoutVertex(anchor, symbolInstance.getAnchor().point, bl));
+                collisionBuffer.vertices.emplace_back(CollisionBoxProgram::layoutVertex(anchor, symbolInstance.getAnchor(__SOURCE_LOCATION__).point, tl));
+                collisionBuffer.vertices.emplace_back(CollisionBoxProgram::layoutVertex(anchor, symbolInstance.getAnchor(__SOURCE_LOCATION__).point, tr));
+                collisionBuffer.vertices.emplace_back(CollisionBoxProgram::layoutVertex(anchor, symbolInstance.getAnchor(__SOURCE_LOCATION__).point, br));
+                collisionBuffer.vertices.emplace_back(CollisionBoxProgram::layoutVertex(anchor, symbolInstance.getAnchor(__SOURCE_LOCATION__).point, bl));
 
                 // Dynamic vertices are initialized so that the vertex count always agrees with
                 // the layout vertex buffer, but they will always be updated before rendering happens
@@ -1129,14 +1129,14 @@ void SymbolLayout::addToDebugBuffers(SymbolBucket& bucket) {
                 segment.indexLength += indexLength;
             }
         };
-        populateCollisionBox(symbolInstance.getTextCollisionFeature(), true /*isText*/);
-        if (symbolInstance.getVerticalTextCollisionFeature()) {
-            populateCollisionBox(*symbolInstance.getVerticalTextCollisionFeature(), true /*isText*/);
+        populateCollisionBox(symbolInstance.getTextCollisionFeature(__SOURCE_LOCATION__), true /*isText*/);
+        if (symbolInstance.getVerticalTextCollisionFeature(__SOURCE_LOCATION__)) {
+            populateCollisionBox(*symbolInstance.getVerticalTextCollisionFeature(__SOURCE_LOCATION__), true /*isText*/);
         }
-        if (symbolInstance.getVerticalIconCollisionFeature()) {
-            populateCollisionBox(*symbolInstance.getVerticalIconCollisionFeature(), false /*isText*/);
+        if (symbolInstance.getVerticalIconCollisionFeature(__SOURCE_LOCATION__)) {
+            populateCollisionBox(*symbolInstance.getVerticalIconCollisionFeature(__SOURCE_LOCATION__), false /*isText*/);
         }
-        populateCollisionBox(symbolInstance.getIconCollisionFeature(), false /*isText*/);
+        populateCollisionBox(symbolInstance.getIconCollisionFeature(__SOURCE_LOCATION__), false /*isText*/);
     }
 }
 

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -878,9 +878,12 @@ void SymbolLayout::createBucket(const ImagePositions&,
                                                        canonical,
                                                        lastAddedSection);
             }
-            symbolInstance.check(__SOURCE_LOCATION__);
-            assert(lastAddedSection); // True, as hasText == true;
-            updatePaintPropertiesForSection(*bucket, feature, *lastAddedSection, canonical);
+            if (symbolInstance.check(__SOURCE_LOCATION__)) {
+                assert(lastAddedSection); // True, as hasText == true;
+                updatePaintPropertiesForSection(*bucket, feature, *lastAddedSection, canonical);
+            } else {
+                break;
+            }
         }
 
         symbolInstance.releaseSharedData();
@@ -889,14 +892,16 @@ void SymbolLayout::createBucket(const ImagePositions&,
     if (showCollisionBoxes) {
         addToDebugBuffers(*bucket);
     }
-    if (bucket->hasData()){
-        for (const auto& pair : layerPaintProperties) {
-            if (!firstLoad) {
-                bucket->justReloaded = true;
+    if (bucket->hasData()) {
+        if (bucket->check(__SOURCE_LOCATION__)) {
+            for (const auto &pair: layerPaintProperties) {
+                if (!firstLoad) {
+                    bucket->justReloaded = true;
+                }
+                renderData.emplace(pair.first, LayerRenderData{bucket, pair.second});
             }
-            renderData.emplace(pair.first, LayerRenderData{bucket, pair.second});
+            bucket->check(__SOURCE_LOCATION__);
         }
-        bucket->check(__SOURCE_LOCATION__);
     }
 }
 

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -68,6 +68,8 @@ public:
     virtual void updateVertices(
         const Placement&, bool /*updateOpacities*/, const TransformState&, const RenderTile&, std::set<uint32_t>&) {}
 
+    virtual bool check(std::string_view) { return true; }
+
 protected:
     Bucket() = default;
     std::atomic<bool> uploaded { false };

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -246,33 +246,33 @@ void SymbolBucket::sortFeatures(const float angle) {
     // The index array buffer is rewritten to reference the (unchanged) vertices in the
     // sorted order.
     for (const SymbolInstance& symbolInstance : getSortedSymbols(angle)) {
-        if (!symbolInstance.check("sortFeatures")) continue;
+        if (!symbolInstance.check(__SOURCE_LOCATION__)) continue;
         if (!symbolInstance.checkIndexes(text.placedSymbols.size(), icon.placedSymbols.size(), sdfIcon.placedSymbols.size(), "sortFeatures")) continue;
-        symbolsSortOrder->push_back(symbolInstance.getDataFeatureIndex());
+        symbolsSortOrder->push_back(symbolInstance.getDataFeatureIndex(__SOURCE_LOCATION__));
 
-        if (symbolInstance.getPlacedRightTextIndex()) {
-            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.getPlacedRightTextIndex()]);
+        if (symbolInstance.getPlacedRightTextIndex(__SOURCE_LOCATION__)) {
+            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.getPlacedRightTextIndex(__SOURCE_LOCATION__)]);
         }
 
-        if (symbolInstance.getPlacedCenterTextIndex() && !symbolInstance.getSingleLine()) {
-            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.getPlacedCenterTextIndex()]);
+        if (symbolInstance.getPlacedCenterTextIndex(__SOURCE_LOCATION__) && !symbolInstance.getSingleLine(__SOURCE_LOCATION__)) {
+            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.getPlacedCenterTextIndex(__SOURCE_LOCATION__)]);
         }
 
-        if (symbolInstance.getPlacedLeftTextIndex() && !symbolInstance.getSingleLine()) {
-            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.getPlacedLeftTextIndex()]);
+        if (symbolInstance.getPlacedLeftTextIndex(__SOURCE_LOCATION__) && !symbolInstance.getSingleLine(__SOURCE_LOCATION__)) {
+            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.getPlacedLeftTextIndex(__SOURCE_LOCATION__)]);
         }
 
-        if (symbolInstance.getPlacedVerticalTextIndex()) {
-            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.getPlacedVerticalTextIndex()]);
+        if (symbolInstance.getPlacedVerticalTextIndex(__SOURCE_LOCATION__)) {
+            addPlacedSymbol(text.triangles, text.placedSymbols[*symbolInstance.getPlacedVerticalTextIndex(__SOURCE_LOCATION__)]);
         }
 
         auto& iconBuffer = symbolInstance.hasSdfIcon() ? sdfIcon : icon;
-        if (symbolInstance.getPlacedIconIndex()) {
-            addPlacedSymbol(iconBuffer.triangles, iconBuffer.placedSymbols[*symbolInstance.getPlacedIconIndex()]);
+        if (symbolInstance.getPlacedIconIndex(__SOURCE_LOCATION__)) {
+            addPlacedSymbol(iconBuffer.triangles, iconBuffer.placedSymbols[*symbolInstance.getPlacedIconIndex(__SOURCE_LOCATION__)]);
         }
 
-        if (symbolInstance.getPlacedVerticalIconIndex()) {
-            addPlacedSymbol(iconBuffer.triangles, iconBuffer.placedSymbols[*symbolInstance.getPlacedVerticalIconIndex()]);
+        if (symbolInstance.getPlacedVerticalIconIndex(__SOURCE_LOCATION__)) {
+            addPlacedSymbol(iconBuffer.triangles, iconBuffer.placedSymbols[*symbolInstance.getPlacedVerticalIconIndex(__SOURCE_LOCATION__)]);
         }
     }
 
@@ -285,12 +285,12 @@ SymbolInstanceReferences SymbolBucket::getSortedSymbols(const float angle) const
     const float cos = std::cos(angle);
 
     std::sort(result.begin(), result.end(), [sin, cos](const SymbolInstance& a, const SymbolInstance& b) {
-        const auto aRotated = std::lround(sin * a.getAnchor().point.x + cos * a.getAnchor().point.y);
-        const auto bRotated = std::lround(sin * b.getAnchor().point.x + cos * b.getAnchor().point.y);
+        const auto aRotated = std::lround(sin * a.getAnchor(__SOURCE_LOCATION__).point.x + cos * a.getAnchor(__SOURCE_LOCATION__).point.y);
+        const auto bRotated = std::lround(sin * b.getAnchor(__SOURCE_LOCATION__).point.x + cos * b.getAnchor(__SOURCE_LOCATION__).point.y);
         if (aRotated != bRotated) {
             return aRotated < bRotated;
         }
-        return a.getDataFeatureIndex() > b.getDataFeatureIndex();  // aRotated == bRotated
+        return a.getDataFeatureIndex(__SOURCE_LOCATION__) > b.getDataFeatureIndex(__SOURCE_LOCATION__);  // aRotated == bRotated
     });
 
     return result;

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -103,6 +103,16 @@ public:
     // returns references to all the symbols if |sortKeyRange| is `nullopt`.
     SymbolInstanceReferences getSymbols(const optional<SortKeyRange>& sortKeyRange = nullopt) const;
 
+    bool check(std::string_view source) override {
+        bool success = true;
+        for (std::size_t i = 0; i < symbolInstances.size(); ++i) {
+            if (!symbolInstances[i].check(std::string(source) + " instance " + util::toString(i))) {
+                success = false;
+            }
+        }
+        return success;
+    }
+
     Immutable<style::SymbolLayoutProperties::PossiblyEvaluated> layout;
     const std::string bucketLeaderID;
     float sortedAngle = std::numeric_limits<float>::max();

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -228,8 +228,18 @@ auto CrossTileSymbolIndex::addLayer(const RenderLayer& layer, float lng) -> AddL
     for (const auto& item : layer.getPlacementData()) {
         const RenderTile& renderTile = item.tile;
         Bucket& bucket = item.bucket;
+
+        if (!bucket.check(std::string("CrossTileSymbolIndex::addLayer1 ") +
+                          item.sourceId + "/" + layer.getID())) {
+          continue;
+        }
+
         auto pair = bucket.registerAtCrossTileIndex(layerIndex, renderTile);
         assert(pair.first != 0u);
+
+        bucket.check(std::string("CrossTileSymbolIndex::addLayer2 ") +
+                     item.sourceId + "/" + layer.getID());
+
         if (pair.second) result |= AddLayerResult::BucketsAdded;
         currentBucketIDs.insert(pair.first);
     }

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -12,8 +12,8 @@ TileLayerIndex::TileLayerIndex(OverscaledTileID coord_,
                                std::string bucketLeaderId_)
     : coord(coord_), bucketInstanceId(bucketInstanceId_), bucketLeaderId(std::move(bucketLeaderId_)) {
     for (SymbolInstance& symbolInstance : symbolInstances) {
-        if (symbolInstance.getCrossTileID() == SymbolInstance::invalidCrossTileID()) continue;
-        indexedSymbolInstances[symbolInstance.getKey()].emplace_back(symbolInstance.getCrossTileID(),
+        if (symbolInstance.getCrossTileID(__SOURCE_LOCATION__) == SymbolInstance::invalidCrossTileID()) continue;
+        indexedSymbolInstances[symbolInstance.getKey(__SOURCE_LOCATION__)].emplace_back(symbolInstance.getCrossTileID(__SOURCE_LOCATION__),
                                                                 getScaledCoordinates(symbolInstance, coord));
     }
 }
@@ -24,8 +24,8 @@ Point<int64_t> TileLayerIndex::getScaledCoordinates(SymbolInstance& symbolInstan
     const double roundingFactor = 512.0 / util::EXTENT / 2.0;
     const double scale = roundingFactor / std::pow(2, childTileCoord.canonical.z - coord.canonical.z);
     return {
-        static_cast<int64_t>(std::floor((childTileCoord.canonical.x * util::EXTENT + symbolInstance.getAnchor().point.x) * scale)),
-        static_cast<int64_t>(std::floor((childTileCoord.canonical.y * util::EXTENT + symbolInstance.getAnchor().point.y) * scale))
+        static_cast<int64_t>(std::floor((childTileCoord.canonical.x * util::EXTENT + symbolInstance.getAnchor(__SOURCE_LOCATION__).point.x) * scale)),
+        static_cast<int64_t>(std::floor((childTileCoord.canonical.y * util::EXTENT + symbolInstance.getAnchor(__SOURCE_LOCATION__).point.y) * scale))
     };
 }
 
@@ -38,12 +38,12 @@ void TileLayerIndex::findMatches(SymbolBucket& bucket,
     if (bucket.bucketLeaderID != bucketLeaderId) return;
 
     for (auto& symbolInstance : symbolInstances) {
-        if (symbolInstance.getCrossTileID()) {
+        if (symbolInstance.getCrossTileID(__SOURCE_LOCATION__)) {
             // already has a match, skip
             continue;
         }
 
-        auto it = indexedSymbolInstances.find(symbolInstance.getKey());
+        auto it = indexedSymbolInstances.find(symbolInstance.getKey(__SOURCE_LOCATION__));
         if (it == indexedSymbolInstances.end()) {
             // No symbol with this key in this bucket
             continue;
@@ -61,7 +61,7 @@ void TileLayerIndex::findMatches(SymbolBucket& bucket,
                 // don't let any other symbols at the same zoom level duplicate against
                 // the same parent (see issue #10844)
                 zoomCrossTileIDs.insert(thisTileSymbol.crossTileID);
-                symbolInstance.setCrossTileID(thisTileSymbol.crossTileID);
+                symbolInstance.setCrossTileID(thisTileSymbol.crossTileID, __SOURCE_LOCATION__);
                 break;
             }
         }
@@ -134,16 +134,16 @@ bool CrossTileSymbolLayerIndex::addBucket(const OverscaledTileID& tileID,
         // For overscaled tiles the viewport might be showing only a small part of the tile,
         // so we filter out the off-screen symbols to improve the performance.
         for (auto& symbolInstance : bucket.symbolInstances) {
-            if (isInVewport(tileMatrix, symbolInstance.getAnchor().point)) {
-                symbolInstance.setCrossTileID(0u);
+            if (isInVewport(tileMatrix, symbolInstance.getAnchor(__SOURCE_LOCATION__).point)) {
+                symbolInstance.setCrossTileID(0u, __SOURCE_LOCATION__);
             } else {
-                symbolInstance.setCrossTileID(SymbolInstance::invalidCrossTileID());
+                symbolInstance.setCrossTileID(SymbolInstance::invalidCrossTileID(), __SOURCE_LOCATION__);
                 bucket.hasUninitializedSymbols = true;
             }
         }
     } else {
         for (auto& symbolInstance : bucket.symbolInstances) {
-            symbolInstance.setCrossTileID(0u);
+            symbolInstance.setCrossTileID(0u, __SOURCE_LOCATION__);
         }
     }
 
@@ -168,10 +168,10 @@ bool CrossTileSymbolLayerIndex::addBucket(const OverscaledTileID& tileID,
     }
 
     for (auto& symbolInstance : bucket.symbolInstances) {
-        if (!symbolInstance.getCrossTileID()) {
+        if (!symbolInstance.getCrossTileID(__SOURCE_LOCATION__)) {
             // symbol did not match any known symbol, assign a new id
-            symbolInstance.setCrossTileID(++maxCrossTileID);
-            thisZoomUsedCrossTileIDs.insert(symbolInstance.getCrossTileID());
+            symbolInstance.setCrossTileID(++maxCrossTileID, __SOURCE_LOCATION__);
+            thisZoomUsedCrossTileIDs.insert(symbolInstance.getCrossTileID(__SOURCE_LOCATION__));
         }
     }
 

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -253,7 +253,7 @@ void GeometryTile::onLayout(std::shared_ptr<LayoutResult> result, const uint64_t
     if (layoutResult) {
         for (const auto& data : layoutResult->layerRenderData) {
             if (data.second.bucket) {
-                data.second.bucket->check("GeometryTile::onLayout1 " __LINE_STRING__);
+                data.second.bucket->check(__SOURCE_LOCATION__);
             }
         }
     }
@@ -263,7 +263,7 @@ void GeometryTile::onLayout(std::shared_ptr<LayoutResult> result, const uint64_t
     if (layoutResult) {
         for (const auto& data : layoutResult->layerRenderData) {
             if (data.second.bucket) {
-                data.second.bucket->check("GeometryTile::onLayout2 " __LINE_STRING__);
+                data.second.bucket->check(__SOURCE_LOCATION__);
             }
         }
     }

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -250,7 +250,23 @@ void GeometryTile::onLayout(std::shared_ptr<LayoutResult> result, const uint64_t
     	atlasTextures = std::make_shared<TileAtlasTextures>();
     }
     
+    if (layoutResult) {
+        for (const auto& data : layoutResult->layerRenderData) {
+            if (data.second.bucket) {
+                data.second.bucket->check("GeometryTile::onLayout1 " __LINE_STRING__);
+            }
+        }
+    }
+
     observer->onTileChanged(*this);
+    
+    if (layoutResult) {
+        for (const auto& data : layoutResult->layerRenderData) {
+            if (data.second.bucket) {
+                data.second.bucket->check("GeometryTile::onLayout2 " __LINE_STRING__);
+            }
+        }
+    }
 }
 
 void GeometryTile::onError(std::exception_ptr err, const uint64_t resultCorrelationID) {


### PR DESCRIPTION
Pass the file and line number of the original call through `SymbolInstance` accessor methods in addition to explicit checks, since the observed failures are from those calls.

Add more explicit checks, particularly before and after the buckets are transferred from the worker threads to the render thread, and avoid using the results when checks fail in hopes of preventing crashes.

Avoid short-circuiting on checks so that if multiple guard values are modified they will all be listed, in order to provide a better sense of the extent of the unexpected changes.