### PR TITLE
Make sure checks are created for Android device tests

### DIFF
--- a/.github/workflows/android-device-test.yml
+++ b/.github/workflows/android-device-test.yml
@@ -55,6 +55,7 @@ jobs:
           }
         ]
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'maplibre' && github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v4
 
@@ -97,7 +98,6 @@ jobs:
           echo "run_device_test=true" >> "$GITHUB_ENV"
 
       - uses: LouisBrunner/checks-action@v2.0.0
-        if: env.run_device_test == 'true'
         id: create_check
         with:
           token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Make sure checks are created for the Android device tests (if the parent workflow was successful).
