### PR TITLE
Address some flaky tests

### DIFF
--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -1808,11 +1808,10 @@ TEST(Map, ObserveTileLifecycle) {
                 case TileOperation::StartParse: {
                     // Parsing is expected to be started early during the request process by a call to `setLayers`
                     EXPECT_THAT(stage,
-                                testing::AnyOf(
-                                    TileOperation::RequestedFromCache,
-                                    TileOperation::RequestedFromNetwork,
-                                    TileOperation::LoadFromCache,
-                                    TileOperation::LoadFromNetwork));
+                                testing::AnyOf(TileOperation::RequestedFromCache,
+                                               TileOperation::RequestedFromNetwork,
+                                               TileOperation::LoadFromCache,
+                                               TileOperation::LoadFromNetwork));
                     EXPECT_FALSE(parsing); // We must not already be parsing when seeing this marker.
                     stage = TileOperation::StartParse;
                     parsing = true;

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -1808,7 +1808,11 @@ TEST(Map, ObserveTileLifecycle) {
                 case TileOperation::StartParse: {
                     // Parsing is expected to be started early during the request process by a call to `setLayers`
                     EXPECT_THAT(stage,
-                                testing::AnyOf(TileOperation::RequestedFromCache, TileOperation::RequestedFromNetwork));
+                                testing::AnyOf(
+                                    TileOperation::RequestedFromCache,
+                                    TileOperation::RequestedFromNetwork,
+                                    TileOperation::LoadFromCache,
+                                    TileOperation::LoadFromNetwork));
                     EXPECT_FALSE(parsing); // We must not already be parsing when seeing this marker.
                     stage = TileOperation::StartParse;
                     parsing = true;

--- a/test/util/run_loop.test.cpp
+++ b/test/util/run_loop.test.cpp
@@ -82,6 +82,7 @@ TEST(RunLoop, PlatformIntegration) {
     loop.setPlatformCallback([&] {
         EXPECT_NE(mainThread, std::this_thread::get_id());
         count1++;
+        std::unique_lock<std::mutex> lock(mutex);
         cv.notify_one();
     });
 
@@ -100,6 +101,7 @@ TEST(RunLoop, PlatformIntegration) {
     while (count2 < 200000) {
         std::unique_lock<std::mutex> lock(mutex);
         cv.wait(lock);
+        lock.unlock();
         loop.runOnce();
     }
 


### PR DESCRIPTION
This PR is the result of running the unit test suite a few thousand times. These two tests are the main ones I saw that act flaky and I've addressed them here.

Somewhat interesting (not addressed here), any test using the offline database cannot be run concurrently with another process also attempting to use the database as the file is locked for mutation by the other process. Not sure if we want more graceful means of handling that in the future.

`Map. ObserveTileLifecycle`: Entry to `StartParse` is possible from both request and loading routines.
`RunLoop.PlatformIntegration`: Possible stall waiting on condition variable when OS scheduler is slow/host is overloaded