### PR TITLE
Avoid style warnings on trace points

### DIFF
--- a/docs/mdbook/src/profiling/tracy-profiling.md
+++ b/docs/mdbook/src/profiling/tracy-profiling.md
@@ -31,7 +31,7 @@ The macro records the timestamps at the start and end of the code scope. The par
 ~~~
 // code is not instrumented
 {
-  MLN_TRACE_ZONE(EmptyZone); // Records from here until the end of the scope
+  MLN_TRACE_ZONE(EmptyZone) // Records from here until the end of the scope
   // code here is instrumented
 }
 // other here not instrumented

--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/identity.hpp>
 
 #include <mapbox/std/weak.hpp>
@@ -134,7 +133,6 @@ public:
     TaggedScheduler(const TaggedScheduler&) = default;
 
     /// @brief Get the wrapped scheduler
-    /// @return
     const std::shared_ptr<Scheduler>& get() const noexcept { return scheduler; }
 
     void schedule(std::function<void()>&& fn) { scheduler->schedule(tag, std::move(fn)); }

--- a/include/mbgl/util/instrumentation.hpp
+++ b/include/mbgl/util/instrumentation.hpp
@@ -25,28 +25,32 @@ const void* castGpuIdToTracyPtr(GpuId id) {
     "MLN_RENDER_BACKEND_OPENGL is not defined. MLN_RENDER_BACKEND_OPENGL is expected to be defined in CMake and Bazel"
 #endif
 
-#define MLN_TRACE_FUNC() ZoneScoped
-#define MLN_TRACE_ZONE(label) ZoneScopedN(#label)
+#define MLN_TRACE_FUNC() ZoneScoped;
+#define MLN_TRACE_ZONE(label) ZoneScopedN(#label);
+
+#define MLN_ZONE_TEXT(label) ZoneText(#label, strlen(#label));
+#define MLN_ZONE_STR(str) ZoneText(str.c_str(), str.size());
+#define MLN_ZONE_VALUE(val) ZoneValue(static_cast<uint64_t>(val));
 
 constexpr const char* tracyTextureMemoryLabel = "Texture Memory";
-#define MLN_TRACE_ALLOC_TEXTURE(id, size) TracyAllocN(castGpuIdToTracyPtr(id), size, tracyTextureMemoryLabel)
-#define MLN_TRACE_FREE_TEXTURE(id) TracyFreeN(castGpuIdToTracyPtr(id), tracyTextureMemoryLabel)
+#define MLN_TRACE_ALLOC_TEXTURE(id, size) TracyAllocN(castGpuIdToTracyPtr(id), size, tracyTextureMemoryLabel);
+#define MLN_TRACE_FREE_TEXTURE(id) TracyFreeN(castGpuIdToTracyPtr(id), tracyTextureMemoryLabel);
 
 constexpr const char* tracyRenderTargetMemoryLabel = "Render Target Memory";
-#define MLN_TRACE_ALLOC_RT(id, size) TracyAllocN(castGpuIdToTracyPtr(id), size, tracyRenderTargetMemoryLabel)
-#define MLN_TRACE_FREE_RT(id) TracyFreeN(castGpuIdToTracyPtr(id), tracyRenderTargetMemoryLabel)
+#define MLN_TRACE_ALLOC_RT(id, size) TracyAllocN(castGpuIdToTracyPtr(id), size, tracyRenderTargetMemoryLabel);
+#define MLN_TRACE_FREE_RT(id) TracyFreeN(castGpuIdToTracyPtr(id), tracyRenderTargetMemoryLabel);
 
 constexpr const char* tracyVertexMemoryLabel = "Vertex Buffer Memory";
-#define MLN_TRACE_ALLOC_VERTEX_BUFFER(id, size) TracyAllocN(castGpuIdToTracyPtr(id), size, tracyVertexMemoryLabel)
-#define MLN_TRACE_FREE_VERTEX_BUFFER(id) TracyFreeN(castGpuIdToTracyPtr(id), tracyVertexMemoryLabel)
+#define MLN_TRACE_ALLOC_VERTEX_BUFFER(id, size) TracyAllocN(castGpuIdToTracyPtr(id), size, tracyVertexMemoryLabel);
+#define MLN_TRACE_FREE_VERTEX_BUFFER(id) TracyFreeN(castGpuIdToTracyPtr(id), tracyVertexMemoryLabel);
 
 constexpr const char* tracyIndexMemoryLabel = "Index Buffer Memory";
-#define MLN_TRACE_ALLOC_INDEX_BUFFER(id, size) TracyAllocN(castGpuIdToTracyPtr(id), size, tracyIndexMemoryLabel)
-#define MLN_TRACE_FREE_INDEX_BUFFER(id) TracyFreeN(castGpuIdToTracyPtr(id), tracyIndexMemoryLabel)
+#define MLN_TRACE_ALLOC_INDEX_BUFFER(id, size) TracyAllocN(castGpuIdToTracyPtr(id), size, tracyIndexMemoryLabel);
+#define MLN_TRACE_FREE_INDEX_BUFFER(id) TracyFreeN(castGpuIdToTracyPtr(id), tracyIndexMemoryLabel);
 
 constexpr const char* tracyConstMemoryLabel = "Constant Buffer Memory";
-#define MLN_TRACE_ALLOC_CONST_BUFFER(id, size) TracyAllocN(castGpuIdToTracyPtr(id), size, tracyConstMemoryLabel)
-#define MLN_TRACE_FREE_CONST_BUFFER(id) TracyFreeN(castGpuIdToTracyPtr(id), tracyConstMemoryLabel)
+#define MLN_TRACE_ALLOC_CONST_BUFFER(id, size) TracyAllocN(castGpuIdToTracyPtr(id), size, tracyConstMemoryLabel);
+#define MLN_TRACE_FREE_CONST_BUFFER(id) TracyFreeN(castGpuIdToTracyPtr(id), tracyConstMemoryLabel);
 
 // Only OpenGL is currently considered for GPU profiling
 // Metal and other APIs need to be handled separately
@@ -66,15 +70,15 @@ constexpr const char* tracyConstMemoryLabel = "Constant Buffer Memory";
 
 #include "tracy/TracyOpenGL.hpp"
 
-#define MLN_TRACE_GL_CONTEXT() TracyGpuContext
-#define MLN_TRACE_GL_ZONE(label) TracyGpuZone(#label)
-#define MLN_TRACE_FUNC_GL() TracyGpuZone(__FUNCTION__)
+#define MLN_TRACE_GL_CONTEXT() TracyGpuContext;
+#define MLN_TRACE_GL_ZONE(label) TracyGpuZone(#label);
+#define MLN_TRACE_FUNC_GL() TracyGpuZone(__FUNCTION__);
 
 #define MLN_END_FRAME()  \
     do {                 \
         FrameMark;       \
         TracyGpuCollect; \
-    } while (0)
+    } while (0);
 
 #undef glGenQueries
 #undef glGetQueryiv
@@ -89,7 +93,7 @@ constexpr const char* tracyConstMemoryLabel = "Constant Buffer Memory";
 #define MLN_TRACE_GL_CONTEXT()
 #define MLN_TRACE_GL_ZONE(label)
 #define MLN_TRACE_FUNC_GL()
-#define MLN_END_FRAME() FrameMark
+#define MLN_END_FRAME() FrameMark;
 
 #endif // MLN_RENDER_BACKEND_OPENGL
 
@@ -97,6 +101,9 @@ constexpr const char* tracyConstMemoryLabel = "Constant Buffer Memory";
 
 #define MLN_TRACE_GL_CONTEXT()
 #define MLN_TRACE_GL_ZONE(label)
+#define MLN_ZONE_TEXT(label)
+#define MLN_ZONE_STR(str)
+#define MLN_ZONE_VALUE(val)
 #define MLN_TRACE_FUNC_GL()
 #define MLN_END_FRAME()
 #define MLN_TRACE_ALLOC_TEXTURE(id, size)

--- a/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.cpp
@@ -4,9 +4,10 @@
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/renderer/renderer_observer.hpp>
 #include <mbgl/util/async_task.hpp>
-#include <mbgl/util/thread.hpp>
-#include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/geojson.hpp>
+#include <mbgl/util/instrumentation.hpp>
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/thread.hpp>
 
 #include "android_renderer_backend.hpp"
 
@@ -78,6 +79,7 @@ void AndroidRendererFrontend::setObserver(RendererObserver& observer) {
 }
 
 void AndroidRendererFrontend::update(std::shared_ptr<UpdateParameters> params) {
+    MLN_TRACE_FUNC()
     updateParams = std::move(params);
     updateAsyncTask->send();
 }

--- a/platform/default/src/mbgl/gl/headless_backend.cpp
+++ b/platform/default/src/mbgl/gl/headless_backend.cpp
@@ -29,7 +29,7 @@ public:
     }
 
     void swap() override {
-        MLN_TRACE_FUNC();
+        MLN_TRACE_FUNC()
 
         backend.swap();
     }
@@ -49,7 +49,7 @@ HeadlessBackend::HeadlessBackend(const Size size_,
       swapBehaviour(swapBehaviour_) {}
 
 HeadlessBackend::~HeadlessBackend() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     gfx::BackendScope guard{*this, gfx::BackendScope::ScopeType::Implicit};
     // Some implementations require active context for GL functions to work
@@ -73,7 +73,7 @@ gl::ProcAddress HeadlessBackend::getExtensionFunctionPointer(const char* name) {
 }
 
 void HeadlessBackend::activate() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     active = true;
 
@@ -86,7 +86,7 @@ void HeadlessBackend::activate() {
 }
 
 void HeadlessBackend::deactivate() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     assert(impl);
     impl->deactivateContext();
@@ -94,7 +94,7 @@ void HeadlessBackend::deactivate() {
 }
 
 gfx::Renderable& HeadlessBackend::getDefaultRenderable() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!resource) {
         resource = std::make_unique<HeadlessRenderableResource>(*this, static_cast<gl::Context&>(getContext()), size);
@@ -103,7 +103,7 @@ gfx::Renderable& HeadlessBackend::getDefaultRenderable() {
 }
 
 void HeadlessBackend::swap() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (swapBehaviour == SwapBehaviour::Flush) static_cast<gl::Context&>(getContext()).finish();
 }
@@ -113,7 +113,7 @@ void HeadlessBackend::updateAssumedState() {
 }
 
 PremultipliedImage HeadlessBackend::readStillImage() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return static_cast<gl::Context&>(getContext()).readFramebuffer<PremultipliedImage>(size);
 }
@@ -129,7 +129,7 @@ namespace gfx {
 template <>
 std::unique_ptr<gfx::HeadlessBackend> Backend::Create<gfx::Backend::Type::OpenGL>(
     const Size size, gfx::Renderable::SwapBehaviour swapBehavior, const gfx::ContextMode contextMode) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return std::make_unique<gl::HeadlessBackend>(size, swapBehavior, contextMode);
 }

--- a/platform/glfw/glfw_gl_backend.cpp
+++ b/platform/glfw/glfw_gl_backend.cpp
@@ -12,14 +12,14 @@ public:
         : backend(backend_) {}
 
     void bind() override {
-        MLN_TRACE_FUNC();
+        MLN_TRACE_FUNC()
 
         backend.setFramebufferBinding(0);
         backend.setViewport(0, 0, backend.getSize());
     }
 
     void swap() override {
-        MLN_TRACE_FUNC();
+        MLN_TRACE_FUNC()
 
         backend.swap();
     }
