### PR TITLE
fix broken links, more code highlighting, small phrasing changes

### DIFF
--- a/docs/mdbook/src/android/annotation-guide.md
+++ b/docs/mdbook/src/android/annotation-guide.md
@@ -74,15 +74,15 @@ Then add markers to the map with GeoJSON:
   <img src="https://github.com/maplibre/maplibre-native/assets/19887090/00446249-9b19-4a48-8a46-00d4c5a2f981" alt="Screenshot with the map in demotile style">
 </div>
 
-[Marker]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.annotations/-marker/index.html
+[Marker]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.annotations/-marker/index.html
 [provided image]: https://github.com/maplibre/maplibre-native/blob/main/platform/android/MapLibreAndroid/src/main/res/drawable-xxxhdpi/maplibre_marker_icon_default.png
-[Polyline]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.annotations/-polyline/index.html
-[Polygon]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.annotations/-polygon/index.html
+[Polyline]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.annotations/-polyline/index.html
+[Polygon]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.annotations/-polygon/index.html
 [marker image]: https://raw.githubusercontent.com/maplibre/maplibre-native/main/test/fixtures/sprites/default_marker.png
-[IconFactory]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.annotations/-icon-factory/index.html
-[Icon]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.annotations/-icon/index.html
+[IconFactory]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.annotations/-icon-factory/index.html
+[Icon]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.annotations/-icon/index.html
 [Quickstart]: ./getting-started-guide.md
 [mvn]: https://mvnrepository.com/artifact/org.maplibre.gl/android-plugin-annotation-v9
 [Android Developer Documentation]: https://developer.android.com/topic/libraries/architecture/coroutines
-[MarkerOptions]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.annotations/-marker-options/index.html
+[MarkerOptions]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.annotations/-marker-options/index.html
 [Test App]: https://github.com/maplibre/maplibre-native/tree/main/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/annotation/JsonApiActivity.kt

--- a/docs/mdbook/src/android/annotation-guide.md
+++ b/docs/mdbook/src/android/annotation-guide.md
@@ -26,14 +26,13 @@ Then add markers to the map with GeoJSON:
 1. In your module Gradle file (usually `<project>/<app-module>/build.gradle`), add
    `okhttp` to simplify code for making HTTP requests.
 
-
-    ```gradle
-    dependencies {
-        ...
-        implementation 'com.squareup.okhttp3:okhttp:4.10.0'
-        ...
-    }
-    ```
+ ```gradle
+ dependencies {
+     ...
+     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+     ...
+ }
+ ```
 
 2. Sync your Android project the with Gradle files.
 
