### PR TITLE
Fixed attribution link in action sheets

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,7 +6,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 
 - Add [Privacy Manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files). MapLibre Native iOS has no built-in tracking, but it does use some system APIs for functional purposes that are marked by Apple as privacy sensitive. ([#1866](https://github.com/maplibre/maplibre-native/issues/1866)).
 - Change default `MLNMapSnapshotter` logo to the MapLibre logo ([#2541](https://github.com/maplibre/maplibre-native/pull/2541)). Note that showing the MapLibre logo is never required. You can configure whether to show the logo with the (now public) `showsLogo` property of `MLNMapSnapshotterOptions`. Check with your tile provider if you need to show a logo.
-
+- Fixed attribution link in action sheets ([#2587](https://github.com/maplibre/maplibre-native/pull/2587)).
 ## 6.5.0
 
 - Allow uses to handle authorization for location services ([#2453](https://github.com/maplibre/maplibre-native/pull/2453)). See [`MLNMapview.shouldRequestAuthorizationToUseLocationServices`](https://maplibre.org/maplibre-native/ios/latest/documentation/maplibre/mlnmapview/shouldrequestauthorizationtouselocationservices).

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -2879,7 +2879,13 @@ public:
     {
         UIAlertAction *action = [UIAlertAction actionWithTitle:[attributionInfo.title.string mgl_titleCasedStringWithLocale:[NSLocale currentLocale]]
                                                          style:UIAlertActionStyleDefault
-                                                       handler:nil];
+                                                       handler:^(UIAlertAction * _Nonnull actionBlock) {
+            NSURL *url = attributionInfo.URL;
+            if (url)
+            {
+                [[UIApplication sharedApplication] openURL:url];
+            }
+        }];
         [attributionController addAction:action];
     }
 


### PR DESCRIPTION
This resolves Issue #2574. The handler for the action sheets was removed in this [PR](https://github.com/maplibre/maplibre-native/commit/d62ff400c6f75750d71b563344b1ca1e07b9b576#diff-00a062c3870157cb87ebec8d21fc095026431d01902cac9e273e5def3875edbe). I have added back the logic to link to webviews when links are sent down. 


https://github.com/maplibre/maplibre-native/assets/5482416/fe9c1939-839d-4233-a35b-a680bf21890a

![Simulator Screenshot - iPhone 15 Pro - 2024-07-09 at 17 59 54](https://github.com/maplibre/maplibre-native/assets/5482416/0d51e596-e4b2-4447-9aa3-08f0aa2c3d99)
