### PR TITLE
Scheduling optimizations and tracing

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -1,9 +1,10 @@
 #include "map_renderer.hpp"
 
-#include <mbgl/renderer/renderer.hpp>
 #include <mbgl/gfx/backend_scope.hpp>
-#include <mbgl/util/run_loop.hpp>
+#include <mbgl/renderer/renderer.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/logging.hpp>
+#include <mbgl/util/run_loop.hpp>
 
 #include <string>
 
@@ -63,6 +64,7 @@ ActorRef<Renderer> MapRenderer::actor() const {
 }
 
 void MapRenderer::schedule(std::function<void()>&& scheduled) {
+    MLN_TRACE_FUNC()
     try {
         // Create a runnable
         android::UniqueEnv _env = android::AttachEnv();
@@ -76,6 +78,7 @@ void MapRenderer::schedule(std::function<void()>&& scheduled) {
         static auto queueEvent = javaClass.GetMethod<void(jni::Object<MapRendererRunnable>)>(*_env, "queueEvent");
         auto weakReference = javaPeer.get(*_env);
         if (weakReference) {
+            MLN_TRACE_ZONE(java)
             weakReference.Call(*_env, queueEvent, peer);
         }
 

--- a/src/mbgl/actor/mailbox.cpp
+++ b/src/mbgl/actor/mailbox.cpp
@@ -98,7 +98,7 @@ void Mailbox::push(std::unique_ptr<Message> message) {
         return;
     }
 
-    bool wasEmpty;
+    bool wasEmpty = false;
     {
         MLN_TRACE_ZONE(queue lock)
         std::lock_guard<std::mutex> queueLock(queueMutex);

--- a/src/mbgl/actor/mailbox.cpp
+++ b/src/mbgl/actor/mailbox.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/actor/mailbox.hpp>
 #include <mbgl/actor/message.hpp>
 #include <mbgl/actor/scheduler.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/scoped.hpp>
 
 #include <cassert>
@@ -75,6 +76,7 @@ bool Mailbox::isOpen() const {
 }
 
 void Mailbox::push(std::unique_ptr<Message> message) {
+    MLN_TRACE_FUNC()
     auto idleState = State::Idle;
     while (!state.compare_exchange_strong(idleState, State::Processing)) {
         if (state == State::Abandoned) {
@@ -88,6 +90,7 @@ void Mailbox::push(std::unique_ptr<Message> message) {
         }
     }};
 
+    MLN_TRACE_ZONE(push lock)
     std::lock_guard<std::mutex> pushingLock(pushingMutex);
 
     if (closed) {
@@ -95,12 +98,20 @@ void Mailbox::push(std::unique_ptr<Message> message) {
         return;
     }
 
-    std::lock_guard<std::mutex> queueLock(queueMutex);
-    bool wasEmpty = queue.empty();
-    queue.push(std::move(message));
-    auto guard = weakScheduler.lock();
-    if (wasEmpty && weakScheduler) {
-        weakScheduler->schedule(schedulerTag, makeClosure(shared_from_this()));
+    bool wasEmpty;
+    {
+        MLN_TRACE_ZONE(queue lock)
+        std::lock_guard<std::mutex> queueLock(queueMutex);
+        wasEmpty = queue.empty();
+        queue.push(std::move(message));
+    }
+
+    if (wasEmpty) {
+        auto guard = weakScheduler.lock();
+        if (weakScheduler) {
+            MLN_TRACE_ZONE(schedule)
+            weakScheduler->schedule(schedulerTag, makeClosure(shared_from_this()));
+        }
     }
 }
 

--- a/src/mbgl/actor/mailbox.cpp
+++ b/src/mbgl/actor/mailbox.cpp
@@ -136,7 +136,7 @@ void Mailbox::receive() {
     }
 
     std::unique_ptr<Message> message;
-    bool wasEmpty;
+    bool wasEmpty = false;
 
     {
         std::lock_guard<std::mutex> queueLock(queueMutex);

--- a/src/mbgl/gl/buffer_allocator.cpp
+++ b/src/mbgl/gl/buffer_allocator.cpp
@@ -2,6 +2,8 @@
 #include <mbgl/gl/defines.hpp>
 #include <mbgl/gl/context.hpp>
 #include <mbgl/gl/uniform_buffer_gl.hpp>
+#include <mbgl/util/instrumentation.hpp>
+
 #include <utility>
 
 namespace mbgl {
@@ -298,6 +300,7 @@ public:
     // Look for buffers that either have zero living references or equal or under FragmentationThresh
     // references. In the latter case, attempt to relocate these allocations to more utilized buffers.
     void defragment(const std::shared_ptr<gl::Fence>& fence) override {
+        MLN_TRACE_FUNC()
         if (buffers.size() == 0) {
             return;
         }

--- a/src/mbgl/renderer/image_manager.cpp
+++ b/src/mbgl/renderer/image_manager.cpp
@@ -198,12 +198,11 @@ void ImageManager::reduceMemoryUseIfCacheSizeExceedsLimit() {
 }
 
 std::set<std::string> ImageManager::getAvailableImages() const {
-    std::set<std::string> copy;
-    {
-        std::lock_guard<std::recursive_mutex> readWriteLock(rwLock);
-        copy = availableImages;
-    }
-    return copy;
+    MLN_TRACE_FUNC()
+    std::lock_guard<std::recursive_mutex> readWriteLock(rwLock);
+
+    MLN_TRACE_ZONE(copy)
+    return availableImages;
 }
 
 void ImageManager::clear() {
@@ -309,9 +308,7 @@ void ImageManager::notify(ImageRequestor& requestor, const ImageRequestPair& pai
 }
 
 void ImageManager::dumpDebugLogs() const {
-    std::ostringstream ss;
-    ss << "ImageManager::loaded: " << loaded;
-    Log::Info(Event::General, ss.str());
+    Log::Info(Event::General, "ImageManager::loaded: " + std::string(loaded ? "1" : "0"));
 }
 
 ImageRequestor::ImageRequestor(std::shared_ptr<ImageManager> imageManager_)

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -30,6 +30,7 @@ namespace mbgl {
 
 LayerRenderData* GeometryTile::LayoutResult::getLayerRenderData(const style::Layer::Impl& layerImpl) {
     MLN_TRACE_FUNC()
+    MLN_ZONE_STR(layerImpl.id)
 
     auto it = layerRenderData.find(layerImpl.id);
     if (it == layerRenderData.end()) {
@@ -258,6 +259,8 @@ void GeometryTile::setLayers(const std::vector<Immutable<LayerProperties>>& laye
     impls.reserve(layers.size());
 
     for (const auto& layer : layers) {
+        MLN_TRACE_ZONE(layer)
+        MLN_ZONE_STR(layer->baseImpl->id)
         // Skip irrelevant layers.
         const auto& layerImpl = *layer->baseImpl;
         assert(layerImpl.getTypeInfo()->source != LayerTypeInfo::Source::NotRequired);

--- a/src/mbgl/util/thread_pool.cpp
+++ b/src/mbgl/util/thread_pool.cpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/platform/settings.hpp>
 #include <mbgl/platform/thread.hpp>
+#include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/monotonic_timer.hpp>
 #include <mbgl/util/platform.hpp>
 #include <mbgl/util/string.hpp>
@@ -109,22 +110,28 @@ void ThreadedSchedulerBase::schedule(std::function<void()>&& fn) {
 }
 
 void ThreadedSchedulerBase::schedule(const util::SimpleIdentity tag, std::function<void()>&& fn) {
+    MLN_TRACE_FUNC()
     assert(fn);
     if (!fn) return;
 
     std::shared_ptr<Queue> q;
     {
+        MLN_TRACE_ZONE(queue)
         std::lock_guard<std::mutex> lock(taggedQueueLock);
-        auto it = taggedQueue.find(tag);
-        if (it == taggedQueue.end()) {
-            q = std::make_shared<Queue>();
-            taggedQueue.insert({tag, q});
-        } else {
-            q = it->second;
+
+        // find or insert
+        auto result = taggedQueue.insert(std::make_pair(tag, std::shared_ptr<Queue>{}));
+        if (result.second) {
+            // new entry inserted
+            result.first->second = std::make_shared<Queue>();
         }
+        q = result.first->second;
+
+        MLN_ZONE_VALUE(taggedQueue.size())
     }
 
     {
+        MLN_TRACE_ZONE(push)
         std::lock_guard<std::mutex> lock(q->lock);
         q->queue.push(std::move(fn));
         taskCount++;


### PR DESCRIPTION
Don't hold the mailbox queue lock while calling `schedule`.
Eliminate a second key lookup when inserting a new item in the tagged queue map.
