### PR TITLE
Make sure swapBehavior is NoFlush

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.hpp
@@ -143,12 +143,13 @@ private:
     std::shared_ptr<UpdateParameters> updateParameters;
     std::mutex updateMutex;
 
-    bool framebufferSizeChanged = false;
     std::atomic<bool> destroyed{false};
-    bool swapBehaviorFlush{true};
 
     std::unique_ptr<SnapshotCallback> snapshotCallback;
     mapbox::base::WeakPtrFactory<Scheduler> weakFactory{this};
+
+    bool framebufferSizeChanged = false;
+    bool swapBehaviorFlush = false;
 };
 
 } // namespace android


### PR DESCRIPTION
There's a performance regression on Android with OpenGL due to calling `glFinish` every frame. This is because the new variable  `MapRenderer::swapBehaviorFlush` is set to `true` by default. This PR simply sets it to `false` to get the previous behavior which doesn't call `glFinish` unless the client explicitly change the behavior by calling `setSwapBehavior`