### PR TITLE
[opengl-2][node] Release node-v5.4.1-pre.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@acalcutt/node-pre-gyp": "^1.0.14",
+        "@acalcutt/node-pre-gyp": "^1.0.15",
         "@acalcutt/node-pre-gyp-github": "1.4.8",
         "minimatch": "^9.0.4",
         "npm-run-all": "^4.1.5"
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@acalcutt/node-pre-gyp": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@acalcutt/node-pre-gyp/-/node-pre-gyp-1.0.14.tgz",
-      "integrity": "sha512-P+xIiJefMa2ylrqPDwCw1S4Xr6ULKvF5TqmbZKifPSzId9jiSgLoplKfTmoP/y3Mq2kWts/rZDX1N9wMaSl6ZA==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@acalcutt/node-pre-gyp/-/node-pre-gyp-1.0.15.tgz",
+      "integrity": "sha512-+9vgfGWqByWMO/XbbCSpKe/ug7n16YbjKixY6D/Wx6goqx43qdmcXhFrGlnqNbyrpzKwbbQASX7AS/YbZNc/rg==",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -4740,9 +4740,9 @@
   },
   "dependencies": {
     "@acalcutt/node-pre-gyp": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@acalcutt/node-pre-gyp/-/node-pre-gyp-1.0.14.tgz",
-      "integrity": "sha512-P+xIiJefMa2ylrqPDwCw1S4Xr6ULKvF5TqmbZKifPSzId9jiSgLoplKfTmoP/y3Mq2kWts/rZDX1N9wMaSl6ZA==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@acalcutt/node-pre-gyp/-/node-pre-gyp-1.0.15.tgz",
+      "integrity": "sha512-+9vgfGWqByWMO/XbbCSpKe/ug7n16YbjKixY6D/Wx6goqx43qdmcXhFrGlnqNbyrpzKwbbQASX7AS/YbZNc/rg==",
       "requires": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.4.0",
+  "version": "5.4.1-pre.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "5.4.0",
+      "version": "5.4.1-pre.0",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@acalcutt/node-pre-gyp": "^1.0.14",
+    "@acalcutt/node-pre-gyp": "^1.0.15",
     "@acalcutt/node-pre-gyp-github": "1.4.8",
     "minimatch": "^9.0.4",
     "npm-run-all": "^4.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.4.0",
+  "version": "5.4.1-pre.0",
   "description": "Renders map tiles with Maplibre GL",
   "keywords": [
     "maplibre",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## main
+
+## 5.4.1-pre.0
 * Fixes crash that happened with some PBF files ([Issue](https://github.com/maplibre/maplibre-native/issues/795), [PR](https://github.com/maplibre/maplibre-native/pull/2460)).
+* Upgrade to nan 2.19 for node 22.x support (https://github.com/maplibre/maplibre-native/pull/2426)
 
 ## 5.4.0
 

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -2,8 +2,9 @@
 ## main
 
 ## 5.4.1-pre.0
-* Fixes crash that happened with some PBF files ([Issue](https://github.com/maplibre/maplibre-native/issues/795), [PR](https://github.com/maplibre/maplibre-native/pull/2460)).
-* Upgrade to nan 2.19 for node 22.x support (https://github.com/maplibre/maplibre-native/pull/2426)
+* Fix crash that happened with some PBF files ([Issue](https://github.com/maplibre/maplibre-native/issues/795), [PR](https://github.com/maplibre/maplibre-native/pull/2460)).
+* Upgrade NAN to 2.19 to support Node 22 (https://github.com/maplibre/maplibre-native/pull/2426)
+* Add Node 22 binary build and publish (https://github.com/maplibre/maplibre-native/pull/2553)
 
 ## 5.4.0
 

--- a/platform/node/README.md
+++ b/platform/node/README.md
@@ -11,7 +11,7 @@ Binaries are available and downloaded during install for the following platforms
   - Ubuntu 22.04 (amd64/arm64)
   - macOS 12 (amd64/arm64)
   - Windows (amd64)
-- Node.js 16, 18, 20
+- Node.js 16, 18, 20, 22
 
 Run:
 

--- a/platform/node/README.md
+++ b/platform/node/README.md
@@ -11,7 +11,7 @@ Binaries are available and downloaded during install for the following platforms
   - Ubuntu 22.04 (amd64/arm64)
   - macOS 12 (amd64/arm64)
   - Windows (amd64)
-  - Node.js 16, 18, 20, 22
+- Node.js 16, 18, 20, 22
 
 Run:
 

--- a/platform/node/README.md
+++ b/platform/node/README.md
@@ -11,7 +11,7 @@ Binaries are available and downloaded during install for the following platforms
   - Ubuntu 22.04 (amd64/arm64)
   - macOS 12 (amd64/arm64)
   - Windows (amd64)
-- Node.js 16, 18, 20, 22
+  - Node.js 16, 18, 20, 22
 
 Run:
 

--- a/platform/node/scripts/publish.sh
+++ b/platform/node/scripts/publish.sh
@@ -9,7 +9,7 @@ if [[ "${CIRCLE_TAG}" == "node-v${PACKAGE_JSON_VERSION}" ]] || [[ "${PUBLISH:-}"
     # Changes to the version targets here should happen in tandem with updates to the
     # EXCLUDE_NODE_ABIS property in cmake/node.cmake and the "node" engines property in
     # package.json.
-    for TARGET in 16.0.0 18.0.0 20.0.0; do
+    for TARGET in 16.0.0 18.0.0 20.0.0 22.0.0; do
         rm -rf build/stage
 
         if [[ "${BUILDTYPE}" == "RelWithDebInfo" ]]; then


### PR DESCRIPTION
Releases node-v5.4.1-pre.0. 

This also adds publishing the node 22 binary so that can be tested in this pre-release. I did not remove Node 16 at the same time, so this isn't a breaking change.

Note, I want to merge this after https://github.com/maplibre/maplibre-native/pull/2552