### PR TITLE
[ios] Switch out deprecated openURL method

### DIFF
--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -2883,7 +2883,7 @@ public:
             NSURL *url = attributionInfo.URL;
             if (url)
             {
-                [[UIApplication sharedApplication] openURL:url];
+                [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
             }
         }];
         [attributionController addAction:action];


### PR DESCRIPTION
The standard [openURL](https://developer.apple.com/documentation/uikit/uiapplication/1622961-openurl) is marked deprecated, switching to the [overloaded version](https://developer.apple.com/documentation/uikit/uiapplication/1648685-openurl?changes=latest_minor&language=objc) works as expected and doesn't create build warnings.