### PR TITLE
Improved compatiblity for NSPredicate predicateWithMLNJSONObject. (#2686)

### DIFF
--- a/platform/darwin/src/NSPredicate+MLNAdditions.mm
+++ b/platform/darwin/src/NSPredicate+MLNAdditions.mm
@@ -177,7 +177,7 @@ static NSDictionary * const MLNPredicateOperatorTypesByJSONOperator = @{
         NSString *key = [objects objectAtIndex:1];
         return [NSPredicate predicateWithFormat:@"(%K!=nil)", key];
     }
-    // Handle ["!has", "attributeName"]. Also handled by expression using mgl_does:have, but this is simpler..
+    // Handle ["!has", "attributeName"].
     if ([op isEqualToString:@"!has"] && objects.count == 2 && [[objects objectAtIndex:1] isKindOfClass:[NSString class]]) {
         NSString *key = [objects objectAtIndex:1];
         return [NSPredicate predicateWithFormat:@"(%K==nil)", key];

--- a/platform/darwin/src/NSPredicate+MLNAdditions.mm
+++ b/platform/darwin/src/NSPredicate+MLNAdditions.mm
@@ -73,7 +73,7 @@ static NSDictionary * const MLNPredicateOperatorTypesByJSONOperator = @{
     if (operatorTypeNumber) {
         NSPredicateOperatorType operatorType = (NSPredicateOperatorType)[operatorTypeNumber unsignedIntegerValue];
         
-        // Handle ["in", "attributeName", "val"..] -> ["in", ["get", "attributeName"], ["literal", "val"..]]
+        // Handle ["in", "attributeName", "val"..] -> ["in", ["get", "attributeName"], ["literal", ["val"..]]]
         if (operatorType == NSInPredicateOperatorType && objects.count >= 3 && [[objects objectAtIndex:1] isKindOfClass:[NSString class]] && ![[objects objectAtIndex:2] isKindOfClass:[NSArray class]]) {
             NSMutableArray *newObjects = [NSMutableArray arrayWithCapacity:3];
             [newObjects addObject:[objects objectAtIndex:0]];

--- a/platform/darwin/src/NSPredicate+MLNAdditions.mm
+++ b/platform/darwin/src/NSPredicate+MLNAdditions.mm
@@ -172,10 +172,19 @@ static NSDictionary * const MLNPredicateOperatorTypesByJSONOperator = @{
                                                              type:NSInPredicateOperatorType
                                                           options:0];
     }
-    if ([op isEqualToString:@"!has"] || [op isEqualToString:@"!in"]) {
-        NSString *opRest = [op substringFromIndex:1];
+    // Handle ["has", "attributeName"]. Also handled by expression using mgl_does:have, but this is simpler..
+    if ([op isEqualToString:@"has"] && objects.count == 2 && [[objects objectAtIndex:1] isKindOfClass:[NSString class]]) {
+        NSString *key = [objects objectAtIndex:1];
+        return [NSPredicate predicateWithFormat:@"(%K!=nil)", key];
+    }
+    // Handle ["!has", "attributeName"]. Also handled by expression using mgl_does:have, but this is simpler..
+    if ([op isEqualToString:@"!has"] && objects.count == 2 && [[objects objectAtIndex:1] isKindOfClass:[NSString class]]) {
+        NSString *key = [objects objectAtIndex:1];
+        return [NSPredicate predicateWithFormat:@"(%K==nil)", key];
+    }
+    if ([op isEqualToString:@"!in"]) {
         NSMutableArray *newObjects = [NSMutableArray arrayWithArray:objects];
-        [newObjects replaceObjectAtIndex:0 withObject:opRest];
+        [newObjects replaceObjectAtIndex:0 withObject:@"in"];
         NSPredicate *predicate = [NSPredicate predicateWithMLNJSONObject:newObjects];
         return [NSCompoundPredicate notPredicateWithSubpredicate:predicate];
     }

--- a/platform/darwin/test/MLNPredicateTests.mm
+++ b/platform/darwin/test/MLNPredicateTests.mm
@@ -582,6 +582,24 @@
 
 -(void)testPredicateCompatibility {
     {
+        NSArray *jsonPredicate = @[@"has", @"x"];
+        NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"(x!=nil)"];
+        XCTAssertEqualObjects([NSPredicate predicateWithMLNJSONObject:jsonPredicate], expectedPredicate);
+        NSDictionary *attributesWith = @{@"x": @33};
+        NSDictionary *attributesWithout = @{@"y": @33};
+        XCTAssertTrue([expectedPredicate evaluateWithObject:attributesWith]);
+        XCTAssertFalse([expectedPredicate evaluateWithObject:attributesWithout]);
+    }
+    {
+        NSArray *jsonPredicate = @[@"!has", @"x"];
+        NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"(x==nil)"];
+        XCTAssertEqualObjects([NSPredicate predicateWithMLNJSONObject:jsonPredicate], expectedPredicate);
+        NSDictionary *attributesWith = @{@"x": @33};
+        NSDictionary *attributesWithout = @{@"y": @33};
+        XCTAssertFalse([expectedPredicate evaluateWithObject:attributesWith]);
+        XCTAssertTrue([expectedPredicate evaluateWithObject:attributesWithout]);
+    }
+    {
         NSArray *jsonPredicate = @[@"!in", @[@"get", @"x"], @[@"literal", @[@6, @5, @4, @3]]];
         NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"NOT x IN {6, 5, 4, 3}"];
         XCTAssertEqualObjects([NSPredicate predicateWithMLNJSONObject:jsonPredicate], expectedPredicate);

--- a/platform/darwin/test/MLNPredicateTests.mm
+++ b/platform/darwin/test/MLNPredicateTests.mm
@@ -608,21 +608,37 @@
         NSArray *jsonPredicate = @[@"in", @"x", @6];
         NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"x IN {6}"];
         XCTAssertEqualObjects([NSPredicate predicateWithMLNJSONObject:jsonPredicate], expectedPredicate);
+        NSDictionary *attributesWith = @{@"x": @6};
+        NSDictionary *attributesWithout = @{@"x": @7, @"y": @6};
+        XCTAssertTrue([expectedPredicate evaluateWithObject:attributesWith]);
+        XCTAssertFalse([expectedPredicate evaluateWithObject:attributesWithout]);
     }
     {
         NSArray *jsonPredicate = @[@"!in", @"x", @6];
         NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"NOT x IN {6}"];
         XCTAssertEqualObjects([NSPredicate predicateWithMLNJSONObject:jsonPredicate], expectedPredicate);
+        NSDictionary *attributesWith = @{@"x": @6};
+        NSDictionary *attributesWithout = @{@"x": @7, @"y": @6};
+        XCTAssertFalse([expectedPredicate evaluateWithObject:attributesWith]);
+        XCTAssertTrue([expectedPredicate evaluateWithObject:attributesWithout]);
     }
     {
         NSArray *jsonPredicate = @[@"in", @"x", @6, @5, @4, @3];
         NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"x IN {6, 5, 4, 3}"];
         XCTAssertEqualObjects([NSPredicate predicateWithMLNJSONObject:jsonPredicate], expectedPredicate);
+        NSDictionary *attributesWith = @{@"x": @5};
+        NSDictionary *attributesWithout = @{@"x": @7, @"y": @5};
+        XCTAssertTrue([expectedPredicate evaluateWithObject:attributesWith]);
+        XCTAssertFalse([expectedPredicate evaluateWithObject:attributesWithout]);
     }
     {
         NSArray *jsonPredicate = @[@"!in", @"x", @6, @5, @4, @3];
         NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"NOT x IN {6, 5, 4, 3}"];
         XCTAssertEqualObjects([NSPredicate predicateWithMLNJSONObject:jsonPredicate], expectedPredicate);
