### PR TITLE
Try using MoltenVK on macOS

### DIFF
--- a/include/mbgl/vulkan/renderer_backend.hpp
+++ b/include/mbgl/vulkan/renderer_backend.hpp
@@ -3,13 +3,16 @@
 #include <mbgl/gfx/renderer_backend.hpp>
 #include <mbgl/gfx/context.hpp>
 
+#define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
+
 #ifdef _WIN32
 #define VK_USE_PLATFORM_WIN32_KHR
 #elif defined(__ANDROID__)
 #define VK_USE_PLATFORM_ANDROID_KHR
+#elif defined(__APPLE__)
+#include <MoltenVK/mvk_vulkan.h>
 #endif
 
-#define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
 #include <vulkan/vulkan.hpp>
 
 #define VMA_VULKAN_VERSION 1000000

--- a/include/mbgl/vulkan/renderer_backend.hpp
+++ b/include/mbgl/vulkan/renderer_backend.hpp
@@ -9,8 +9,6 @@
 #define VK_USE_PLATFORM_WIN32_KHR
 #elif defined(__ANDROID__)
 #define VK_USE_PLATFORM_ANDROID_KHR
-#elif defined(__APPLE__)
-#include <MoltenVK/mvk_vulkan.h>
 #endif
 
 #include <vulkan/vulkan.hpp>

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -215,7 +215,7 @@ GLFWView::GLFWView(bool fullscreen_,
     bool capFrameRate = !benchmark; // disable VSync in benchmark mode
     backend = GLFWBackend::Create(window, capFrameRate);
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(MLN_RENDER_BACKEND_VULKAN)
     int fbW, fbH;
     glfwGetFramebufferSize(window, &fbW, &fbH);
     backend->setSize({static_cast<uint32_t>(fbW), static_cast<uint32_t>(fbH)});

--- a/platform/glfw/glfw_vulkan_backend.cpp
+++ b/platform/glfw/glfw_vulkan_backend.cpp
@@ -16,13 +16,7 @@ public:
     explicit GLFWVulkanRenderableResource(GLFWVulkanBackend& backend_)
         : SurfaceRenderableResource(backend_) {}
 
-    std::vector<const char*> getDeviceExtensions() override {
-        return {VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-#ifdef __APPLE__ // https://github.com/KhronosGroup/MoltenVK/issues/1626#issuecomment-1166309712
-                VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME
-#endif
-        };
-    }
+    std::vector<const char*> getDeviceExtensions() override { return {VK_KHR_SWAPCHAIN_EXTENSION_NAME}; }
 
     void createPlatformSurface() override {
         auto& glfwBackend = static_cast<GLFWVulkanBackend&>(backend);

--- a/platform/glfw/glfw_vulkan_backend.cpp
+++ b/platform/glfw/glfw_vulkan_backend.cpp
@@ -16,7 +16,13 @@ public:
     explicit GLFWVulkanRenderableResource(GLFWVulkanBackend& backend_)
         : SurfaceRenderableResource(backend_) {}
 
-    std::vector<const char*> getDeviceExtensions() override { return {VK_KHR_SWAPCHAIN_EXTENSION_NAME}; }
+    std::vector<const char*> getDeviceExtensions() override {
+        return {VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+#ifdef __APPLE__ // https://github.com/KhronosGroup/MoltenVK/issues/1626#issuecomment-1166309712
+                VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME
+#endif
+        };
+    }
 
     void createPlatformSurface() override {
         auto& glfwBackend = static_cast<GLFWVulkanBackend&>(backend);

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -41,17 +41,22 @@ if(MLN_WITH_METAL)
 endif()
 
 if(MLN_WITH_VULKAN)
-    if(NOT VULKAN_SDK)
-        message(FATAL_ERROR "VULKAN_SDK variable is not set. Please set it when configuring Vulkan on macOS.")
-    endif()
+    find_package(Vulkan REQUIRED)
 
     target_sources(
         mbgl-core
         PRIVATE
             ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/vulkan/headless_backend.cpp
     )
-    include_directories("${VULKAN_SDK}/include")
-    set(CMAKE_INSTALL_RPATH "${VULKAN_SDK}/lib")
+
+    if(Vulkan_FOUND)
+        get_filename_component(Vulkan_LIBRARY_DIR ${Vulkan_LIBRARY} DIRECTORY)
+        set(CMAKE_INSTALL_RPATH ${Vulkan_LIBRARY_DIR})
+    else()
+        set(CMAKE_INSTALL_RPATH "/usr/local/lib/")
+        message(STATUS "Vulkan SDK not found! Using default homebrew install path")
+    endif()
+
     set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 endif()
 

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "14.3")
 
 # Override default CMake NATIVE_ARCH_ACTUAL
 # https://gitlab.kitware.com/cmake/cmake/-/issues/20893
@@ -38,6 +38,21 @@ if(MLN_WITH_METAL)
         PRIVATE
             ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/mtl/headless_backend.cpp
     )
+endif()
+
+if(MLN_WITH_VULKAN)
+    if(NOT VULKAN_SDK)
+        message(FATAL_ERROR "VULKAN_SDK variable is not set. Please set it when configuring Vulkan on macOS.")
+    endif()
+
+    target_sources(
+        mbgl-core
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/vulkan/headless_backend.cpp
+    )
+    include_directories("${VULKAN_SDK}/include")
+    set(CMAKE_INSTALL_RPATH "${VULKAN_SDK}/lib")
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 endif()
 
 target_sources(

--- a/src/mbgl/vulkan/renderer_backend.cpp
+++ b/src/mbgl/vulkan/renderer_backend.cpp
@@ -103,14 +103,20 @@ std::vector<const char*> RendererBackend::getLayers() {
 
 std::vector<const char*> RendererBackend::getInstanceExtensions() {
     return {
-#ifdef __APPLE__ // https://github.com/KhronosGroup/MoltenVK/blob/main/Docs/MoltenVK_Runtime_UserGuide.md#install
-        "VK_KHR_portability_subset", "VK_KHR_get_physical_device_properties2", "VK_KHR_portability_enumeration"
+#ifdef __APPLE__
+    "VK_KHR_portability_enumeration"
 #endif
     };
 }
 
 std::vector<const char*> RendererBackend::getDeviceExtensions() {
-    return getDefaultRenderable().getResource<SurfaceRenderableResource>().getDeviceExtensions();
+    auto extensions = getDefaultRenderable().getResource<SurfaceRenderableResource>().getDeviceExtensions();
+
+#ifdef __APPLE__
+    extensions.push_back("VK_KHR_portability_subset");
+#endif
+
+    return extensions;
 }
 
 std::vector<const char*> RendererBackend::getDebugExtensions() {
@@ -327,8 +333,14 @@ void RendererBackend::initInstance() {
 
     // Vulkan 1.1 on Android is supported on 71% of devices (compared to 1.3 with 6%) as of April 23 2024
     // https://vulkan.gpuinfo.org/
+#ifdef __APPLE__
+    vk::InstanceCreateFlags instanceFlags = vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
+#else
+    vk::InstanceCreateFlags instanceFlags = {};
+#endif
+
     vk::ApplicationInfo appInfo("maplibre-native", 1, "maplibre-native", 1, VK_API_VERSION_1_0);
-    vk::InstanceCreateInfo createInfo(vk::InstanceCreateFlags(), &appInfo);
+    vk::InstanceCreateInfo createInfo(instanceFlags, &appInfo);
 
     const auto& layers = getLayers();
 
@@ -505,7 +517,7 @@ void RendererBackend::initDevice() {
     // TODO
     // - WideLines disabled on Android (20.77% device coverage https://vulkan.gpuinfo.org/listfeaturescore10.php)
     // - Rework this to a dynamic toggle based on MLN_TRIANGULATE_FILL_OUTLINES/MLN_ENABLE_POLYLINE_DRAWABLES
-#if !defined(__ANDROID__) && !defined(__apple__)
+#if !defined(__ANDROID__) && !defined(__APPLE__)
     if (supportedDeviceFeatures.wideLines) {
         physicalDeviceFeatures.setWideLines(true);
 

--- a/src/mbgl/vulkan/renderer_backend.cpp
+++ b/src/mbgl/vulkan/renderer_backend.cpp
@@ -104,7 +104,7 @@ std::vector<const char*> RendererBackend::getLayers() {
 std::vector<const char*> RendererBackend::getInstanceExtensions() {
     return {
 #ifdef __APPLE__
-    "VK_KHR_portability_enumeration"
+        "VK_KHR_portability_enumeration"
 #endif
     };
 }

--- a/src/mbgl/vulkan/renderer_backend.cpp
+++ b/src/mbgl/vulkan/renderer_backend.cpp
@@ -102,7 +102,11 @@ std::vector<const char*> RendererBackend::getLayers() {
 }
 
 std::vector<const char*> RendererBackend::getInstanceExtensions() {
-    return {};
+    return {
+#ifdef __APPLE__ // https://github.com/KhronosGroup/MoltenVK/blob/main/Docs/MoltenVK_Runtime_UserGuide.md#install
+        "VK_KHR_portability_subset", "VK_KHR_get_physical_device_properties2", "VK_KHR_portability_enumeration"
+#endif
+    };
 }
 
 std::vector<const char*> RendererBackend::getDeviceExtensions() {


### PR DESCRIPTION
```
cmake -D MLN_WITH_VULKAN=ON -DMLN_DRAWABLE_RENDERER=ON -DCMAKE_BUILD_TYPE=Debug -B build -S . -GNinja -DVULKAN_SDK=/Users/bart/VulkanSDK/1.3.290.0/macOS
cmake --build build --target mbgl-glfw
```

Does not quite work yet:

```
build/platform/glfw/mbgl-glfw         
2024-09-17 16:16:16.142 mbgl-glfw[35844:887089] [ERROR] {}[Render]: Vulkan extensions not found
libc++abi: terminating due to uncaught exception of type vk::IncompatibleDriverError
zsh: abort      build/platform/glfw/mbgl-glfw
```