### PR TITLE
Improve deferred destruction

### DIFF
--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -145,15 +145,15 @@ public:
         runOnRenderThread(tag, std::move(func));
     }
 
-protected:
-    std::function<void(const std::exception_ptr)> handler;
-
     void waitForDeferred() {
         std::unique_lock<std::mutex> counterLock(deferredSignalLock);
         while (deferredDeletionsPending > 0) {
             deferredSignal.wait(counterLock);
         }
     }
+
+protected:
+    std::function<void(const std::exception_ptr)> handler;
 
 private:
     size_t deferredDeletionsPending{0};
@@ -221,6 +221,8 @@ public:
     void releaseOnRenderThread(T&& owner) {
         scheduler->releaseOnRenderThread<T>(tag, std::forward<T>(owner));
     }
+
+    void waitForDeferred() { scheduler->waitForDeferred(); }
 
     const mbgl::util::SimpleIdentity tag;
 

--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -107,9 +107,7 @@ public:
     [[nodiscard]] static std::shared_ptr<Scheduler> GetSequenced();
 
     /// Set a function to be called when an exception occurs on a thread controlled by the scheduler
-    void setExceptionHandler(std::function<void(const std::exception_ptr)> handler_) {
-        handler = std::move(handler_);
-    }
+    void setExceptionHandler(std::function<void(const std::exception_ptr)> handler_) { handler = std::move(handler_); }
 
     /// Capture an object and release it on a thread in the pool.
     /// @tparam T The arbitrary type to be captured

--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -4,6 +4,7 @@
 
 #include <mapbox/std/weak.hpp>
 
+#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <type_traits>
@@ -106,7 +107,9 @@ public:
     [[nodiscard]] static std::shared_ptr<Scheduler> GetSequenced();
 
     /// Set a function to be called when an exception occurs on a thread controlled by the scheduler
-    void setExceptionHandler(std::function<void(const std::exception_ptr)> handler_) { handler = std::move(handler_); }
+    void setExceptionHandler(std::function<void(const std::exception_ptr)> handler_) {
+        handler = std::move(handler_);
+    }
 
     /// Capture an object and release it on a thread in the pool.
     /// @tparam T The arbitrary type to be captured
@@ -162,11 +165,11 @@ private:
     template <typename T>
     struct CaptureWrapper {
         CaptureWrapper(T&& item_)
-                : item(std::move(item_)) {}
+            : item(std::move(item_)) {}
         CaptureWrapper(const CaptureWrapper& other)
-                : item(other.item) {}
+            : item(other.item) {}
         CaptureWrapper(CaptureWrapper&& other)
-                : item(std::move(other.item)) {}
+            : item(std::move(other.item)) {}
         T item;
     };
 

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -94,6 +94,7 @@ void MapRenderer::waitForEmpty([[maybe_unused]] const util::SimpleIdentity tag) 
         if (auto weakReference = javaPeer.get(*_env)) {
             return weakReference.Call(*_env, waitForEmpty);
         }
+        waitForDeferred();
     } catch (...) {
         Log::Error(Event::Android, "MapRenderer::waitForEmpty failed");
         jni::ThrowJavaError(*android::AttachEnv(), std::current_exception());

--- a/platform/android/src/run_loop.cpp
+++ b/platform/android/src/run_loop.cpp
@@ -256,6 +256,7 @@ void RunLoop::wake() {
 
 void RunLoop::waitForEmpty([[maybe_unused]] const SimpleIdentity tag) {
     impl->waitForEmpty();
+    waitForDeferred();
 }
 
 void RunLoop::run() {

--- a/platform/darwin/src/run_loop.cpp
+++ b/platform/darwin/src/run_loop.cpp
@@ -61,6 +61,7 @@ void RunLoop::waitForEmpty([[maybe_unused]] const SimpleIdentity tag) {
 
         runOnce();
     }
+    waitForDeferred();
 }
 
 } // namespace util

--- a/platform/default/src/mbgl/util/run_loop.cpp
+++ b/platform/default/src/mbgl/util/run_loop.cpp
@@ -163,6 +163,7 @@ void RunLoop::waitForEmpty([[maybe_unused]] const mbgl::util::SimpleIdentity tag
 
         runOnce();
     }
+    waitForDeferred();
 }
 
 void RunLoop::addWatch(int fd, Event event, std::function<void(int, Event)>&& callback) {

--- a/platform/qt/src/mbgl/run_loop.cpp
+++ b/platform/qt/src/mbgl/run_loop.cpp
@@ -105,6 +105,7 @@ void RunLoop::waitForEmpty([[maybe_unused]] const mbgl::util::SimpleIdentity tag
 
         runOnce();
     }
+    waitForDeferred();
 }
 
 void RunLoop::addWatch(int fd, Event event, std::function<void(int, Event)>&& cb) {

--- a/platform/qt/src/utils/scheduler.cpp
+++ b/platform/qt/src/utils/scheduler.cpp
@@ -55,6 +55,8 @@ void Scheduler::waitForEmpty([[maybe_unused]] const mbgl::util::SimpleIdentity t
     }
 
     assert(m_taskQueue.size() + pendingItems == 0);
+
+    waitForDeferred();
 }
 
 } // namespace QMapLibre

