### PR TITLE
Do not evaluate tracy.cmake when MLN_USE_TRACY is false

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1381,7 +1381,7 @@ target_link_libraries(
         Mapbox::Base::geojson.hpp
         Mapbox::Base::geometry.hpp
         Mapbox::Base::variant
-        "$<$<BOOL:${MLN_USE_TRACY}>:TracyClient>"
+        $<$<BOOL:${MLN_USE_TRACY}>:TracyClient>
         unordered_dense
 )
 
@@ -1412,7 +1412,6 @@ export(TARGETS
     mbgl-vendor-unique_resource
     mbgl-vendor-vector-tile
     mbgl-vendor-wagyu
-    "$<$<BOOL:${MLN_USE_TRACY}>:TracyClient>"
     unordered_dense
 
     FILE MapboxCoreTargets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1381,7 +1381,7 @@ target_link_libraries(
         Mapbox::Base::geojson.hpp
         Mapbox::Base::geometry.hpp
         Mapbox::Base::variant
-        $<$<BOOL:${MLN_USE_TRACY}>:TracyClient>
+        "$<$<BOOL:${MLN_USE_TRACY}>:TracyClient>"
         unordered_dense
 )
 
@@ -1412,7 +1412,7 @@ export(TARGETS
     mbgl-vendor-unique_resource
     mbgl-vendor-vector-tile
     mbgl-vendor-wagyu
-    $<$<BOOL:${MLN_USE_TRACY}>:TracyClient>
+    "$<$<BOOL:${MLN_USE_TRACY}>:TracyClient>"
     unordered_dense
 
     FILE MapboxCoreTargets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1381,7 +1381,7 @@ target_link_libraries(
         Mapbox::Base::geojson.hpp
         Mapbox::Base::geometry.hpp
         Mapbox::Base::variant
-        TracyClient
+        $<$<BOOL:${MLN_USE_TRACY}>:TracyClient>
         unordered_dense
 )
 
@@ -1412,7 +1412,7 @@ export(TARGETS
     mbgl-vendor-unique_resource
     mbgl-vendor-vector-tile
     mbgl-vendor-wagyu
-    TracyClient
+    $<$<BOOL:${MLN_USE_TRACY}>:TracyClient>
     unordered_dense
 
     FILE MapboxCoreTargets.cmake

--- a/vendor/tracy.cmake
+++ b/vendor/tracy.cmake
@@ -1,6 +1,8 @@
 if (MLN_USE_TRACY)
     add_definitions(-DTRACY_ENABLE)
     add_definitions(-DMLN_TRACY_ENABLE)
+else()
+    return()
 endif()
 
 include(FetchContent)


### PR DESCRIPTION
We have some issues with CI because `travy.cmake` is evaluated when `MLN_USE_TRACY` is false.