### PR TITLE
[node][opengl-2] Cherry pick node publish fixes to opengl-2

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -213,7 +213,6 @@ jobs:
 
       - name: Configure maplibre-native (Linux)
         if: runner.os == 'Linux'
-        shell: bash -leo pipefail {0}
         run: |
           cmake . -B build \
             -G Ninja \

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -261,9 +261,6 @@ jobs:
 
       - name: Run render tests on macOS
         if: runner.os == 'macOS'
-        # A few are failing
-        # https://github.com/maplibre/maplibre-native/issues/2741
-        # Almost all are failing on Intel GitHub runners (but only on CI)
         continue-on-error: true
         run: ./build/mbgl-render-test-runner --manifestPath metrics/macos-xcode11-release-style.json
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -79,9 +79,9 @@ jobs:
             arch: x86_64
           - runs-on: [self-hosted, linux, ARM64]
             arch: arm64
-          - runs-on: macos-12
+          - runs-on: macos-13
             arch: x86_64
-          - runs-on: macos-13-xlarge
+          - runs-on: macos-14
             arch: arm64
           - runs-on: windows-2022
             arch: x86_64

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -149,6 +149,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: npm ci
+        working-directory: platform/node
         run: npm ci --ignore-scripts
 
       - name: Set up msvc dev cmd (Windows)

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -37,7 +37,7 @@ on:
 
   pull_request:
     branches:
-      - opengl-2
+      - "*"
     paths:
       - CMakeLists.txt
       - "platform/linux/**"
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -196,7 +196,7 @@ jobs:
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}
 
       - name: Cache cmake-node-module deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # downloaded with platform/node/cmake/module.cmake
           path: build/headers
@@ -229,7 +229,7 @@ jobs:
 
       - name: Restore vcpkg cache (Windows)
         if: runner.os == 'Windows'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ github.workspace }}/platform/windows/vendor/vcpkg
@@ -252,7 +252,7 @@ jobs:
       - name: Build maplibre-native (MacOS/Linux)
         if: runner.os == 'MacOS' || runner.os == 'Linux'
         run: |
-          cmake --build build -j $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)
+          cmake --build build -j "$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)"
 
       - name: Build maplibre-native (Windows)
         if: runner.os == 'Windows'
@@ -260,12 +260,16 @@ jobs:
           cmake --build build
 
       - name: Run render tests on macOS
-        if: runner.os == 'macOS' && matrix.arch != 'arm64'
-        run: set -o pipefail && ./build/mbgl-render-test-runner --manifestPath metrics/macos-xcode11-release-style.json
+        if: runner.os == 'macOS'
+        # A few are failing
+        # https://github.com/maplibre/maplibre-native/issues/2741
+        # Almost all are failing on Intel GitHub runners (but only on CI)
+        continue-on-error: true
+        run: ./build/mbgl-render-test-runner --manifestPath metrics/macos-xcode11-release-style.json
 
       - name: Upload render test artifacts (MacOS)
-        if: always()
-        uses: actions/upload-artifact@v3
+        if: runner.os == 'MacOS'
+        uses: actions/upload-artifact@v4
         with:
           name: render-query-test-results_${{ runner.os }}_${{ matrix.arch }}
           path: metrics/macos-xcode11-release-style.html

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -165,7 +165,7 @@ jobs:
             ${{ matrix.runs-on }}-${{ env.BUILDTYPE }}-${{ github.job }}
 
       - name: Cache cmake-node-module deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # downloaded with platform/node/cmake/module.cmake
           path: build/headers
@@ -198,7 +198,7 @@ jobs:
 
       - name: Restore vcpkg cache (Windows)
         if: runner.os == 'Windows'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ github.workspace }}/platform/windows/vendor/vcpkg
@@ -221,7 +221,7 @@ jobs:
       - name: Build maplibre-native (MacOS/Linux)
         if: runner.os == 'MacOS' || runner.os == 'Linux'
         run: |
-          cmake --build build -j $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)
+          cmake --build build -j "$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)"
 
       - name: Build maplibre-native (Windows)
         if: runner.os == 'Windows'
@@ -258,7 +258,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -311,7 +311,7 @@ jobs:
         if: ${{ steps.prepare_release.outputs.prerelease == 'false' }}
         working-directory: platform/node
         run: |
-          npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
           npm publish --access public
         env:
           NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
@@ -320,7 +320,7 @@ jobs:
         if: ${{ steps.prepare_release.outputs.prerelease == 'true' }}
         working-directory: platform/node
         run: |
-          npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
           npm publish --tag next --access public
         env:
           NPM_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -48,9 +48,9 @@ jobs:
             arch: x86_64
           - runs-on: [self-hosted, linux, ARM64]
             arch: arm64
-          - runs-on: macos-12
+          - runs-on: macos-13
             arch: x86_64
-          - runs-on: macos-13-xlarge
+          - runs-on: macos-14
             arch: arm64
           - runs-on: windows-2022
             arch: x86_64

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -118,6 +118,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: npm ci
+        working-directory: platform/node
         run: npm ci --ignore-scripts
 
       - name: Set up msvc dev cmd (Windows)
@@ -177,11 +178,15 @@ jobs:
             -G Ninja \
             -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DMLN_WITH_NODE=ON
+            -DMLN_WITH_NODE=ON \
+            -DMLN_WITH_OPENGL=OFF \
+            -DMLN_WITH_METAL=ON \
+            -DMLN_LEGACY_RENDERER=OFF \
+            -DMLN_DRAWABLE_RENDERER=ON \
+            -DMLN_WITH_WERROR=OFF
 
       - name: Configure maplibre-native (Linux)
         if: runner.os == 'Linux'
-        shell: bash -leo pipefail {0}
         run: |
           cmake . -B build \
             -G Ninja \

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -178,12 +178,7 @@ jobs:
             -G Ninja \
             -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DMLN_WITH_NODE=ON \
-            -DMLN_WITH_OPENGL=OFF \
-            -DMLN_WITH_METAL=ON \
-            -DMLN_LEGACY_RENDERER=OFF \
-            -DMLN_DRAWABLE_RENDERER=ON \
-            -DMLN_WITH_WERROR=OFF
+            -DMLN_WITH_NODE=ON
 
       - name: Configure maplibre-native (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
I would like to make at least one final release from the opengl-2 branch to release the last pre-release.  This PR brings over some fixes to the workflow so that a release can be published.

- This brings over fixes to run npm ci in platform/node from https://github.com/maplibre/maplibre-native/pull/2751 so the publish can succeed. 
- I have set the macos runners to the free x86_64 and arm64 ones
- I have brought over some changes from the main workflows (mostly updating a few actions and adding quotes)
