### PR TITLE
[node][main] fix npm ci to run in platform/node 

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -148,6 +148,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: npm ci
+        working-directory: platform/node
         run: npm ci --ignore-scripts
 
       - name: Set up msvc dev cmd (Windows)

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -178,11 +178,15 @@ jobs:
             -G Ninja \
             -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DMLN_WITH_NODE=ON
+            -DMLN_WITH_NODE=ON \
+            -DMLN_WITH_OPENGL=OFF \
+            -DMLN_WITH_METAL=ON \
+            -DMLN_LEGACY_RENDERER=OFF \
+            -DMLN_DRAWABLE_RENDERER=ON \
+            -DMLN_WITH_WERROR=OFF
 
       - name: Configure maplibre-native (Linux)
         if: runner.os == 'Linux'
-        shell: bash -leo pipefail {0}
         run: |
           cmake . -B build \
             -G Ninja \

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -118,6 +118,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: npm ci
+        working-directory: platform/node
         run: npm ci --ignore-scripts
 
       - name: Set up msvc dev cmd (Windows)


### PR DESCRIPTION
 fix npm ci to run in platform/node so that the node-pre-gyp publish.sh needs exists