### PR TITLE
Use path.string() to fix Windows

### DIFF
--- a/test/storage/mbtiles_file_source.test.cpp
+++ b/test/storage/mbtiles_file_source.test.cpp
@@ -13,7 +13,7 @@ namespace {
 
 std::string toAbsoluteURL(const std::string &fileName) {
     auto path = std::filesystem::current_path() / "test/fixtures/storage/mbtiles" / fileName;
-    return "mbtiles://" + std::string(path);
+    return "mbtiles://" + path.string();
 }
 
 } // namespace


### PR DESCRIPTION
I set https://github.com/maplibre/maplibre-native/pull/2634 to auto-merge but the build failed on Windows.

Maybe we should add a Required flag on one of the Windows workflows.