### PR TITLE
Allow selecting renderer on for Android release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -2,6 +2,15 @@ name: android-release
 
 on:
   workflow_dispatch:
+    inputs:
+      renderer:
+        description: 'Select renderering backend'
+        required: true
+        default: 'OpenGL'
+        type: choice
+        options:
+          - OpenGL
+          - Vulkan
 
 jobs:
   build:
@@ -14,6 +23,15 @@ jobs:
       BUILDTYPE: Release
       IS_LOCAL_DEVELOPMENT: false
     steps:
+      - name: Map renderer input
+        id: backend_lowercase
+        run: |
+          if [ "${{ github.event.inputs.renderer }}" = "OpenGL" ]; then
+            echo "backend_lowercase=drawable" >> "$GITHUB_ENV"
+          elif [ "${{ github.event.inputs.renderer }}" = "Vulkan" ]; then
+            echo "backend_lowercase=vulkan" >> "$GITHUB_ENV"
+          fi
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -97,6 +115,8 @@ jobs:
 
       - name: Build package
         run: make apackage
+        env:
+          RENDERER: ${{ env.backend_lowercase }}
 
       - name: Build release Test App
         run: |
@@ -119,6 +139,18 @@ jobs:
           echo version_tag="$( git describe --tags --match=android-v*.*.* --abbrev=0 )" >> "$GITHUB_OUTPUT"
         shell: bash
 
+      - name: Check if version is valid semver
+        id: check_version
+        run: |
+          version_tag="${{ steps.prepare_release.outputs.version_tag }}"
+          if [[ $version_tag =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Valid semver: $version_tag"
+            echo "prerelease=false" >> "$GITHUB_ENV"
+          else
+            echo "Invalid semver: $version_tag"
+            echo "prerelease=true" >> "$GITHUB_ENV"
+          fi
+
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -129,7 +161,7 @@ jobs:
           release_name: ${{steps.prepare_release.outputs.version_tag }}
           body_path: ${{ steps.prepare_release.outputs.release_notes }}
           draft: false
-          prerelease: false
+          prerelease: ${{ env.prerelease }}
 
       - name: Upload aar
         id: upload-release-asset
@@ -138,7 +170,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: platform/android/MapLibreAndroid/build/outputs/aar/MapLibreAndroid-drawable-release.aar
+          asset_path: platform/android/MapLibreAndroid/build/outputs/aar/MapLibreAndroid-${{ env.backend_lowercase }}-release.aar
           asset_name: MapLibreAndroid-release.aar
           asset_content_type: application/zip
 

--- a/platform/android/Makefile
+++ b/platform/android/Makefile
@@ -1,4 +1,5 @@
 export BUILDTYPE ?= Debug
+export RENDERER ?= drawable
 export IS_LOCAL_DEVELOPMENT ?= true
 export TARGET_BRANCH ?= main
 
@@ -11,6 +12,12 @@ else ifeq ($(BUILDTYPE), Sanitize)
 else ifeq ($(BUILDTYPE), Debug)
 else
   $(error BUILDTYPE must be Debug, Sanitize, Release or RelWithDebInfo)
+endif
+
+ifeq ($(RENDERER), drawable)
+else ifeq ($(RENDERER), vulkan)
+else
+  $(error RENDERER must be 'drawable' (OpenGL) or 'vulkan')
 endif
 
 buildtype := $(shell echo "$(BUILDTYPE)" | tr "[A-Z]" "[a-z]")
@@ -70,7 +77,7 @@ android-benchmark-$1:
 # Build SDK for for specified abi
 .PHONY: android-lib-$1
 android-lib-$1:
-	$(MLN_ANDROID_GRADLE) -Pmaplibre.abis=$2 :MapLibreAndroid:assemble$(BUILDTYPE)
+	$(MLN_ANDROID_GRADLE) -Pmaplibre.abis=$2 :MapLibreAndroid:assemble$(RENDERER)$(BUILDTYPE)
 
 # Build test app and SDK for for specified abi
 .PHONY: android-$1
@@ -217,11 +224,12 @@ run-android-unit-test-%:
 
 # Builds a release package and .tar.gz with debug symbols of the Android SDK
 .PHONY: apackage
-apackage: 
+apackage:
+	echo "Building for $(RENDERER)"
 	make android-lib-arm-v7 && make android-lib-arm-v8 && make android-lib-x86 && make android-lib-x86-64
-	$(MLN_ANDROID_GRADLE) -Pmaplibre.abis=all assembleDrawable$(BUILDTYPE)
+	$(MLN_ANDROID_GRADLE) -Pmaplibre.abis=all assemble$(RENDERER)$(BUILDTYPE)
 	mkdir -p build
-	tar -czvf build/debug-symbols.tar.gz -C MapLibreAndroid/build/intermediates/library_jni/drawableRelease/copyDrawableReleaseJniLibsProjectOnly/jni .
+	tar -czvf build/debug-symbols.tar.gz -C MapLibreAndroid/build/intermediates/library_jni/*/*JniLibsProjectOnly/jni .
 
 # Build test app instrumentation tests apk and test app apk for all abi's
 .PHONY: android-ui-test


### PR DESCRIPTION
- Allow selecting backend when making a release for Android.
- Also fixes https://github.com/maplibre/maplibre-native/issues/2588 where pre-releases are not marked as such on GitHub.