### PR TITLE
[ios] MapLibre logo with MLNMapSnapshotter

### DIFF
--- a/platform/darwin/src/MLNMapCamera.h
+++ b/platform/darwin/src/MLNMapCamera.h
@@ -8,13 +8,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  An `MLNMapCamera` object represents a viewpoint from which the user observes
- some point on an `MLNMapView`.
+ some point on an ``MLNMapView``.
 
  #### Related examples
- TODO: Camera animation, learn how to create a camera that rotates
+ - <doc:BlockingGesturesExample>: learn how to use the
+ ``MLNMapViewDelegate/mapView:shouldChangeFromCamera:toCamera:`` method of ``MLNMapViewDelegate`` to
+ restrict panning.
+ - *TODO:* Camera animation, learn how to create a camera that rotates
  around a central point.
- TODO: Restrict map panning to an area, learn how to restrict map
- panning using `MLNMapViewDelegate`'s `-mapView:shouldChangeFromCamera:toCamera:` method.
  */
 MLN_EXPORT
 @interface MLNMapCamera : NSObject <NSSecureCoding, NSCopying>
@@ -38,17 +39,17 @@ MLN_EXPORT
  The altitude is the distance from the viewpoint to the map, perpendicular to
  the map plane. This property does not account for physical elevation.
 
- This property’s value may be less than that of the `viewingDistance` property.
- Setting this property automatically updates the `viewingDistance` property
- based on the `pitch` property’s current value.
+ This property’s value may be less than that of the ``viewingDistance`` property.
+ Setting this property automatically updates the ``viewingDistance`` property
+ based on the ``pitch`` property’s current value.
  */
 @property (nonatomic) CLLocationDistance altitude;
 
 /**
- The straight-line distance from the viewpoint to the `centerCoordinate`.
+ The straight-line distance from the viewpoint to the ``centerCoordinate``.
 
- Setting this property automatically updates the `altitude` property based on
- the `pitch` property’s current value.
+ Setting this property automatically updates the ``altitude`` property based on
+ the ``pitch`` property’s current value.
  */
 @property (nonatomic) CLLocationDistance viewingDistance;
 
@@ -76,12 +77,12 @@ MLN_EXPORT
 
  This method interprets the distance as a straight-line distance from the
  viewpoint to the center coordinate. To specify the altitude of the viewpoint,
- use the `-cameraLookingAtCenterCoordinate:altitude:pitch:heading:` method.
+ use the ``cameraLookingAtCenterCoordinate:altitude:pitch:heading:`` method.
 
  @param centerCoordinate The geographic coordinate on which the map should be
     centered.
  @param distance The straight-line distance from the viewpoint to the
-    `centerCoordinate`.
+    ``centerCoordinate``.
  @param pitch The viewing angle of the camera, measured in degrees. A value of
     `0` results in a camera pointed straight down at the map. Angles greater
     than `0` result in a camera angled toward the horizon.
@@ -117,11 +118,11 @@ MLN_EXPORT
                                         heading:(CLLocationDirection)heading;
 
 /**
- @note This initializer incorrectly interprets the `distance` parameter. To
-    specify the straight-line distance from the viewpoint to `centerCoordinate`,
-    use the `-cameraLookingAtCenterCoordinate:acrossDistance:pitch:heading:`
+ > This initializer incorrectly interprets the `distance` parameter. To
+    specify the straight-line distance from the viewpoint to ``centerCoordinate``,
+    use the ``cameraLookingAtCenterCoordinate:acrossDistance:pitch:heading:``
     method. To specify the altitude of the viewpoint, use the
-    `-cameraLookingAtCenterCoordinate:altitude:pitch:heading:` method, which has
+    ``cameraLookingAtCenterCoordinate:altitude:pitch:heading:`` method, which has
     the same behavior as this initializer.
  */
 + (instancetype)cameraLookingAtCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate
@@ -135,7 +136,7 @@ MLN_EXPORT
  Returns a Boolean value indicating whether the given camera is functionally
  equivalent to the receiver.
 
