### PR TITLE
Avoid re-creating fill extrusion drawables unnecessarily

### DIFF
--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -314,7 +314,7 @@ void RenderFillExtrusionLayer::update(gfx::ShaderRegistry& shaders,
     stats.drawablesRemoved += tileLayerGroup->removeDrawablesIf([&](gfx::Drawable& drawable) {
         // If the render pass has changed or the tile has  dropped out of the cover set, remove it.
         const auto& tileID = drawable.getTileID();
-        if (drawable.getRenderPass() != passes || (tileID && !hasRenderTile(*tileID))) {
+        if (!(drawable.getRenderPass() & passes) || (tileID && !hasRenderTile(*tileID))) {
             return true;
         }
         return false;


### PR DESCRIPTION
`passes` is a bitmask and the equality test was resulting in the drawables being removed and rebuilt constantly