### PR TITLE
[opengl-2][node] Release node-v5.4.1

### DIFF
--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,7 +1,8 @@
 
 ## main
 
-## 5.4.1-pre.1
+## 5.4.1
+* [Note] This is a OpenGL-2 release. It does not include metal support.
 * Fix crash that happened with some PBF files ([Issue](https://github.com/maplibre/maplibre-native/issues/795), [PR](https://github.com/maplibre/maplibre-native/pull/2460)).
 * Upgrade NAN to 2.19 to support Node 22 (https://github.com/maplibre/maplibre-native/pull/2426)
 * Add Node 22 binary build and publish (https://github.com/maplibre/maplibre-native/pull/2553)

--- a/platform/node/package-lock.json
+++ b/platform/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.4.1-pre.1",
+  "version": "5.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "5.4.1-pre.1",
+      "version": "5.4.1",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/platform/node/package.json
+++ b/platform/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "5.4.1-pre.1",
+  "version": "5.4.1",
   "description": "Renders map tiles with MapLibre Native",
   "keywords": [
     "maplibre",


### PR DESCRIPTION
Create a final release of node-v5.4.1 . 

The test publish worked as expected.