@@ -39,7 +39,7 @@ GLFWGLBackend::GLFWGLBackend(GLFWwindow* window_, const bool capFrameRate)
           }(),
           std::make_unique<GLFWGLRenderableResource>(*this)),
       window(window_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     glfwMakeContextCurrent(window);
     if (!capFrameRate) {
@@ -53,13 +53,13 @@ GLFWGLBackend::GLFWGLBackend(GLFWwindow* window_, const bool capFrameRate)
 GLFWGLBackend::~GLFWGLBackend() = default;
 
 void GLFWGLBackend::activate() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     glfwMakeContextCurrent(window);
 }
 
 void GLFWGLBackend::deactivate() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     glfwMakeContextCurrent(nullptr);
 }
@@ -69,7 +69,7 @@ mbgl::gl::ProcAddress GLFWGLBackend::getExtensionFunctionPointer(const char* nam
 }
 
 void GLFWGLBackend::updateAssumedState() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     assumeFramebufferBinding(0);
     setViewport(0, 0, size);
@@ -84,7 +84,7 @@ void GLFWGLBackend::setSize(const mbgl::Size newSize) {
 }
 
 void GLFWGLBackend::swap() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     glfwSwapBuffers(window);
 }
@@ -94,7 +94,7 @@ namespace gfx {
 
 template <>
 std::unique_ptr<GLFWBackend> Backend::Create<mbgl::gfx::Backend::Type::OpenGL>(GLFWwindow* window, bool capFrameRate) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return std::make_unique<GLFWGLBackend>(window, capFrameRate);
 }

