### PR TITLE
Cleanup mbgl/actor/mailbox* implementation for repetition in ensuring valid weakScheduler exists before usage

### DIFF
--- a/include/mbgl/actor/mailbox.hpp
+++ b/include/mbgl/actor/mailbox.hpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <queue>
 
 #include <mapbox/std/weak.hpp>
@@ -39,10 +40,8 @@ public:
     void push(std::unique_ptr<Message>);
     void receive();
 
-    static void maybeReceive(const std::weak_ptr<Mailbox>&);
-    static std::function<void()> makeClosure(std::weak_ptr<Mailbox>);
-
 private:
+    void scheduleToRecieve(const std::optional<util::SimpleIdentity>& tag = std::nullopt);
     enum class State : uint32_t {
         Idle = 0,
         Processing,

--- a/src/mbgl/actor/mailbox.cpp
+++ b/src/mbgl/actor/mailbox.cpp
@@ -149,8 +149,7 @@ void Mailbox::receive() {
     }
 }
 
-void Mailbox::scheduleToRecieve(const std::optional<util::SimpleIdentity>& tag)
-{
+void Mailbox::scheduleToRecieve(const std::optional<util::SimpleIdentity>& tag) {
     auto guard = weakScheduler.lock();
     if (weakScheduler) {
         std::weak_ptr<Mailbox> mailbox = shared_from_this();
@@ -159,16 +158,10 @@ void Mailbox::scheduleToRecieve(const std::optional<util::SimpleIdentity>& tag)
                 locked->receive();
             }
         };
-        if(tag)
-        {
-            weakScheduler->schedule(
-                *tag,
-                std::move(setToRecieve)
-            );
+        if (tag) {
+            weakScheduler->schedule(*tag, std::move(setToRecieve));
         } else {
-            weakScheduler->schedule(
-                std::move(setToRecieve)
-            );
+            weakScheduler->schedule(std::move(setToRecieve));
         }
     }
 }

--- a/src/mbgl/actor/mailbox.cpp
+++ b/src/mbgl/actor/mailbox.cpp
@@ -38,10 +38,7 @@ void Mailbox::open(Scheduler& scheduler_) {
     weakScheduler = scheduler_.makeWeakPtr();
 
     if (!queue.empty()) {
-        auto guard = weakScheduler.lock();
-        if (weakScheduler) {
-            weakScheduler->schedule(makeClosure(shared_from_this()));
-        }
+        scheduleToRecieve();
     }
 }
 
@@ -107,11 +104,8 @@ void Mailbox::push(std::unique_ptr<Message> message) {
     }
 
     if (wasEmpty) {
-        auto guard = weakScheduler.lock();
-        if (weakScheduler) {
-            MLN_TRACE_ZONE(schedule)
-            weakScheduler->schedule(schedulerTag, makeClosure(shared_from_this()));
-        }
+        MLN_TRACE_ZONE(schedule)
+        scheduleToRecieve(schedulerTag);
     }
 }
 
@@ -151,25 +145,32 @@ void Mailbox::receive() {
     // If there are more messages in the queue and the scheduler
     // is still active, create a new task to handle the next one
     if (!wasEmpty) {
-        auto guard = weakScheduler.lock();
-        if (weakScheduler) {
-            weakScheduler->schedule(makeClosure(shared_from_this()));
+        scheduleToRecieve();
+    }
+}
+
+void Mailbox::scheduleToRecieve(const std::optional<util::SimpleIdentity>& tag)
+{
+    auto guard = weakScheduler.lock();
+    if (weakScheduler) {
+        std::weak_ptr<Mailbox> mailbox = shared_from_this();
+        auto setToRecieve = [mbox = std::move(mailbox)]() {
+            if (auto locked = mbox.lock()) {
+                locked->receive();
+            }
+        };
+        if(tag)
+        {
+            weakScheduler->schedule(
+                *tag,
+                std::move(setToRecieve)
+            );
+        } else {
+            weakScheduler->schedule(
+                std::move(setToRecieve)
+            );
         }
     }
-}
-
-// static
-void Mailbox::maybeReceive(const std::weak_ptr<Mailbox>& mailbox) {
-    if (auto locked = mailbox.lock()) {
-        locked->receive();
-    }
-}
-
-// static
-std::function<void()> Mailbox::makeClosure(std::weak_ptr<Mailbox> mailbox) {
-    return [mailbox = std::move(mailbox)]() {
-        maybeReceive(mailbox);
-    };
 }
 
 } // namespace mbgl


### PR DESCRIPTION
Ensure that valid weakScheduler exists before using it to schedule. Remove repetition of weakScheduler guarantee such that it is captured in a method. 