### PR TITLE
Take locks before signaling thread condition variables

### DIFF
--- a/src/mbgl/tile/tile_cache.cpp
+++ b/src/mbgl/tile/tile_cache.cpp
@@ -53,6 +53,8 @@ void TileCache::deferredRelease(std::unique_ptr<Tile>&& tile) {
     // last one and the destruction actually occurs here on this thread.
     std::function<void()> func{[tile_{CaptureWrapper<Tile>{std::move(tile)}}, this]() mutable {
         tile_.item = {};
+
+        std::lock_guard<std::mutex> counterLock(deferredSignalLock);
         deferredDeletionsPending--;
         deferredSignal.notify_all();
     }};

--- a/src/mbgl/tile/tile_cache.hpp
+++ b/src/mbgl/tile/tile_cache.hpp
@@ -50,10 +50,9 @@ private:
     std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;
     std::list<OverscaledTileID> orderedKeys;
     TaggedScheduler threadPool;
-    std::atomic<size_t> deferredDeletionsPending{0};
+    size_t deferredDeletionsPending{0};
     std::mutex deferredSignalLock;
     std::condition_variable deferredSignal;
-
     size_t size;
 };
 

--- a/src/mbgl/util/thread_pool.cpp
+++ b/src/mbgl/util/thread_pool.cpp
@@ -130,6 +130,8 @@ void ThreadedSchedulerBase::schedule(const util::SimpleIdentity tag, std::functi
         taskCount++;
     }
 
+    // Take the worker lock before notifying to prevent threads from waiting while we try to wake them
+    std::lock_guard<std::mutex> workerLock(workerMutex);
     cvAvailable.notify_one();
 }
 


### PR DESCRIPTION
When notifying condition variables for the thread pool, it is possible that threads are just about to wait on the variable at the same time an external thread is about to notify. This can result in the notification being lost, and threads get stuck sleeping. Taking the condition locks prior to notifying prevents this from happening. This was most commonly observed with jobs sent to a sequenced scheduler which only has 1 worker thread.