### PR TITLE
Line atlas fix

### DIFF
--- a/platform/darwin/.gitignore
+++ b/platform/darwin/.gitignore
@@ -1,3 +1,5 @@
 # Generated list files from code generation
 /scripts/generate-style-code.list
 /scripts/update-examples.list
+vulkan.xcworkspace
+

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -558,19 +558,17 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
 
             // texture
             if (const auto& atlases = tile.getAtlasTextures(); atlases && atlases->icon) {
-                if (!iconTweaker) {
-                    iconTweaker = std::make_shared<gfx::DrawableAtlasesTweaker>(
-                        atlases,
-                        std::nullopt,
-                        idLineImageTexture,
-                        /*isText*/ false,
-                        /*sdfIcons*/ true, // to force linear filter
-                        /*rotationAlignment_*/ AlignmentType::Auto,
-                        /*iconScaled*/ false,
-                        /*textSizeIsZoomConstant_*/ false);
-                }
+                auto iconTweaker = std::make_shared<gfx::DrawableAtlasesTweaker>(
+                    atlases,
+                    std::nullopt,
+                    idLineImageTexture,
+                    /*isText*/ false,
+                    /*sdfIcons*/ true, // to force linear filter
+                    /*rotationAlignment_*/ AlignmentType::Auto,
+                    /*iconScaled*/ false,
+                    /*textSizeIsZoomConstant_*/ false);
 
-                builder->addTweaker(iconTweaker);
+                builder->addTweaker(std::move(iconTweaker));
 
                 setSegments(builder, bucket);
 

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -92,8 +92,6 @@ private:
     gfx::ShaderGroupPtr lineGradientShaderGroup;
     gfx::ShaderGroupPtr lineSDFShaderGroup;
     gfx::ShaderGroupPtr linePatternShaderGroup;
-
-    gfx::DrawableTweakerPtr iconTweaker;
 #endif
 };
 


### PR DESCRIPTION
I think this came from the fill layer or something, but doesn't make sense here.  We can potentially share some of these, because they are generated in the worker and assigned to multiple buckets, but we would have to use a map and look them up not just have a single cache item, and that's probably not worth it.

Resolves #2735