--- a/src/mbgl/actor/scheduler.cpp
+++ b/src/mbgl/actor/scheduler.cpp
@@ -16,7 +16,7 @@ std::function<void()> Scheduler::bindOnce(std::function<void()> fn) {
 static auto& current() {
     static util::ThreadLocal<Scheduler> scheduler;
     return scheduler;
-};
+}
 
 void Scheduler::SetCurrent(Scheduler* scheduler) {
     current().set(scheduler);

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -105,10 +105,15 @@ Context::~Context() noexcept {
         backend.getThreadPool().runRenderJobs(true /* closeQueue */);
 
         reset();
+
 #if !defined(NDEBUG)
+        // Make sure deferred cleanup is done before we check stats
+        backend.getThreadPool().waitForEmpty();
+        backend.getThreadPool().runRenderJobs();
+        performCleanup();
         Log::Debug(Event::General, "Rendering Stats:\n" + stats.toString("\n"));
-#endif
         assert(stats.isZero());
+#endif
     }
 }
 

--- a/src/mbgl/mtl/context.cpp
+++ b/src/mbgl/mtl/context.cpp
@@ -61,6 +61,9 @@ Context::~Context() noexcept {
         }
 
 #if !defined(NDEBUG)
+        // Make sure deferred cleanup is done before we check stats
+        backend.getThreadPool().waitForEmpty();
+        backend.getThreadPool().runRenderJobs();
         Log::Debug(Event::General, "Rendering Stats:\n" + stats.toString("\n"));
 #endif
         assert(stats.isZero());

