### PR TITLE
Attempt to fix Android C++ Unit Tests on AWS Device Farm

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -187,8 +187,8 @@ jobs:
     - name: Build C++ Unit Tests App
       run: |
         ./gradlew assembleDebug assembleAndroidTest
-        cp app/build/outputs/apk/debug/app-debug.apk CppUnitTestsApp.apk
-        cp app/build/outputs/apk/androidTest/release/app-release-androidTest.apk CppUnitTests.apk
+        cp app/build/outputs/apk/debug/app-debug.apk .
+        cp app/build/outputs/apk/androidTest/release/app-release-androidTest.apk .
 
     - name: Store C++ Unit Tests .apk files
       uses: actions/upload-artifact@v4
@@ -196,8 +196,8 @@ jobs:
         name: android-cpp-tests
         if-no-files-found: error
         path: |
-          ./test/android/CppUnitTestsApp.apk
-          ./test/android/CppUnitTests.apk
+          ./test/android/app-debug.apk
+          ./test/android/app-release-androidTest.apk
 
   android-build-render-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/android-device-test.yml
+++ b/.github/workflows/android-device-test.yml
@@ -167,7 +167,7 @@ jobs:
           private_key: ${{ secrets.MAPLIBRE_NATIVE_BOT_PRIVATE_KEY }}
 
       - uses: LouisBrunner/checks-action@v2.0.0
-        if: always() && env.run_device_test == 'true'
+        if: always()
         with:
           token: ${{ steps.generate_token_2.outputs.token }}
           check_id: ${{ steps.create_check.outputs.check_id }}

--- a/.github/workflows/android-device-test.yml
+++ b/.github/workflows/android-device-test.yml
@@ -46,12 +46,11 @@ jobs:
           },
           {
             artifactName: android-cpp-tests,
-            testFile: CppUnitTests.apk,
-            appFile: CppUnitTestsApp.apk,
+            testFile: app-release-androidTest.apk,
+            appFile: app-debug.apk,
             name: "Android C++ Unit Tests",
             # Google Pixel 7 Pro
-            devicePool: "arn:aws:devicefarm:us-west-2:373521797162:devicepool:20687d72-0e46-403e-8f03-0941850665bc/9692fe7f-86a9-4ecc-908f-175600968564",
-            testSpecArn: "arn:aws:devicefarm:us-west-2:373521797162:upload:20687d72-0e46-403e-8f03-0941850665bc/09e0738e-c91e-4c5f-81e6-06a06cc340d8"
+            devicePool: "arn:aws:devicefarm:us-west-2:373521797162:devicepool:20687d72-0e46-403e-8f03-0941850665bc/9692fe7f-86a9-4ecc-908f-175600968564"
           }
         ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Apparently renaming these files makes the test fail...

I tried running it manually without a rename and it works again. Hope it will also work on CI.