### PR TITLE
Fix some compiler warnings

### DIFF
--- a/include/mbgl/mtl/renderer_backend.hpp
+++ b/include/mbgl/mtl/renderer_backend.hpp
@@ -32,7 +32,7 @@ public:
 
     const MTLDevicePtr& getDevice() const { return device; }
     const MTLCommandQueuePtr& getCommandQueue() const { return commandQueue; }
-    const bool isBaseVertexInstanceDrawingSupported() const { return baseVertexInstanceDrawingSupported; }
+    bool isBaseVertexInstanceDrawingSupported() const { return baseVertexInstanceDrawingSupported; }
 
 protected:
     std::unique_ptr<gfx::Context> createContext() override;

--- a/src/mbgl/gfx/stencil_mode.hpp
+++ b/src/mbgl/gfx/stencil_mode.hpp
@@ -44,14 +44,5 @@ public:
     }
 };
 
-template <StencilFunctionType F>
-constexpr StencilFunctionType StencilMode::SimpleTest<F>::func;
-
-template <StencilFunctionType F>
-constexpr uint32_t StencilMode::SimpleTest<F>::mask;
-
-template <StencilFunctionType F>
-constexpr StencilFunctionType StencilMode::MaskedTest<F>::func;
-
 } // namespace gfx
 } // namespace mbgl


### PR DESCRIPTION
Building with `[-Werror,-Wignored-qualifiers]` and `[-Werror,-Wdeprecated]` revealed two issues (clang 15).