### PR TITLE
Fixed annotation delay in demo app for 120Hz devices

### DIFF
--- a/platform/ios/app/Info.plist
+++ b/platform/ios/app/Info.plist
@@ -67,5 +67,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CADisableMinimumFrameDurationOnPhone</key><true/>
 </dict>
 </plist>


### PR DESCRIPTION
Based on Apple documentation:
https://developer.apple.com/documentation/quartzcore/optimizing_promotion_refresh_rates_for_iphone_13_pro_and_ipad_pro?language=objc