### PR TITLE
ensure ReentrantLock is unlocked after being locked, and on same thread

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/storage/FileSource.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/storage/FileSource.java
@@ -203,7 +203,7 @@ public class FileSource {
     @Override
     protected Void doInBackground(Context... contexts) {
       getResourcesCachePath(contexts[0]);
-      getInternalCachePath(context[0]);
+      getInternalCachePath(contexts[0]);
     }
   }
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/storage/FileSource.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/storage/FileSource.java
@@ -204,6 +204,7 @@ public class FileSource {
     protected Void doInBackground(Context... contexts) {
       getResourcesCachePath(contexts[0]);
       getInternalCachePath(contexts[0]);
+      return null;
     }
   }
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/storage/FileSource.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/storage/FileSource.java
@@ -195,33 +195,15 @@ public class FileSource {
   @UiThread
   public static void initializeFileDirsPaths(Context context) {
     ThreadUtils.checkThread(TAG);
-    lockPathLoaders();
-    if (resourcesCachePath == null || internalCachePath == null) {
-      new FileDirsPathsTask().execute(context);
-    }
+    new FileDirsPathsTask().execute(context);
   }
 
-  private static class FileDirsPathsTask extends AsyncTask<Context, Void, String[]> {
+  private static class FileDirsPathsTask extends AsyncTask<Context, Void, Void> {
 
     @Override
-    protected void onCancelled() {
-      unlockPathLoaders();
-    }
-
-    @NonNull
-    @Override
-    protected String[] doInBackground(Context... contexts) {
-      return new String[] {
-        getCachePath(contexts[0]),
-        contexts[0].getCacheDir().getAbsolutePath()
-      };
-    }
-
-    @Override
-    protected void onPostExecute(String[] paths) {
-      resourcesCachePath = paths[0];
-      internalCachePath = paths[1];
-      unlockPathLoaders();
+    protected Void doInBackground(Context... contexts) {
+      getResourcesCachePath(contexts[0]);
+      getInternalCachePath(context[0]);
     }
   }
 
@@ -356,16 +338,6 @@ public class FileSource {
       return false;
     }
     return new File(path).canWrite();
-  }
-
-  private static void lockPathLoaders() {
-    internalCachePathLoaderLock.lock();
-    resourcesCachePathLoaderLock.lock();
-  }
-
-  private static void unlockPathLoaders() {
-    resourcesCachePathLoaderLock.unlock();
-    internalCachePathLoaderLock.unlock();
   }
 
   @Keep


### PR DESCRIPTION
fixes #2432

The reentrant locks were engaged unconditionally on the then-main thread but the async task was only started conditionally. The unlocking of the locks was managed by the async task.
This lead to two issues:

- if the condition checked for in `initializeFileDirsPaths` was already met, the locks were engaged but never unlocked. Any subsequent attempt to lock would just block execution forever.

- (hypothetical, not tested:) the thread id of the app's main thread when the async task finished and thus calls `onPostExecute` or `onCancel` on that thread may differ from the thread id of the app's main thread when `initializeFileDirsPaths` was invoked: E.g. if the app was sent to background and effectively re-started later by the Android system. However, reentrant locks require to be locked/unlocked on the same thread, otherwise they will throw an `IllegalMonitorStateException`. The previous mechanism could not ensure this.

In any case, I am pretty sure either of these two issues is the cause for #2432.