- Unlike `-isEqual:`, this method returns `YES` if the difference between the
+ Unlike `isEqual:`, this method returns `YES` if the difference between the
  coordinates, altitudes, pitches, or headings of the two camera objects is
  negligible.
 

--- a/platform/darwin/src/MLNMapSnapshotter.h
+++ b/platform/darwin/src/MLNMapSnapshotter.h
@@ -9,8 +9,8 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MLNMapSnapshotterDelegate;
 
 /**
- An overlay that is placed within a `MLNMapSnapshot`.
- To access this object, use `-[MLNMapSnapshotter startWithOverlayHandler:completionHandler:]`.
+ An overlay that is placed within a ``MLNMapSnapshot``.
+ To access this object, use ``MLNMapSnapshotter/startWithOverlayHandler:completionHandler:``.
  */
 
 MLN_EXPORT
@@ -53,12 +53,12 @@ MLN_EXPORT
 A block provided during the snapshot drawing process, enabling the ability to
 draw custom overlays rendered with Core Graphics.
 
- @param snapshotOverlay The `MLNMapSnapshotOverlay` provided during snapshot drawing.
+ @param snapshotOverlay The ``MLNMapSnapshotOverlay`` provided during snapshot drawing.
  */
 typedef void (^MLNMapSnapshotOverlayHandler)(MLNMapSnapshotOverlay *snapshotOverlay);
 
 /**
- The options to use when creating images with the `MLNMapSnapshotter`.
+ The options to use when creating images with the ``MLNMapSnapshotter``.
  */
 MLN_EXPORT
 @interface MLNMapSnapshotOptions : NSObject <NSCopying>
@@ -94,9 +94,9 @@ MLN_EXPORT
 /**
  A camera representing the viewport visible in the snapshot.
 
- If this property is non-nil and the `coordinateBounds` property is set to a
+ If this property is non-nil and the ``coordinateBounds`` property is set to a
  non-empty coordinate bounds, the camera’s center coordinate and altitude are
- ignored in favor of the `coordinateBounds` property.
+ ignored in favor of the ``coordinateBounds`` property.
  */
 @property (nonatomic) MLNMapCamera *camera;
 
@@ -170,7 +170,7 @@ MLN_EXPORT
 /**
  A block to processes the result or error of a snapshot request.
 
- @param snapshot The `MLNMapSnapshot` that was generated or `nil` if an error
+ @param snapshot The ``MLNMapSnapshot`` that was generated or `nil` if an error
     occurred.
  @param error The error that occured or `nil` when successful.
  */
@@ -178,10 +178,10 @@ typedef void (^MLNMapSnapshotCompletionHandler)(MLNMapSnapshot *_Nullable snapsh
                                                 NSError *_Nullable error);
 
 /**
- An `MLNMapSnapshotter` generates static raster images of the map. Each snapshot
- image depicts a portion of a map defined by an `MLNMapSnapshotOptions` object
- you provide. The snapshotter generates an `MLNMapSnapshot` object
- asynchronously, calling `MLNMapSnapshotterDelegate` methods if defined, then
+ An ``MLNMapSnapshotter`` generates static raster images of the map. Each snapshot
+ image depicts a portion of a map defined by an ``MLNMapSnapshotOptions`` object
+ you provide. The snapshotter generates an ``MLNMapSnapshot`` object
+ asynchronously, calling ``MLNMapSnapshotterDelegate`` methods if defined, then
  passing it into a completion handler once tiles and other resources needed for
  the snapshot are finished loading.
 
@@ -190,9 +190,9 @@ typedef void (^MLNMapSnapshotCompletionHandler)(MLNMapSnapshot *_Nullable snapsh
  snapshot at a time. If you need to generate multiple snapshots concurrently,
  create multiple snapshotter objects.
 
- For an interactive map, use the `MLNMapView` class. Both `MLNMapSnapshotter`
- and `MLNMapView` are compatible with offline packs managed by the
- `MLNOfflineStorage` class.
+ For an interactive map, use the ``MLNMapView`` class. Both ``MLNMapSnapshotter``
+ and ``MLNMapView`` are compatible with offline packs managed by the
+ ``MLNOfflineStorage`` class.
 
  From a snapshot, you can obtain an image and convert geographic coordinates to
  the image’s coordinate space in order to superimpose markers and overlays. If
@@ -277,7 +277,7 @@ MLN_EXPORT
  Cancels the snapshot creation request, if any.
 
  Once you call this method, you cannot resume the snapshot. In order to obtain
- the snapshot, create a new `MLNMapSnapshotter` object.
+ the snapshot, create a new ``MLNMapSnapshotter`` object.
  */
 - (void)cancel;
 
