### PR TITLE
Prepare MapLibre Android 11.5.1 release

### DIFF
--- a/.github/workflows/gh-pages-android-api.yml
+++ b/.github/workflows/gh-pages-android-api.yml
@@ -2,6 +2,10 @@ name: gh-pages-android-api
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: [android-release]
+    types:
+      - completed
 
 jobs:
   gh-pages-android-api:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/a
 ```gradle
     dependencies {
         ...
-        implementation 'org.maplibre.gl:android-sdk:11.5.0'
+        implementation 'org.maplibre.gl:android-sdk:11.5.1'
         ...
     }
 ```

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ### 🐞 Bug fixes
 
+## 11.5.1
+
+### ✨ Features and improvements
+
+- Add `PropertyFactory.iconPadding(Float)` overload for better backcompat ([#2880](https://github.com/maplibre/maplibre-native/pull/2880)).
+
+### 🐞 Bug fixes
+
+- Android renderThreadManager changed to non static ([#2872](https://github.com/maplibre/maplibre-native/pull/2872)).
+- Make sure `Scheduler::GetCurrent()` cannot return a nullptr ([#2887](https://github.com/maplibre/maplibre-native/pull/2887)). This should fix a crash on startup when the library is not initialized on the main thread.
+
 ## 11.5.0
 
 ### ✨ Features and improvements


### PR DESCRIPTION
Releasing this as a patch release, because technically the `setPadding(Float)` which was added for better backwards compatibility is not a new API.

This release contains two (possible) bug fixes.

This PR also ensures that a new version of the Android API docs are released after a release.