### PR TITLE
Fix reported crash when exception was thrown

### DIFF
--- a/include/mbgl/layermanager/layer_factory.hpp
+++ b/include/mbgl/layermanager/layer_factory.hpp
@@ -38,7 +38,7 @@ public:
     /// Returns a new Layout instance on success call; returns `nullptr` otherwise.
     virtual std::unique_ptr<Layout> createLayout(const LayoutParameters&,
                                                  std::unique_ptr<GeometryTileLayer>,
-                                                 const std::vector<Immutable<style::LayerProperties>>&) noexcept;
+                                                 const std::vector<Immutable<style::LayerProperties>>&);
 
 protected:
     std::optional<std::string> getSource(const style::conversion::Convertible& value) const noexcept;

--- a/include/mbgl/layermanager/layer_manager.hpp
+++ b/include/mbgl/layermanager/layer_manager.hpp
@@ -47,7 +47,7 @@ public:
     /// Returns a new Layout instance on success call; returns `nullptr` otherwise.
     std::unique_ptr<Layout> createLayout(const LayoutParameters&,
                                          std::unique_ptr<GeometryTileLayer>,
-                                         const std::vector<Immutable<style::LayerProperties>>&) noexcept;
+                                         const std::vector<Immutable<style::LayerProperties>>&);
 
     /**
      * @brief a build-time flag to enable/disable annotations in

--- a/include/mbgl/layermanager/symbol_layer_factory.hpp
+++ b/include/mbgl/layermanager/symbol_layer_factory.hpp
@@ -11,7 +11,7 @@ protected:
                                               const style::conversion::Convertible& value) noexcept final;
     std::unique_ptr<Layout> createLayout(const LayoutParameters& parameters,
                                          std::unique_ptr<GeometryTileLayer> tileLayer,
-                                         const std::vector<Immutable<style::LayerProperties>>& group) noexcept final;
+                                         const std::vector<Immutable<style::LayerProperties>>& group) final;
     std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept final;
 };
 

--- a/src/mbgl/layermanager/background_layer_factory.cpp
+++ b/src/mbgl/layermanager/background_layer_factory.cpp
@@ -13,7 +13,7 @@ const style::LayerTypeInfo* BackgroundLayerFactory::getTypeInfo() const noexcept
 std::unique_ptr<style::Layer> BackgroundLayerFactory::createLayer(
     const std::string& id, const style::conversion::Convertible& value) noexcept {
     (void)value;
-    return std::unique_ptr<style::Layer>(new (std::nothrow) style::BackgroundLayer(id));
+    return std::unique_ptr<style::Layer>(new style::BackgroundLayer(id));
 }
 
 std::unique_ptr<RenderLayer> BackgroundLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {

--- a/src/mbgl/layermanager/circle_layer_factory.cpp
+++ b/src/mbgl/layermanager/circle_layer_factory.cpp
@@ -14,22 +14,24 @@ const style::LayerTypeInfo* CircleLayerFactory::getTypeInfo() const noexcept {
 
 std::unique_ptr<style::Layer> CircleLayerFactory::createLayer(const std::string& id,
                                                               const style::conversion::Convertible& value) noexcept {
-    const auto source = getSource(value);
-    return std::unique_ptr<style::Layer>(source ? new (std::nothrow) style::CircleLayer(id, *source) : nullptr);
+    auto const source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+
+    return std::unique_ptr<style::Layer>(new style::CircleLayer(id, *source));
 }
 
 std::unique_ptr<Layout> CircleLayerFactory::createLayout(
     const LayoutParameters& parameters,
     std::unique_ptr<GeometryTileLayer> layer,
     const std::vector<Immutable<style::LayerProperties>>& group) noexcept {
-    return std::unique_ptr<Layout>(new (std::nothrow)
-                                       CircleLayout(parameters.bucketParameters, group, std::move(layer)));
+    return std::make_unique<CircleLayout>(parameters.bucketParameters, group, std::move(layer));
 }
 
 std::unique_ptr<RenderLayer> CircleLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    return std::unique_ptr<RenderLayer>(new (std::nothrow)
-                                            RenderCircleLayer(staticImmutableCast<style::CircleLayer::Impl>(impl)));
+    return std::make_unique<RenderCircleLayer>(staticImmutableCast<style::CircleLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/fill_extrusion_layer_factory.cpp
+++ b/src/mbgl/layermanager/fill_extrusion_layer_factory.cpp
@@ -13,8 +13,12 @@ const style::LayerTypeInfo* FillExtrusionLayerFactory::getTypeInfo() const noexc
 
 std::unique_ptr<style::Layer> FillExtrusionLayerFactory::createLayer(
     const std::string& id, const style::conversion::Convertible& value) noexcept {
-    const auto source = getSource(value);
-    return std::unique_ptr<style::Layer>(source ? new (std::nothrow) style::FillExtrusionLayer(id, *source) : nullptr);
+    auto const source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+
+    return std::unique_ptr<style::Layer>(new style::FillExtrusionLayer(id, *source));
 }
 
 std::unique_ptr<Layout> FillExtrusionLayerFactory::createLayout(
@@ -23,14 +27,12 @@ std::unique_ptr<Layout> FillExtrusionLayerFactory::createLayout(
     const std::vector<Immutable<style::LayerProperties>>& group) noexcept {
     using namespace style;
     using LayoutType = PatternLayout<FillExtrusionBucket, FillExtrusionLayerProperties, FillExtrusionPattern>;
-    return std::unique_ptr<Layout>(new (std::nothrow)
-                                       LayoutType(parameters.bucketParameters, group, std::move(layer), parameters));
+    return std::make_unique<LayoutType>(parameters.bucketParameters, group, std::move(layer), parameters);
 }
 
 std::unique_ptr<RenderLayer> FillExtrusionLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    auto renderImpl = staticImmutableCast<style::FillExtrusionLayer::Impl>(impl);
-    return std::unique_ptr<RenderLayer>(new (std::nothrow) RenderFillExtrusionLayer(std::move(renderImpl)));
+    return std::make_unique<RenderFillExtrusionLayer>(staticImmutableCast<style::FillExtrusionLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/fill_layer_factory.cpp
+++ b/src/mbgl/layermanager/fill_layer_factory.cpp
@@ -27,17 +27,14 @@ std::unique_ptr<Layout> FillLayerFactory::createLayout(
         PatternLayout<FillBucket, FillLayerProperties, FillPattern, FillLayoutProperties, FillSortKey>;
     auto layerProperties = staticImmutableCast<FillLayerProperties>(group.front());
     if (layerProperties->layerImpl().layout.get<FillSortKey>().isUndefined()) {
-        return std::unique_ptr<Layout>(
-            new (std::nothrow) LayoutTypeUnsorted(parameters.bucketParameters, group, std::move(layer), parameters));
+        return std::make_unique<LayoutTypeUnsorted>(parameters.bucketParameters, group, std::move(layer), parameters);
     }
-    return std::unique_ptr<Layout>(
-        new (std::nothrow) LayoutTypeSorted(parameters.bucketParameters, group, std::move(layer), parameters));
+    return std::make_unique<LayoutTypeSorted>(parameters.bucketParameters, group, std::move(layer), parameters);
 }
 
 std::unique_ptr<RenderLayer> FillLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    auto fillImpl = staticImmutableCast<style::FillLayer::Impl>(impl);
-    return std::unique_ptr<RenderLayer>(new (std::nothrow) RenderFillLayer(std::move(fillImpl)));
+    return std::make_unique<RenderFillLayer>(staticImmutableCast<style::FillLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/heatmap_layer_factory.cpp
+++ b/src/mbgl/layermanager/heatmap_layer_factory.cpp
@@ -13,11 +13,12 @@ const style::LayerTypeInfo* HeatmapLayerFactory::getTypeInfo() const noexcept {
 
 std::unique_ptr<style::Layer> HeatmapLayerFactory::createLayer(const std::string& id,
                                                                const style::conversion::Convertible& value) noexcept {
-    const auto source = getSource(value);
+    auto const source = getSource(value);
     if (!source) {
         return nullptr;
     }
-    return std::unique_ptr<style::Layer>(new (std::nothrow) style::HeatmapLayer(id, *source));
+
+    return std::unique_ptr<style::Layer>(new style::HeatmapLayer(id, *source));
 }
 
 std::unique_ptr<Bucket> HeatmapLayerFactory::createBucket(

--- a/src/mbgl/layermanager/hillshade_layer_factory.cpp
+++ b/src/mbgl/layermanager/hillshade_layer_factory.cpp
@@ -12,11 +12,13 @@ const style::LayerTypeInfo* HillshadeLayerFactory::getTypeInfo() const noexcept 
 
 std::unique_ptr<style::Layer> HillshadeLayerFactory::createLayer(const std::string& id,
                                                                  const style::conversion::Convertible& value) noexcept {
-    const auto source = getSource(value);
+    auto const source = getSource(value);
     if (!source) {
         return nullptr;
     }
-    return std::unique_ptr<style::Layer>(new (std::nothrow) style::HillshadeLayer(id, *source));
+
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::HillshadeLayer(id, *source));
+    return layer;
 }
 
 std::unique_ptr<RenderLayer> HillshadeLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {

--- a/src/mbgl/layermanager/layer_factory.cpp
+++ b/src/mbgl/layermanager/layer_factory.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<Bucket> LayerFactory::createBucket(const BucketParameters&,
 
 std::unique_ptr<Layout> LayerFactory::createLayout(const LayoutParameters&,
                                                    std::unique_ptr<GeometryTileLayer>,
-                                                   const std::vector<Immutable<style::LayerProperties>>&) noexcept {
+                                                   const std::vector<Immutable<style::LayerProperties>>&) {
     assert(false);
     return nullptr;
 }

--- a/src/mbgl/layermanager/layer_manager.cpp
+++ b/src/mbgl/layermanager/layer_manager.cpp
@@ -38,10 +38,9 @@ std::unique_ptr<Bucket> LayerManager::createBucket(
     return factory->createBucket(parameters, layers);
 }
 
-std::unique_ptr<Layout> LayerManager::createLayout(
-    const LayoutParameters& parameters,
-    std::unique_ptr<GeometryTileLayer> tileLayer,
-    const std::vector<Immutable<style::LayerProperties>>& layers) noexcept {
+std::unique_ptr<Layout> LayerManager::createLayout(const LayoutParameters& parameters,
+                                                   std::unique_ptr<GeometryTileLayer> tileLayer,
+                                                   const std::vector<Immutable<style::LayerProperties>>& layers) {
     assert(!layers.empty());
     assert(parameters.bucketParameters.layerType->layout == style::LayerTypeInfo::Layout::Required);
     LayerFactory* factory = getFactory(parameters.bucketParameters.layerType);

--- a/src/mbgl/layermanager/line_layer_factory.cpp
+++ b/src/mbgl/layermanager/line_layer_factory.cpp
@@ -13,8 +13,11 @@ const style::LayerTypeInfo* LineLayerFactory::getTypeInfo() const noexcept {
 
 std::unique_ptr<style::Layer> LineLayerFactory::createLayer(const std::string& id,
                                                             const style::conversion::Convertible& value) noexcept {
-    const auto source = getSource(value);
-    return std::unique_ptr<style::Layer>(source ? new (std::nothrow) style::LineLayer(id, *source) : nullptr);
+    auto const source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+    return std::unique_ptr<style::Layer>(new style::LineLayer(id, *source));
 }
 
 std::unique_ptr<Layout> LineLayerFactory::createLayout(
@@ -27,17 +30,14 @@ std::unique_ptr<Layout> LineLayerFactory::createLayout(
         PatternLayout<LineBucket, LineLayerProperties, LinePattern, LineLayoutProperties, LineSortKey>;
     auto layerProperties = staticImmutableCast<LineLayerProperties>(group.front());
     if (layerProperties->layerImpl().layout.get<LineSortKey>().isUndefined()) {
-        return std::unique_ptr<Layout>(
-            new (std::nothrow) LayoutTypeUnsorted(parameters.bucketParameters, group, std::move(layer), parameters));
+        return std::make_unique<LayoutTypeUnsorted>(parameters.bucketParameters, group, std::move(layer), parameters);
     }
-    return std::unique_ptr<Layout>(
-        new (std::nothrow) LayoutTypeSorted(parameters.bucketParameters, group, std::move(layer), parameters));
+    return std::make_unique<LayoutTypeSorted>(parameters.bucketParameters, group, std::move(layer), parameters);
 }
 
 std::unique_ptr<RenderLayer> LineLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
     assert(impl->getTypeInfo() == getTypeInfo());
-    auto lineImpl = staticImmutableCast<style::LineLayer::Impl>(impl);
-    return std::unique_ptr<RenderLayer>(new (std::nothrow) RenderLineLayer(std::move(lineImpl)));
+    return std::make_unique<RenderLineLayer>(staticImmutableCast<style::LineLayer::Impl>(impl));
 }
 
 } // namespace mbgl

--- a/src/mbgl/layermanager/raster_layer_factory.cpp
+++ b/src/mbgl/layermanager/raster_layer_factory.cpp
@@ -12,11 +12,13 @@ const style::LayerTypeInfo* RasterLayerFactory::getTypeInfo() const noexcept {
 
 std::unique_ptr<style::Layer> RasterLayerFactory::createLayer(const std::string& id,
                                                               const style::conversion::Convertible& value) noexcept {
-    const auto source = getSource(value);
+    auto const source = getSource(value);
     if (!source) {
         return nullptr;
     }
-    return std::unique_ptr<style::Layer>(new (std::nothrow) style::RasterLayer(id, *source));
+
+    std::unique_ptr<style::Layer> layer = std::unique_ptr<style::Layer>(new style::RasterLayer(id, *source));
+    return layer;
 }
 
 std::unique_ptr<RenderLayer> RasterLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {

--- a/src/mbgl/layermanager/symbol_layer_factory.cpp
+++ b/src/mbgl/layermanager/symbol_layer_factory.cpp
@@ -20,10 +20,9 @@ std::unique_ptr<style::Layer> SymbolLayerFactory::createLayer(const std::string&
     return std::unique_ptr<style::Layer>(new style::SymbolLayer(id, *source));
 }
 
-std::unique_ptr<Layout> SymbolLayerFactory::createLayout(
-    const LayoutParameters& parameters,
-    std::unique_ptr<GeometryTileLayer> tileLayer,
-    const std::vector<Immutable<style::LayerProperties>>& group) noexcept {
+std::unique_ptr<Layout> SymbolLayerFactory::createLayout(const LayoutParameters& parameters,
+                                                         std::unique_ptr<GeometryTileLayer> tileLayer,
+                                                         const std::vector<Immutable<style::LayerProperties>>& group) {
     return std::make_unique<SymbolLayout>(parameters.bucketParameters, group, std::move(tileLayer), parameters);
 }
 

--- a/src/mbgl/layermanager/symbol_layer_factory.cpp
+++ b/src/mbgl/layermanager/symbol_layer_factory.cpp
@@ -13,16 +13,18 @@ const style::LayerTypeInfo* SymbolLayerFactory::getTypeInfo() const noexcept {
 
 std::unique_ptr<style::Layer> SymbolLayerFactory::createLayer(const std::string& id,
                                                               const style::conversion::Convertible& value) noexcept {
-    const auto source = getSource(value);
-    return std::unique_ptr<style::Layer>(source ? new (std::nothrow) style::SymbolLayer(id, *source) : nullptr);
+    std::optional<std::string> source = getSource(value);
+    if (!source) {
+        return nullptr;
+    }
+    return std::unique_ptr<style::Layer>(new style::SymbolLayer(id, *source));
 }
 
 std::unique_ptr<Layout> SymbolLayerFactory::createLayout(
     const LayoutParameters& parameters,
     std::unique_ptr<GeometryTileLayer> tileLayer,
     const std::vector<Immutable<style::LayerProperties>>& group) noexcept {
-    return std::unique_ptr<Layout>(
-        new (std::nothrow) SymbolLayout(parameters.bucketParameters, group, std::move(tileLayer), parameters));
+    return std::make_unique<SymbolLayout>(parameters.bucketParameters, group, std::move(tileLayer), parameters);
 }
 
 std::unique_ptr<RenderLayer> SymbolLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {


### PR DESCRIPTION
When the constructor of `SymbolLayout` throws these methods marked `noexcept` crash the program.

Reverts #1875. Fixes #2678.

I can make a release once this is merged.