### PR TITLE
Vulkan build tweaks

### DIFF
--- a/bazel/core.bzl
+++ b/bazel/core.bzl
@@ -682,6 +682,7 @@ MLN_CORE_HEADERS = [
     "include/mbgl/layermanager/layer_factory.hpp",
     "include/mbgl/layermanager/layer_manager.hpp",
     "include/mbgl/layermanager/line_layer_factory.hpp",
+    "include/mbgl/layermanager/location_indicator_layer_factory.hpp",
     "include/mbgl/layermanager/raster_layer_factory.hpp",
     "include/mbgl/layermanager/symbol_layer_factory.hpp",
     "include/mbgl/map/bound_options.hpp",
@@ -921,7 +922,6 @@ MLN_OPENGL_SOURCE = [
 MLN_OPENGL_HEADERS = [
     "include/mbgl/gl/renderable_resource.hpp",
     "include/mbgl/gl/renderer_backend.hpp",
-    "include/mbgl/layermanager/location_indicator_layer_factory.hpp",
     "include/mbgl/platform/gl_functions.hpp",
 ]
 

--- a/include/mbgl/shaders/shader_manifest.hpp
+++ b/include/mbgl/shaders/shader_manifest.hpp
@@ -2,7 +2,7 @@
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 
-#if !MLN_RENDER_BACKEND_METAL
+#if MLN_RENDER_BACKEND_OPENGL
 #include <mbgl/shaders/gl/drawable_background.hpp>
 #include <mbgl/shaders/gl/drawable_background_pattern.hpp>
 #include <mbgl/shaders/gl/drawable_circle.hpp>

--- a/shaders/generate_shader_code.mjs
+++ b/shaders/generate_shader_code.mjs
@@ -276,7 +276,7 @@ fs.writeFileSync(path.join(outputRoot, "shader_manifest.hpp"),
 #pragma once
 #include <mbgl/shaders/shader_source.hpp>
 
-#if !MLN_RENDER_BACKEND_METAL
+#if MLN_RENDER_BACKEND_OPENGL
 ${generatedHeaders.join('\n')}
 #endif
 `);

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -36,7 +36,7 @@
 constexpr auto EnableMetalCapture = 0;
 constexpr auto CaptureFrameStart = 0; // frames are 0-based
 constexpr auto CaptureFrameCount = 1;
-#else // !MLN_RENDER_BACKEND_METAL
+#elif MLN_RENDER_BACKEND_OPENGL
 #include <mbgl/gl/defines.hpp>
 #if MLN_DRAWABLE_RENDERER
 #include <mbgl/gl/drawable_gl.hpp>


### PR DESCRIPTION
With the addition of a third rendering backend, some preprocessor checks need to be made more explicit. Additionally, the `location_indicator_layer_factory` header isn't currently visible to the Vulkan backend if consuming the bazel file listing for a Vulkan build.