### PR TITLE
Use GitHub's OIDC provider to authenticate with AWS

### DIFF
--- a/.github/actions/aws-device-farm-run/action.yml
+++ b/.github/actions/aws-device-farm-run/action.yml
@@ -51,14 +51,12 @@ runs:
   using: "composite"
   steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-          role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 3600
-          role-session-name: MySessionName
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+          role-duration-seconds: 14400
 
       - name: Create upload app
         shell: bash

--- a/.github/actions/aws-device-farm-run/action.yml
+++ b/.github/actions/aws-device-farm-run/action.yml
@@ -54,7 +54,7 @@ runs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-west-2
-          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
           role-duration-seconds: 14400
 

--- a/.github/workflows/android-device-test.yml
+++ b/.github/workflows/android-device-test.yml
@@ -141,7 +141,7 @@ jobs:
           testFilter: ${{ matrix.test.testFilter }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_ROLE_TO_ASSUME: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          AWS_ROLE_TO_ASSUME: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           AWS_DEVICE_FARM_PROJECT_ARN: ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }}
           AWS_DEVICE_FARM_DEVICE_POOL_ARN: ${{ matrix.test.devicePool }}
           externalData: ${{ env.external_data_arn }}

--- a/.github/workflows/ios-device-test.yml
+++ b/.github/workflows/ios-device-test.yml
@@ -57,7 +57,7 @@ jobs:
           testType: XCTEST
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_ROLE_TO_ASSUME: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          AWS_ROLE_TO_ASSUME: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           AWS_DEVICE_FARM_PROJECT_ARN: ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }}
           AWS_DEVICE_FARM_DEVICE_POOL_ARN: ${{ vars.AWS_DEVICE_FARM_IPHONE_DEVICE_POOL_ARN }}
 


### PR DESCRIPTION
This is the [recommended](https://github.com/aws-actions/configure-aws-credentials?tab=readme-ov-file#using-this-action) approach.

Also increases the timeout because it is timing out sometimes.

- [ ] Delete `AWS_ROLE_TO_ASSUME` variable after this is merged.