### PR TITLE
Fix null-pointer dereference MapRenderer Android

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -6,8 +6,11 @@
 
 - Avoid logging error for onMove(0,0) on Android ([#2580](https://github.com/maplibre/maplibre-native/pull/2580)).
 - Experimental API to toggle tile cache in map view ([#2590](https://github.com/maplibre/maplibre-native/pull/2590)). This can reduce memory usage at the cost of having to parse tile data again when the zoom level changes.
+- Add TaggedScheduler, couple lifetime of tasks and orchestrator ([#2398](https://github.com/maplibre/maplibre-native/pull/2398)).
 
 ### 🐞 Bug fixes
+
+- Fix null pointer dereference MapRenderer Android.
 
 ## 11.0.2-pre0
 

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -182,6 +182,7 @@ void MapRenderer::render(JNIEnv&) {
     }
 
     // Activate the backend
+    assert(backend);
     gfx::BackendScope backendGuard{*backend};
 
     // Ensure that the "current" scheduler on the render thread is
@@ -207,6 +208,7 @@ void MapRenderer::onSurfaceCreated(JNIEnv&) {
     std::lock_guard<std::mutex> lock(initialisationMutex);
 
     // The GL context is already active if get a new surface.
+    assert(backend);
     gfx::BackendScope backendGuard{*backend, gfx::BackendScope::ScopeType::Implicit};
 
     // The android system will have already destroyed the underlying

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -23,7 +23,8 @@ MapRenderer::MapRenderer(jni::JNIEnv& _env,
       localIdeographFontFamily(localIdeographFontFamily_ ? jni::Make<std::string>(_env, localIdeographFontFamily_)
                                                          : std::optional<std::string>{}),
       threadPool(Scheduler::GetBackground(), {}),
-      mailboxData(this) {}
+      mailboxData(this),
+      backend(std::make_unique<AndroidRendererBackend>(threadPool)) {}
 
 MapRenderer::MailboxData::MailboxData(Scheduler* scheduler_)
     : scheduler(scheduler_) {

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -160,7 +160,7 @@ void MapRenderer::requestSnapshot(SnapshotCallback callback) {
 
 void MapRenderer::resetRenderer() {
     renderer.reset();
-    backend.reset();
+    backend = std::make_unique<AndroidRendererBackend>(threadPool);
 }
 
 void MapRenderer::scheduleSnapshot(std::unique_ptr<SnapshotCallback> callback) {


### PR DESCRIPTION
In the Android-specific `MapRenderer` class a `std::unique_ptr<AndroidRendererBackend>` is dereferenced that may be a `nullptr`. This can of course lead to a crash, which was reported in https://github.com/maplibre/maplibre-native/issues/2579

I am surprised this has not resulted in more crashes being reported, because I think the null-pointer dereference happens every time `onSurfaceCreated` is (initially) called, and a method is even called on the dereferenced null-pointer...

We should probably release 11.1.0 once this is released.