### PR TITLE
Fix Mesa3D download file names

### DIFF
--- a/platform/windows/Get-VendorPackages.ps1
+++ b/platform/windows/Get-VendorPackages.ps1
@@ -39,7 +39,7 @@ if($Renderer -eq 'OSMesa' -and -not (Test-Path ([System.IO.Path]::Combine($PWD.P
 {
     New-Item -Name temp -Type Directory | Out-Null
     Invoke-WebRequest https://www.7-zip.org/a/7zr.exe -OutFile ([System.IO.Path]::Combine($PWD.Path, 'temp', '7zr.exe'))
-    (Invoke-WebRequest https://api.github.com/repos/pal1000/mesa-dist-win/releases | ConvertFrom-Json)[0].assets | Where-Object name -match 'mesa3d-.+-(release|development-pack)-msvc\.7z' | foreach { Invoke-WebRequest $_.browser_download_url -OutFile ([System.IO.Path]::Combine($PWD.Path, 'temp', $_.name)) }
+    (Invoke-WebRequest https://api.github.com/repos/pal1000/mesa-dist-win/releases | ConvertFrom-Json)[0].assets | Where-Object name -match 'mesa3d-.+-(release|devel)-msvc\.7z' | foreach { Invoke-WebRequest $_.browser_download_url -OutFile ([System.IO.Path]::Combine($PWD.Path, 'temp', $_.name)) }
     Get-ChildItem 'temp\*.7z' | foreach { .\temp\7zr.exe x -ovendor\mesa3d $_.FullName }
     Remove-Item temp -Recurse
 }


### PR DESCRIPTION
The last releases of [Mesa3D](https://github.com/pal1000/mesa-dist-win) have different file names, for example:

In v24.1.3, the developer file was called [mesa3d-24.1.3-development-pack-msvc.7z](https://github.com/pal1000/mesa-dist-win/releases/download/24.1.3/mesa3d-24.1.3-development-pack-msvc.7z), while in the last version, the correspondent file is called [mesa3d-24.2.3-devel-msvc.7z](https://github.com/pal1000/mesa-dist-win/releases/download/24.2.3/mesa3d-24.2.3-devel-msvc.7z).

So we need this change to be reflected in the Windows script which is responsible to download the files.