--- a/platform/glfw/glfw_renderer_frontend.cpp
+++ b/platform/glfw/glfw_renderer_frontend.cpp
@@ -33,7 +33,7 @@ const mbgl::TaggedScheduler& GLFWRendererFrontend::getThreadPool() const {
 }
 
 void GLFWRendererFrontend::render() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     assert(renderer);
 

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -79,7 +79,7 @@ class SnapshotObserver final : public mbgl::MapSnapshotterObserver {
 public:
     ~SnapshotObserver() override = default;
     void onDidFinishLoadingStyle() override {
-        MLN_TRACE_FUNC();
+        MLN_TRACE_FUNC()
 
         if (didFinishLoadingStyleCallback) {
             didFinishLoadingStyleCallback();
@@ -90,7 +90,7 @@ public:
 
 namespace {
 void addFillExtrusionLayer(mbgl::style::Style &style, bool visible) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     using namespace mbgl::style;
     using namespace mbgl::style::expression::dsl;
@@ -137,7 +137,7 @@ GLFWView::GLFWView(bool fullscreen_,
       snapshotterObserver(std::make_unique<SnapshotObserver>()),
       mapResourceOptions(resourceOptions.clone()),
       mapClientOptions(clientOptions.clone()) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     glfwSetErrorCallback(glfwError);
 
@@ -278,33 +278,33 @@ GLFWView::GLFWView(bool fullscreen_,
 }
 
 GLFWView::~GLFWView() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     glfwDestroyWindow(window);
     glfwTerminate();
 }
 
 void GLFWView::setMap(mbgl::Map *map_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     map = map_;
     map->addAnnotationImage(makeImage("default_marker", 22, 22, 1));
 }
 
 void GLFWView::setRenderFrontend(GLFWRendererFrontend *rendererFrontend_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     rendererFrontend = rendererFrontend_;
 }
 
 mbgl::gfx::RendererBackend &GLFWView::getRendererBackend() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return backend->getRendererBackend();
 }
 
 void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, int mods) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
 
@@ -606,7 +606,7 @@ struct Interpolator<mbgl::LatLng> {
 } // namespace mbgl
 
 void GLFWView::updateFreeCameraDemo() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     const mbgl::LatLng trainStartPos = {60.171367, 24.941359};
     const mbgl::LatLng trainEndPos = {60.185147, 24.936668};
@@ -655,7 +655,7 @@ std::unique_ptr<mbgl::style::Image> GLFWView::makeImage(const std::string &id,
                                                         int width,
                                                         int height,
                                                         float pixelRatio) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     const int r = static_cast<int>(255 * (static_cast<double>(std::rand()) / RAND_MAX));
     const int g = static_cast<int>(255 * (static_cast<double>(std::rand()) / RAND_MAX));
@@ -702,7 +702,7 @@ void GLFWView::nextOrientation() {
 }
 
 void GLFWView::addRandomCustomPointAnnotations(int count) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     for (int i = 0; i < count; i++) {
         static int spriteID = 1;
@@ -714,7 +714,7 @@ void GLFWView::addRandomCustomPointAnnotations(int count) {
 }
 
 void GLFWView::addRandomPointAnnotations(int count) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     for (int i = 0; i < count; ++i) {
         annotationIDs.push_back(map->addAnnotation(mbgl::SymbolAnnotation{makeRandomPoint(), "default_marker"}));
@@ -722,7 +722,7 @@ void GLFWView::addRandomPointAnnotations(int count) {
 }
 
 void GLFWView::addRandomLineAnnotations(int count) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     for (int i = 0; i < count; ++i) {
         mbgl::LineString<double> lineString;
@@ -734,7 +734,7 @@ void GLFWView::addRandomLineAnnotations(int count) {
 }
 
 void GLFWView::addRandomShapeAnnotations(int count) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     for (int i = 0; i < count; ++i) {
         mbgl::Polygon<double> triangle;
@@ -745,7 +745,7 @@ void GLFWView::addRandomShapeAnnotations(int count) {
 }
 
 void GLFWView::addAnimatedAnnotation() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     const double started = glfwGetTime();
     animatedAnnotationIDs.push_back(map->addAnnotation(mbgl::SymbolAnnotation{{0, 0}, "default_marker"}));
@@ -753,7 +753,7 @@ void GLFWView::addAnimatedAnnotation() {
 }
 
 void GLFWView::updateAnimatedAnnotations() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     const double time = glfwGetTime();
     for (size_t i = 0; i < animatedAnnotationIDs.size(); i++) {
@@ -786,7 +786,7 @@ void GLFWView::cycleDebugOptions() {
 }
 
 void GLFWView::clearAnnotations() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     for (const auto &id : annotationIDs) {
         map->removeAnnotation(id);
@@ -811,7 +811,7 @@ void GLFWView::popAnnotation() {
 }
 
 void GLFWView::makeSnapshot(bool withOverlay) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!snapshotter || snapshotter->getStyleURL() != map->getStyle().getURL()) {
         snapshotter = std::make_unique<mbgl::MapSnapshotter>(map->getMapOptions().size(),
@@ -853,7 +853,7 @@ void GLFWView::makeSnapshot(bool withOverlay) {
 }
 
 void GLFWView::onScroll(GLFWwindow *window, double /*xOffset*/, double yOffset) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     double delta = yOffset * 40;
@@ -883,7 +883,7 @@ void GLFWView::onScroll(GLFWwindow *window, double /*xOffset*/, double yOffset) 
 }
 
 void GLFWView::onWindowResize(GLFWwindow *window, int width, int height) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     view->width = width;
@@ -898,7 +898,7 @@ void GLFWView::onWindowResize(GLFWwindow *window, int width, int height) {
 }
 
 void GLFWView::onFramebufferResize(GLFWwindow *window, int width, int height) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     view->backend->setSize({static_cast<uint32_t>(width), static_cast<uint32_t>(height)});
@@ -911,7 +911,7 @@ void GLFWView::onFramebufferResize(GLFWwindow *window, int width, int height) {
 }
 
 void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modifiers) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
 
@@ -944,7 +944,7 @@ void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modi
 }
 
 void GLFWView::onMouseMove(GLFWwindow *window, double x, double y) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     if (view->tracking) {
@@ -1006,7 +1006,7 @@ void GLFWView::onMouseMove(GLFWwindow *window, double x, double y) {
 }
 
 void GLFWView::onWindowFocus(GLFWwindow *window, int focused) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (focused == GLFW_FALSE) { // Focus lost.
         auto *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
@@ -1015,13 +1015,13 @@ void GLFWView::onWindowFocus(GLFWwindow *window, int focused) {
 }
 
 void GLFWView::run() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto callback = [&] {
-        MLN_TRACE_ZONE(GLFWView_runLoop_callback);
+        MLN_TRACE_ZONE(GLFWView_runLoop_callback)
 
         {
-            MLN_TRACE_ZONE(glfwWindowShouldClose);
+            MLN_TRACE_ZONE(glfwWindowShouldClose)
             if (glfwWindowShouldClose(window)) {
                 runLoop.stop();
                 return;
@@ -1029,18 +1029,18 @@ void GLFWView::run() {
         }
 
         {
-            MLN_TRACE_ZONE(glfwPollEvents);
+            MLN_TRACE_ZONE(glfwPollEvents)
             glfwPollEvents();
         }
 
         if (dirty && rendererFrontend) {
-            MLN_TRACE_ZONE(ReRender);
+            MLN_TRACE_ZONE(ReRender)
 
             dirty = false;
             const double started = glfwGetTime();
 
             if (animateRouteCallback) {
-                MLN_TRACE_ZONE(animateRouteCallback);
+                MLN_TRACE_ZONE(animateRouteCallback)
 
                 animateRouteCallback(map);
             }
@@ -1087,7 +1087,7 @@ mbgl::Size GLFWView::getSize() const {
 }
 
 void GLFWView::invalidate() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     dirty = true;
     glfwPostEmptyEvent();
@@ -1117,20 +1117,20 @@ void GLFWView::setChangeStyleCallback(std::function<void()> callback) {
 }
 
 void GLFWView::setShouldClose() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     glfwSetWindowShouldClose(window, true);
     glfwPostEmptyEvent();
 }
 
 void GLFWView::setWindowTitle(const std::string &title) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     glfwSetWindowTitle(window, (std::string{"MapLibre Native (GLFW): "} + title).c_str());
 }
 
 void GLFWView::onDidFinishLoadingStyle() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
 #if defined(MLN_RENDER_BACKEND_OPENGL) && !defined(MBGL_LAYER_CUSTOM_DISABLE_ALL)
     puck = nullptr;
@@ -1142,14 +1142,14 @@ void GLFWView::onDidFinishLoadingStyle() {
 }
 
 void GLFWView::toggle3DExtrusions(bool visible) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     show3DExtrusions = visible;
     addFillExtrusionLayer(map->getStyle(), show3DExtrusions);
 }
 
 void GLFWView::toggleCustomSource() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!map->getStyle().getSource("custom")) {
         mbgl::style::CustomGeometrySource::Options options;
@@ -1201,7 +1201,7 @@ void GLFWView::toggleCustomSource() {
 }
 
 void GLFWView::toggleLocationIndicatorLayer() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
 #if defined(MLN_RENDER_BACKEND_OPENGL) && !defined(MBGL_LAYER_LOCATION_INDICATOR_DISABLE_ALL)
     puck = static_cast<mbgl::style::LocationIndicatorLayer *>(map->getStyle().getLayer("puck"));
@@ -1266,7 +1266,7 @@ void GLFWView::toggleLocationIndicatorLayer() {
 using Nanoseconds = std::chrono::nanoseconds;
 
 void GLFWView::onWillStartRenderingFrame() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
 #if defined(MLN_RENDER_BACKEND_OPENGL) && !defined(MBGL_LAYER_LOCATION_INDICATOR_DISABLE_ALL)
     puck = static_cast<mbgl::style::LocationIndicatorLayer *>(map->getStyle().getLayer("puck"));

--- a/src/mbgl/actor/scheduler.cpp
+++ b/src/mbgl/actor/scheduler.cpp
@@ -16,7 +16,7 @@ std::function<void()> Scheduler::bindOnce(std::function<void()> fn) {
 static auto& current() {
     static util::ThreadLocal<Scheduler> scheduler;
     return scheduler;
-};
+}
 
 void Scheduler::SetCurrent(Scheduler* scheduler) {
     current().set(scheduler);

--- a/src/mbgl/annotation/render_annotation_source.cpp
+++ b/src/mbgl/annotation/render_annotation_source.cpp
@@ -26,7 +26,7 @@ void RenderAnnotationSource::update(Immutable<style::Source::Impl> baseImpl_,
                                     const bool needsRendering,
                                     const bool needsRelayout,
                                     const TileParameters& parameters) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     std::swap(baseImpl, baseImpl_);
 

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -836,7 +836,6 @@ void Context::draw(const gfx::DrawMode& drawMode, std::size_t indexOffset, std::
 
 void Context::performCleanup() {
     MLN_TRACE_FUNC()
-
 #ifndef NDEBUG
     // In debug builds, un-bind all texture units so that any incorrect use results in an
     // error rather than using whatever texture happened to have been bound previously.

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -113,7 +113,7 @@ Context::~Context() noexcept {
 }
 
 void Context::beginFrame() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     backend.getThreadPool().runRenderJobs();
 
@@ -133,7 +133,7 @@ void Context::beginFrame() {
 }
 
 void Context::endFrame() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
 #if MLN_DRAWABLE_RENDERER
     if (!frameInFlightFence) {
@@ -145,7 +145,7 @@ void Context::endFrame() {
 }
 
 void Context::initializeExtensions(const std::function<gl::ProcAddress(const char*)>& getProcAddress) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (const auto* extensions = reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_EXTENSIONS)))) {
         auto fn = [&](std::initializer_list<std::pair<const char*, const char*>> probes) -> ProcAddress {
@@ -175,7 +175,7 @@ void Context::initializeExtensions(const std::function<gl::ProcAddress(const cha
         extension::loadTimeStampQueryExtension(fn);
 #endif
     }
-    MLN_TRACE_GL_CONTEXT();
+    MLN_TRACE_GL_CONTEXT()
 }
 
 void Context::enableDebugging() {
@@ -239,14 +239,14 @@ UniqueProgram Context::createProgram(ShaderID vertexShader, ShaderID fragmentSha
 }
 
 void Context::linkProgram(ProgramID program_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     MBGL_CHECK_ERROR(glLinkProgram(program_));
     verifyProgramLinkage(program_);
 }
 
 void Context::verifyProgramLinkage(ProgramID program_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     GLint status;
     MBGL_CHECK_ERROR(glGetProgramiv(program_, GL_LINK_STATUS, &status));
@@ -266,7 +266,7 @@ void Context::verifyProgramLinkage(ProgramID program_) {
 }
 
 UniqueTexture Context::createUniqueTexture() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (pooledTextures.empty()) {
         pooledTextures.resize(TextureMax);
@@ -282,7 +282,7 @@ UniqueTexture Context::createUniqueTexture() {
 }
 
 VertexArray Context::createVertexArray() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     VertexArrayID id = 0;
     MBGL_CHECK_ERROR(glGenVertexArrays(1, &id));
@@ -292,7 +292,7 @@ VertexArray Context::createVertexArray() {
 }
 
 UniqueFramebuffer Context::createFramebuffer() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     FramebufferID id = 0;
     MBGL_CHECK_ERROR(glGenFramebuffers(1, &id));
@@ -304,7 +304,7 @@ UniqueFramebuffer Context::createFramebuffer() {
 std::unique_ptr<gfx::TextureResource> Context::createTextureResource(const Size size,
                                                                      const gfx::TexturePixelType format,
                                                                      const gfx::TextureChannelDataType type) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto obj = createUniqueTexture();
     int textureByteSize = gl::TextureResource::getStorageSize(size, format, type);
@@ -340,11 +340,11 @@ std::unique_ptr<gfx::TextureResource> Context::createTextureResource(const Size 
 
 std::unique_ptr<gfx::RenderbufferResource> Context::createRenderbufferResource(const gfx::RenderbufferPixelType type,
                                                                                const Size size) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     RenderbufferID id = 0;
     MBGL_CHECK_ERROR(glGenRenderbuffers(1, &id));
-    MLN_TRACE_ALLOC_RT(id, renderBufferByteSize(type, size));
+    MLN_TRACE_ALLOC_RT(id, renderBufferByteSize(type, size))
     // NOLINTNEXTLINE(performance-move-const-arg)
     UniqueRenderbuffer renderbuffer{std::move(id), {this}};
 
@@ -359,8 +359,8 @@ std::unique_ptr<gfx::RenderbufferResource> Context::createRenderbufferResource(c
 std::unique_ptr<uint8_t[]> Context::readFramebuffer(const Size size,
                                                     const gfx::TexturePixelType format,
                                                     const bool flip) {
-    MLN_TRACE_FUNC();
-    MLN_TRACE_FUNC_GL();
+    MLN_TRACE_FUNC()
+    MLN_TRACE_FUNC_GL()
 
     const size_t stride = size.width * (format == gfx::TexturePixelType::RGBA ? 4 : 1);
     auto data = std::make_unique<uint8_t[]>(stride * size.height);
@@ -388,7 +388,7 @@ std::unique_ptr<uint8_t[]> Context::readFramebuffer(const Size size,
 namespace {
 
 void checkFramebuffer() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     GLenum status = MBGL_CHECK_ERROR(glCheckFramebufferStatus(GL_FRAMEBUFFER));
     if (status != GL_FRAMEBUFFER_COMPLETE) {
@@ -421,8 +421,8 @@ void checkFramebuffer() {
 }
 
 void bindDepthStencilRenderbuffer(const gfx::Renderbuffer<gfx::RenderbufferPixelType::DepthStencil>& depthStencil) {
-    MLN_TRACE_FUNC();
-    MLN_TRACE_FUNC_GL();
+    MLN_TRACE_FUNC()
+    MLN_TRACE_FUNC_GL()
 
     auto& depthStencilResource = depthStencil.getResource<gl::RenderbufferResource>();
 #ifdef GL_DEPTH_STENCIL_ATTACHMENT
@@ -441,7 +441,7 @@ void bindDepthStencilRenderbuffer(const gfx::Renderbuffer<gfx::RenderbufferPixel
 Framebuffer Context::createFramebuffer(
     const gfx::Renderbuffer<gfx::RenderbufferPixelType::RGBA>& color,
     const gfx::Renderbuffer<gfx::RenderbufferPixelType::DepthStencil>& depthStencil) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (color.getSize() != depthStencil.getSize()) {
         throw std::runtime_error("Renderbuffer size mismatch");
@@ -458,7 +458,7 @@ Framebuffer Context::createFramebuffer(
 }
 
 Framebuffer Context::createFramebuffer(const gfx::Renderbuffer<gfx::RenderbufferPixelType::RGBA>& color) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto fbo = createFramebuffer();
     bindFramebuffer = fbo;
@@ -471,7 +471,7 @@ Framebuffer Context::createFramebuffer(const gfx::Renderbuffer<gfx::Renderbuffer
 
 Framebuffer Context::createFramebuffer(
     const gfx::Texture& color, const gfx::Renderbuffer<gfx::RenderbufferPixelType::DepthStencil>& depthStencil) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (color.size != depthStencil.getSize()) {
         throw std::runtime_error("Renderbuffer size mismatch");
@@ -486,7 +486,7 @@ Framebuffer Context::createFramebuffer(
 }
 
 Framebuffer Context::createFramebuffer(const gfx::Texture& color) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto fbo = createFramebuffer();
     bindFramebuffer = fbo;
@@ -498,7 +498,7 @@ Framebuffer Context::createFramebuffer(const gfx::Texture& color) {
 
 Framebuffer Context::createFramebuffer(const gfx::Texture& color,
                                        const gfx::Renderbuffer<gfx::RenderbufferPixelType::Depth>& depth) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
     if (color.size != depth.getSize()) {
         throw std::runtime_error("Renderbuffer size mismatch");
     }
@@ -516,19 +516,19 @@ Framebuffer Context::createFramebuffer(const gfx::Texture& color,
 
 std::unique_ptr<gfx::OffscreenTexture> Context::createOffscreenTexture(const Size size,
                                                                        const gfx::TextureChannelDataType type) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return std::make_unique<gl::OffscreenTexture>(*this, size, type);
 }
 
 std::unique_ptr<gfx::DrawScopeResource> Context::createDrawScopeResource() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return std::make_unique<gl::DrawScopeResource>(createVertexArray());
 }
 
 void Context::reset() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     std::copy(pooledTextures.begin(), pooledTextures.end(), std::back_inserter(abandonedTextures));
     pooledTextures.resize(0);
@@ -537,8 +537,8 @@ void Context::reset() {
 
 #if MLN_DRAWABLE_RENDERER
 void Context::resetState(gfx::DepthMode depthMode, gfx::ColorMode colorMode) {
-    MLN_TRACE_FUNC();
-    MLN_TRACE_FUNC_GL();
+    MLN_TRACE_FUNC()
+    MLN_TRACE_FUNC_GL()
 
     // Reset GL state to a known state so the CustomLayer always has a clean slate.
     bindVertexArray = value::BindVertexArray::Default;
@@ -552,7 +552,7 @@ bool Context::emplaceOrUpdateUniformBuffer(gfx::UniformBufferPtr& buffer,
                                            const void* data,
                                            std::size_t size,
                                            bool persistent) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (buffer) {
         buffer->update(data, size);
@@ -564,7 +564,7 @@ bool Context::emplaceOrUpdateUniformBuffer(gfx::UniformBufferPtr& buffer,
 }
 
 void Context::bindGlobalUniformBuffers(gfx::RenderPass&) const noexcept {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     for (size_t id = 0; id < globalUniformBuffers.allocatedSize(); id++) {
         const auto& globalUniformBuffer = globalUniformBuffers.get(id);
@@ -580,7 +580,7 @@ void Context::bindGlobalUniformBuffers(gfx::RenderPass&) const noexcept {
 }
 
 void Context::unbindGlobalUniformBuffers(gfx::RenderPass&) const noexcept {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     for (size_t id = 0; id < globalUniformBuffers.allocatedSize(); id++) {
         const auto& globalUniformBuffer = globalUniformBuffers.get(id);
@@ -592,7 +592,7 @@ void Context::unbindGlobalUniformBuffers(gfx::RenderPass&) const noexcept {
 #endif
 
 void Context::setDirtyState() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     // Note: does not set viewport/scissorTest/bindFramebuffer to dirty
     // since they are handled separately in the view object.
@@ -632,19 +632,19 @@ void Context::setDirtyState() {
 
 #if MLN_DRAWABLE_RENDERER
 gfx::UniqueDrawableBuilder Context::createDrawableBuilder(std::string name) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return std::make_unique<gl::DrawableGLBuilder>(std::move(name));
 }
 
 gfx::UniformBufferPtr Context::createUniformBuffer(const void* data, std::size_t size, bool /*persistent*/) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return std::make_shared<gl::UniformBufferGL>(data, size, *uboAllocator);
 }
 
 gfx::ShaderProgramBasePtr Context::getGenericShader(gfx::ShaderRegistry& shaders, const std::string& name) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto shaderGroup = shaders.getShaderGroup(name);
     if (!shaderGroup) {
@@ -654,31 +654,31 @@ gfx::ShaderProgramBasePtr Context::getGenericShader(gfx::ShaderRegistry& shaders
 }
 
 TileLayerGroupPtr Context::createTileLayerGroup(int32_t layerIndex, std::size_t initialCapacity, std::string name) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return std::make_shared<TileLayerGroupGL>(layerIndex, initialCapacity, std::move(name));
 }
 
 LayerGroupPtr Context::createLayerGroup(int32_t layerIndex, std::size_t initialCapacity, std::string name) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return std::make_shared<LayerGroupGL>(layerIndex, initialCapacity, std::move(name));
 }
 
 gfx::Texture2DPtr Context::createTexture2D() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return std::make_shared<gl::Texture2D>(*this);
 }
 
 RenderTargetPtr Context::createRenderTarget(const Size size, const gfx::TextureChannelDataType type) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return std::make_shared<RenderTarget>(*this, size, type);
 }
 
 Framebuffer Context::createFramebuffer(const gfx::Texture2D& color) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto fbo = createFramebuffer();
     bindFramebuffer = fbo;
@@ -698,8 +698,8 @@ gfx::VertexAttributeArrayPtr Context::createVertexAttributeArray() const {
 #endif
 
 void Context::clear(std::optional<mbgl::Color> color, std::optional<float> depth, std::optional<int32_t> stencil) {
-    MLN_TRACE_FUNC();
-    MLN_TRACE_FUNC_GL();
+    MLN_TRACE_FUNC()
+    MLN_TRACE_FUNC_GL()
 
     GLbitfield mask = 0;
 
@@ -788,7 +788,7 @@ void Context::setColorMode(const gfx::ColorMode& color) {
 }
 
 std::unique_ptr<gfx::CommandEncoder> Context::createCommandEncoder() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     backend.updateAssumedState();
     if (backend.contextIsShared()) {
@@ -798,8 +798,8 @@ std::unique_ptr<gfx::CommandEncoder> Context::createCommandEncoder() {
 }
 
 void Context::finish() {
-    MLN_TRACE_FUNC();
-    MLN_TRACE_FUNC_GL();
+    MLN_TRACE_FUNC()
+    MLN_TRACE_FUNC_GL()
 
     MBGL_CHECK_ERROR(glFinish());
 }
@@ -811,8 +811,8 @@ std::shared_ptr<gl::Fence> Context::getCurrentFrameFence() const {
 #endif
 
 void Context::draw(const gfx::DrawMode& drawMode, std::size_t indexOffset, std::size_t indexLength) {
-    MLN_TRACE_FUNC();
-    MLN_TRACE_FUNC_GL();
+    MLN_TRACE_FUNC()
+    MLN_TRACE_FUNC_GL()
 
     switch (drawMode.type) {
         case gfx::DrawModeType::Points:
@@ -835,7 +835,7 @@ void Context::draw(const gfx::DrawMode& drawMode, std::size_t indexOffset, std::
 }
 
 void Context::performCleanup() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
 #ifndef NDEBUG
     // In debug builds, un-bind all texture units so that any incorrect use results in an
@@ -920,8 +920,8 @@ void Context::performCleanup() {
 }
 
 void Context::reduceMemoryUsage() {
-    MLN_TRACE_FUNC();
-    MLN_TRACE_FUNC_GL();
+    MLN_TRACE_FUNC()
+    MLN_TRACE_FUNC_GL()
 
     performCleanup();
 
@@ -941,8 +941,8 @@ void Context::visualizeDepthBuffer([[maybe_unused]] const float depthRangeSize) 
 #endif
 
 void Context::clearStencilBuffer(const int32_t bits) {
-    MLN_TRACE_FUNC();
-    MLN_TRACE_FUNC_GL();
+    MLN_TRACE_FUNC()
+    MLN_TRACE_FUNC_GL()
 
     MBGL_CHECK_ERROR(glClearStencil(bits));
     MBGL_CHECK_ERROR(glClear(GL_STENCIL_BUFFER_BIT));

--- a/src/mbgl/gl/fence.cpp
+++ b/src/mbgl/gl/fence.cpp
@@ -26,7 +26,7 @@ std::string glErrors() {
 Fence::Fence() {}
 
 Fence::~Fence() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (fence) {
         glDeleteSync(fence);
@@ -34,14 +34,14 @@ Fence::~Fence() {
 }
 
 void Fence::insert() noexcept {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     assert(!fence);
     fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
 }
 
 bool Fence::isSignaled() const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!fence) {
         return false;

--- a/src/mbgl/gl/index_buffer_resource.cpp
+++ b/src/mbgl/gl/index_buffer_resource.cpp
@@ -7,11 +7,9 @@ namespace gl {
 
 IndexBufferResource::IndexBufferResource(UniqueBuffer&& buffer_, int byteSize_)
     : buffer(std::move(buffer_)),
-      byteSize(byteSize_) {
-    MLN_TRACE_ALLOC_INDEX_BUFFER(buffer.get(), byteSize)
-}
+      byteSize(byteSize_){MLN_TRACE_ALLOC_INDEX_BUFFER(buffer.get(), byteSize)}
 
-IndexBufferResource::~IndexBufferResource() noexcept {
+      IndexBufferResource::~IndexBufferResource() noexcept {
     MLN_TRACE_FREE_INDEX_BUFFER(buffer.get())
     auto& stats = buffer.get_deleter().context.renderingStats();
     stats.memIndexBuffers -= byteSize;

--- a/src/mbgl/gl/index_buffer_resource.cpp
+++ b/src/mbgl/gl/index_buffer_resource.cpp
@@ -8,11 +8,11 @@ namespace gl {
 IndexBufferResource::IndexBufferResource(UniqueBuffer&& buffer_, int byteSize_)
     : buffer(std::move(buffer_)),
       byteSize(byteSize_) {
-    MLN_TRACE_ALLOC_INDEX_BUFFER(buffer.get(), byteSize);
+    MLN_TRACE_ALLOC_INDEX_BUFFER(buffer.get(), byteSize)
 }
 
 IndexBufferResource::~IndexBufferResource() noexcept {
-    MLN_TRACE_FREE_INDEX_BUFFER(buffer.get());
+    MLN_TRACE_FREE_INDEX_BUFFER(buffer.get())
     auto& stats = buffer.get_deleter().context.renderingStats();
     stats.memIndexBuffers -= byteSize;
     assert(stats.memIndexBuffers >= 0);

--- a/src/mbgl/gl/layer_group_gl.cpp
+++ b/src/mbgl/gl/layer_group_gl.cpp
@@ -10,6 +10,7 @@
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/shaders/gl/shader_program_gl.hpp>
 #include <mbgl/util/convert.hpp>
+#include <mbgl/util/instrumentation.hpp>
 
 namespace mbgl {
 namespace gl {
@@ -23,6 +24,9 @@ void TileLayerGroupGL::upload(gfx::UploadPass& uploadPass) {
     if (!enabled) {
         return;
     }
+
+    MLN_TRACE_FUNC()
+    MLN_ZONE_STR(name)
 
     visitDrawables([&](gfx::Drawable& drawable) {
         if (!drawable.getEnabled()) {
@@ -49,6 +53,8 @@ void TileLayerGroupGL::render(RenderOrchestrator&, PaintParameters& parameters) 
         return;
     }
 
+    MLN_TRACE_FUNC()
+
     auto& context = static_cast<gl::Context&>(parameters.context);
 
     // `stencilModeFor3D` uses a different stencil mask value each time its called, so if the
@@ -60,6 +66,7 @@ void TileLayerGroupGL::render(RenderOrchestrator&, PaintParameters& parameters) 
     gfx::StencilMode stencilMode3d;
 
     if (getDrawableCount()) {
+        MLN_TRACE_ZONE(clip masks)
 #if !defined(NDEBUG)
         const auto label_clip = getName() + (getName().empty() ? "" : "-") + "tile-clip-masks";
         const auto debugGroupClip = parameters.encoder->createDebugGroup(label_clip.c_str());
@@ -148,6 +155,7 @@ void TileLayerGroupGL::bindUniformBuffers() const {
 }
 
 void TileLayerGroupGL::unbindUniformBuffers() const {
+    MLN_TRACE_FUNC()
     for (size_t id = 0; id < uniformBuffers.allocatedSize(); id++) {
         const auto& uniformBuffer = uniformBuffers.get(id);
         if (!uniformBuffer) continue;

--- a/src/mbgl/gl/renderbuffer_resource.cpp
+++ b/src/mbgl/gl/renderbuffer_resource.cpp
@@ -6,7 +6,7 @@ namespace mbgl {
 namespace gl {
 
 RenderbufferResource::~RenderbufferResource() noexcept {
-    MLN_TRACE_FREE_RT(renderbuffer.get());
+    MLN_TRACE_FREE_RT(renderbuffer.get())
 }
 
 } // namespace gl

--- a/src/mbgl/gl/renderer_backend.cpp
+++ b/src/mbgl/gl/renderer_backend.cpp
@@ -23,7 +23,7 @@ RendererBackend::RendererBackend(const gfx::ContextMode contextMode_, const Tagg
     : gfx::RendererBackend(contextMode_, threadPool_) {}
 
 std::unique_ptr<gfx::Context> RendererBackend::createContext() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto result = std::make_unique<gl::Context>(
         *this); // Tagged background thread pool will be owned by the RendererBackend
@@ -33,13 +33,13 @@ std::unique_ptr<gfx::Context> RendererBackend::createContext() {
 }
 
 PremultipliedImage RendererBackend::readFramebuffer(const Size& size) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return getContext<gl::Context>().readFramebuffer<PremultipliedImage>(size);
 }
 
 void RendererBackend::assumeFramebufferBinding(const gl::FramebufferID fbo) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     getContext<gl::Context>().bindFramebuffer.setCurrentValue(fbo);
     if (fbo != ImplicitFramebufferBinding) {
@@ -48,27 +48,27 @@ void RendererBackend::assumeFramebufferBinding(const gl::FramebufferID fbo) {
 }
 
 void RendererBackend::assumeViewport(int32_t x, int32_t y, const Size& size) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     getContext<gl::Context>().viewport.setCurrentValue({x, y, size});
     assert(gl::value::Viewport::Get() == getContext<gl::Context>().viewport.getCurrentValue());
 }
 
 void RendererBackend::assumeScissorTest(bool enabled) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     getContext<gl::Context>().scissorTest.setCurrentValue(enabled);
     assert(gl::value::ScissorTest::Get() == getContext<gl::Context>().scissorTest.getCurrentValue());
 }
 
 bool RendererBackend::implicitFramebufferBound() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return getContext<gl::Context>().bindFramebuffer.getCurrentValue() == ImplicitFramebufferBinding;
 }
 
 void RendererBackend::setFramebufferBinding(const gl::FramebufferID fbo) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     getContext<gl::Context>().bindFramebuffer = fbo;
     if (fbo != ImplicitFramebufferBinding) {
@@ -77,14 +77,14 @@ void RendererBackend::setFramebufferBinding(const gl::FramebufferID fbo) {
 }
 
 void RendererBackend::setViewport(int32_t x, int32_t y, const Size& size) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     getContext<gl::Context>().viewport = {x, y, size};
     assert(gl::value::Viewport::Get() == getContext<gl::Context>().viewport.getCurrentValue());
 }
 
 void RendererBackend::setScissorTest(bool enabled) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     getContext<gl::Context>().scissorTest = enabled;
     assert(gl::value::ScissorTest::Get() == getContext<gl::Context>().scissorTest.getCurrentValue());
@@ -99,7 +99,7 @@ RendererBackend::~RendererBackend() = default;
 /// @param programParameters ProgramParameters used to initialize each instance
 template <shaders::BuiltIn... ShaderID>
 void registerTypes(gfx::ShaderRegistry& registry, const ProgramParameters& programParameters) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     /// The following fold expression will create a shader for every type
     /// in the parameter pack and register it with the shader registry.
@@ -118,7 +118,7 @@ void registerTypes(gfx::ShaderRegistry& registry, const ProgramParameters& progr
 }
 
 void RendererBackend::initShaders(gfx::ShaderRegistry& shaders, const ProgramParameters& programParameters) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     registerTypes<shaders::BuiltIn::BackgroundShader,
                   shaders::BuiltIn::BackgroundPatternShader,

--- a/src/mbgl/gl/texture_resource.cpp
+++ b/src/mbgl/gl/texture_resource.cpp
@@ -34,11 +34,9 @@ static int channelStorageSize(gfx::TextureChannelDataType type) {
 
 TextureResource::TextureResource(UniqueTexture&& texture_, int byteSize_)
     : texture(std::move(texture_)),
-      byteSize(byteSize_) {
-    MLN_TRACE_ALLOC_TEXTURE(texture.get(), byteSize)
-}
+      byteSize(byteSize_){MLN_TRACE_ALLOC_TEXTURE(texture.get(), byteSize)}
 
-TextureResource::~TextureResource() noexcept {
+      TextureResource::~TextureResource() noexcept {
     auto& stats = texture.get_deleter().context->renderingStats();
     MLN_TRACE_FREE_TEXTURE(texture.get())
     stats.memTextures -= byteSize;

--- a/src/mbgl/gl/texture_resource.cpp
+++ b/src/mbgl/gl/texture_resource.cpp
@@ -35,12 +35,12 @@ static int channelStorageSize(gfx::TextureChannelDataType type) {
 TextureResource::TextureResource(UniqueTexture&& texture_, int byteSize_)
     : texture(std::move(texture_)),
       byteSize(byteSize_) {
-    MLN_TRACE_ALLOC_TEXTURE(texture.get(), byteSize);
+    MLN_TRACE_ALLOC_TEXTURE(texture.get(), byteSize)
 }
 
 TextureResource::~TextureResource() noexcept {
     auto& stats = texture.get_deleter().context->renderingStats();
-    MLN_TRACE_FREE_TEXTURE(texture.get());
+    MLN_TRACE_FREE_TEXTURE(texture.get())
     stats.memTextures -= byteSize;
     assert(stats.memTextures >= 0);
 }

--- a/src/mbgl/gl/uniform_buffer_gl.cpp
+++ b/src/mbgl/gl/uniform_buffer_gl.cpp
@@ -32,7 +32,7 @@ UniformBufferGL::UniformBufferGL(const void* data_, std::size_t size_, IBufferAl
       uniqueDebugId(generateDebugId()),
 #endif
       managedBuffer(allocator_, this) {
-    MLN_TRACE_ALLOC_CONST_BUFFER(uniqueDebugId, size_);
+    MLN_TRACE_ALLOC_CONST_BUFFER(uniqueDebugId, size_)
     if (size_ > managedBuffer.allocator.pageSize()) {
         // Buffer is very large, won't fit in the provided allocator
         MBGL_CHECK_ERROR(glGenBuffers(1, &localID));
@@ -66,7 +66,7 @@ UniformBufferGL::UniformBufferGL(const UniformBufferGL& other)
       uniqueDebugId(generateDebugId()),
 #endif
       managedBuffer(other.managedBuffer.allocator, this) {
-    MLN_TRACE_ALLOC_CONST_BUFFER(uniqueDebugId, other.size);
+    MLN_TRACE_ALLOC_CONST_BUFFER(uniqueDebugId, other.size)
     managedBuffer.setOwner(this);
     if (other.isManagedAllocation) {
         managedBuffer.allocate(other.managedBuffer.getContents().data(), other.size);
@@ -83,7 +83,7 @@ UniformBufferGL::~UniformBufferGL() {
 #ifdef MLN_TRACY_ENABLE
     assert(uniqueDebugId > 0);
 #endif
-    MLN_TRACE_FREE_CONST_BUFFER(uniqueDebugId);
+    MLN_TRACE_FREE_CONST_BUFFER(uniqueDebugId)
     if (isManagedAllocation) {
         return;
     }

--- a/src/mbgl/gl/vertex_buffer_resource.cpp
+++ b/src/mbgl/gl/vertex_buffer_resource.cpp
@@ -7,11 +7,9 @@ namespace gl {
 
 VertexBufferResource::VertexBufferResource(UniqueBuffer&& buffer_, int byteSize_)
     : buffer(std::move(buffer_)),
-      byteSize(byteSize_) {
-    MLN_TRACE_ALLOC_VERTEX_BUFFER(buffer.get(), byteSize)
-}
+      byteSize(byteSize_){MLN_TRACE_ALLOC_VERTEX_BUFFER(buffer.get(), byteSize)}
 
-VertexBufferResource::~VertexBufferResource() noexcept {
+      VertexBufferResource::~VertexBufferResource() noexcept {
     MLN_TRACE_FREE_VERTEX_BUFFER(buffer.get())
     auto& stats = buffer.get_deleter().context.renderingStats();
     stats.memVertexBuffers -= byteSize;

--- a/src/mbgl/gl/vertex_buffer_resource.cpp
+++ b/src/mbgl/gl/vertex_buffer_resource.cpp
@@ -8,11 +8,11 @@ namespace gl {
 VertexBufferResource::VertexBufferResource(UniqueBuffer&& buffer_, int byteSize_)
     : buffer(std::move(buffer_)),
       byteSize(byteSize_) {
-    MLN_TRACE_ALLOC_VERTEX_BUFFER(buffer.get(), byteSize);
+    MLN_TRACE_ALLOC_VERTEX_BUFFER(buffer.get(), byteSize)
 }
 
 VertexBufferResource::~VertexBufferResource() noexcept {
-    MLN_TRACE_FREE_VERTEX_BUFFER(buffer.get());
+    MLN_TRACE_FREE_VERTEX_BUFFER(buffer.get())
     auto& stats = buffer.get_deleter().context.renderingStats();
     stats.memVertexBuffers -= byteSize;
     assert(stats.memVertexBuffers >= 0);

--- a/src/mbgl/renderer/backend_scope.cpp
+++ b/src/mbgl/renderer/backend_scope.cpp
@@ -23,7 +23,7 @@ BackendScope::BackendScope(RendererBackend& backend_, ScopeType scopeType_)
       nextScope(nullptr),
       backend(backend_),
       scopeType(scopeType_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (priorScope) {
         assert(priorScope->nextScope == nullptr);
@@ -37,7 +37,7 @@ BackendScope::BackendScope(RendererBackend& backend_, ScopeType scopeType_)
 }
 
 BackendScope::~BackendScope() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     assert(nextScope == nullptr);
     deactivate();
@@ -53,7 +53,7 @@ BackendScope::~BackendScope() {
 }
 
 void BackendScope::activate() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (scopeType == ScopeType::Explicit && !(priorScope && this->backend == priorScope->backend) &&
         !(nextScope && this->backend == nextScope->backend)) {

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/renderer/image_manager_observer.hpp>
 #include <mbgl/util/constants.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/logging.hpp>
 
 #include <sstream>
@@ -191,6 +192,7 @@ void ImageManager::reduceMemoryUse() {
 
 void ImageManager::reduceMemoryUseIfCacheSizeExceedsLimit() {
     if (requestedImagesCacheSize > util::DEFAULT_ON_DEMAND_IMAGES_CACHE_SIZE) {
+        MLN_TRACE_FUNC()
         reduceMemoryUse();
     }
 }

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -85,7 +85,7 @@ public:
           updateSymbolOpacities(updateSymbolOpacities_) {}
 
     void prepare() override {
-        MLN_TRACE_FUNC();
+        MLN_TRACE_FUNC()
 
         for (auto it = layersNeedPlacement.rbegin(); it != layersNeedPlacement.rend(); ++it) {
             placement->updateLayerBuckets(*it, parameters->transformParams.state, updateSymbolOpacities);
@@ -133,7 +133,7 @@ RenderOrchestrator::RenderOrchestrator(bool backgroundLayerAsColor_,
 }
 
 RenderOrchestrator::~RenderOrchestrator() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (contextLost) {
         // Signal all RenderLayers that the context was lost
@@ -158,7 +158,7 @@ void RenderOrchestrator::setObserver(RendererObserver* observer_) {
 
 std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
     const std::shared_ptr<UpdateParameters>& updateParameters) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     const auto startTime = util::MonotonicTimer::now().count();
 
@@ -359,6 +359,9 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
 
     // Update all sources and initialize renderItems.
     for (const auto& sourceImpl : *sourceImpls) {
+        MLN_TRACE_ZONE(update source)
+        MLN_ZONE_STR(sourceImpl->id)
+
         RenderSource* source = renderSources.at(sourceImpl->id).get();
         bool sourceNeedsRendering = false;
         bool sourceNeedsRelayout = false;
@@ -436,7 +439,11 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
 
     auto opaquePassCutOffEstimation = layerRenderItems.size();
     for (auto& renderItem : layerRenderItems) {
+        MLN_TRACE_ZONE(prepare layer)
+
         RenderLayer& renderLayer = renderItem.layer;
+        MLN_ZONE_STR(renderLayer.getID())
+
         renderLayer.prepare(
             {renderItem.source, *imageManager, *patternAtlas, *lineAtlas, updateParameters->transformState});
         if (renderLayer.needsPlacement()) {
@@ -449,6 +456,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
             }
         }
     }
+
     // Symbol placement.
     assert((updateParameters->mode == MapMode::Tile) || !placedSymbolDataCollected);
     bool symbolBucketsChanged = false;
@@ -466,6 +474,8 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
     }
 
     if (isMapModeContinuous) {
+        MLN_TRACE_ZONE(placement)
+
         std::optional<Duration> placementUpdatePeriodOverride;
         if (symbolBucketsAdded && !tiltedView) {
             // If the view is not tilted, we want *the new* symbols to show up
@@ -500,6 +510,8 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
             updateParameters->timePoint);
         renderTreeParameters->needsRepaint = hasTransitions(updateParameters->timePoint);
     } else {
+        MLN_TRACE_ZONE(placement)
+
         renderTreeParameters->placementChanged = symbolBucketsChanged = !layersNeedPlacement.empty();
         if (renderTreeParameters->placementChanged) {
             Mutable<Placement> placement = Placement::create(updateParameters);
@@ -538,7 +550,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
 
 std::vector<Feature> RenderOrchestrator::queryRenderedFeatures(const ScreenLineString& geometry,
                                                                const RenderedQueryOptions& options) const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     std::unordered_map<std::string, const RenderLayer*> layers;
     if (options.layerIDs) {
@@ -560,7 +572,7 @@ void RenderOrchestrator::queryRenderedSymbols(std::unordered_map<std::string, st
                                               const ScreenLineString& geometry,
                                               const std::unordered_map<std::string, const RenderLayer*>& layers,
                                               const RenderedQueryOptions& options) const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     const auto hasCrossTileIndex = [](const auto& pair) {
         return pair.second->baseImpl->getTypeInfo()->crossTileIndex == style::LayerTypeInfo::CrossTileIndex::Required;
@@ -610,7 +622,7 @@ std::vector<Feature> RenderOrchestrator::queryRenderedFeatures(
     const ScreenLineString& geometry,
     const RenderedQueryOptions& options,
     const std::unordered_map<std::string, const RenderLayer*>& layers) const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     std::unordered_set<std::string> sourceIDs;
     std::unordered_map<std::string, const RenderLayer*> filteredLayers;
@@ -661,7 +673,7 @@ std::vector<Feature> RenderOrchestrator::queryRenderedFeatures(
 }
 
 std::vector<Feature> RenderOrchestrator::queryShapeAnnotations(const ScreenLineString& geometry) const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     assert(LayerManager::annotationsEnabled);
     std::unordered_map<std::string, const RenderLayer*> shapeAnnotationLayers;
@@ -683,7 +695,7 @@ std::vector<Feature> RenderOrchestrator::queryShapeAnnotations(const ScreenLineS
 
 std::vector<Feature> RenderOrchestrator::querySourceFeatures(const std::string& sourceID,
                                                              const SourceQueryOptions& options) const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     const RenderSource* source = getRenderSource(sourceID);
     if (!source) return {};
@@ -697,7 +709,7 @@ FeatureExtensionValue RenderOrchestrator::queryFeatureExtensions(
     const std::string& extension,
     const std::string& extensionField,
     const std::optional<std::map<std::string, Value>>& args) const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (RenderSource* renderSource = getRenderSource(sourceID)) {
         return renderSource->queryFeatureExtensions(feature, extension, extensionField, args);
@@ -709,7 +721,7 @@ void RenderOrchestrator::setFeatureState(const std::string& sourceID,
                                          const std::optional<std::string>& sourceLayerID,
                                          const std::string& featureID,
                                          const FeatureState& state) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (RenderSource* renderSource = getRenderSource(sourceID)) {
         renderSource->setFeatureState(sourceLayerID, featureID, state);
@@ -720,7 +732,7 @@ void RenderOrchestrator::getFeatureState(FeatureState& state,
                                          const std::string& sourceID,
                                          const std::optional<std::string>& sourceLayerID,
                                          const std::string& featureID) const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (RenderSource* renderSource = getRenderSource(sourceID)) {
         renderSource->getFeatureState(state, sourceLayerID, featureID);
@@ -731,7 +743,7 @@ void RenderOrchestrator::removeFeatureState(const std::string& sourceID,
                                             const std::optional<std::string>& sourceLayerID,
                                             const std::optional<std::string>& featureID,
                                             const std::optional<std::string>& stateKey) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (RenderSource* renderSource = getRenderSource(sourceID)) {
         renderSource->removeFeatureState(sourceLayerID, featureID, stateKey);
@@ -747,7 +759,7 @@ void RenderOrchestrator::setTileCacheEnabled(bool enable) {
 }
 
 void RenderOrchestrator::reduceMemoryUse() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     filteredLayersForSource.shrink_to_fit();
     for (const auto& entry : renderSources) {
@@ -758,7 +770,7 @@ void RenderOrchestrator::reduceMemoryUse() {
 }
 
 void RenderOrchestrator::dumpDebugLogs() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     for (const auto& entry : renderSources) {
         entry.second->dumpDebugLogs();
@@ -815,7 +827,7 @@ bool RenderOrchestrator::hasTransitions(TimePoint timePoint) const {
 }
 
 bool RenderOrchestrator::isLoaded() const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     // do the simple boolean check before iterating over all the tiles in all the sources
     if (!imageManager->isLoaded()) {
@@ -832,7 +844,7 @@ bool RenderOrchestrator::isLoaded() const {
 }
 
 void RenderOrchestrator::clearData() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!sourceImpls->empty()) sourceImpls = makeMutable<std::vector<Immutable<style::Source::Impl>>>();
     if (!layerImpls->empty()) layerImpls = makeMutable<std::vector<Immutable<style::Layer::Impl>>>();
@@ -868,7 +880,7 @@ void RenderOrchestrator::addChanges(UniqueChangeRequestVec& changes) {
 }
 
 void RenderOrchestrator::updateLayerIndex(LayerGroupBasePtr layerGroup, const int32_t newIndex) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!layerGroup || layerGroup->getLayerIndex() == newIndex) {
         return;
@@ -887,7 +899,7 @@ void RenderOrchestrator::updateLayerIndex(LayerGroupBasePtr layerGroup, const in
 }
 
 bool RenderOrchestrator::addLayerGroup(LayerGroupBasePtr layerGroup) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     const auto index = layerGroup->getLayerIndex();
     const auto range = layerGroupsByLayerIndex.equal_range(index);
@@ -909,7 +921,7 @@ bool RenderOrchestrator::addLayerGroup(LayerGroupBasePtr layerGroup) {
 }
 
 bool RenderOrchestrator::removeLayerGroup(const LayerGroupBasePtr& layerGroup) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!layerGroup) {
         return false;
@@ -929,7 +941,7 @@ size_t RenderOrchestrator::numLayerGroups() const noexcept {
 }
 
 int32_t RenderOrchestrator::maxLayerIndex() const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!layerGroupsByLayerIndex.empty()) {
         assert(layerGroupsByLayerIndex.crbegin()->first == layerGroupsByLayerIndex.crbegin()->second->getLayerIndex());
@@ -943,7 +955,7 @@ void RenderOrchestrator::updateLayers(gfx::ShaderRegistry& shaders,
                                       const TransformState& state,
                                       const std::shared_ptr<UpdateParameters>& updateParameters,
                                       const RenderTree& renderTree) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     const bool isMapModeContinuous = updateParameters->mode == MapMode::Continuous;
     const auto transitionOptions = isMapModeContinuous ? updateParameters->transitionOptions
@@ -1005,7 +1017,7 @@ void RenderOrchestrator::updateDebugLayerGroups(const RenderTree& renderTree, Pa
 void RenderOrchestrator::onGlyphsError(const FontStack& fontStack,
                                        const GlyphRange& glyphRange,
                                        std::exception_ptr error) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     Log::Error(Event::Style,
                "Failed to load glyph range " + std::to_string(glyphRange.first) + "-" +
@@ -1015,7 +1027,7 @@ void RenderOrchestrator::onGlyphsError(const FontStack& fontStack,
 }
 
 void RenderOrchestrator::onTileError(RenderSource& source, const OverscaledTileID& tileID, std::exception_ptr error) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     Log::Error(Event::Style,
                "Failed to load tile " + util::toString(tileID) + " for source " + source.baseImpl->id + ": " +
@@ -1024,19 +1036,19 @@ void RenderOrchestrator::onTileError(RenderSource& source, const OverscaledTileI
 }
 
 void RenderOrchestrator::onTileChanged(RenderSource&, const OverscaledTileID&) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     observer->onInvalidate();
 }
 
 void RenderOrchestrator::onStyleImageMissing(const std::string& id, const std::function<void()>& done) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     observer->onStyleImageMissing(id, done);
 }
 
 void RenderOrchestrator::onRemoveUnusedStyleImages(const std::vector<std::string>& unusedImageIDs) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     observer->onRemoveUnusedStyleImages(unusedImageIDs);
 }

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -30,7 +30,7 @@ void Renderer::setObserver(RendererObserver* observer) {
 }
 
 void Renderer::render(const std::shared_ptr<UpdateParameters>& updateParameters) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
     assert(updateParameters);
     if (auto renderTree = impl->orchestrator.createRenderTree(updateParameters)) {
         renderTree->prepare();

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -74,7 +74,7 @@ void Renderer::Impl::setObserver(RendererObserver* observer_) {
 
 void Renderer::Impl::render(const RenderTree& renderTree,
                             [[maybe_unused]] const std::shared_ptr<UpdateParameters>& updateParameters) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
     auto& context = backend.getContext();
 #if MLN_RENDER_BACKEND_METAL
     if constexpr (EnableMetalCapture) {
@@ -541,7 +541,7 @@ void Renderer::Impl::render(const RenderTree& renderTree,
     }
 
     frameCount += 1;
-    MLN_END_FRAME();
+    MLN_END_FRAME()
 }
 
 void Renderer::Impl::reduceMemoryUse() {

--- a/src/mbgl/renderer/source_state.cpp
+++ b/src/mbgl/renderer/source_state.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/renderer/source_state.hpp>
 #include <mbgl/style/conversion_impl.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/logging.hpp>
 
 namespace mbgl {
@@ -42,6 +43,7 @@ void SourceFeatureState::getState(FeatureState& result,
 }
 
 void SourceFeatureState::coalesceChanges(std::vector<RenderTile>& tiles) {
+    MLN_TRACE_FUNC()
     LayerFeatureStates changes;
     for (const auto& layerStatesEntry : stateChanges) {
         const auto& sourceLayer = layerStatesEntry.first;

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -7,6 +7,7 @@
 #include <mbgl/renderer/tile_render_data.hpp>
 #include <mbgl/tile/vector_tile.hpp>
 #include <mbgl/util/constants.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/math.hpp>
 
 #if MLN_DRAWABLE_RENDERER
@@ -401,6 +402,8 @@ std::unique_ptr<RenderItem> RenderTileSource::createRenderItem() {
 }
 
 void RenderTileSource::prepare(const SourcePrepareParameters& parameters) {
+    MLN_TRACE_FUNC()
+    MLN_ZONE_STR(baseImpl->id)
     bearing = static_cast<float>(parameters.transform.state.getBearing());
     filteredRenderTiles = nullptr;
     renderTilesSortedByY = nullptr;

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -16,25 +16,25 @@ Style::Style(std::shared_ptr<FileSource> fileSource, float pixelRatio, const Tag
 Style::~Style() = default;
 
 void Style::loadJSON(const std::string& json) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->loadJSON(json);
 }
 
 void Style::loadURL(const std::string& url) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->loadURL(url);
 }
 
 std::string Style::getJSON() const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return impl->getJSON();
 }
 
 std::string Style::getURL() const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return impl->getURL();
 }
@@ -44,19 +44,19 @@ std::string Style::getName() const {
 }
 
 CameraOptions Style::getDefaultCamera() const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return impl->getDefaultCamera();
 }
 
 TransitionOptions Style::getTransitionOptions() const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return impl->getTransitionOptions();
 }
 
 void Style::setTransitionOptions(const TransitionOptions& options) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->mutated = true;
     impl->setTransitionOptions(options);
@@ -76,7 +76,7 @@ const Light* Style::getLight() const {
 }
 
 std::optional<Image> Style::getImage(const std::string& name) const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto image = impl->getImage(name);
     if (!image) return std::nullopt;
@@ -84,94 +84,94 @@ std::optional<Image> Style::getImage(const std::string& name) const {
 }
 
 void Style::addImage(std::unique_ptr<Image> image) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->mutated = true;
     impl->addImage(std::move(image));
 }
 
 void Style::removeImage(const std::string& name) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->mutated = true;
     impl->removeImage(name);
 }
 
 std::vector<Source*> Style::getSources() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->mutated = true;
     return impl->getSources();
 }
 
 std::vector<const Source*> Style::getSources() const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return const_cast<const Impl&>(*impl).getSources();
 }
 
 Source* Style::getSource(const std::string& id) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->mutated = true;
     return impl->getSource(id);
 }
 
 const Source* Style::getSource(const std::string& id) const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return impl->getSource(id);
 }
 
 void Style::addSource(std::unique_ptr<Source> source) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->mutated = true;
     impl->addSource(std::move(source));
 }
 
 std::unique_ptr<Source> Style::removeSource(const std::string& sourceID) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->mutated = true;
     return impl->removeSource(sourceID);
 }
 
 std::vector<Layer*> Style::getLayers() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->mutated = true;
     return impl->getLayers();
 }
 
 std::vector<const Layer*> Style::getLayers() const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return const_cast<const Impl&>(*impl).getLayers();
 }
 
 Layer* Style::getLayer(const std::string& layerID) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->mutated = true;
     return impl->getLayer(layerID);
 }
 
 const Layer* Style::getLayer(const std::string& layerID) const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return impl->getLayer(layerID);
 }
 
 void Style::addLayer(std::unique_ptr<Layer> layer, const std::optional<std::string>& before) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->mutated = true;
     impl->addLayer(std::move(layer), before);
 }
 
 std::unique_ptr<Layer> Style::removeLayer(const std::string& id) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     impl->mutated = true;
     return impl->removeLayer(id);

--- a/src/mbgl/text/cross_tile_symbol_index.cpp
+++ b/src/mbgl/text/cross_tile_symbol_index.cpp
@@ -1,8 +1,10 @@
 #include <mbgl/text/cross_tile_symbol_index.hpp>
+
 #include <mbgl/layout/symbol_instance.hpp>
 #include <mbgl/renderer/buckets/symbol_bucket.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/tile/tile.hpp>
+#include <mbgl/util/instrumentation.hpp>
 
 namespace mbgl {
 
@@ -216,6 +218,9 @@ bool CrossTileSymbolLayerIndex::removeStaleBuckets(const std::unordered_set<uint
 CrossTileSymbolIndex::CrossTileSymbolIndex() = default;
 
 auto CrossTileSymbolIndex::addLayer(const RenderLayer& layer, float lng) -> AddLayerResult {
+    MLN_TRACE_FUNC()
+    MLN_ZONE_STR(layer.getID())
+
     auto found = layerIndexes.find(layer.getID());
     if (found == layerIndexes.end()) {
         found = layerIndexes
@@ -246,6 +251,8 @@ auto CrossTileSymbolIndex::addLayer(const RenderLayer& layer, float lng) -> AddL
 }
 
 void CrossTileSymbolIndex::pruneUnusedLayers(const std::set<std::string>& usedLayers) {
+    MLN_TRACE_FUNC()
+
     for (auto it = layerIndexes.begin(); it != layerIndexes.end();) {
         if (usedLayers.find(it->first) == usedLayers.end()) {
             it = layerIndexes.erase(it);

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -1,13 +1,16 @@
-#include <list>
+#include <mbgl/text/placement.hpp>
+
 #include <mbgl/layout/symbol_layout.hpp>
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/renderer/buckets/symbol_bucket.hpp>
 #include <mbgl/renderer/render_layer.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/renderer/update_parameters.hpp>
-#include <mbgl/text/placement.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/math.hpp>
+
+#include <list>
 #include <utility>
 
 namespace mbgl {
@@ -1631,6 +1634,7 @@ bool TilePlacement::shouldRetryPlacement(const JointPlacement& placement, const 
 // static
 Mutable<Placement> Placement::create(std::shared_ptr<const UpdateParameters> updateParameters_,
                                      std::optional<Immutable<Placement>> prevPlacement) {
+    MLN_TRACE_FUNC()
     assert(updateParameters_);
     switch (updateParameters_->mode) {
         case MapMode::Continuous:

--- a/src/mbgl/tile/geojson_tile.cpp
+++ b/src/mbgl/tile/geojson_tile.cpp
@@ -17,7 +17,7 @@ GeoJSONTile::GeoJSONTile(const OverscaledTileID& overscaledTileID,
 }
 
 void GeoJSONTile::updateData(std::shared_ptr<style::GeoJSONData> data_, bool needsRelayout) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     assert(data_);
     data = std::move(data_);
@@ -33,7 +33,7 @@ void GeoJSONTile::updateData(std::shared_ptr<style::GeoJSONData> data_, bool nee
 }
 
 void GeoJSONTile::querySourceFeatures(std::vector<Feature>& result, const SourceQueryOptions& options) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     // Ignore the sourceLayer, there is only one
     if (auto tileData = getData()) {

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -29,7 +29,7 @@
 namespace mbgl {
 
 LayerRenderData* GeometryTile::LayoutResult::getLayerRenderData(const style::Layer::Impl& layerImpl) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto it = layerRenderData.find(layerImpl.id);
     if (it == layerRenderData.end()) {
@@ -65,7 +65,7 @@ private:
 using namespace style;
 
 std::optional<ImagePosition> GeometryTileRenderData::getPattern(const std::string& pattern) const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (layoutResult) {
         const auto& iconAtlas = layoutResult->iconAtlas;
@@ -78,7 +78,7 @@ std::optional<ImagePosition> GeometryTileRenderData::getPattern(const std::strin
 }
 
 void GeometryTileRenderData::upload(gfx::UploadPass& uploadPass) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!layoutResult) return;
 
@@ -134,7 +134,7 @@ void GeometryTileRenderData::upload(gfx::UploadPass& uploadPass) {
 }
 
 void GeometryTileRenderData::prepare(const SourcePrepareParameters& parameters) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!layoutResult) return;
     imagePatches = layoutResult->iconAtlas.getImagePatchesAndUpdateVersions(parameters.imageManager);
@@ -187,7 +187,7 @@ GeometryTile::GeometryTile(const OverscaledTileID& id_, std::string sourceID_, c
       showCollisionBoxes(parameters.debugOptions & MapDebugOptions::Collision) {}
 
 GeometryTile::~GeometryTile() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     markObsolete();
 
@@ -215,7 +215,7 @@ void GeometryTile::setError(std::exception_ptr err) {
 }
 
 void GeometryTile::setData(std::unique_ptr<const GeometryTileData> data_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (obsolete) {
         return;
@@ -231,7 +231,7 @@ void GeometryTile::setData(std::unique_ptr<const GeometryTileData> data_) {
 }
 
 void GeometryTile::reset() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     // Mark the tile as pending again if it was complete before to prevent
     // signaling a complete state despite pending parse operations.
@@ -242,13 +242,13 @@ void GeometryTile::reset() {
 }
 
 std::unique_ptr<TileRenderData> GeometryTile::createRenderData() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return std::make_unique<GeometryTileRenderData>(layoutResult, atlasTextures);
 }
 
 void GeometryTile::setLayers(const std::vector<Immutable<LayerProperties>>& layers) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     // Mark the tile as pending again if it was complete before to prevent
     // signaling a complete state despite pending parse operations.
@@ -276,7 +276,7 @@ void GeometryTile::setLayers(const std::vector<Immutable<LayerProperties>>& laye
 }
 
 void GeometryTile::setShowCollisionBoxes(const bool showCollisionBoxes_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (showCollisionBoxes != showCollisionBoxes_) {
         showCollisionBoxes = showCollisionBoxes_;
@@ -286,7 +286,7 @@ void GeometryTile::setShowCollisionBoxes(const bool showCollisionBoxes_) {
 }
 
 void GeometryTile::onLayout(std::shared_ptr<LayoutResult> result, const uint64_t resultCorrelationID) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     loaded = true;
     renderable = true;
@@ -311,13 +311,13 @@ void GeometryTile::onError(std::exception_ptr err, const uint64_t resultCorrelat
 }
 
 void GeometryTile::onGlyphsAvailable(GlyphMap glyphs) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     worker.self().invoke(&GeometryTileWorker::onGlyphsAvailable, std::move(glyphs));
 }
 
 void GeometryTile::getGlyphs(GlyphDependencies glyphDependencies) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (fileSource) {
         glyphManager->getGlyphs(*this, std::move(glyphDependencies), *fileSource);
@@ -328,7 +328,7 @@ void GeometryTile::onImagesAvailable(ImageMap images,
                                      ImageMap patterns,
                                      ImageVersionMap versionMap,
                                      uint64_t imageCorrelationID) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     worker.self().invoke(&GeometryTileWorker::onImagesAvailable,
                          std::move(images),
@@ -338,7 +338,7 @@ void GeometryTile::onImagesAvailable(ImageMap images,
 }
 
 void GeometryTile::getImages(ImageRequestPair pair) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     imageManager->getImages(*this, std::move(pair));
 }
@@ -348,7 +348,7 @@ std::shared_ptr<FeatureIndex> GeometryTile::getFeatureIndex() const {
 }
 
 bool GeometryTile::layerPropertiesUpdated(const Immutable<style::LayerProperties>& layerProperties) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     LayerRenderData* renderData = getLayerRenderData(*layerProperties->baseImpl);
     if (!renderData) {
@@ -371,13 +371,13 @@ const GeometryTileData* GeometryTile::getData() const {
 }
 
 LayerRenderData* GeometryTile::getLayerRenderData(const style::Layer::Impl& layerImpl) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     return layoutResult ? layoutResult->getLayerRenderData(layerImpl) : nullptr;
 }
 
 float GeometryTile::getQueryPadding(const std::unordered_map<std::string, const RenderLayer*>& layers) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     float queryPadding = 0;
     for (const auto& pair : layers) {
@@ -396,7 +396,7 @@ void GeometryTile::queryRenderedFeatures(std::unordered_map<std::string, std::ve
                                          const RenderedQueryOptions& options,
                                          const mat4& projMatrix,
                                          const SourceFeatureState& featureState) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!getData()) return;
 
@@ -420,7 +420,7 @@ void GeometryTile::queryRenderedFeatures(std::unordered_map<std::string, std::ve
 }
 
 void GeometryTile::querySourceFeatures(std::vector<Feature>& result, const SourceQueryOptions& options) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     // Data not yet available, or tile is empty
     if (!getData()) {
@@ -477,7 +477,7 @@ void GeometryTile::performedFadePlacement() {
 }
 
 void GeometryTile::setFeatureState(const LayerFeatureStates& states) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     auto layers = getData();
     if ((layers == nullptr) || states.empty() || !layoutResult) {

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -29,7 +29,7 @@ static double signedArea(const GeometryCoordinates& ring) {
 }
 
 static LinearRing<int32_t> toWagyuPath(const GeometryCoordinates& ring) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     LinearRing<int32_t> result;
     result.reserve(ring.size());
@@ -40,7 +40,7 @@ static LinearRing<int32_t> toWagyuPath(const GeometryCoordinates& ring) {
 }
 
 static GeometryCollection toGeometryCollection(MultiPolygon<int16_t>&& multipolygon) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     GeometryCollection result;
     for (auto& polygon : multipolygon) {
@@ -52,7 +52,7 @@ static GeometryCollection toGeometryCollection(MultiPolygon<int16_t>&& multipoly
 }
 
 GeometryCollection fixupPolygons(const GeometryCollection& rings) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     using namespace mapbox::geometry::wagyu;
 
@@ -69,7 +69,7 @@ GeometryCollection fixupPolygons(const GeometryCollection& rings) {
 }
 
 std::vector<GeometryCollection> classifyRings(const GeometryCollection& rings) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     std::vector<GeometryCollection> polygons;
 
@@ -107,7 +107,7 @@ std::vector<GeometryCollection> classifyRings(const GeometryCollection& rings) {
 }
 
 void limitHoles(GeometryCollection& polygon, uint32_t maxHoles) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (polygon.size() > 1 + maxHoles) {
         std::nth_element(
@@ -119,7 +119,7 @@ void limitHoles(GeometryCollection& polygon, uint32_t maxHoles) {
 }
 
 Feature::geometry_type convertGeometry(const GeometryTileFeature& geometryTileFeature, const CanonicalTileID& tileID) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     const double size = util::EXTENT * std::pow(2, tileID.z);
     const double x0 = util::EXTENT * static_cast<double>(tileID.x);
@@ -192,7 +192,7 @@ Feature::geometry_type convertGeometry(const GeometryTileFeature& geometryTileFe
 }
 
 GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFeature, const CanonicalTileID& tileID) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     const double size = util::EXTENT * std::pow(2, tileID.z);
     const double x0 = util::EXTENT * static_cast<double>(tileID.x);
@@ -275,7 +275,7 @@ GeometryCollection convertGeometry(const Feature::geometry_type& geometryTileFea
 }
 
 Feature convertFeature(const GeometryTileFeature& geometryTileFeature, const CanonicalTileID& tileID) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     Feature feature{convertGeometry(geometryTileFeature, tileID)};
     feature.properties = geometryTileFeature.getProperties();

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -49,7 +49,7 @@ GeometryTileWorker::GeometryTileWorker(ActorRef<GeometryTileWorker> self_,
       showCollisionBoxes(showCollisionBoxes_) {}
 
 GeometryTileWorker::~GeometryTileWorker() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     scheduler.runOnRenderThread([renderData_{std::move(renderData)}]() {});
 }
@@ -128,7 +128,7 @@ GeometryTileWorker::~GeometryTileWorker() {
 void GeometryTileWorker::setData(std::unique_ptr<const GeometryTileData> data_,
                                  std::set<std::string> availableImages_,
                                  uint64_t correlationID_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     try {
         data = std::move(data_);
@@ -155,7 +155,7 @@ void GeometryTileWorker::setData(std::unique_ptr<const GeometryTileData> data_,
 void GeometryTileWorker::setLayers(std::vector<Immutable<LayerProperties>> layers_,
                                    std::set<std::string> availableImages_,
                                    uint64_t correlationID_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     try {
         layers = std::move(layers_);
@@ -198,7 +198,7 @@ void GeometryTileWorker::reset(uint64_t correlationID_) {
 }
 
 void GeometryTileWorker::setShowCollisionBoxes(bool showCollisionBoxes_, uint64_t correlationID_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     try {
         showCollisionBoxes = showCollisionBoxes_;
@@ -228,7 +228,7 @@ void GeometryTileWorker::setShowCollisionBoxes(bool showCollisionBoxes_, uint64_
 }
 
 void GeometryTileWorker::symbolDependenciesChanged() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     try {
         switch (state) {
@@ -258,7 +258,7 @@ void GeometryTileWorker::symbolDependenciesChanged() {
 }
 
 void GeometryTileWorker::coalesced() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     try {
         switch (state) {
@@ -289,14 +289,14 @@ void GeometryTileWorker::coalesced() {
 }
 
 void GeometryTileWorker::coalesce() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     state = Coalescing;
     self.invoke(&GeometryTileWorker::coalesced);
 }
 
 void GeometryTileWorker::onGlyphsAvailable(GlyphMap newGlyphMap) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     for (auto& newFontGlyphs : newGlyphMap) {
         FontStackHash fontStack = newFontGlyphs.first;
@@ -327,7 +327,7 @@ void GeometryTileWorker::onImagesAvailable(ImageMap newIconMap,
                                            ImageMap newPatternMap,
                                            ImageVersionMap newVersionMap,
                                            uint64_t imageCorrelationID_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (imageCorrelationID != imageCorrelationID_) {
         return; // Ignore outdated image request replies.
@@ -340,7 +340,7 @@ void GeometryTileWorker::onImagesAvailable(ImageMap newIconMap,
 }
 
 void GeometryTileWorker::requestNewGlyphs(const GlyphDependencies& glyphDependencies) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     for (auto& fontDependencies : glyphDependencies) {
         auto fontGlyphs = glyphMap.find(FontStackHasher()(fontDependencies.first));
@@ -356,7 +356,7 @@ void GeometryTileWorker::requestNewGlyphs(const GlyphDependencies& glyphDependen
 }
 
 void GeometryTileWorker::requestNewImages(const ImageDependencies& imageDependencies) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     pendingImageDependencies = imageDependencies;
 
@@ -366,7 +366,7 @@ void GeometryTileWorker::requestNewImages(const ImageDependencies& imageDependen
 }
 
 void GeometryTileWorker::parse() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!data || !layers) {
         return;
@@ -489,7 +489,7 @@ bool GeometryTileWorker::hasPendingParseResult() const {
 }
 
 void GeometryTileWorker::finalizeLayout() {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!data || !layers || !hasPendingParseResult() || hasPendingDependencies()) {
         return;

--- a/src/mbgl/tile/tile_cache.cpp
+++ b/src/mbgl/tile/tile_cache.cpp
@@ -6,7 +6,7 @@
 namespace mbgl {
 
 void TileCache::setSize(size_t size_) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     size = size_;
 
@@ -40,7 +40,7 @@ struct CaptureWrapper {
 } // namespace
 
 void TileCache::deferredRelease(std::unique_ptr<Tile>&& tile) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     tile->cancel();
 
@@ -66,7 +66,7 @@ void TileCache::deferredRelease(std::unique_ptr<Tile>&& tile) {
 }
 
 void TileCache::add(const OverscaledTileID& key, std::unique_ptr<Tile>&& tile) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!tile->isRenderable() || !size) {
         deferredRelease(std::move(tile));

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -38,7 +38,7 @@ FeatureIdentifier VectorTileFeature::getID() const {
 }
 
 const GeometryCollection& VectorTileFeature::getGeometries() const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!lines) {
         const auto scale = static_cast<float>(util::EXTENT) / feature.getExtent();
@@ -81,7 +81,7 @@ std::unique_ptr<GeometryTileData> VectorTileData::clone() const {
 }
 
 std::unique_ptr<GeometryTileLayer> VectorTileData::getLayer(const std::string& name) const {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (!parsed) {
         // We're parsing this lazily so that we can construct VectorTileData

--- a/src/mbgl/util/http_header.cpp
+++ b/src/mbgl/util/http_header.cpp
@@ -21,7 +21,7 @@ namespace mbgl {
 namespace http {
 
 CacheControl CacheControl::parse(const std::string& value) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     namespace qi = boost::spirit::qi;
     namespace phoenix = boost::phoenix;
@@ -43,7 +43,7 @@ std::optional<Timestamp> CacheControl::toTimePoint() const {
 
 std::optional<Timestamp> parseRetryHeaders(const std::optional<std::string>& retryAfter,
                                            const std::optional<std::string>& xRateLimitReset) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (retryAfter) {
         try {

--- a/src/mbgl/util/http_timeout.cpp
+++ b/src/mbgl/util/http_timeout.cpp
@@ -11,7 +11,7 @@ namespace http {
 Duration errorRetryTimeout(Response::Error::Reason failedRequestReason,
                            uint32_t failedRequests,
                            std::optional<Timestamp> retryAfter) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     if (failedRequestReason == Response::Error::Reason::Server) {
         // Retry after one second three times, then start exponential backoff.

--- a/src/mbgl/util/io.cpp
+++ b/src/mbgl/util/io.cpp
@@ -22,7 +22,7 @@ IOException::IOException(int err, const std::string &msg)
       code(err) {}
 
 void write_file(const std::string &filename, const std::string &data) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     FILE *fd = fopen(filename.c_str(), MBGL_FOPEN_MODE_WBE);
     if (fd) {
@@ -34,7 +34,7 @@ void write_file(const std::string &filename, const std::string &data) {
 }
 
 std::string read_file(const std::string &filename) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     std::ifstream file(filename, std::ios::binary);
     if (file.good()) {
@@ -47,7 +47,7 @@ std::string read_file(const std::string &filename) {
 }
 
 std::optional<std::string> readFile(const std::string &filename) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     std::ifstream file(filename, std::ios::binary);
     if (file.good()) {
@@ -59,7 +59,7 @@ std::optional<std::string> readFile(const std::string &filename) {
 }
 
 void deleteFile(const std::string &filename) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     const int ret = std::remove(filename.c_str());
     if (ret != 0 && errno != ENOENT) {
@@ -68,7 +68,7 @@ void deleteFile(const std::string &filename) {
 }
 
 void copyFile(const std::string &destination, const std::string &source) {
-    MLN_TRACE_FUNC();
+    MLN_TRACE_FUNC()
 
     std::ifstream src(source, std::ios::binary);
     if (!src.good()) {

--- a/test/platform/settings.test.cpp
+++ b/test/platform/settings.test.cpp
@@ -9,8 +9,6 @@ TEST(Settings, SetAndGet) {
     using Object = mapbox::base::ValueObject;
 
     auto& settings = Settings::getInstance();
-    auto value = settings.get(EXPERIMENTAL_THREAD_PRIORITY_WORKER);
-    EXPECT_TRUE(value.is<mapbox::base::NullValue>());
 
     Value lowPrioValue{19.0};
     settings.set(EXPERIMENTAL_THREAD_PRIORITY_WORKER, lowPrioValue);


### PR DESCRIPTION
Move semicolons into the preprocessor definitions to eliminate "empty statement" warnings on each use when they are disabled and evaluate to nothing.

Add more trace points.

Eliminate a check in one test that fails if the test is run multiple times in one process.