### PR TITLE
Fix raster masking bug

### DIFF
--- a/src/mbgl/gfx/index_vector.hpp
+++ b/src/mbgl/gfx/index_vector.hpp
@@ -123,6 +123,7 @@ public:
         static_assert(sizeof...(args) % groupSize == 0, "wrong buffer element count");
         assert(!released);
         util::ignore({(v.emplace_back(std::forward<Args>(args)), 0)...});
+        dirty = true;
     }
 };
 

--- a/src/mbgl/renderer/buckets/raster_bucket.cpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.cpp
@@ -113,6 +113,9 @@ void RasterBucket::setMask(TileMask&& mask_) {
         segment.vertexLength += vertexLength;
         segment.indexLength += 6;
     }
+
+    vertices.updateModified();
+    indices.updateModified();
 }
 
 bool RasterBucket::hasData() const {


### PR DESCRIPTION
Index buffer updates weren't setting the dirty flag, and the dirty flag wasn't updating the modified time.  The former problem existed before #2629.