### PR TITLE
Add `zoomLevel` options for `flyTo` camera

### DIFF
--- a/platform/ios/src/MLNMapView.h
+++ b/platform/ios/src/MLNMapView.h
@@ -1241,6 +1241,20 @@ MLN_EXPORT
 
 /**
  Moves the viewpoint to a different location using a transition animation that
+ evokes powered flight and a default duration based on the length of the flight
+ path.
+
+ The transition animation seamlessly incorporates zooming and panning to help
+ the user find his or her bearings even after traversing a great distance.
+
+ @param camera The new viewpoint.
+ @param zoomLevel The new zoom level for the map.
+ @param completion The block to execute after the animation finishes.
+ */
+- (void)flyToCamera:(MLNMapCamera *)camera zoomLevel:(double)zoomLevel completionHandler:(nullable void (^)(void))completion;
+
+/**
+ Moves the viewpoint to a different location using a transition animation that
  evokes powered flight and an optional transition duration.
 
  The transition animation seamlessly incorporates zooming and panning to help
@@ -1254,6 +1268,26 @@ MLN_EXPORT
  @param completion The block to execute after the animation finishes.
  */
 - (void)flyToCamera:(MLNMapCamera *)camera
+         withDuration:(NSTimeInterval)duration
+    completionHandler:(nullable void (^)(void))completion;
+
+/**
+ Moves the viewpoint to a different location using a transition animation that
+ evokes powered flight and an optional transition duration.
+
+ The transition animation seamlessly incorporates zooming and panning to help
+ the user find his or her bearings even after traversing a great distance.
+
+ @param camera The new viewpoint.
+ @param zoomLevel The new zoom level for the map.
+ @param duration The amount of time, measured in seconds, that the transition
+    animation should take. Specify `0` to jump to the new viewpoint
+    instantaneously. Specify a negative value to use the default duration, which
+    is based on the length of the flight path.
+ @param completion The block to execute after the animation finishes.
+ */
+- (void)flyToCamera:(MLNMapCamera *)camera
+          zoomLevel:(double)zoomLevel
          withDuration:(NSTimeInterval)duration
     completionHandler:(nullable void (^)(void))completion;
 
@@ -1282,6 +1316,31 @@ MLN_EXPORT
 
 /**
  Moves the viewpoint to a different location using a transition animation that
+ evokes powered flight and an optional transition duration and peak altitude.
+
+ The transition animation seamlessly incorporates zooming and panning to help
+ the user find his or her bearings even after traversing a great distance.
+
+ @param camera The new viewpoint.
+ @param zoomLevel The new zoom level for the map.
+ @param duration The amount of time, measured in seconds, that the transition
+    animation should take. Specify `0` to jump to the new viewpoint
+    instantaneously. Specify a negative value to use the default duration, which
+    is based on the length of the flight path.
+ @param peakAltitude The altitude, measured in meters, at the midpoint of the
+    animation. The value of this parameter is ignored if it is negative or if
+    the animation transition resulting from a similar call to
+    `-setCamera:animated:` would have a midpoint at a higher altitude.
+ @param completion The block to execute after the animation finishes.
+ */
+- (void)flyToCamera:(MLNMapCamera *)camera
+          zoomLevel:(double)zoomLevel
+         withDuration:(NSTimeInterval)duration
+         peakAltitude:(CLLocationDistance)peakAltitude
+    completionHandler:(nullable void (^)(void))completion;
+
+/**
+ Moves the viewpoint to a different location using a transition animation that
  evokes powered flight.
 
  The transition animation seamlessly incorporates zooming and panning to help
@@ -1297,6 +1356,29 @@ MLN_EXPORT
  @param completion The block to execute after the animation finishes.
  */
 - (void)flyToCamera:(MLNMapCamera *)camera
+          edgePadding:(UIEdgeInsets)insets
+         withDuration:(NSTimeInterval)duration
+    completionHandler:(nullable void (^)(void))completion;
+
+/**
+ Moves the viewpoint to a different location using a transition animation that
+ evokes powered flight.
+
+ The transition animation seamlessly incorporates zooming and panning to help
+ the user find his or her bearings even after traversing a great distance.
+
+ @param camera The new viewpoint.
+ @param zoomLevel The new zoom level for the map.
+ @param duration The amount of time, measured in seconds, that the transition
+    animation should take. Specify `0` to jump to the new viewpoint
+    instantaneously. Specify a negative value to use the default duration, which
+    is based on the length of the flight path.
+ @param edgePadding The minimum padding (in screen points) that would be visible
+ around the returned camera object if it were set as the receiver’s camera.
+ @param completion The block to execute after the animation finishes.
+ */
+- (void)flyToCamera:(MLNMapCamera *)camera
+          zoomLevel:(double)zoomLevel
           edgePadding:(UIEdgeInsets)insets
          withDuration:(NSTimeInterval)duration
     completionHandler:(nullable void (^)(void))completion;

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -4190,19 +4190,19 @@ static void *windowScreenContext = &windowScreenContext;
 - (void)flyToCamera:(MLNMapCamera *)camera completionHandler:(nullable void (^)(void))completion
 {
     MLNLogDebug(@"Setting flyToCamera: %@ completionHandler: %@", camera, completion);
-    [self flyToCamera:camera withDuration:-1 completionHandler:completion];
+    [self flyToCamera:camera zoomLevel: self.zoomLevel withDuration:-1 completionHandler:completion];
 }
 
 - (void)flyToCamera:(MLNMapCamera *)camera withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion
 {
     MLNLogDebug(@"Setting flyToCamera: %@ withDuration: %f completionHandler: %@", camera, duration, completion);
-    [self flyToCamera:camera withDuration:duration peakAltitude:-1 completionHandler:completion];
+    [self flyToCamera:camera zoomLevel: self.zoomLevel withDuration:duration peakAltitude:-1 completionHandler:completion];
 }
 
 - (void)flyToCamera:(MLNMapCamera *)camera withDuration:(NSTimeInterval)duration peakAltitude:(CLLocationDistance)peakAltitude completionHandler:(nullable void (^)(void))completion
 {
     MLNLogDebug(@"Setting flyToCamera: %@ withDuration: %f peakAltitude: %f completionHandler: %@", camera, duration, peakAltitude, completion);
-    [self _flyToCamera:camera edgePadding:self.contentInset withDuration:duration peakAltitude:peakAltitude completionHandler:completion];
+    [self _flyToCamera:camera zoomLevel: self.zoomLevel edgePadding:self.contentInset withDuration:duration peakAltitude:peakAltitude completionHandler:completion];
 }
 
 - (void)flyToCamera:(MLNMapCamera *)camera edgePadding:(UIEdgeInsets)insets withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion {
@@ -4210,10 +4210,36 @@ static void *windowScreenContext = &windowScreenContext;
                                                     self.contentInset.left + insets.left,
                                                     self.contentInset.bottom + insets.bottom,
                                                     self.contentInset.right + insets.right);