@@ -308,21 +308,14 @@ MLN_EXPORT
 /**
  The style displayed in the resulting snapshot.
 
- Unlike the `MLNMapSnapshotOptions.styleURL` property, this property is set to
+ Unlike the ``MLNMapSnapshotOptions/styleURL`` property, this property is set to
  an object that allows you to manipulate every aspect of the style locally.
 
  This property is set to `nil` until the style finishes loading. If the style
  has failed to load, this property is set to `nil`. Because the style loads
  asynchronously, you should manipulate it in the
- `-[MLNMapSnapshotterDelegate mapSnapshotter:didFinishLoadingStyle:]` method. It
+ ``MLNMapSnapshotterDelegate/mapSnapshotter:didFinishLoadingStyle:`` method. It
  is not possible to manipulate the style before it has finished loading.
-
- @note The default styles provided by Mapbox contain sources and layers with
-    identifiers that will change over time. Applications that use APIs that
-    manipulate a style’s sources and layers must first set the style URL to an
-    explicitly versioned style using a convenience method like
-    `+[MLNStyle outdoorsStyleURLWithVersion:]` or a manually constructed
-    `NSURL`.
  */
 @property (nonatomic, readonly, nullable) MLNStyle *style;
 
@@ -330,7 +323,7 @@ MLN_EXPORT
 
 /**
  Optional methods about significant events when creating a snapshot using an
- `MLNMapSnapshotter` object.
+ ``MLNMapSnapshotter`` object.
  */
 @protocol MLNMapSnapshotterDelegate <NSObject>
 @optional
@@ -352,8 +345,8 @@ MLN_EXPORT
  Tells the delegate that the snapshotter has just finished loading a style.
 
  This method is called in response to
- `-[MLNMapSnapshotter startWithQueue:completionHandler:]` as long as the
- `MLNMapSnapshotter.delegate` property is set. Changes to sources or layers of
+ ``MLNMapSnapshotter/startWithQueue:completionHandler:`` as long as the
+ ``MLNMapSnapshotter/delegate`` property is set. Changes to sources or layers of
  the style being snapshotted do not cause this method to be called.
 
  @param snapshotter The snapshotter that has just loaded a style.

--- a/platform/darwin/src/MLNMapSnapshotter.mm
+++ b/platform/darwin/src/MLNMapSnapshotter.mm
@@ -134,13 +134,7 @@ private:
 
 /**
  :nodoc:
- Whether the Mapbox wordmark is displayed.
-
- @note The Mapbox terms of service, which governs the use of Mapbox-hosted
- vector tiles and styles,
- <a href="https://docs.mapbox.com/help/how-mapbox-works/attribution/">requires</a> most Mapbox
- customers to display the Mapbox wordmark. If this applies to you, do not
- hide the wordmark or change its contents.
+ Whether to include the MapLibre logo. Note this is not required.
  */
 @property (nonatomic, readwrite) BOOL showsLogo;
 @end
