### PR TITLE
Use `thread_local` for thread local scheduler

### DIFF
--- a/src/mbgl/actor/scheduler.cpp
+++ b/src/mbgl/actor/scheduler.cpp
@@ -14,18 +14,16 @@ std::function<void()> Scheduler::bindOnce(std::function<void()> fn) {
 }
 
 namespace {
-auto& current() {
-    static util::ThreadLocal<Scheduler> scheduler;
-    return scheduler;
-}
+
+thread_local Scheduler *localScheduler;
 } // namespace
 
 void Scheduler::SetCurrent(Scheduler* scheduler) {
-    current().set(scheduler);
+    localScheduler = scheduler;
 }
 
 Scheduler* Scheduler::GetCurrent() {
-    return current().get();
+    return localScheduler;
 }
 
 // static

--- a/src/mbgl/actor/scheduler.cpp
+++ b/src/mbgl/actor/scheduler.cpp
@@ -15,7 +15,7 @@ std::function<void()> Scheduler::bindOnce(std::function<void()> fn) {
 
 namespace {
 
-thread_local Scheduler *localScheduler;
+thread_local Scheduler* localScheduler;
 } // namespace
 
 void Scheduler::SetCurrent(Scheduler* scheduler) {


### PR DESCRIPTION
In an attempt to fix #2779, drop the custom thread local storage and use `thread_local` which is available since C++11 and should be supported by all platforms now.