### PR TITLE
Add justfile to simplify docker usage

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,6 +6,10 @@ set shell := ["bash", "-c"]
 @_default:
     {{just_executable()}} --list
 
+# interactively clean-up git repository, keeping IDE files
+git-clean:
+    git clean -dxfi -e .idea -e .clwb -e .vscode
+
 # (re-)build `maplibre-native-image` docker image for the current user
 init-docker:
     docker build -t maplibre-native-image --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -f docker/Dockerfile docker

--- a/justfile
+++ b/justfile
@@ -16,4 +16,4 @@ init-docker:
 
 # run a build command with docker, e.g. `just docker bazel build ...`, or open container shell with `just docker`
 docker *ARGS:
-    docker run --rm -it -v "$PWD:/app/" -v "$PWD/docker/.cache:/home/user/.cache" maplibre-native-image
+    docker run --rm -it -v "$PWD:/app/" -v "$PWD/docker/.cache:/home/user/.cache" maplibre-native-image {{ARGS}}

--- a/justfile
+++ b/justfile
@@ -14,6 +14,6 @@ git-clean:
 init-docker:
     docker build -t maplibre-native-image --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -f docker/Dockerfile docker
 
-# run a build command with docker, e.g. `just docker bazel build ...`, or open container shell with `just docker`
+# run command with docker, e.g. `just docker bazel build //:mbgl-core`, or open docker shell with `just docker`
 docker *ARGS:
     docker run --rm -it -v "$PWD:/app/" -v "$PWD/docker/.cache:/home/user/.cache" maplibre-native-image {{ARGS}}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,15 @@
+#!/usr/bin/env just --justfile
+
+# Always require bash. If we allow it to be default, it may work incorrectly on Windows
+set shell := ["bash", "-c"]
+
+@_default:
+    {{just_executable()}} --list
+
+# (re-)build `maplibre-native-image` docker image for the current user
+init-docker:
+    docker build -t maplibre-native-image --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -f docker/Dockerfile docker
+
+# run a build command with docker, e.g. `just docker bazel build ...`, or open container shell with `just docker`
+docker *ARGS:
+    docker run --rm -it -v "$PWD:/app/" -v "$PWD/docker/.cache:/home/user/.cache" maplibre-native-image


### PR DESCRIPTION
This adds a [justfile](https://just.systems/man/en/) to simplify docker usage. Eventually more recipes can be added to it to make executing any kind of long complex commands simpler.

![image](https://github.com/user-attachments/assets/07748ebd-dff6-4df1-9cca-e4e30a717cd0)

Just is a very popular task runner, with 19k stars and 7.5 million downloads. It supports autocomplete, IDE integration, CI installation, and even github highlighting

This is an **optional** feature, and does not have to be used. I think we may want to use this method to keep all CI scripts in one place as well - in order to be able to run them both locally or in a workflow.