### PR TITLE
Tiny iOS docs fixes

### DIFF
--- a/platform/ios/MapLibre.docc/GettingStarted.md
+++ b/platform/ios/MapLibre.docc/GettingStarted.md
@@ -45,7 +45,7 @@ struct SimpleMap: UIViewRepresentable {
 }
 ```
 
-You can use this view directly in a SwiftUI View hierarcy, for example:
+You can use this view directly in a SwiftUI View hierarchy, for example:
 
 ```swift
 struct MyApp: App {

--- a/platform/ios/MapLibre.docc/GettingStarted.md
+++ b/platform/ios/MapLibre.docc/GettingStarted.md
@@ -49,10 +49,9 @@ You can use this view directly in a SwiftUI View hierarcy, for example:
 
 ```swift
 struct MyApp: App {
-
     var body: some Scene {
         WindowGroup {
-            MapLibreMapView().edgesIgnoringSafeArea(.all)
+            SimpleMap().edgesIgnoringSafeArea(.all)
         }
     }
 }


### PR DESCRIPTION
I happened to notice two minor errors in the iOS docs:

- Spelling of "hierarchy".
- Example code that references a view uses a different name from what was defined in the code block above it.
