### PR TITLE
Make minor cleanup improvements in scheduler.hpp

### DIFF
--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -7,6 +7,7 @@
 
 #include <functional>
 #include <memory>
+#include <type_traits>
 
 namespace mbgl {
 
@@ -70,7 +71,8 @@ public:
     template <typename TaskFn, typename ReplyFn>
     void scheduleAndReplyValue(const util::SimpleIdentity tag, TaskFn&& task, ReplyFn&& reply) {
         assert(GetCurrent());
-        scheduleAndReplyValue(tag, task, reply, GetCurrent()->makeWeakPtr());
+        static_assert(std::is_invocable_v<TaskFn>);
+        scheduleAndReplyValue(tag, std::forward<TaskFn>(task), std::forward<ReplyFn>(reply), GetCurrent()->makeWeakPtr());
     }
 
     /// Wait until there's nothing pending or in process
@@ -103,10 +105,13 @@ public:
     void setExceptionHandler(std::function<void(const std::exception_ptr)> handler_) { handler = std::move(handler_); }
 
 protected:
+    std::function<void(const std::exception_ptr)> handler;
+
+private:
     template <typename TaskFn, typename ReplyFn>
     void scheduleAndReplyValue(const util::SimpleIdentity tag,
-                               const TaskFn& task,
-                               const ReplyFn& reply,
+                               TaskFn&& task,
+                               ReplyFn&& reply,
                                mapbox::base::WeakPtr<Scheduler> replyScheduler) {
         schedule(tag, [replyScheduler = std::move(replyScheduler), tag, task, reply] {
             auto lock = replyScheduler.lock();
@@ -115,7 +120,6 @@ protected:
         });
     }
 
-    std::function<void(const std::exception_ptr)> handler;
 };
 
 /// @brief A TaggedScheduler pairs a scheduler with an identifier. Tasklets submitted via a TaggedScheduler


### PR DESCRIPTION
- follow through on using perfect forwarding instead of changing method signature of scheduleAndReplyValue
- make previously protected scheduleAndReplyValue method private as all current use-cases do not require it
- add trivial compile-time check for TaskFn to be invokable