### PR TITLE
[node][main] Add macos-14 back to node publish

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -48,12 +48,10 @@ jobs:
             arch: x86_64
           - runs-on: [self-hosted, linux, ARM64]
             arch: arm64
-          # Disabled until Metal backend is complete
-          # A release for macOS can be made from the opengl-2 branch
-          # - runs-on: macos-12
-          #   arch: x86_64
-          # - runs-on: macos-13-xlarge
-          #   arch: arm64
+          - runs-on: macos-14
+            arch: arm64
+          - runs-on: macos-14-large
+            arch: x86_64
           - runs-on: windows-2022
             arch: x86_64
     continue-on-error: true


### PR DESCRIPTION
I noticed on the release that macOS publishing was disabled. 

I canceled the release before anything was done, so this PR should just release the current release