### PR TITLE
Fix puck rendering behavior Android

### DIFF
--- a/src/mbgl/gl/drawable_gl.cpp
+++ b/src/mbgl/gl/drawable_gl.cpp
@@ -71,6 +71,8 @@ void DrawableGL::draw(PaintParameters& parameters) const {
             context.draw(glSeg.getMode(), mlSeg.indexOffset, mlSeg.indexLength);
         }
     }
+    // Unbind the VAO so that future buffer commands outside Drawable do not change the current VAO state
+    glBindVertexArray(0);
 
 #ifndef NDEBUG
     context.bindVertexArray = value::BindVertexArray::Default;

--- a/src/mbgl/gl/drawable_gl.cpp
+++ b/src/mbgl/gl/drawable_gl.cpp
@@ -72,11 +72,9 @@ void DrawableGL::draw(PaintParameters& parameters) const {
         }
     }
     // Unbind the VAO so that future buffer commands outside Drawable do not change the current VAO state
-    glBindVertexArray(0);
-
-#ifndef NDEBUG
     context.bindVertexArray = value::BindVertexArray::Default;
 
+#ifndef NDEBUG
     unbindTextures();
     unbindUniformBuffers();
 #endif


### PR DESCRIPTION
The puck is typically rendered last and while its VAO is bound command that change the VAO are executed causing glitches. I didn't debug what commands are affecting the VAO but as a workaround the VAO is unbound after drawing which ensures the state of a Drawable object remains clean without adding overhead. This works around #2879 