### PR TITLE
[ios] Fix version in action sheet

### DIFF
--- a/platform/darwin/bazel/example_config.bzl
+++ b/platform/darwin/bazel/example_config.bzl
@@ -8,6 +8,3 @@ BUNDLE_ID_PREFIX = "com.firstnamelastname"
 
 # Enter your API key for MapTiler here, if you have one.
 API_KEY = "0000000000"
-
-# Semantic version number to include in plist files.
-SEM_VER = "0.0.0"

--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -146,10 +146,7 @@ NSString *HTTPFileSource::Impl::getUserAgent() const {
 
     NSBundle *sdkBundle = HTTPFileSource::Impl::getSDKBundle();
     if (sdkBundle) {
-        NSString *versionString = sdkBundle.infoDictionary[@"MLNSemanticVersionString"];
-        if (!versionString) {
-            versionString = sdkBundle.infoDictionary[@"CFBundleShortVersionString"];
-        }
+        NSString *versionString = sdkBundle.infoDictionary[@"CFBundleShortVersionString"];
         if (versionString) {
             [userAgentComponents addObject:[NSString stringWithFormat:@"%@/%@",
                                             sdkBundle.infoDictionary[@"CFBundleName"], versionString]];

--- a/platform/ios/BUILD.bazel
+++ b/platform/ios/BUILD.bazel
@@ -182,6 +182,11 @@ _IOS_APPLICATION_RESOURCES = [
     "app/Assets.xcassets/**",
 ])
 
+apple_bundle_version(
+    name = "maplibre_app_version",
+    build_version = "1.0.0",
+)
+
 ios_application(
     name = "App",
     bundle_id = "{}.maplibre.app".format(BUNDLE_ID_PREFIX),
@@ -193,6 +198,7 @@ ios_application(
     minimum_os_version = "12.0",
     provisioning_profile = "xcode_profile",
     resources = _IOS_APPLICATION_RESOURCES,
+    version = ":maplibre_app_version",
     visibility = ["//visibility:public"],
     deps = [
         "//platform:iosapp",

--- a/platform/ios/Integration_Test_Harness/Info.plist
+++ b/platform/ios/Integration_Test_Harness/Info.plist
@@ -16,8 +16,6 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>5.9.0</string>
 	<key>CFBundleVersion</key>
 	<string>15256</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/platform/ios/Integration_Tests/Info.plist
+++ b/platform/ios/Integration_Tests/Info.plist
@@ -14,8 +14,6 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>5.9.0</string>
 	<key>CFBundleVersion</key>
 	<string>15256</string>
 </dict>

--- a/platform/ios/app/Info.plist
+++ b/platform/ios/app/Info.plist
@@ -16,8 +16,6 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>5.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>MBGL</string>
 	<key>CFBundleVersion</key>

--- a/platform/ios/bazel/macros.bzl
+++ b/platform/ios/bazel/macros.bzl
@@ -1,4 +1,4 @@
-load("@darwin_config//:config.bzl", "API_KEY", "SEM_VER")
+load("@darwin_config//:config.bzl", "API_KEY")
 
 def info_plist(name, base_info_plist, out, **kwargs):
     native.genrule(
@@ -14,9 +14,7 @@ def info_plist(name, base_info_plist, out, **kwargs):
         cp $(location {}) $@
         plutil -replace MLNCommitHash -string $$(cat $(location //:git_hash)) $@
         
-        sem_version=\"""" + SEM_VER + """\"
         token=\"""" + API_KEY + """\"
-        plutil -replace MLNSemanticVersionString -string $$sem_version $@
         plutil -replace MLNApiKey -string $$token $@
     """).format(base_info_plist),
         **kwargs

--- a/platform/ios/benchmark/Info.plist
+++ b/platform/ios/benchmark/Info.plist
@@ -20,8 +20,6 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>5.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>MBGL</string>
 	<key>CFBundleVersion</key>

--- a/platform/ios/framework/Info-static.plist
+++ b/platform/ios/framework/Info-static.plist
@@ -10,16 +10,12 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundleShortVersionString</key>
-	<string>5.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>15256</string>
 	<key>MLNCommitHash</key>
 	<string>$(CURRENT_COMMIT_HASH)</string>
-	<key>MLNSemanticVersionString</key>
-	<string>$(CURRENT_SEMANTIC_VERSION)</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/platform/ios/framework/Info.plist
+++ b/platform/ios/framework/Info.plist
@@ -14,16 +14,12 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>5.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>15256</string>
 	<key>MLNCommitHash</key>
 	<string>$(CURRENT_COMMIT_HASH)</string>
-	<key>MLNSemanticVersionString</key>
-	<string>$(CURRENT_SEMANTIC_VERSION)</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/platform/ios/iosapp-UITests/Info.plist
+++ b/platform/ios/iosapp-UITests/Info.plist
@@ -14,8 +14,6 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
-	<key>CFBundleShortVersionString</key>
-	<string>5.9.0</string>
 	<key>CFBundleVersion</key>
 	<string>15256</string>
 </dict>

--- a/platform/ios/resources/Base.lproj/Localizable.strings
+++ b/platform/ios/resources/Base.lproj/Localizable.strings
@@ -71,7 +71,7 @@
 "ROAD_REF_A11Y_FMT" = "Route %@";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* User-friendly error description */
 "STYLE_NOT_FOUND_DESC" = "The map failed to load because the style can’t be found or is incompatible.";

--- a/platform/ios/resources/ca.lproj/Localizable.strings
+++ b/platform/ios/resources/ca.lproj/Localizable.strings
@@ -53,7 +53,7 @@
 "PARSE_STYLE_FAILED_DESC" = "El mapa no s’ha carregat perquè s’ha corromput l’estil.";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* User-friendly error description */
 "STYLE_NOT_FOUND_DESC" = "El mapa no s’ha carregat perquè no es troba l’estil o bé és incompatible.";

--- a/platform/ios/resources/cs.lproj/Localizable.strings
+++ b/platform/ios/resources/cs.lproj/Localizable.strings
@@ -71,7 +71,7 @@
 "ROAD_REF_A11Y_FMT" = "Route %@";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* User-friendly error description */
 "STYLE_NOT_FOUND_DESC" = "The map failed to load because the style can’t be found or is incompatible.";

--- a/platform/ios/resources/da.lproj/Localizable.strings
+++ b/platform/ios/resources/da.lproj/Localizable.strings
@@ -77,7 +77,7 @@
 "ROAD_REF_A11Y_FMT" = "Rute %@";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* User-friendly error description */
 "STYLE_NOT_FOUND_DESC" = "Kortet kunne ikke hentes fordi det enten ikke findes, eller ikke er kompatibelt.";

--- a/platform/ios/resources/de.lproj/Localizable.strings
+++ b/platform/ios/resources/de.lproj/Localizable.strings
@@ -53,7 +53,7 @@
 "PARSE_STYLE_FAILED_DESC" = "Die Karte konnte nicht geladen werden, da diese Form beschädigt ist.";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* User-friendly error description */
 "STYLE_NOT_FOUND_DESC" = "Die Karte konnte nicht geladen werden, da diese Form nicht gefunden werden kann oder nicht kompatibel ist.";

--- a/platform/ios/resources/he.lproj/Localizable.strings
+++ b/platform/ios/resources/he.lproj/Localizable.strings
@@ -77,7 +77,7 @@
 "ROAD_REF_A11Y_FMT" = "כביש %@";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* User-friendly error description */
 "STYLE_NOT_FOUND_DESC" = "טעינת המפה נכשלה - לא ניתן למצוא את הסגנון או שהסגנון אינו תואם.";

--- a/platform/ios/resources/hu.lproj/Localizable.strings
+++ b/platform/ios/resources/hu.lproj/Localizable.strings
@@ -53,7 +53,7 @@
 "PARSE_STYLE_FAILED_DESC" = "Nem sikerült betölteni a térképet, mert a stílus sérült.";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* User-friendly error description */
 "STYLE_NOT_FOUND_DESC" = "Nem sikerült betölteni a térképet, mert a stílus nem található vagy inkompatibilis.";

--- a/platform/ios/resources/ja.lproj/Localizable.strings
+++ b/platform/ios/resources/ja.lproj/Localizable.strings
@@ -41,7 +41,7 @@
 "MAP_A11Y_VALUE" = "ズーム %1$d倍\n%2$ld ピン現れる";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* Telemetry prompt message */
 "TELEMETRY_DISABLED_MSG" = "You can help make OpenStreetMap and Mapbox maps better by contributing anonymous usage data.";

--- a/platform/ios/resources/lt.lproj/Localizable.strings
+++ b/platform/ios/resources/lt.lproj/Localizable.strings
@@ -53,7 +53,7 @@
 "PARSE_STYLE_FAILED_DESC" = "Nepavyko užkrauti žemėlapio, nes stilius yra netinkamo formato.";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* User-friendly error description */
 "STYLE_NOT_FOUND_DESC" = "Nepavyko užkrauti žemėlapio, nes neįmanoma rasti stiliaus arba jis nėra suderinamas.";

--- a/platform/ios/resources/pt-BR.lproj/Localizable.strings
+++ b/platform/ios/resources/pt-BR.lproj/Localizable.strings
@@ -53,7 +53,7 @@
 "PARSE_STYLE_FAILED_DESC" = "Falha ao carregar mapa porque o estilo está corrompido.";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* User-friendly error description */
 "STYLE_NOT_FOUND_DESC" = "Falha ao carregar mapa porque o estilo não pode ser encontrado ou é incompatível.";

--- a/platform/ios/resources/sv.lproj/Localizable.strings
+++ b/platform/ios/resources/sv.lproj/Localizable.strings
@@ -77,7 +77,7 @@
 "ROAD_REF_A11Y_FMT" = "Rutt %@";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* User-friendly error description */
 "STYLE_NOT_FOUND_DESC" = "Kartan kunde inte laddas för att kartstilen kunde inte hittas eller för att den är inkompatibel.";

--- a/platform/ios/resources/zh-Hans.lproj/Localizable.strings
+++ b/platform/ios/resources/zh-Hans.lproj/Localizable.strings
@@ -53,7 +53,7 @@
 "PARSE_STYLE_FAILED_DESC" = "The map failed to load because the style is corrupted.";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* User-friendly error description */
 "STYLE_NOT_FOUND_DESC" = "The map failed to load because the style can’t be found or is incompatible.";

--- a/platform/ios/resources/zh-Hant.lproj/Localizable.strings
+++ b/platform/ios/resources/zh-Hant.lproj/Localizable.strings
@@ -53,7 +53,7 @@
 "PARSE_STYLE_FAILED_DESC" = "樣式表有毀損，無法載入地圖。";
 
 /* Action sheet title */
-"SDK_NAME" = "MapLibre Maps SDK for iOS";
+"SDK_NAME" = "MapLibre Native iOS";
 
 /* User-friendly error description */
 "STYLE_NOT_FOUND_DESC" = "找不到樣式表或樣式表不兼容，無法載入地圖。";

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -2864,14 +2864,14 @@ public:
         }
     }
 
-    NSString *actionSheetTitle = NSLocalizedStringWithDefaultValue(@"SDK_NAME", nil, nil, @"MapLibre Native for iOS", @"Action sheet title");
+    NSString *actionSheetTitle = NSLocalizedStringWithDefaultValue(@"SDK_NAME", nil, nil, @"MapLibre Native iOS", @"Action sheet title");
     UIAlertController *attributionController = [UIAlertController alertControllerWithTitle:actionSheetTitle
                                                                                    message:nil
                                                                             preferredStyle:UIAlertControllerStyleActionSheet];
-
-    if (shouldShowVersion)
+    NSString *version = [NSBundle mgl_frameworkInfoDictionary][@"CFBundleShortVersionString"];
+    if (shouldShowVersion && version != nil && ![version isEqualToString:@""]) 
     {
-        attributionController.title = [actionSheetTitle stringByAppendingFormat:@" %@", [NSBundle mgl_frameworkInfoDictionary][@"MLNSemanticVersionString"]];
+        attributionController.title = [actionSheetTitle stringByAppendingFormat:@" %@", version];
     }
     
     NSArray *attributionInfos = [self.style attributionInfosWithFontSize:[UIFont buttonFontSize] linkColor:nil];


### PR DESCRIPTION
Closes #2601

Removes hardcoded versions from `.plist` files as well. 

The source of truth for the version is the `apple_bundle_version` rule, which is read from the file `VERSION` at build time. Gets rid of `MLNSemanticVersionString` and just uses `CFBundleShortVersionString` which gets added to the `Info.plist` of the XCFramework at build time.

<img width="453" alt="image" src="https://github.com/maplibre/maplibre-native/assets/649392/311fbfc2-7374-4fbe-a4e7-e9f867a95739">

Note that no version will be shown during development, because `apple_bundle_version` only can be applied to e.g. `apple_xcframework` and not `objc_library`.