### PR TITLE
Expose RENDERMODE_CONTINUOUSLY and RENDERMODE_WHEN_DIRTY

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
@@ -140,10 +140,10 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     // add accessibility support
     setContentDescription(context.getString(R.string.maplibre_mapActionDescription));
     setWillNotDraw(false);
-    initialiseDrawingSurface(options);
+    initializeDrawingSurface(options);
   }
 
-  private void initialiseMap() {
+  private void initializeMap() {
     Context context = getContext();
 
     // callback for focal point invalidation
@@ -305,7 +305,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
   }
 
-  private void initialiseDrawingSurface(MapLibreMapOptions options) {
+  private void initializeDrawingSurface(MapLibreMapOptions options) {
     mapRenderer = MapRenderer.create(options, getContext(), () -> MapView.this.onSurfaceCreated());
     renderView = mapRenderer.getView();
 
@@ -321,9 +321,9 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     post(new Runnable() {
       @Override
       public void run() {
-        // Initialise only when not destroyed and only once
+        // Initialize only when not destroyed and only once
         if (!destroyed && maplibreMap == null) {
-          MapView.this.initialiseMap();
+          MapView.this.initializeMap();
           maplibreMap.onStart();
         }
       }
@@ -463,6 +463,34 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     } else {
       throw new IllegalStateException("Calling MapView#setMaximumFps before mapRenderer is created.");
     }
+  }
+
+  /**
+   * Set the rendering refresh mode and wake up the render thread if it is sleeping.
+   *
+   * @param mode can be:
+   * {@link MapRenderer.RenderingRefreshMode#CONTINUOUS} or {@link MapRenderer.RenderingRefreshMode#WHEN_DIRTY}
+   * default is {@link MapRenderer.RenderingRefreshMode#WHEN_DIRTY}
+   */
+  public void setRenderingRefreshMode(MapRenderer.RenderingRefreshMode mode) {
+    if (mapRenderer != null) {
+      mapRenderer.setRenderingRefreshMode(mode);
+    } else {
+      throw new IllegalStateException("Calling MapView#setRenderingRefreshMode before mapRenderer is created.");
+    }
+  }
+
+  /**
+   * Get the rendering refresh mode
+   *
+   * @return one of the MapRenderer.RenderingRefreshMode modes
+   * @see #setRenderingRefreshMode
+   */
+  public MapRenderer.RenderingRefreshMode getRenderingRefreshMode() {
+    if (mapRenderer == null) {
+      throw new IllegalStateException("Calling MapView#getRenderingRefreshMode before mapRenderer is created.");
+    }
+    return mapRenderer.getRenderingRefreshMode();
   }
 
   /**

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/MapRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/MapRenderer.java
@@ -30,7 +30,24 @@ public abstract class MapRenderer implements MapRendererScheduler {
 
   private static final String TAG = "Mbgl-MapRenderer";
 
-  // Holds the pointer to the native peer after initialisation
+  /**
+   * Rendering presentation refresh mode.
+   */
+  public enum RenderingRefreshMode {
+    /**
+     * The map is rendered only in response to an event that affects the rendering of the map.
+     * This mode is preferred to improve battery life and overall system performance
+     */
+    WHEN_DIRTY,
+
+    /**
+     * The map is repeatedly re-rendered at the refresh rate of the display.
+     * This mode is preferred when benchmarking the rendering
+     */
+    CONTINUOUS,
+  }
+
+  // Holds the pointer to the native peer after initialization
   private long nativePtr = 0;
   private double expectedRenderTime = 0;
   private MapLibreMap.OnFpsChangedListener onFpsChangedListener;
@@ -57,7 +74,7 @@ public abstract class MapRenderer implements MapRendererScheduler {
   public MapRenderer(@NonNull Context context, String localIdeographFontFamily) {
     float pixelRatio = context.getResources().getDisplayMetrics().density;
 
-    // Initialise native peer
+    // Initialize native peer
     nativeInitialize(this, pixelRatio, localIdeographFontFamily);
   }
 
@@ -82,6 +99,10 @@ public abstract class MapRenderer implements MapRendererScheduler {
   public void onDestroy() {
     // Implement if needed
   }
+
+  public abstract void setRenderingRefreshMode(RenderingRefreshMode mode);
+
+  public abstract RenderingRefreshMode getRenderingRefreshMode();
 
   public void setOnFpsChangedListener(MapLibreMap.OnFpsChangedListener listener) {
     onFpsChangedListener = listener;

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/surfaceview/SurfaceViewMapRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/surfaceview/SurfaceViewMapRenderer.java
@@ -112,4 +112,20 @@ public class SurfaceViewMapRenderer extends MapRenderer {
   public void waitForEmpty() {
     surfaceView.waitForEmpty();
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setRenderingRefreshMode(MapRenderer.RenderingRefreshMode mode) {
+    surfaceView.setRenderingRefreshMode(mode);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public MapRenderer.RenderingRefreshMode getRenderingRefreshMode() {
+    return surfaceView.getRenderingRefreshMode();
+  }
 }

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/textureview/TextureViewMapRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/textureview/TextureViewMapRenderer.java
@@ -132,4 +132,22 @@ public class TextureViewMapRenderer extends MapRenderer {
   public boolean isTranslucentSurface() {
     return translucentSurface;
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setRenderingRefreshMode(MapRenderer.RenderingRefreshMode mode) {
+    throw new RuntimeException("setRenderingRefreshMode is not supported for TextureViewMapRenderer. "
+                                + "Use SurfaceViewMapRenderer to set the rendering refresh mode.");
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public MapRenderer.RenderingRefreshMode getRenderingRefreshMode() {
+    throw new RuntimeException("getRenderingRefreshMode is not supported for TextureViewMapRenderer. "
+                                + "Use SurfaceViewMapRenderer to set the rendering refresh mode.");
+  }
 }

--- a/platform/android/MapLibreAndroid/src/opengl/java/org/maplibre/android/maps/renderer/surfaceview/GLSurfaceViewMapRenderer.java
+++ b/platform/android/MapLibreAndroid/src/opengl/java/org/maplibre/android/maps/renderer/surfaceview/GLSurfaceViewMapRenderer.java
@@ -6,8 +6,7 @@ import androidx.annotation.NonNull;
 import org.maplibre.android.maps.renderer.egl.EGLConfigChooser;
 import org.maplibre.android.maps.renderer.egl.EGLContextFactory;
 import org.maplibre.android.maps.renderer.egl.EGLWindowSurfaceFactory;
-
-import static android.opengl.GLSurfaceView.RENDERMODE_WHEN_DIRTY;
+import org.maplibre.android.maps.renderer.MapRenderer;
 
 public class GLSurfaceViewMapRenderer extends SurfaceViewMapRenderer {
 
@@ -20,7 +19,7 @@ public class GLSurfaceViewMapRenderer extends SurfaceViewMapRenderer {
     surfaceView.setEGLWindowSurfaceFactory(new EGLWindowSurfaceFactory());
     surfaceView.setEGLConfigChooser(new EGLConfigChooser());
     surfaceView.setRenderer(this);
-    surfaceView.setRenderMode(RENDERMODE_WHEN_DIRTY);
+    surfaceView.setRenderingRefreshMode(MapRenderer.RenderingRefreshMode.WHEN_DIRTY);
     surfaceView.setPreserveEGLContextOnPause(true);
   }
 }

--- a/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/maps/MapLibreMapTest.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/maps/MapLibreMapTest.kt
@@ -19,6 +19,7 @@ import org.maplibre.android.annotations.PolylineOptions
 import org.maplibre.android.exceptions.InvalidMarkerPositionException
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.maps.MapLibreMap.InfoWindowAdapter
+import org.maplibre.android.maps.renderer.MapRenderer.RenderingRefreshMode
 import org.maplibre.android.testapp.R
 import org.maplibre.android.testapp.activity.EspressoTest
 
@@ -477,6 +478,19 @@ class MapLibreMapTest : EspressoTest() {
 
             maplibreMap.tileCacheEnabled = true
             assertTrue(maplibreMap.tileCacheEnabled == true)
+        }
+    }
+
+    @Test
+    fun testRenderingRefreshMode() {
+        validateTestSetup()
+        rule.runOnUiThread {
+            mapView = rule.getActivity().findViewById(R.id.mapView)
+            // Default RenderingRefreshMode is WHEN_DIRTY
+            assertTrue(mapView.getRenderingRefreshMode() == RenderingRefreshMode.WHEN_DIRTY)
+            // Switch to CONTINUOUS rendering
+            mapView.setRenderingRefreshMode(RenderingRefreshMode.CONTINUOUS)
+            assertTrue(mapView.getRenderingRefreshMode() == RenderingRefreshMode.CONTINUOUS)
         }
     }
 

--- a/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/maps/NativeMapViewTest.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/maps/NativeMapViewTest.kt
@@ -437,6 +437,8 @@ class NativeMapViewTest : AppCenter() {
 
     class DummyRenderer(context: Context) : MapRenderer(context, null) {
 
+        private var renderingRefreshMode: RenderingRefreshMode = RenderingRefreshMode.WHEN_DIRTY
+
         override fun requestRender() {
             // no-op
         }
@@ -451,6 +453,14 @@ class NativeMapViewTest : AppCenter() {
 
         override fun getView(): View? {
             return null;
+        }
+
+        override fun setRenderingRefreshMode(mode : RenderingRefreshMode) {
+            renderingRefreshMode = mode
+        }
+
+        override fun getRenderingRefreshMode() : RenderingRefreshMode{
+            return renderingRefreshMode
         }
     }
 }

--- a/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/testapp/activity/BaseTest.java
+++ b/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/testapp/activity/BaseTest.java
@@ -50,7 +50,7 @@ public abstract class BaseTest extends AppCenter {
   @Before
   @CallSuper
   public void beforeTest() {
-    initialiseMap();
+    initializeMap();
     holdTestRunnerForStyleLoad();
   }
 
@@ -71,15 +71,15 @@ public abstract class BaseTest extends AppCenter {
     if (!MapLibre.isConnected()) {
       Timber.e("Not connected to the internet while running test");
     }
-    assertNotNull("MapView isn't initialised", mapView);
-    assertNotNull("MapLibreMap isn't initialised", maplibreMap);
-    assertNotNull("Style isn't initialised", maplibreMap.getStyle());
+    assertNotNull("MapView isn't initialized", mapView);
+    assertNotNull("MapLibreMap isn't initialized", maplibreMap);
+    assertNotNull("Style isn't initialized", maplibreMap.getStyle());
     assertTrue("Style isn't fully loaded", maplibreMap.getStyle().isFullyLoaded());
   }
 
   protected abstract Class getActivityClass();
 
-  private void initialiseMap() {
+  private void initializeMap() {
     try {
       rule.runOnUiThread(() -> {
         mapView = rule.getActivity().findViewById(R.id.mapView);

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/maplayout/DebugModeActivity.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/maplayout/DebugModeActivity.kt
@@ -11,6 +11,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
 import org.maplibre.android.maps.*
 import org.maplibre.android.maps.MapLibreMap.OnCameraMoveListener
 import org.maplibre.android.maps.MapLibreMap.OnFpsChangedListener
+import org.maplibre.android.maps.renderer.MapRenderer
 import org.maplibre.android.style.layers.Layer
 import org.maplibre.android.style.layers.Property
 import org.maplibre.android.style.layers.PropertyFactory
@@ -29,6 +30,7 @@ open class DebugModeActivity : AppCompatActivity(), OnMapReadyCallback, OnFpsCha
     private var actionBarDrawerToggle: ActionBarDrawerToggle? = null
     private var currentStyleIndex = 0
     private var isReportFps = true
+    private var isContinuousRendering = false
     private var fpsView: TextView? = null
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -167,6 +169,13 @@ open class DebugModeActivity : AppCompatActivity(), OnMapReadyCallback, OnFpsCha
             mapView.setMaximumFps(30)
         } else if (itemId == R.id.menu_action_limit_to_60_fps) {
             mapView.setMaximumFps(60)
+        } else if (itemId == R.id.menu_action_toggle_continuous_rendering) {
+            isContinuousRendering = !isContinuousRendering
+            if (isContinuousRendering) {
+                mapView.setRenderingRefreshMode(MapRenderer.RenderingRefreshMode.CONTINUOUS)
+            } else {
+                mapView.setRenderingRefreshMode(MapRenderer.RenderingRefreshMode.WHEN_DIRTY)
+            }
         }
         return actionBarDrawerToggle!!.onOptionsItemSelected(item) || super.onOptionsItemSelected(
             item

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/menu/menu_debug.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/menu/menu_debug.xml
@@ -13,5 +13,9 @@
         android:id="@+id/menu_action_limit_to_60_fps"
         android:title="Limit FPS to 60"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/menu_action_toggle_continuous_rendering"
+        android:title="Toggle continuous rendering"
+        app:showAsAction="never" />
 
 </menu>


### PR DESCRIPTION
To save power, MapLibre only renders the map scene when it becomes dirty (an Android event causes the map to change). This behavior is desired in production. However, when testing performance and particularly trying to automatically detect stuttering, it is better to use continuous rendering.
`GLSurfaceView` already has the ability to switch between `RENDERMODE_CONTINUOUSLY` and `RENDERMODE_WHEN_DIRTY`. This PR simply exposes these options to MapLibre client apps.