--- a/src/mbgl/renderer/source_state.cpp
+++ b/src/mbgl/renderer/source_state.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/renderer/source_state.hpp>
 #include <mbgl/style/conversion_impl.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/logging.hpp>
 
 namespace mbgl {
@@ -42,6 +43,7 @@ void SourceFeatureState::getState(FeatureState& result,
 }
 
 void SourceFeatureState::coalesceChanges(std::vector<RenderTile>& tiles) {
+    MLN_TRACE_FUNC();
     LayerFeatureStates changes;
     for (const auto& layerStatesEntry : stateChanges) {
         const auto& sourceLayer = layerStatesEntry.first;

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -7,6 +7,7 @@
 #include <mbgl/renderer/tile_render_data.hpp>
 #include <mbgl/tile/vector_tile.hpp>
 #include <mbgl/util/constants.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/math.hpp>
 
 #if MLN_DRAWABLE_RENDERER
@@ -402,6 +403,7 @@ std::unique_ptr<RenderItem> RenderTileSource::createRenderItem() {
 }
 
 void RenderTileSource::prepare(const SourcePrepareParameters& parameters) {
+    MLN_TRACE_FUNC();
     bearing = static_cast<float>(parameters.transform.state.getBearing());
     filteredRenderTiles = nullptr;
     renderTilesSortedByY = nullptr;
@@ -412,8 +414,10 @@ void RenderTileSource::prepare(const SourcePrepareParameters& parameters) {
         tiles->back().prepare(parameters);
     }
     featureState.coalesceChanges(*tiles);
-    threadPool.deferredRelease(std::move(renderTiles));
-    renderTiles = std::move(tiles);
+    {
+        MLN_TRACE_ZONE(release);
+        renderTiles = std::move(tiles);
+    }
 }
 
 void RenderTileSource::updateFadingTiles() {

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -386,7 +386,8 @@ void TileSourceRenderItem::updateDebugDrawables(DebugLayerGroupMap& debugLayerGr
 RenderTileSource::RenderTileSource(Immutable<style::Source::Impl> impl_, const TaggedScheduler& threadPool_)
     : RenderSource(std::move(impl_)),
       tilePyramid(threadPool_),
-      renderTiles(makeMutable<std::vector<RenderTile>>()) {
+      renderTiles(makeMutable<std::vector<RenderTile>>()),
+      threadPool(threadPool_) {
     tilePyramid.setObserver(this);
 }
 
@@ -411,6 +412,7 @@ void RenderTileSource::prepare(const SourcePrepareParameters& parameters) {
         tiles->back().prepare(parameters);
     }
     featureState.coalesceChanges(*tiles);
+    threadPool.deferredRelease(std::move(renderTiles));
     renderTiles = std::move(tiles);
 }
 

--- a/src/mbgl/renderer/sources/render_tile_source.hpp
+++ b/src/mbgl/renderer/sources/render_tile_source.hpp
@@ -57,6 +57,7 @@ protected:
     Immutable<std::vector<RenderTile>> renderTiles;
     mutable RenderTiles filteredRenderTiles;
     mutable RenderTiles renderTilesSortedByY;
+    TaggedScheduler threadPool;
 
 private:
     float bearing = 0.0F;

--- a/src/mbgl/renderer/tile_render_data.cpp
+++ b/src/mbgl/renderer/tile_render_data.cpp
@@ -2,12 +2,13 @@
 
 namespace mbgl {
 
-TileRenderData::TileRenderData() = default;
+TileRenderData::TileRenderData(std::shared_ptr<TileAtlasTextures> atlasTextures_, const TaggedScheduler& threadPool_)
+    : atlasTextures(std::move(atlasTextures_)),
+      threadPool(threadPool_) {}
 
-TileRenderData::TileRenderData(std::shared_ptr<TileAtlasTextures> atlasTextures_)
-    : atlasTextures(std::move(atlasTextures_)) {}
-
-TileRenderData::~TileRenderData() = default;
+TileRenderData::~TileRenderData() {
+    threadPool.releaseOnRenderThread(std::move(atlasTextures));
+}
 
 #if MLN_DRAWABLE_RENDERER
 static gfx::Texture2DPtr noTexture;

--- a/src/mbgl/renderer/tile_render_data.cpp
+++ b/src/mbgl/renderer/tile_render_data.cpp
@@ -6,10 +6,6 @@ TileRenderData::TileRenderData(std::shared_ptr<TileAtlasTextures> atlasTextures_
     : atlasTextures(std::move(atlasTextures_)),
       threadPool(threadPool_) {}
 
-TileRenderData::~TileRenderData() {
-    threadPool.releaseOnRenderThread(std::move(atlasTextures));
-}
-
 #if MLN_DRAWABLE_RENDERER
 static gfx::Texture2DPtr noTexture;
 

--- a/src/mbgl/renderer/tile_render_data.hpp
+++ b/src/mbgl/renderer/tile_render_data.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/actor/scheduler.hpp>
 #include <mbgl/gfx/texture.hpp>
 #include <mbgl/renderer/image_atlas.hpp>
 #include <mbgl/style/layer_impl.hpp>
@@ -54,16 +55,17 @@ public:
     virtual void prepare(const SourcePrepareParameters&) {}
 
 protected:
-    TileRenderData();
-    TileRenderData(std::shared_ptr<TileAtlasTextures>);
+    TileRenderData(std::shared_ptr<TileAtlasTextures>, const TaggedScheduler&);
     std::shared_ptr<TileAtlasTextures> atlasTextures;
+    TaggedScheduler threadPool;
 };
 
 template <typename BucketType>
 class SharedBucketTileRenderData final : public TileRenderData {
 public:
-    SharedBucketTileRenderData(std::shared_ptr<BucketType> bucket_)
-        : bucket(std::move(bucket_)) {}
+    SharedBucketTileRenderData(std::shared_ptr<BucketType> bucket_, const TaggedScheduler& threadPool_)
+        : TileRenderData({}, threadPool_),
+          bucket(std::move(bucket_)) {}
 
 private:
     // TileRenderData overrides.

--- a/src/mbgl/renderer/tile_render_data.hpp
+++ b/src/mbgl/renderer/tile_render_data.hpp
@@ -36,7 +36,7 @@ public:
 
 class TileRenderData {
 public:
-    virtual ~TileRenderData();
+    virtual ~TileRenderData() = default;
 
 #if MLN_DRAWABLE_RENDERER
     const gfx::Texture2DPtr& getGlyphAtlasTexture() const;

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -1,8 +1,10 @@
 #include <mbgl/text/cross_tile_symbol_index.hpp>
+
 #include <mbgl/layout/symbol_instance.hpp>
 #include <mbgl/renderer/buckets/symbol_bucket.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/tile/tile.hpp>
+#include <mbgl/util/instrumentation.hpp>
 
 namespace mbgl {
 
@@ -246,6 +248,7 @@ auto CrossTileSymbolIndex::addLayer(const RenderLayer& layer, float lng) -> AddL
 }
 
 void CrossTileSymbolIndex::pruneUnusedLayers(const std::set<std::string>& usedLayers) {
+    MLN_TRACE_FUNC();
     for (auto it = layerIndexes.begin(); it != layerIndexes.end();) {
         if (usedLayers.find(it->first) == usedLayers.end()) {
             it = layerIndexes.erase(it);

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -1,4 +1,3 @@
-#include <list>
 #include <mbgl/layout/symbol_layout.hpp>
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/renderer/buckets/symbol_bucket.hpp>
@@ -7,7 +6,10 @@
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/text/placement.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/math.hpp>
+
+#include <list>
 #include <utility>
 
 namespace mbgl {
@@ -154,6 +156,7 @@ PlacementController::PlacementController()
     : placement(makeMutable<Placement>()) {}
 
 void PlacementController::setPlacement(Immutable<Placement> placement_) {
+    MLN_TRACE_FUNC();
     placement = std::move(placement_);
     stale = false;
 }
@@ -200,6 +203,7 @@ Placement::Placement()
 Placement::~Placement() = default;
 
 void Placement::placeLayers(const RenderLayerReferences& layers) {
+    MLN_TRACE_FUNC();
     for (auto it = layers.crbegin(); it != layers.crend(); ++it) {
         std::set<uint32_t> seenCrossTileIDs;
         placeLayer(*it, seenCrossTileIDs);
@@ -1631,6 +1635,7 @@ bool TilePlacement::shouldRetryPlacement(const JointPlacement& placement, const 
 // static
 Mutable<Placement> Placement::create(std::shared_ptr<const UpdateParameters> updateParameters_,
                                      std::optional<Immutable<Placement>> prevPlacement) {
+    MLN_TRACE_ZONE(create placement);
     assert(updateParameters_);
     switch (updateParameters_->mode) {
         case MapMode::Continuous:

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -195,8 +195,8 @@ GeometryTile::~GeometryTile() {
     imageManager->removeRequestor(*this);
 
     if (layoutResult) {
-        threadPool.runOnRenderThread(
-            [layoutResult_{std::move(layoutResult)}, atlasTextures_{std::move(atlasTextures)}]() {});
+        threadPool.releaseOnRenderThread(std::move(layoutResult));
+        threadPool.releaseOnRenderThread(std::move(atlasTextures));
     }
 }
 

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -46,8 +46,9 @@ LayerRenderData* GeometryTile::LayoutResult::getLayerRenderData(const style::Lay
 class GeometryTileRenderData final : public TileRenderData {
 public:
     GeometryTileRenderData(std::shared_ptr<GeometryTile::LayoutResult> layoutResult_,
-                           std::shared_ptr<TileAtlasTextures> atlasTextures_)
-        : TileRenderData(std::move(atlasTextures_)),
+                           std::shared_ptr<TileAtlasTextures> atlasTextures_,
+                           const TaggedScheduler& threadPool_)
+        : TileRenderData(std::move(atlasTextures_), threadPool_),
           layoutResult(std::move(layoutResult_)) {}
 
 private:
@@ -244,7 +245,7 @@ void GeometryTile::reset() {
 std::unique_ptr<TileRenderData> GeometryTile::createRenderData() {
     MLN_TRACE_FUNC();
 
-    return std::make_unique<GeometryTileRenderData>(layoutResult, atlasTextures);
+    return std::make_unique<GeometryTileRenderData>(layoutResult, atlasTextures, threadPool);
 }
 
 void GeometryTile::setLayers(const std::vector<Immutable<LayerProperties>>& layers) {

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -51,7 +51,7 @@ GeometryTileWorker::GeometryTileWorker(ActorRef<GeometryTileWorker> self_,
 GeometryTileWorker::~GeometryTileWorker() {
     MLN_TRACE_FUNC();
 
-    scheduler.runOnRenderThread([renderData_{std::move(renderData)}]() {});
+    scheduler.releaseOnRenderThread(std::move(renderData));
 }
 
 /*

--- a/src/mbgl/tile/raster_dem_tile.cpp
+++ b/src/mbgl/tile/raster_dem_tile.cpp
@@ -42,7 +42,7 @@ RasterDEMTile::~RasterDEMTile() {
 }
 
 std::unique_ptr<TileRenderData> RasterDEMTile::createRenderData() {
-    return std::make_unique<SharedBucketTileRenderData<HillshadeBucket>>(bucket);
+    return std::make_unique<SharedBucketTileRenderData<HillshadeBucket>>(bucket, threadPool);
 }
 
 void RasterDEMTile::setError(std::exception_ptr err) {

--- a/src/mbgl/tile/raster_dem_tile.cpp
+++ b/src/mbgl/tile/raster_dem_tile.cpp
@@ -37,7 +37,7 @@ RasterDEMTile::~RasterDEMTile() {
 
     // The bucket has resources that need to be released on the render thread.
     if (bucket) {
-        threadPool.runOnRenderThread([bucket_{std::move(bucket)}]() {});
+        threadPool.releaseOnRenderThread(std::move(bucket));
     }
 }
 

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -26,7 +26,7 @@ RasterTile::~RasterTile() {
 
     // The bucket has resources that need to be released on the render thread.
     if (bucket) {
-        threadPool.runOnRenderThread([bucket_{std::move(bucket)}]() {});
+        threadPool.releaseOnRenderThread(std::move(bucket));
     }
 }
 

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -31,7 +31,7 @@ RasterTile::~RasterTile() {
 }
 
 std::unique_ptr<TileRenderData> RasterTile::createRenderData() {
-    return std::make_unique<SharedBucketTileRenderData<RasterBucket>>(bucket);
+    return std::make_unique<SharedBucketTileRenderData<RasterBucket>>(bucket, threadPool);
 }
 
 void RasterTile::setError(std::exception_ptr err) {

--- a/src/mbgl/tile/tile_cache.cpp
+++ b/src/mbgl/tile/tile_cache.cpp
@@ -5,7 +5,12 @@
 
 namespace mbgl {
 
-void TileCache::setSize(size_t size_) {
+TileCache::~TileCache() {
+    clear();
+    threadPool.waitForDeferred();
+}
+
+    void TileCache::setSize(size_t size_) {
     MLN_TRACE_FUNC();
 
     size = size_;

--- a/src/mbgl/tile/tile_cache.cpp
+++ b/src/mbgl/tile/tile_cache.cpp
@@ -25,44 +25,12 @@ void TileCache::setSize(size_t size_) {
     assert(orderedKeys.size() <= size);
 }
 
-namespace {
-
-/// This exists solely to prevent a problem where temporary lambda captures
-/// are retained for the duration of the scope instead of being destroyed immediately.
-template <typename T>
-struct CaptureWrapper {
-    CaptureWrapper(std::unique_ptr<T>&& item_)
-        : item(std::move(item_)) {}
-    CaptureWrapper(const CaptureWrapper& other)
-        : item(other.item) {}
-    std::shared_ptr<T> item;
-};
-} // namespace
-
 void TileCache::deferredRelease(std::unique_ptr<Tile>&& tile) {
     MLN_TRACE_FUNC();
 
     tile->cancel();
 
-    // The `std::function` must be created in a separate statement from the `schedule` call.
-    // Creating a `std::function` from a lambda involves a copy, which is why we must use
-    // `shared_ptr` rather than `unique_ptr` for the capture.  As a result, a temporary holds
-    // a reference until the construction is complete and the lambda is destroyed.
-    // If this temporary outlives the `schedule` call, and the function is executed immediately
-    // by a waiting thread and is already complete, that temporary reference ends up being the
-    // last one and the destruction actually occurs here on this thread.
-    std::function<void()> func{[tile_{CaptureWrapper<Tile>{std::move(tile)}}, this]() mutable {
-        tile_.item = {};
-
-        std::lock_guard<std::mutex> counterLock(deferredSignalLock);
-        deferredDeletionsPending--;
-        deferredSignal.notify_all();
-    }};
-
-    std::unique_lock<std::mutex> counterLock(deferredSignalLock);
-    deferredDeletionsPending++;
-
-    threadPool.schedule(std::move(func));
+    threadPool.deferredRelease(std::shared_ptr<Tile>(std::move(tile)));
 }
 
 void TileCache::add(const OverscaledTileID& key, std::unique_ptr<Tile>&& tile) {

--- a/src/mbgl/tile/tile_cache.hpp
+++ b/src/mbgl/tile/tile_cache.hpp
@@ -21,9 +21,6 @@ public:
 
     ~TileCache() { clear(); }
 
-    /// Destroy a tile without blocking
-    void deferredRelease(std::unique_ptr<Tile>&&);
-
     /// Change the maximum size of the cache.
     void setSize(size_t);
 
@@ -38,6 +35,9 @@ public:
     Tile* get(const OverscaledTileID& key);
     bool has(const OverscaledTileID& key);
     void clear();
+
+    /// Destroy a tile without blocking
+    void deferredRelease(std::unique_ptr<Tile>&&);
 
 private:
     std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;

--- a/src/mbgl/tile/tile_cache.hpp
+++ b/src/mbgl/tile/tile_cache.hpp
@@ -19,7 +19,7 @@ public:
         : threadPool(threadPool_),
           size(size_) {}
 
-    ~TileCache() { clear(); }
+    ~TileCache();
 
     /// Change the maximum size of the cache.
     void setSize(size_t);

--- a/src/mbgl/util/thread_pool.cpp
+++ b/src/mbgl/util/thread_pool.cpp
@@ -161,6 +161,7 @@ void ThreadedSchedulerBase::waitForEmpty(const util::SimpleIdentity tag) {
             std::lock_guard<std::mutex> lock(taggedQueueLock);
             taggedQueue.erase(tagToFind);
         }
+        waitForDeferred();
     }
 }
 

--- a/src/mbgl/util/thread_pool.hpp
+++ b/src/mbgl/util/thread_pool.hpp
@@ -2,9 +2,10 @@
 
 #include <mbgl/actor/mailbox.hpp>
 #include <mbgl/actor/scheduler.hpp>
-#include <mbgl/util/thread_local.hpp>
 #include <mbgl/util/containers.hpp>
 #include <mbgl/util/identity.hpp>
+#include <mbgl/util/instrumentation.hpp>
+#include <mbgl/util/thread_local.hpp>
 
 #include <algorithm>
 #include <condition_variable>
@@ -107,6 +108,8 @@ public:
     }
 
     void runRenderJobs(const util::SimpleIdentity tag, bool closeQueue = false) override {
+        MLN_TRACE_FUNC();
+
         std::shared_ptr<RenderQueue> queue;
         std::unique_lock<std::mutex> lock(taggedRenderQueueLock);
 

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/math/log2.hpp>
 #include <mbgl/util/bounding_volumes.hpp>
 #include <mbgl/util/constants.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/interpolate.hpp>
 #include <mbgl/util/tile_coordinate.hpp>
 #include <mbgl/util/tile_cover.hpp>
@@ -157,6 +158,8 @@ int32_t coveringZoomLevel(double zoom, style::SourceType type, uint16_t size) no
 std::vector<OverscaledTileID> tileCover(const TransformState& state,
                                         uint8_t z,
                                         const std::optional<uint8_t>& overscaledZ) {
+    MLN_TRACE_FUNC();
+
     struct Node {
         AABB aabb;
         uint8_t zoom;


### PR DESCRIPTION
Refactor and generalize deferred release use with things other than tiles.

Unfortunately, deferring the release of `RenderTiles`  from `RenderTileSource` seems to cause problems, likely because there's a bare reference to `Tile` in there.  Deferring just the `RenderTileData` doesn't seem practical because of the `Immutable` wrapper.  So, for now, this is just refactoring to allow for more deferral.