@@ -388,7 +382,7 @@ MLNImage *MLNAttributedSnapshot(mbgl::MapSnapshotter::Attributions attributions,
     CGPoint attributionOrigin = CGPointMake(mglImage.size.width - 10 - attributionBackgroundSize.width,
                                             logoImageRect.origin.y + (logoImageRect.size.height / 2) - (attributionBackgroundSize.height / 2) + 1);
     if (!logoImage) {
-        CGSize defaultLogoSize = [MLNMapSnapshotter mapboxLongStyleLogo].size;
+        CGSize defaultLogoSize = [MLNMapSnapshotter maplibreLongStyleLogo].size;
         logoImageRect = CGRectMake(0, mglImage.size.height - (MLNLogoImagePosition.y + defaultLogoSize.height), 0, defaultLogoSize.height);
         attributionOrigin = CGPointMake(10, logoImageRect.origin.y + (logoImageRect.size.height / 2) - (attributionBackgroundSize.height / 2) + 1);
     }
@@ -461,7 +455,7 @@ MLNImage *MLNAttributedSnapshot(mbgl::MapSnapshotter::Attributions attributions,
     CGPoint attributionOrigin = CGPointMake(targetFrame.size.width - 10 - attributionBackgroundSize.width,
                                             MLNLogoImagePosition.y + 1);
     if (!logoImage) {
-        CGSize defaultLogoSize = [MLNMapSnapshotter mapboxLongStyleLogo].size;
+        CGSize defaultLogoSize = [MLNMapSnapshotter maplibreLongStyleLogo].size;
         logoImageRect = CGRectMake(0, MLNLogoImagePosition.y, 0, defaultLogoSize.height);
         attributionOrigin = CGPointMake(10, attributionOrigin.y);
     }
@@ -630,11 +624,11 @@ NSArray<MLNAttributionInfo *> *MLNAttributionInfosFromAttributions(mbgl::MapSnap
     MLNImage *logoImage;
     switch (style) {
         case MLNAttributionInfoStyleLong:
-            logoImage = [MLNMapSnapshotter mapboxLongStyleLogo];
+            logoImage = [MLNMapSnapshotter maplibreLongStyleLogo];
             break;
         case MLNAttributionInfoStyleMedium:
 #if TARGET_OS_IPHONE
-            logoImage = [UIImage imageNamed:@"mapbox_helmet" inBundle:[NSBundle mgl_frameworkBundle] compatibleWithTraitCollection:nil];
+            logoImage = [UIImage imageNamed:@"maplibre-logo-icon" inBundle:[NSBundle mgl_frameworkBundle] compatibleWithTraitCollection:nil];
 #else
             logoImage = [[NSImage alloc] initWithContentsOfFile:[[NSBundle mgl_frameworkBundle] pathForResource:@"mapbox_helmet" ofType:@"pdf"]];
 #endif
@@ -646,11 +640,11 @@ NSArray<MLNAttributionInfo *> *MLNAttributionInfosFromAttributions(mbgl::MapSnap
     return logoImage;
 }
 
-+ (MLNImage *)mapboxLongStyleLogo
++ (MLNImage *)maplibreLongStyleLogo
 {
     MLNImage *logoImage;
 #if TARGET_OS_IPHONE
-    logoImage =[UIImage imageNamed:@"mapbox" inBundle:[NSBundle mgl_frameworkBundle] compatibleWithTraitCollection:nil];
+    logoImage =[UIImage imageNamed:@"maplibre-logo-stroke-gray" inBundle:[NSBundle mgl_frameworkBundle] compatibleWithTraitCollection:nil];
 #else
     logoImage = [[NSImage alloc] initWithContentsOfFile:[[NSBundle mgl_frameworkBundle] pathForResource:@"mapbox" ofType:@"pdf"]];
 #endif

--- a/platform/darwin/src/MLNSettings.h
+++ b/platform/darwin/src/MLNSettings.h
@@ -40,12 +40,12 @@ MLN_EXPORT
 // MARK: Authorizing Access
 
 /**
- The API Key used by all instances of `MLNMapView` in the current application.
+ The API Key used by all instances of ``MLNMapView`` in the current application.
  Setting this property to a value of `nil` has no effect.
 
  @note You must set the API key before attempting to load any style which
     requires the token. Therefore, you should generally set it before creating an instance of
-    `MLNMapView`. The recommended way to set an api key is to add an entry
+    ``MLNMapView``. The recommended way to set an api key is to add an entry
     to your application’s Info.plist file with the key `MLNApiKey`
     and the type `String`. Alternatively, you may call this method from your
     application delegate’s `-applicationDidFinishLaunching:` method.

--- a/platform/ios/BUILD.bazel
+++ b/platform/ios/BUILD.bazel
@@ -244,6 +244,7 @@ filegroup(
     name = "extra_files",
     srcs = [
         "BAZEL.md",
+        "CHANGELOG.md",
         "MapLibre.podspec",
         "PrivacyInfo.xcprivacy",
         "README.md",

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -5,7 +5,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 ## main
 
 - Add [Privacy Manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files). MapLibre Native iOS has no built-in tracking, but it does use some system APIs for functional purposes that are marked by Apple as privacy sensitive. ([#1866](https://github.com/maplibre/maplibre-native/issues/1866)).
-- Change default `MLNMapSnapshotter` logo to the MapLibre logo ([#2537](https://github.com/maplibre/maplibre-native/pull/2537)). Note that showing the MapLibre logo is never required. Check with your tile provider if you need to show a logo.
+- Change default `MLNMapSnapshotter` logo to the MapLibre logo ([#2541](https://github.com/maplibre/maplibre-native/pull/2541)). Note that showing the MapLibre logo is never required. Check with your tile provider if you need to show a logo.
 
 ## 6.5.0
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -5,6 +5,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 ## main
 
 - Add [Privacy Manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files). MapLibre Native iOS has no built-in tracking, but it does use some system APIs for functional purposes that are marked by Apple as privacy sensitive. ([#1866](https://github.com/maplibre/maplibre-native/issues/1866)).
+- Change default `MLNMapSnapshotter` logo to the MapLibre logo ([#2537](https://github.com/maplibre/maplibre-native/pull/2537)). Note that showing the MapLibre logo is never required. Check with your tile provider if you need to show a logo.
 
 ## 6.5.0
 

--- a/platform/ios/resources/Images.xcassets/maplibre-logo-icon.imageset/Contents.json
+++ b/platform/ios/resources/Images.xcassets/maplibre-logo-icon.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "maplibre-logo-icon.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/platform/ios/resources/Images.xcassets/maplibre-logo-icon.imageset/maplibre-logo-icon.svg
+++ b/platform/ios/resources/Images.xcassets/maplibre-logo-icon.imageset/maplibre-logo-icon.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="12.497967"
+   height="18.851223"
+   fill="none"
+   version="1.1"
+   id="svg7"
+   sodipodi:docname="maplibregl-ctrl-logo.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <path
+     d="m 4.1636559,14.355648 a 0.484,0.657 0 0 0 -0.486,0.659 v 1.84 a 0.484,0.657 0 0 0 0.486,0.659 h 4.101 a 0.484,0.657 0 0 0 0.486,-0.659 v -1.84 a 0.484,0.657 0 0 0 -0.486,-0.659 z m 3.56,1.16 h -3.017 v 0.838 h 3.017 z"
+     style="fill:#ffffff;fill-rule:evenodd;stroke-width:1.036"
+     id="path4" />
+  <g
+     style="stroke-width:1.12604"
+     id="g7"
+     transform="translate(-0.91034412,-1.5923522)">
+    <path
+       d="m -9.408,-1.416 c -3.833,-0.025 -7.056,2.912 -7.08,6.615 -0.02,3.08 1.653,4.832 3.107,6.268 0.903,0.892 1.721,1.74 2.32,2.902 l -0.525,-0.004 c -0.543,-0.003 -0.992,0.304 -1.24,0.639 a 1.87,1.87 0 0 0 -0.362,1.121 l -0.011,1.877 c -0.003,0.402 0.104,0.787 0.347,1.125 0.244,0.338 0.688,0.653 1.23,0.656 l 4.142,0.028 c 0.542,0.003 0.99,-0.306 1.238,-0.641 a 1.87,1.87 0 0 0 0.363,-1.121 l 0.012,-1.875 a 1.87,1.87 0 0 0 -0.348,-1.127 c -0.243,-0.338 -0.688,-0.653 -1.23,-0.656 l -0.518,-0.004 c 0.597,-1.145 1.425,-1.983 2.348,-2.87 1.473,-1.414 3.18,-3.149 3.2,-6.226 -0.016,-3.59 -2.923,-6.684 -6.993,-6.707 m -0.006,1.1 v 0.002 c 3.274,0.02 5.92,2.532 5.9,5.6 -0.017,2.706 -1.39,4.026 -2.863,5.44 -1.034,0.994 -2.118,2.033 -2.814,3.633 -0.018,0.041 -0.052,0.055 -0.075,0.065 q -0.013,0.004 -0.02,0.01 a 0.34,0.34 0 0 1 -0.226,0.084 0.34,0.34 0 0 1 -0.224,-0.086 l -0.092,-0.077 c -0.699,-1.615 -1.768,-2.669 -2.781,-3.67 -1.454,-1.435 -2.797,-2.762 -2.78,-5.478 0.02,-3.067 2.7,-5.545 5.975,-5.523 m -0.02,2.826 c -1.62,-0.01 -2.944,1.315 -2.955,2.96 -0.01,1.646 1.295,2.988 2.916,2.999 h 0.002 C -7.85,8.479 -6.528,7.153 -6.518,5.508 -6.507,3.862 -7.812,2.52 -9.434,2.51 m -0.005,1.1 c 1.017,0.006 1.829,0.83 1.822,1.89 -0.007,1.06 -0.83,1.874 -1.848,1.867 -1.018,-0.006 -1.829,-0.83 -1.822,-1.89 0.007,-1.06 0.83,-1.874 1.848,-1.868 m -2.155,11.857 4.14,0.025 c 0.271,0.002 0.49,0.305 0.487,0.676 l -0.013,1.875 c -0.003,0.37 -0.224,0.67 -0.495,0.668 l -4.14,-0.025 c -0.27,-0.002 -0.487,-0.306 -0.485,-0.676 l 0.012,-1.875 c 0.003,-0.37 0.224,-0.67 0.494,-0.668"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:400;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:evenodd;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.4;fill-rule:evenodd;stroke:none;stroke-width:2.47728;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+       transform="matrix(0.88807,0,0,0.88807,15.553,2.85)"
+       id="path5" />
+    <path
+       d="m -9.415,-0.316 c -3.275,-0.022 -5.955,2.456 -5.975,5.523 -0.017,2.716 1.326,4.041 2.78,5.477 1.013,1 2.081,2.055 2.78,3.67 l 0.092,0.076 a 0.34,0.34 0 0 0 0.225,0.086 0.34,0.34 0 0 0 0.227,-0.083 l 0.019,-0.01 c 0.022,-0.009 0.057,-0.024 0.074,-0.064 0.697,-1.6 1.78,-2.64 2.814,-3.634 1.473,-1.414 2.847,-2.733 2.864,-5.44 0.02,-3.067 -2.627,-5.58 -5.901,-5.601 m -0.057,8.784 c 1.621,0.011 2.944,-1.315 2.955,-2.96 0.01,-1.646 -1.295,-2.988 -2.916,-2.999 -1.622,-0.01 -2.945,1.315 -2.955,2.96 -0.01,1.645 1.295,2.989 2.916,3"
+       style="clip-rule:evenodd;fill:#e1e3e9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.47728;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.4"
+       transform="matrix(0.88807,0,0,0.88807,15.553,2.85)"
+       id="path6" />
+    <path
+       d="m -11.594,15.465 c -0.27,-0.002 -0.492,0.297 -0.494,0.668 l -0.012,1.876 c -0.003,0.371 0.214,0.673 0.485,0.675 l 4.14,0.027 c 0.271,0.002 0.492,-0.298 0.495,-0.668 l 0.012,-1.877 c 0.003,-0.37 -0.215,-0.672 -0.485,-0.674 z"
+       style="clip-rule:evenodd;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.47728;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.4"
+       transform="matrix(0.88807,0,0,0.88807,15.553,2.85)"
+       id="path7" />
+  </g>
+</svg>


### PR DESCRIPTION
Replaces the Mapbox logo in snapshots.

An icon is used in place of the full logo when attribution needs to be shown.