### PR TITLE
Update Android Gradle Plugin across project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,20 +14,18 @@ updates:
       - dependency-name: 'codecov/codecov-action'
         versions: ['4']
     groups:
-      dependencies:
+      github-actions:
         patterns:
           - '*'
   - package-ecosystem: 'gradle'
     open-pull-requests-limit: 1
     directories:
-      - '/platform/android'
-      - '/render-test/android'
-      - '/test/android'
+      - '*'
     schedule:
       interval: 'weekly'
     ignore:
       - dependency-name: 'io.github.vvb2060.ndk:curl'
     groups:
-      dependencies:
+      gradle-deps:
         patterns:
           - '*'

--- a/render-test/android/gradle/libs.versions.toml
+++ b/render-test/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "8.5.2"
+androidGradlePlugin = "8.6.0"
 espresso = "3.6.1"
 
 [libraries]

--- a/test/android/build.gradle
+++ b/test/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.2'
+        classpath 'com.android.tools.build:gradle:8.6.0'
     }
 }
 


### PR DESCRIPTION
Somehow Dependabot is not updating some Gradle roots, so I am updating AGP manually with this PR.

Maybe the change to `.github/dependabot.yml` will fix it.