### PR TITLE
Make sure `Scheduler::GetCurrent()` cannot return a nullptr

### DIFF
--- a/include/mbgl/actor/scheduler.hpp
+++ b/include/mbgl/actor/scheduler.hpp
@@ -65,7 +65,8 @@ public:
     }
 
     /// Set/Get the current Scheduler for this thread
-    static Scheduler* GetCurrent();
+    /// @param init initialize if missing
+    static Scheduler* GetCurrent(bool init = true);
     static void SetCurrent(Scheduler*);
 
     /// Get the scheduler for asynchronous tasks. This method

--- a/platform/android/MapboxGLAndroidSDK/src/cpp/jni_native.cpp
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/jni_native.cpp
@@ -67,8 +67,6 @@ void registerNatives(JavaVM *vm) {
 
     jni::JNIEnv& env = jni::GetEnv(*vm, jni::jni_version_1_6);
 
-    // For the FileSource
-    static mbgl::util::RunLoop mainRunLoop;
     FileSource::registerNative(env);
 
     // Basic types

--- a/platform/darwin/src/run_loop.cpp
+++ b/platform/darwin/src/run_loop.cpp
@@ -19,7 +19,7 @@ RunLoop* RunLoop::Get() {
 
 RunLoop::RunLoop(Type)
   : impl(std::make_unique<Impl>()) {
-    assert(!Scheduler::GetCurrent());
+    assert(!Scheduler::GetCurrent(false));
     Scheduler::SetCurrent(this);
     impl->async = std::make_unique<AsyncTask>(std::bind(&RunLoop::process, this));
 }

--- a/src/mbgl/actor/scheduler.cpp
+++ b/src/mbgl/actor/scheduler.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/util/thread_local.hpp>
 #include <mbgl/util/thread_pool.hpp>
+#include <mbgl/util/run_loop.hpp>
 
 namespace mbgl {
 
@@ -13,17 +14,20 @@ std::function<void()> Scheduler::bindOnce(std::function<void()> fn) {
     };
 }
 
-static auto& current() {
-    static util::ThreadLocal<Scheduler> scheduler;
-    return scheduler;
-};
+namespace {
+thread_local Scheduler* localScheduler;
+} // namespace
 
 void Scheduler::SetCurrent(Scheduler* scheduler) {
-    current().set(scheduler);
+    localScheduler = scheduler;
 }
 
-Scheduler* Scheduler::GetCurrent() {
-    return current().get();
+Scheduler* Scheduler::GetCurrent(bool init) {
+    if (!localScheduler && init) {
+        thread_local util::RunLoop runLoop;
+        SetCurrent(&runLoop);
+    }
+    return localScheduler;
 }
 
 // static


### PR DESCRIPTION
Cherry-pick 4d7d5f50cf60cd41b9b669f191193177785d8a4d