### PR TITLE
[iOS] Version number string bug in action sheet #2601

### DIFF
--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -2871,7 +2871,7 @@ public:
 
     if (shouldShowVersion)
     {
-        attributionController.title = [actionSheetTitle stringByAppendingFormat:@" %@", [NSBundle mgl_frameworkInfoDictionary][@"MLNSemanticVersionString"]];
+        attributionController.title = [actionSheetTitle stringByAppendingFormat:@" %@", [NSBundle mgl_frameworkInfoDictionary][@"CFBundleShortVersionString"]];
     }
     
     NSArray *attributionInfos = [self.style attributionInfosWithFontSize:[UIFont buttonFontSize] linkColor:nil];


### PR DESCRIPTION
This resolves issue #2601  When doing a long press on the attribution button the action sheet should show the version number. Currently it shows 0.0.0 since it is looking at the "MLNSemanticVersionString". I have changed code to look at "CFBundleShortVersionString".

## Before
![image](https://github.com/user-attachments/assets/b7c890e4-dd9f-417f-a1f3-84bb26578b27)

## After
![image](https://github.com/user-attachments/assets/9fd7dcf2-bde9-4f09-92dd-30319735eab1)
