### PR TITLE
Add all Android roots to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,10 @@ updates:
           - '*'
   - package-ecosystem: 'gradle'
     open-pull-requests-limit: 1
-    directory: '/platform/android'
+    directories:
+      - '/platform/android'
+      - '/render-test/android'
+      - '/test/android'
     schedule:
       interval: 'weekly'
     groups:


### PR DESCRIPTION
Make sure all Android roots are updated by Dependabot.