### PR TITLE
[node][main] Release node v6.0.0-pre.1

### DIFF
--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## main
 
-## 6.0.0-pre.0
+## 6.0.0-pre.1
 * [Note] This is the first release that is back on the main branch.
 * This is the first release that uses Metal for rendering for macOS. This is a graphics API from Apple that replaces OpenGL (ES) on Apple platforms.
 * This is the first release that uses OpenGL ES 3.0 for Windows and Linux.

--- a/platform/node/package-lock.json
+++ b/platform/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "6.0.0-pre.0",
+  "version": "6.0.0-pre.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "6.0.0-pre.0",
+      "version": "6.0.0-pre.1",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/platform/node/package.json
+++ b/platform/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "6.0.0-pre.0",
+  "version": "6.0.0-pre.1",
   "description": "Renders map tiles with MapLibre Native",
   "keywords": [
     "maplibre",


### PR DESCRIPTION
This is a re-release of node v6.0.0-pre.0, which did not publish the binaries properly. Hopefully  https://github.com/maplibre/maplibre-native/pull/2749 and https://github.com/maplibre/maplibre-native/pull/2751 fixes that