-    [self _flyToCamera:camera edgePadding:finalEdgeInsets withDuration:duration peakAltitude:-1 completionHandler:completion];
+    [self _flyToCamera:camera zoomLevel: self.zoomLevel edgePadding:finalEdgeInsets withDuration:duration peakAltitude:-1 completionHandler:completion];
 }
 
-- (void)_flyToCamera:(MLNMapCamera *)camera edgePadding:(UIEdgeInsets)insets withDuration:(NSTimeInterval)duration peakAltitude:(CLLocationDistance)peakAltitude completionHandler:(nullable void (^)(void))completion
+- (void)flyToCamera:(MLNMapCamera *)camera zoomLevel:(double)zoomLevel completionHandler:(nullable void (^)(void))completion
+{
+    MLNLogDebug(@"Setting flyToCamera: %@ completionHandler: %@", camera, completion);
+    [self flyToCamera:camera zoomLevel:zoomLevel withDuration:-1 completionHandler:completion];
+}
+
+- (void)flyToCamera:(MLNMapCamera *)camera zoomLevel:(double)zoomLevel withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion
+{
+    MLNLogDebug(@"Setting flyToCamera: %@ withDuration: %f completionHandler: %@", camera, duration, completion);
+    [self flyToCamera:camera zoomLevel:zoomLevel withDuration:duration peakAltitude:-1 completionHandler:completion];
+}
+
+- (void)flyToCamera:(MLNMapCamera *)camera zoomLevel:(double)zoomLevel withDuration:(NSTimeInterval)duration peakAltitude:(CLLocationDistance)peakAltitude completionHandler:(nullable void (^)(void))completion
+{
+    MLNLogDebug(@"Setting flyToCamera: %@ withDuration: %f peakAltitude: %f completionHandler: %@", camera, duration, peakAltitude, completion);
+    [self _flyToCamera:camera zoomLevel:zoomLevel edgePadding:self.contentInset withDuration:duration peakAltitude:peakAltitude completionHandler:completion];
+}
+
+- (void)flyToCamera:(MLNMapCamera *)camera zoomLevel:(double)zoomLevel edgePadding:(UIEdgeInsets)insets withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion {
+    UIEdgeInsets finalEdgeInsets = UIEdgeInsetsMake(self.contentInset.top + insets.top,
+                                                    self.contentInset.left + insets.left,
+                                                    self.contentInset.bottom + insets.bottom,
+                                                    self.contentInset.right + insets.right);
+    [self _flyToCamera:camera zoomLevel:zoomLevel edgePadding:finalEdgeInsets withDuration:duration peakAltitude:-1 completionHandler:completion];
+}
+
+- (void)_flyToCamera:(MLNMapCamera *)camera zoomLevel:(double)zoomLevel edgePadding:(UIEdgeInsets)insets withDuration:(NSTimeInterval)duration peakAltitude:(CLLocationDistance)peakAltitude completionHandler:(nullable void (^)(void))completion
 {
     if (!_mbglMap)
     {
@@ -4269,6 +4295,7 @@ static void *windowScreenContext = &windowScreenContext;
     self.cameraChangeReasonBitmask |= MLNCameraChangeReasonProgrammatic;
 
     mbgl::CameraOptions cameraOptions = [self cameraOptionsObjectForAnimatingToCamera:camera edgePadding:insets];
+    cameraOptions.zoom = zoomLevel;
     self.mbglMap.flyTo(cameraOptions, animationOptions);
     [self didChangeValueForKey:@"camera"];
 }

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -6267,6 +6267,7 @@ static void *windowScreenContext = &windowScreenContext;
 
     __weak MLNMapView *weakSelf = self;
     [self _flyToCamera:camera
+             zoomLevel:self.zoomLevel
            edgePadding:self.edgePaddingForFollowing
           withDuration:animated ? -1 : 0
           peakAltitude:-1


### PR DESCRIPTION
Add zoom-level options for `flyTo` function, for some use cases like flying from somewhere on the screen to the current user location, with a specific zoom level.