### PR TITLE
Disable flaky Vulkan render test

### DIFF
--- a/metrics/ignores/linux-vulkan.json
+++ b/metrics/ignores/linux-vulkan.json
@@ -1,3 +1,4 @@
 {
-  "render-tests/fill-extrusion-color/function": "failing for Vulkan"
+  "render-tests/fill-extrusion-color/function": "failing for Vulkan",
+  "render-tests/tilejson-bounds/default": "flaky on CI"
 }


### PR DESCRIPTION
Added `render-tests/tilejson-bounds/default` to ignores. 
The test seems flaky on CI (locally the test passed 5000/5000 iterations).