### PR TITLE
Make sure Codecov reports line coverage

### DIFF
--- a/.github/scripts/gcov_wrapper
+++ b/.github/scripts/gcov_wrapper
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This script is used in linux-ci.yml.
+# Bazel 7 started including branch coverage in the coverage report.
+# Now codecov is reporting branch coverage instead of line coverage.
+# This script makes sure branch coverage is not included so codecov reports line coveage.
+
+filtered_args=()
+
+for arg in "$@"; do
+  # Skip the argument if it's "-b"
+  if [ "$arg" != "-b" ]; then
+    filtered_args+=("$arg")
+  fi
+done
+
+gcov "${filtered_args[@]}"

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -216,6 +216,7 @@ jobs:
           xvfb-run -a \
             bazel coverage --combined_report=lcov  --instrumentation_filter="//:mbgl-core" \
             --test_output=errors --local_test_jobs=1 \
+            --repo_env=GCOV="$PWD/.github/scripts/gcov_wrapper" \
             --test_env=DISPLAY --test_env=XAUTHORITY --copt="-DCI_BUILD" \
             //test:core //render-test:render-test //expression-test:test
           echo coverage_report="$(bazel info output_path)"/_coverage/_coverage_report.dat >> "$GITHUB_ENV"


### PR DESCRIPTION
In Bazel 7 branch coverage started to be included with gcov.

This is when our coverage number dropped from 85% to 55%.

However, since C++ has a lot of branches and even things like asserts create a new branch, this number is not a good indication of our coverage. Nor is it helpful. Codecov should have an easy way configure reporting line coverage, but it seems when branch coverage is included, that is what it reports.

This PR filters the `-b` argument when Bazel passes it to gcov.

https://github.com/bazelbuild/bazel/blob/57ae1ff52ffbb2494ac9d43c1e49c2ba9425495e/tools/test/collect_cc_coverage.sh#L168