### PR TITLE
Allow building the legacy renderer for Android

### DIFF
--- a/platform/android/Makefile
+++ b/platform/android/Makefile
@@ -15,9 +15,10 @@ else
 endif
 
 ifeq ($(RENDERER), drawable)
+else ifeq ($(RENDERER), legacy)
 else ifeq ($(RENDERER), vulkan)
 else
-  $(error RENDERER must be 'drawable' (OpenGL) or 'vulkan')
+  $(error RENDERER must be 'legacy' (OpenGL), 'drawable' (OpenGL) or 'vulkan')
 endif
 
 buildtype := $(shell echo "$(BUILDTYPE)" | tr "[A-Z]" "[a-z]")


### PR DESCRIPTION
Suppress the build error when legacy renderer is selected on Android. The legacy renderer is still useful because it is stable when running on an Emulator. The legacy renderer can be fully removed when [2791](https://github.com/maplibre/maplibre-native/issues/2791) is fixed.