+        NSDictionary *attributesWith = @{@"x": @5};
+        NSDictionary *attributesWithout = @{@"x": @7, @"y": @5};
+        XCTAssertFalse([expectedPredicate evaluateWithObject:attributesWith]);
+        XCTAssertTrue([expectedPredicate evaluateWithObject:attributesWithout]);
     }
 }
 

--- a/platform/darwin/test/MLNPredicateTests.mm
+++ b/platform/darwin/test/MLNPredicateTests.mm
@@ -580,6 +580,34 @@
     }
 }
 
+-(void)testPredicateCompatibility {
+    {
+        NSArray *jsonPredicate = @[@"!in", @[@"get", @"x"], @[@"literal", @[@6, @5, @4, @3]]];
+        NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"NOT x IN {6, 5, 4, 3}"];
+        XCTAssertEqualObjects([NSPredicate predicateWithMLNJSONObject:jsonPredicate], expectedPredicate);
+    }
+    {
+        NSArray *jsonPredicate = @[@"in", @"x", @6];
+        NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"x IN {6}"];
+        XCTAssertEqualObjects([NSPredicate predicateWithMLNJSONObject:jsonPredicate], expectedPredicate);
+    }
+    {
+        NSArray *jsonPredicate = @[@"!in", @"x", @6];
+        NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"NOT x IN {6}"];
+        XCTAssertEqualObjects([NSPredicate predicateWithMLNJSONObject:jsonPredicate], expectedPredicate);
+    }
+    {
+        NSArray *jsonPredicate = @[@"in", @"x", @6, @5, @4, @3];
+        NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"x IN {6, 5, 4, 3}"];
+        XCTAssertEqualObjects([NSPredicate predicateWithMLNJSONObject:jsonPredicate], expectedPredicate);
+    }
+    {
+        NSArray *jsonPredicate = @[@"!in", @"x", @6, @5, @4, @3];
+        NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"NOT x IN {6, 5, 4, 3}"];
+        XCTAssertEqualObjects([NSPredicate predicateWithMLNJSONObject:jsonPredicate], expectedPredicate);
+    }
+}
+
 - (void)testSymmetryWithPredicate:(NSPredicate *)forwardPredicate mustRoundTrip:(BOOL)mustRoundTrip {
     auto forwardFilter = forwardPredicate.mgl_filter;
     NSPredicate *forwardPredicateAfter = [NSPredicate mgl_predicateWithFilter:forwardFilter];


### PR DESCRIPTION
* Support `!has` and `!in`.
* Support `["in", "attributeName", "val"..]`.

Closes #2686