### PR TITLE
Android renderThreadManager changed to non static

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreSurfaceView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreSurfaceView.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 public abstract class MapLibreSurfaceView extends SurfaceView implements SurfaceHolder.Callback2 {
 
   protected static final String TAG = "MapLibreSurfaceView";
-  protected static final RenderThreadManager renderThreadManager = new RenderThreadManager();
+  protected final RenderThreadManager renderThreadManager = new RenderThreadManager();
 
   protected SurfaceViewMapRenderer renderer;
   protected RenderThread renderThread;
@@ -266,13 +266,14 @@ public abstract class MapLibreSurfaceView extends SurfaceView implements Surface
    * sRenderThreadManager object. This avoids multiple-lock ordering issues.
    */
   abstract static class RenderThread extends Thread {
-    RenderThread() {
+    RenderThread(RenderThreadManager aRenderThreadManager) {
       super();
       width = 0;
       height = 0;
       requestRender = true;
       renderMode = MapRenderer.RenderingRefreshMode.WHEN_DIRTY;
       wantRenderNotification = false;
+      renderThreadManager = aRenderThreadManager;
     }
 
     @Override
@@ -489,6 +490,7 @@ public abstract class MapLibreSurfaceView extends SurfaceView implements Surface
     protected ArrayList<Runnable> eventQueue = new ArrayList<>();
     protected boolean sizeChanged = true;
     protected Runnable finishDrawingRunnable = null;
+    protected RenderThreadManager renderThreadManager = null;
     // End of member variables protected by the sRenderThreadManager monitor.
 
   }

--- a/platform/android/MapLibreAndroid/src/opengl/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreGLSurfaceView.java
+++ b/platform/android/MapLibreAndroid/src/opengl/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreGLSurfaceView.java
@@ -116,7 +116,7 @@ public class MapLibreGLSurfaceView extends MapLibreSurfaceView {
 
   @Override
   protected void createRenderThread() {
-    renderThread = new GLThread(viewWeakReference, renderThreadManager);
+    renderThread = new GLThread(viewWeakReference);
   }
 
   /**
@@ -323,8 +323,8 @@ public class MapLibreGLSurfaceView extends MapLibreSurfaceView {
    * sGLThreadManager object. This avoids multiple-lock ordering issues.
    */
   static class GLThread extends MapLibreSurfaceView.RenderThread {
-    GLThread(WeakReference<MapLibreGLSurfaceView> surfaceViewWeakRef, RenderThreadManager aRenderThreadManager) {
-      super(aRenderThreadManager);
+    GLThread(WeakReference<MapLibreGLSurfaceView> surfaceViewWeakRef) {
+      super(surfaceViewWeakRef.get().renderThreadManager);
 
       mSurfaceViewWeakRef = surfaceViewWeakRef;
     }

--- a/platform/android/MapLibreAndroid/src/opengl/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreGLSurfaceView.java
+++ b/platform/android/MapLibreAndroid/src/opengl/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreGLSurfaceView.java
@@ -116,7 +116,7 @@ public class MapLibreGLSurfaceView extends MapLibreSurfaceView {
 
   @Override
   protected void createRenderThread() {
-    renderThread = new GLThread(viewWeakReference);
+    renderThread = new GLThread(viewWeakReference, renderThreadManager);
   }
 
   /**
@@ -323,8 +323,8 @@ public class MapLibreGLSurfaceView extends MapLibreSurfaceView {
    * sGLThreadManager object. This avoids multiple-lock ordering issues.
    */
   static class GLThread extends MapLibreSurfaceView.RenderThread {
-    GLThread(WeakReference<MapLibreGLSurfaceView> surfaceViewWeakRef) {
-      super();
+    GLThread(WeakReference<MapLibreGLSurfaceView> surfaceViewWeakRef, RenderThreadManager aRenderThreadManager) {
+      super(aRenderThreadManager);
 
       mSurfaceViewWeakRef = surfaceViewWeakRef;
     }

--- a/platform/android/MapLibreAndroid/src/vulkan/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreVulkanSurfaceView.java
+++ b/platform/android/MapLibreAndroid/src/vulkan/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreVulkanSurfaceView.java
@@ -25,7 +25,7 @@ public class MapLibreVulkanSurfaceView extends MapLibreSurfaceView {
 
   static class VulkanThread extends MapLibreSurfaceView.RenderThread {
     VulkanThread(WeakReference<MapLibreVulkanSurfaceView> surfaceViewWeakRef) {
-      super();
+      super(surfaceViewWeakRef.get().renderThreadManager);
       mSurfaceViewWeakRef = surfaceViewWeakRef;
     }
 


### PR DESCRIPTION
Variable `renderThreadManager` from `MapLibreSurfaceView` changed to non-static behavior.
This could improve [Android SurfaceView shutdowns may be causing ANRs](https://github.com/maplibre/maplibre-native/issues/2848). 