### PR TITLE
Eliminate redundant attribute updates

### DIFF
--- a/include/mbgl/gfx/vertex_attribute.hpp
+++ b/include/mbgl/gfx/vertex_attribute.hpp
@@ -328,10 +328,10 @@ public:
     }
 
     /// Call the provided delegate with each value, providing the override if one exists.
-    /// @param foundDelegate The function called for each attribute in `default`, with the corresponding override, if present
-    /// @param missingDelegate The function called for any overrides with no corresponding default
+    /// @param foundDelegate Called for each attribute in `default`, with the corresponding override, if present
+    /// @param missingDelegate Called for any overrides with no corresponding default
     template <typename ResolveFunc /* void(const size_t, VertexAttribute&, const std::unique_ptr<VertexAttribute>&) */,
-            typename MissingFunc /* void(const size_t, const std::unique_ptr<VertexAttribute>&) */>
+              typename MissingFunc /* void(const size_t, const std::unique_ptr<VertexAttribute>&) */>
     void resolve(const VertexAttributeArray& overrides, ResolveFunc foundDelegate, MissingFunc missingDelegate) const {
         for (size_t id = 0; id < attrs.size(); id++) {
             const auto& override = overrides.get(id);

--- a/include/mbgl/gfx/vertex_attribute.hpp
+++ b/include/mbgl/gfx/vertex_attribute.hpp
@@ -328,11 +328,17 @@ public:
     }
 
     /// Call the provided delegate with each value, providing the override if one exists.
-    template <typename Func /* void(const size_t, VertexAttribute&, const std::unique_ptr<VertexAttribute>&) */>
-    void resolve(const VertexAttributeArray& overrides, Func delegate) const {
+    /// @param foundDelegate The function called for each attribute in `default`, with the corresponding override, if present
+    /// @param missingDelegate The function called for any overrides with no corresponding default
+    template <typename ResolveFunc /* void(const size_t, VertexAttribute&, const std::unique_ptr<VertexAttribute>&) */,
+            typename MissingFunc /* void(const size_t, const std::unique_ptr<VertexAttribute>&) */>
+    void resolve(const VertexAttributeArray& overrides, ResolveFunc foundDelegate, MissingFunc missingDelegate) const {
         for (size_t id = 0; id < attrs.size(); id++) {
+            const auto& override = overrides.get(id);
             if (const auto& attr = attrs[id]) {
-                delegate(id, *attr, overrides.get(id));
+                foundDelegate(id, *attr, override);
+            } else if (override) {
+                missingDelegate(id, override);
             }
         }
     }

--- a/src/mbgl/gl/buffer_allocator.cpp
+++ b/src/mbgl/gl/buffer_allocator.cpp
@@ -2,6 +2,8 @@
 #include <mbgl/gl/defines.hpp>
 #include <mbgl/gl/context.hpp>
 #include <mbgl/gl/uniform_buffer_gl.hpp>
+#include <mbgl/util/instrumentation.hpp>
+
 #include <utility>
 
 namespace mbgl {
@@ -503,6 +505,7 @@ void UniformBufferAllocator::release(BufferRef* ref) noexcept {
 }
 
 void UniformBufferAllocator::defragment(const std::shared_ptr<gl::Fence>& fence) {
+    MLN_TRACE_FUNC();
     impl->defragment(fence);
 }
 

--- a/src/mbgl/gl/drawable_gl.cpp
+++ b/src/mbgl/gl/drawable_gl.cpp
@@ -7,6 +7,7 @@
 #include <mbgl/gl/vertex_buffer_resource.hpp>
 #include <mbgl/programs/segment.hpp>
 #include <mbgl/shaders/gl/shader_program_gl.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/logging.hpp>
 
 namespace mbgl {
@@ -22,6 +23,8 @@ DrawableGL::~DrawableGL() {
 }
 
 void DrawableGL::draw(PaintParameters& parameters) const {
+    MLN_TRACE_FUNC();
+
     if (isCustom) {
         return;
     }
@@ -147,6 +150,8 @@ void DrawableGL::upload(gfx::UploadPass& uploadPass) {
         return;
     }
 
+    MLN_TRACE_FUNC();
+
     const bool build = vertexAttributes &&
                        (vertexAttributes->isDirty() ||
                         std::any_of(impl->segments.begin(), impl->segments.end(), [](const auto& seg) {
@@ -238,6 +243,7 @@ gfx::StencilMode DrawableGL::makeStencilMode(PaintParameters& parameters) const 
 }
 
 void DrawableGL::uploadTextures() const {
+    MLN_TRACE_FUNC();
     for (const auto& texture : textures) {
         if (texture) {
             texture->upload();

--- a/src/mbgl/gl/layer_group_gl.cpp
+++ b/src/mbgl/gl/layer_group_gl.cpp
@@ -10,6 +10,7 @@
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/shaders/gl/shader_program_gl.hpp>
 #include <mbgl/util/convert.hpp>
+#include <mbgl/util/instrumentation.hpp>
 
 namespace mbgl {
 namespace gl {
@@ -20,6 +21,8 @@ TileLayerGroupGL::TileLayerGroupGL(int32_t layerIndex_, std::size_t initialCapac
     : TileLayerGroup(layerIndex_, initialCapacity, std::move(name_)) {}
 
 void TileLayerGroupGL::upload(gfx::UploadPass& uploadPass) {
+    MLN_TRACE_FUNC();
+
     if (!enabled) {
         return;
     }

--- a/src/mbgl/gl/timestamp_query_extension.cpp
+++ b/src/mbgl/gl/timestamp_query_extension.cpp
@@ -12,7 +12,7 @@ using namespace platform;
 
 namespace {
 
-static constexpr const char* const extName = "GL_EXT_disjoint_timer_query";
+constexpr const char *const extName = "GL_EXT_disjoint_timer_query";
 
 struct TimestampQueryLoader {
     TimestampQueryLoader(const GlContexsLoader &loadExtension)
@@ -25,8 +25,10 @@ struct TimestampQueryLoader {
           glGetQueryiv(loadExtension({{extName, "glGetQueryiv"}, {extName, "glGetQueryivEXT"}})),
           glGetQueryObjectiv(loadExtension({{extName, "glGetQueryObjectiv"}, {extName, "glGetQueryObjectivEXT"}})),
           glGetQueryObjectuiv(loadExtension({{extName, "glGetQueryObjectuiv"}, {extName, "glGetQueryObjectuivEXT"}})),
-          glGetQueryObjecti64v(loadExtension({{extName, "glGetQueryObjecti64v"}, {extName, "glGetQueryObjecti64vEXT"}})),
-          glGetQueryObjectui64v(loadExtension({{extName, "glGetQueryObjectui64v"}, {extName, "glGetQueryObjectui64vEXT"}})),
+          glGetQueryObjecti64v(
+              loadExtension({{extName, "glGetQueryObjecti64v"}, {extName, "glGetQueryObjecti64vEXT"}})),
+          glGetQueryObjectui64v(
+              loadExtension({{extName, "glGetQueryObjectui64v"}, {extName, "glGetQueryObjectui64vEXT"}})),
           glGetInteger64v(loadExtension({{extName, "glGetInteger64v"}, {extName, "glGetInteger64vEXT"}})) {}
 
     ExtensionFunction<void(GLsizei n, GLuint *ids)> glGenQueries;

--- a/src/mbgl/gl/timestamp_query_extension.cpp
+++ b/src/mbgl/gl/timestamp_query_extension.cpp
@@ -12,20 +12,22 @@ using namespace platform;
 
 namespace {
 
+static constexpr const char* const extName = "GL_EXT_disjoint_timer_query";
+
 struct TimestampQueryLoader {
     TimestampQueryLoader(const GlContexsLoader &loadExtension)
-        : glGenQueries(loadExtension({{"GL_EXT_disjoint_timer_query", "glGenQueries"}})),
-          glDeleteQueries(loadExtension({{"GL_EXT_disjoint_timer_query", "glDeleteQueries"}})),
-          glIsQuery(loadExtension({{"GL_EXT_disjoint_timer_query", "glIsQuery"}})),
-          glBeginQuery(loadExtension({{"GL_EXT_disjoint_timer_query", "glBeginQuery"}})),
-          glEndQuery(loadExtension({{"GL_EXT_disjoint_timer_query", "glEndQuery"}})),
-          glQueryCounter(loadExtension({{"GL_EXT_disjoint_timer_query", "glQueryCounter"}})),
-          glGetQueryiv(loadExtension({{"GL_EXT_disjoint_timer_query", "glGetQueryiv"}})),
-          glGetQueryObjectiv(loadExtension({{"GL_EXT_disjoint_timer_query", "glGetQueryObjectiv"}})),
-          glGetQueryObjectuiv(loadExtension({{"GL_EXT_disjoint_timer_query", "glGetQueryObjectuiv"}})),
-          glGetQueryObjecti64v(loadExtension({{"GL_EXT_disjoint_timer_query", "glGetQueryObjecti64v"}})),
-          glGetQueryObjectui64v(loadExtension({{"GL_EXT_disjoint_timer_query", "glGetQueryObjectui64v"}})),
-          glGetInteger64v(loadExtension({{"GL_EXT_disjoint_timer_query", "glGetInteger64v"}})) {}
+        : glGenQueries(loadExtension({{extName, "glGenQueries"}, {extName, "glGenQueriesEXT"}})),
+          glDeleteQueries(loadExtension({{extName, "glDeleteQueries"}, {extName, "glDeleteQueriesEXT"}})),
+          glIsQuery(loadExtension({{extName, "glIsQuery"}, {extName, "glIsQueryEXT"}})),
+          glBeginQuery(loadExtension({{extName, "glBeginQuery"}, {extName, "glBeginQueryEXT"}})),
+          glEndQuery(loadExtension({{extName, "glEndQuery"}, {extName, "glEndQueryEXT"}})),
+          glQueryCounter(loadExtension({{extName, "glQueryCounter"}, {extName, "glQueryCounterEXT"}})),
+          glGetQueryiv(loadExtension({{extName, "glGetQueryiv"}, {extName, "glGetQueryivEXT"}})),
+          glGetQueryObjectiv(loadExtension({{extName, "glGetQueryObjectiv"}, {extName, "glGetQueryObjectivEXT"}})),
+          glGetQueryObjectuiv(loadExtension({{extName, "glGetQueryObjectuiv"}, {extName, "glGetQueryObjectuivEXT"}})),
+          glGetQueryObjecti64v(loadExtension({{extName, "glGetQueryObjecti64v"}, {extName, "glGetQueryObjecti64vEXT"}})),
+          glGetQueryObjectui64v(loadExtension({{extName, "glGetQueryObjectui64v"}, {extName, "glGetQueryObjectui64vEXT"}})),
+          glGetInteger64v(loadExtension({{extName, "glGetInteger64v"}, {extName, "glGetInteger64vEXT"}})) {}
 
     ExtensionFunction<void(GLsizei n, GLuint *ids)> glGenQueries;
     ExtensionFunction<void(GLsizei n, const GLuint *ids)> glDeleteQueries;

--- a/src/mbgl/gl/upload_pass.cpp
+++ b/src/mbgl/gl/upload_pass.cpp
@@ -268,6 +268,8 @@ gfx::AttributeBindingArray UploadPass::buildAttributeBindings(
             return;
         }
 
+        overrideAttr->setDirty(false);
+
         bindings[index] = {
             /*.attribute = */ {defaultAttr.getDataType(), offset},
             /* vertexStride = */ static_cast<uint32_t>(stride),
@@ -280,7 +282,11 @@ gfx::AttributeBindingArray UploadPass::buildAttributeBindings(
         // The vertex stride is the sum of the attribute strides
         vertexStride += static_cast<uint32_t>(stride);
     };
-    defaults.resolve(overrides, resolveAttr);
+    // This version is called when the attribute is available, but isn't being used by the shader
+    const auto missingAttr = [&](const size_t, auto& missingAttr) -> void {
+        missingAttr->setDirty(false);
+    };
+    defaults.resolve(overrides, resolveAttr, missingAttr);
 
     assert(vertexStride * vertexCount <= allData.size());
 

--- a/src/mbgl/mtl/upload_pass.cpp
+++ b/src/mbgl/mtl/upload_pass.cpp
@@ -190,14 +190,14 @@ gfx::AttributeBindingArray UploadPass::buildAttributeBindings(
         }
 
         // If the attribute references data shared with a bucket, get the corresponding buffer.
-        if (const auto& buffer = getBuffer(effectiveAttr.getSharedRawData(), usage)) {
+        if (const auto& buffer_ = getBuffer(effectiveAttr.getSharedRawData(), usage)) {
             assert(effectiveAttr.getSharedStride() * effectiveAttr.getSharedVertexOffset() <
                    effectiveAttr.getSharedRawData()->getRawSize() * effectiveAttr.getSharedRawData()->getRawCount());
 
             bindings[index] = {
                 /*.attribute = */ {effectiveAttr.getSharedType(), effectiveAttr.getSharedOffset()},
                 /*.vertexStride = */ effectiveAttr.getSharedStride(),
-                /*.vertexBufferResource = */ buffer.get(),
+                /*.vertexBufferResource = */ buffer_.get(),
                 /*.vertexOffset = */ effectiveAttr.getSharedVertexOffset(),
             };
             return;
@@ -206,11 +206,11 @@ gfx::AttributeBindingArray UploadPass::buildAttributeBindings(
         assert(effectiveAttr.getStride() > 0);
 
         // Otherwise, turn the data managed by the attribute into a buffer.
-        if (const auto& buffer = VertexAttribute::getBuffer(effectiveAttr, *this, gfx::BufferUsageType::StaticDraw)) {
+        if (const auto& buffer_ = VertexAttribute::getBuffer(effectiveAttr, *this, gfx::BufferUsageType::StaticDraw)) {
             bindings[index] = {
                 /*.attribute = */ {effectiveAttr.getDataType(), /*offset=*/0},
                 /*.vertexStride = */ static_cast<uint32_t>(effectiveAttr.getStride()),
-                /*.vertexBufferResource = */ buffer.get(),
+                /*.vertexBufferResource = */ buffer_.get(),
                 /*.vertexOffset = */ 0,
             };
             return;

--- a/src/mbgl/mtl/upload_pass.cpp
+++ b/src/mbgl/mtl/upload_pass.cpp
@@ -139,9 +139,9 @@ const gfx::UniqueVertexBufferResource& UploadPass::getBuffer(const gfx::VertexVe
         }
         // Otherwise, create a new one
         if (rawBufSize > 0) {
-            auto buffer = std::make_unique<VertexBuffer>();
-            buffer->resource = createVertexBufferResource(rawBufPtr, rawBufSize, usage, /*persistent=*/false);
-            vec->setBuffer(std::move(buffer));
+            auto buffer_ = std::make_unique<VertexBuffer>();
+            buffer_->resource = createVertexBufferResource(rawBufPtr, rawBufSize, usage, /*persistent=*/false);
+            vec->setBuffer(std::move(buffer_));
             vec->setDirty(false);
             return static_cast<VertexBuffer*>(vec->getBuffer())->resource;
         }
@@ -218,7 +218,11 @@ gfx::AttributeBindingArray UploadPass::buildAttributeBindings(
 
         assert(false);
     };
-    defaults.resolve(overrides, resolveAttr);
+    // This version is called when the attribute is available, but isn't being used by the shader
+    const auto missingAttr = [&](const size_t, auto& missingAttr) -> void {
+        missingAttr->setDirty(false);
+    };
+    defaults.resolve(overrides, resolveAttr, missingAttr);
 
     return bindings;
 }

--- a/src/mbgl/mtl/upload_pass.cpp
+++ b/src/mbgl/mtl/upload_pass.cpp
@@ -6,6 +6,7 @@
 #include <mbgl/mtl/renderable_resource.hpp>
 #include <mbgl/mtl/vertex_attribute.hpp>
 #include <mbgl/mtl/vertex_buffer_resource.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/logging.hpp>
 
 #include <Metal/Metal.hpp>
@@ -157,6 +158,8 @@ gfx::AttributeBindingArray UploadPass::buildAttributeBindings(
     const gfx::VertexAttributeArray& overrides,
     const gfx::BufferUsageType usage,
     /*out*/ std::vector<std::unique_ptr<gfx::VertexBufferResource>>& outBuffers) {
+    MLN_TRACE_FUNC();
+
     gfx::AttributeBindingArray bindings;
     bindings.resize(defaults.allocatedSize());
 

--- a/src/mbgl/mtl/vertex_attribute.cpp
+++ b/src/mbgl/mtl/vertex_attribute.cpp
@@ -25,6 +25,7 @@ const gfx::UniqueVertexBufferResource& VertexAttribute::getBuffer(gfx::VertexAtt
                     attrib.rawData.data(), attrib.rawData.size(), usage, false);
                 attrib.setBuffer(std::move(buffer));
                 attrib.setRawData({});
+                attrib_.setDirty(false);
             } else {
                 assert(false);
             }

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -8,10 +8,11 @@
 #include <mbgl/renderer/render_static_data.hpp>
 #include <mbgl/programs/programs.hpp>
 #include <mbgl/gfx/cull_face_mode.hpp>
+#include <mbgl/util/constants.hpp>
+#include <mbgl/util/instrumentation.hpp>
+#include <mbgl/util/logging.hpp>
 #include <mbgl/util/tile_coordinate.hpp>
 #include <mbgl/util/tile_cover.hpp>
-#include <mbgl/util/logging.hpp>
-#include <mbgl/util/constants.hpp>
 
 namespace mbgl {
 
@@ -89,6 +90,7 @@ std::unique_ptr<RenderItem> RenderImageSource::createRenderItem() {
 }
 
 void RenderImageSource::prepare(const SourcePrepareParameters& parameters) {
+    MLN_TRACE_FUNC();
     assert(!renderData);
     if (!isLoaded()) {
         renderData = std::make_unique<ImageSourceRenderData>(bucket, std::vector<mat4>{}, baseImpl->id);

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -148,7 +148,7 @@ public:
     std::optional<CollisionBoundaries> avoidEdges;
 };
 
-// PlacementController implemenation
+// PlacementController implementation
 
 PlacementController::PlacementController()
     : placement(makeMutable<Placement>()) {}

--- a/src/mbgl/text/placement.hpp
+++ b/src/mbgl/text/placement.hpp
@@ -155,7 +155,7 @@ protected:
                                  const std::vector<ProjectedCollisionBox>& /*textBoxes*/,
                                  const std::vector<ProjectedCollisionBox>& /*iconBoxes*/
     ) {}
-    // Implentation specific hooks, which get called during a symbol bucket placement.
+    // Implementation specific hooks, which get called during a symbol bucket placement.
     virtual std::optional<CollisionBoundaries> getAvoidEdges(const SymbolBucket&, const mat4& /*posMatrix*/) {
         return std::nullopt;
     }


### PR DESCRIPTION
- Add some trace points
- Add alternate GL extension function names to allow for Tracy profiling on Pixel 8
- Reset the dirty flag on attributes even when they aren't used by the shader, e.g., `FloorWidth` on line layers, or `FillColor` on fill outlines (which share the attribute buffer with fills).
