### PR TITLE
Enable crash mitigation when running OpenGL in the Android emulator

### DIFF
--- a/include/mbgl/renderer/renderer.hpp
+++ b/include/mbgl/renderer/renderer.hpp
@@ -113,6 +113,10 @@ public:
     void reduceMemoryUse();
     void clearData();
 
+#if MLN_RENDER_BACKEND_OPENGL
+    void enableAndroidEmulatorGoldfishMitigation(bool enable);
+#endif
+
 private:
     class Impl;
     std::unique_ptr<Impl> impl;

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -31,7 +31,7 @@ bool inEmulator() {
     return androidSysProp("ro.kernel.qemu") == "1" || androidSysProp("ro.boot.qemu") == "1" ||
            androidSysProp("ro.hardware.egl") == "emulation";
 }
-}
+} // namespace
 #endif
 
 namespace mbgl {

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -13,6 +13,27 @@
 #include "android_renderer_backend.hpp"
 #include "map_renderer_runnable.hpp"
 
+#if MLN_RENDER_BACKEND_OPENGL
+#include <sys/system_properties.h>
+
+namespace {
+std::string androidSysProp(const char* key) {
+    assert(strlen(key) < PROP_NAME_MAX);
+    if (__system_property_find(key) == nullptr) {
+        return "";
+    }
+    char prop[PROP_VALUE_MAX + 1];
+    __system_property_get(key, prop);
+    return prop;
+}
+
+bool inEmulator() {
+    return androidSysProp("ro.kernel.qemu") == "1" || androidSysProp("ro.boot.qemu") == "1" ||
+           androidSysProp("ro.hardware.egl") == "emulation";
+}
+}
+#endif
+
 namespace mbgl {
 namespace android {
 
@@ -231,6 +252,14 @@ void MapRenderer::onSurfaceCreated(JNIEnv& env, const jni::Object<AndroidSurface
     backend = AndroidRendererBackend::Create(window.get());
     renderer = std::make_unique<Renderer>(backend->getImpl(), pixelRatio, localIdeographFontFamily);
     rendererRef = std::make_unique<ActorRef<Renderer>>(*renderer, mailboxData.getMailbox());
+
+#if MLN_RENDER_BACKEND_OPENGL
+    // If we're running the emulator with the OpenGL backend, we're going to crash eventually,
+    // unless we enable this mitigation.
+    if (inEmulator()) {
+        renderer->enableAndroidEmulatorGoldfishMitigation(true);
+    }
+#endif
 
     backend->setSwapBehavior(swapBehaviorFlush ? gfx::Renderable::SwapBehaviour::Flush
                                                : gfx::Renderable::SwapBehaviour::NoFlush);

--- a/src/mbgl/renderer/layers/render_heatmap_layer.hpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.hpp
@@ -33,6 +33,10 @@ public:
                 const std::shared_ptr<UpdateParameters>&,
                 const RenderTree&,
                 UniqueChangeRequestVec&) override;
+
+    /// Remove all the drawables for tiles
+    /// @return The number of drawables actually removed.
+    std::size_t removeAllDrawables() override;
 #endif
 
 private:
@@ -63,10 +67,6 @@ private:
     /// Remove all drawables for the tile from the layer group
     /// @return The number of drawables actually removed.
     std::size_t removeTile(RenderPass, const OverscaledTileID&) override;
-
-    /// Remove all the drawables for tiles
-    /// @return The number of drawables actually removed.
-    std::size_t removeAllDrawables() override;
 #endif
 
     // Paint properties

--- a/src/mbgl/renderer/layers/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.hpp
@@ -98,6 +98,9 @@ public:
                 const std::shared_ptr<UpdateParameters>&,
                 const RenderTree&,
                 UniqueChangeRequestVec&) override;
+
+    /// Remove all the drawables for tiles
+    std::size_t removeAllDrawables() override;
 #endif // MLN_DRAWABLE_RENDERER
 
 protected:
@@ -119,9 +122,6 @@ protected:
 
     /// Remove all drawables for the tile from the layer group
     std::size_t removeTile(RenderPass, const OverscaledTileID&) override;
-
-    /// Remove all the drawables for tiles
-    std::size_t removeAllDrawables() override;
 #endif // MLN_DRAWABLE_RENDERER
 
 private:

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -191,6 +191,9 @@ public:
 
     /// Returns the current renderability mode of the layer
     bool isLayerRenderable() const noexcept { return isRenderable; }
+
+    /// Remove all the drawables for tiles
+    virtual std::size_t removeAllDrawables();
 #endif
 
     using Dependency = style::expression::Dependency;
@@ -246,9 +249,6 @@ protected:
     /// Remove all drawables for the tile from the layer group
     /// @return The number of drawables actually removed.
     virtual std::size_t removeTile(RenderPass, const OverscaledTileID&);
-
-    /// Remove all the drawables for tiles
-    virtual std::size_t removeAllDrawables();
 
     /// Update `renderTileIDs` from `renderTiles`
     void updateRenderTileIDs();

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -993,6 +993,13 @@ void RenderOrchestrator::updateLayers(gfx::ShaderRegistry& shaders,
 
     for (const auto& item : items) {
         auto& renderLayer = item.layer.get();
+#if MLN_RENDER_BACKEND_OPENGL
+    // Android Emulator: Goldfish is *very* broken. This will prevent a crash
+    // inside the GL translation layer at the cost of emulator performance.
+    if (androidGoldfishMitigationEnabled) {
+        renderLayer.removeAllDrawables();
+    }
+#endif
         renderLayer.update(shaders, context, state, updateParameters, renderTree, changes);
     }
     addChanges(changes);

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -994,11 +994,11 @@ void RenderOrchestrator::updateLayers(gfx::ShaderRegistry& shaders,
     for (const auto& item : items) {
         auto& renderLayer = item.layer.get();
 #if MLN_RENDER_BACKEND_OPENGL
-    // Android Emulator: Goldfish is *very* broken. This will prevent a crash
-    // inside the GL translation layer at the cost of emulator performance.
-    if (androidGoldfishMitigationEnabled) {
-        renderLayer.removeAllDrawables();
-    }
+        // Android Emulator: Goldfish is *very* broken. This will prevent a crash
+        // inside the GL translation layer at the cost of emulator performance.
+        if (androidGoldfishMitigationEnabled) {
+            renderLayer.removeAllDrawables();
+        }
 #endif
         renderLayer.update(shaders, context, state, updateParameters, renderTree, changes);
     }

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -62,9 +62,7 @@ public:
     ~RenderOrchestrator() override;
 
 #if MLN_RENDER_BACKEND_OPENGL
-    void enableAndroidEmulatorGoldfishMitigation(bool enable) {
-        androidGoldfishMitigationEnabled = enable;
-    }
+    void enableAndroidEmulatorGoldfishMitigation(bool enable) { androidGoldfishMitigationEnabled = enable; }
 #endif
 
     void markContextLost() { contextLost = true; };

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -61,6 +61,12 @@ public:
                        const std::optional<std::string>& localFontFamily_);
     ~RenderOrchestrator() override;
 
+#if MLN_RENDER_BACKEND_OPENGL
+    void enableAndroidEmulatorGoldfishMitigation(bool enable) {
+        androidGoldfishMitigationEnabled = enable;
+    }
+#endif
+
     void markContextLost() { contextLost = true; };
     // TODO: Introduce RenderOrchestratorObserver.
     void setObserver(RendererObserver*);
@@ -211,6 +217,10 @@ private:
     bool contextLost = false;
     bool placedSymbolDataCollected = false;
     bool tileCacheEnabled = true;
+
+#if MLN_RENDER_BACKEND_OPENGL
+    bool androidGoldfishMitigationEnabled{false};
+#endif
 
     // Vectors with reserved capacity of layerImpls->size() to avoid
     // reallocation on each frame.

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -152,4 +152,10 @@ void Renderer::clearData() {
     impl->orchestrator.clearData();
 }
 
+#if MLN_RENDER_BACKEND_OPENGL
+    void Renderer::enableAndroidEmulatorGoldfishMitigation(bool enable) {
+        impl->orchestrator.enableAndroidEmulatorGoldfishMitigation(enable);
+    }
+#endif
+
 } // namespace mbgl

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -153,9 +153,9 @@ void Renderer::clearData() {
 }
 
 #if MLN_RENDER_BACKEND_OPENGL
-    void Renderer::enableAndroidEmulatorGoldfishMitigation(bool enable) {
-        impl->orchestrator.enableAndroidEmulatorGoldfishMitigation(enable);
-    }
+void Renderer::enableAndroidEmulatorGoldfishMitigation(bool enable) {
+    impl->orchestrator.enableAndroidEmulatorGoldfishMitigation(enable);
+}
 #endif
 
 } // namespace mbgl


### PR DESCRIPTION
In the Android Open Source Project, there exists a translation layer that sits between an OpenGL client application and the driver, called Goldfish. For whatever reason, MapLibre's OpenGL backend crashes Goldfish inside `GL2Encoder::s_glDrawElements`. The following mitigation addresses this crash by first detecting if we're in an emulated environment and then deleting all drawables every frame. The crash appears to be related to buffer re-use, but I've yet to locate a minimum reproduction sample that triggers this crash.

Just deleting all drawables every frame and rebuilding them works around the reuse problem, at the cost of emulator performance. It sure beats crashing though.
 
Closes #2791