### PR TITLE
Skip macos-ci based on paths

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -5,10 +5,42 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'platform/macos/**'
+      - 'platform/darwin/**'
+      - '.github/workflows/macos-ci.yml'
+      - 'bin/**'
+      - 'include/**'
+      - 'platform/default/**'
+      - 'src/**'
+      - 'vendor/**'
+      - '.gitmodules'
+      - '!**/*.md'
+      - 'WORKSPACE'
+      - 'BUILD.bazel'
+      - '.bazelrc'
+      - '.bazelversion'
+      - 'pnpm-lock.yaml'
 
   pull_request:
     branches:
       - main
+    paths:
+      - 'platform/macos/**'
+      - 'platform/darwin/**'
+      - '.github/workflows/macos-ci.yml'
+      - 'bin/**'
+      - 'include/**'
+      - 'platform/default/**'
+      - 'src/**'
+      - 'vendor/**'
+      - '.gitmodules'
+      - '!**/*.md'
+      - 'WORKSPACE'
+      - 'BUILD.bazel'
+      - '.bazelrc'
+      - '.bazelversion'
+      - 'pnpm-lock.yaml'
 
 concurrency:
   # cancel jobs on PRs only


### PR DESCRIPTION
Only run macOS CI when certain paths change. Should save some time / compute.