@@ -69,7 +68,7 @@ Then add markers to the map with GeoJSON:
 {{#include ../../../../platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/annotation/JsonApiActivity.kt:addMarkers}}
 ```
 
-7. Here is the final result. For the full contents of `JsonApiActivity`, please visit source code of [Test APP]
+7. Here is the final result. For the full contents of `JsonApiActivity`, please visit source code of our [Test App].
 
 <div style="align: center">
   <img src="https://github.com/maplibre/maplibre-native/assets/19887090/00446249-9b19-4a48-8a46-00d4c5a2f981" alt="Screenshot with the map in demotile style">

--- a/docs/mdbook/src/android/location-component-guide.md
+++ b/docs/mdbook/src/android/location-component-guide.md
@@ -87,14 +87,14 @@ val locationComponentOptions =
       They provide the right context to your users at the correct time.  
 [^2]: Menu items to manage user location icon are used in the [Test App], too.  
 
-[LocationComponent]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.location/-location-component/index.html
+[LocationComponent]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.location/-location-component/index.html
 [Android Developer Documentation]: https://developer.android.com/training/location/permissions
-[onMapReadyCallback]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.maps/-on-map-ready-callback/index.html
-[PermissionManager]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.location.permissions/-permissions-manager/index.html
-[LocationComponentOptions]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.location/-location-component-options/index.html
+[onMapReadyCallback]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.maps/-on-map-ready-callback/index.html
+[PermissionManager]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.location.permissions/-permissions-manager/index.html
+[LocationComponentOptions]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.location/-location-component-options/index.html
 [demotiles]: https://demotiles.maplibre.org/style.json
 [predefined styles]: https://github.com/maplibre/maplibre-native/tree/main/src/mbgl/util/tile_server_options.cpp
-[LocationComponentActivationOptions]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.location/-location-component-activation-options/index.html
-[LocationEngine]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.location.engine/-location-engine/index.html
+[LocationComponentActivationOptions]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.location/-location-component-activation-options/index.html
+[LocationEngine]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.location.engine/-location-engine/index.html
 [Test APP]: https://github.com/maplibre/maplibre-native/tree/main/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/location/BasicLocationPulsingCircleActivity.kt
-[camera modes]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.location.modes/-camera-mode/index.html
+[camera modes]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.location.modes/-camera-mode/index.html

--- a/docs/mdbook/src/android/location-component-guide.md
+++ b/docs/mdbook/src/android/location-component-guide.md
@@ -78,14 +78,14 @@ val locationComponentOptions =
        .build()
 ```
 
-7. Here is the final results with different color configurations. For the complete content of this demo, please refer to the source code of the [Test APP] [^2].
+7. Here is the final results with different color configurations. For the complete content of this demo, please refer to the source code of the [Test App] [^2].
 
    ![result](https://github.com/maplibre/maplibre-native/assets/19887090/03dfc87b-111b-4dd0-b4a3-d89e30ed6b63)
 
 
 [^1]: A variety of [camera modes] determine how the camera will track the user location.  
       They provide the right context to your users at the correct time.  
-[^2]: In [Test APP], it also uses menu items to manage user location icon.  
+[^2]: Menu items to manage user location icon are used in the [Test App], too.  
 
 [LocationComponent]: https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20for%20-android/com.mapbox.mapboxsdk.location/-location-component/index.html
 [Android Developer Documentation]: https://developer.android.com/training/location/permissions

--- a/docs/mdbook/src/introduction.md
+++ b/docs/mdbook/src/introduction.md
@@ -1,5 +1,5 @@
 # Introduction
 
 *[MapLibre Native](https://github.com/maplibre/maplibre-native)* is a community led fork of *Mapbox GL Native*. It's a C++ library that powers 
-vector maps in native applications on multiple platforms by taking stylesheets that conform to the *MapLibre Style Specification,* a fork of the 
-MapLibre Style Spec. Since it is derived from Mapbox's original work it also uses *Mapbox Vector Tile Specification* as its choice of vector tile format.
+vector maps in native applications on multiple platforms by taking stylesheets that conform to the *[MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/)*, a fork of the 
+Mapbox Style Spec. Since it is derived from Mapbox's original work it also uses *Mapbox Vector Tile Specification* as its choice of vector tile format.

--- a/docs/mdbook/src/profiling/tracy-profiling.md
+++ b/docs/mdbook/src/profiling/tracy-profiling.md
@@ -28,7 +28,7 @@ The file `include/mbgl/util/instrumentation.hpp` defines the following instrumen
 ##### `MLN_TRACE_ZONE(label)`
 The macro records the timestamps at the start and end of the code scope. The parameter label is a user defined name for the zone. Example:
 
-~~~
+~~~cpp
 // code is not instrumented
 {
   MLN_TRACE_ZONE(EmptyZone) // Records from here until the end of the scope
@@ -39,7 +39,7 @@ The macro records the timestamps at the start and end of the code scope. The par
 
 ##### `MLN_TRACE_FUNC()`
 The macro is meant to be placed at the start of a function and expands to:
-~~~
+~~~cpp
 MLN_TRACE_ZONE(__FUNCTION__)
 ~~~
 
@@ -90,7 +90,7 @@ Make sure you generate the MapLibre project with the option `MLN_USE_TRACY` enab
 As an example, the glfw sample is used.
 
 With CMake, in MapLibre repository root do
-~~~
+~~~bash
 # generate project
 cmake -B build -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMLN_WITH_CLANG_TIDY=OFF -DMLN_WITH_COVERAGE=OFF -DMLN_DRAWABLE_RENDERER=ON -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DMLN_USE_TRACY=ON
 # build
@@ -99,7 +99,7 @@ cmake --build build --target mbgl-glfw -j 8
 ./build/platform/glfw/mbgl-glfw --style https://raw.githubusercontent.com/maplibre/demotiles/gh-pages/style.json --benchmark
 ~~~
 with Bazel
-~~~
+~~~bash
 # build and run
 bazel run //platform/glfw:glfw_app -- --style https://raw.githubusercontent.com/maplibre/demotiles/gh-pages/style.json --benchmark
 ~~~
@@ -108,16 +108,13 @@ In the Tracy Profiler hit the connect button (or select the glfw application fro
 
 #### Connecting the profiler to a MapLibre Android application
 The Android application communicates instrumentation data to the profiler (Tracy server) on the network using port 8086 by default. You can expose the port to the profiler using Android Debug Bridge by running the command:
-~~~
+~~~bash
 adb forward tcp:8086 tcp:8086
 ~~~
 
 #### More information and advanced usage in Tracy
 
-[Tracy Github page](https://github.com/wolfpld/tracy/)
-
-[Tracy user guide](https://github.com/wolfpld/tracy/releases/latest/download/tracy.pdf)
-
-[Tracy demo on Youtube](https://www.youtube.com/watch?v=fB5B46lbapc)
-
-[Tracy CppCon presentation on Youtube](https://www.youtube.com/watch?v=ghXk3Bk5F2U&t=37s)
+- [Tracy Github page](https://github.com/wolfpld/tracy/)
+- [Tracy user guide](https://github.com/wolfpld/tracy/releases/latest/download/tracy.pdf)
+- [Tracy demo on Youtube](https://www.youtube.com/watch?v=fB5B46lbapc)
+- [Tracy CppCon presentation on Youtube](https://www.youtube.com/watch?v=ghXk3Bk5F2U&t=37s)


### PR DESCRIPTION
A small documentation-only pull request.

#### Summary
- fix broken links in mdbook to the android API docs
- some phrasing changes, e.g. *"a fork of the MapLibre Style Spec"* to *"a fork of the Mapbox Style Spec"*
- some formatting and code highlighting