### PR TITLE
Fix LineBucket::addGeometry() empty coordinates.

### DIFF
--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -54,6 +54,10 @@ void LineBucket::addFeature(const GeometryTileFeature& feature,
 void LineBucket::addGeometry(const GeometryCoordinates& coordinates,
                              const GeometryTileFeature& feature,
                              const CanonicalTileID& canonical) {
+    // Ignore empty coordinates.
+    if (coordinates.empty()) {
+        return;
+    }
     gfx::PolylineGenerator<LineLayoutVertex, Segment<LineAttributes>> generator(
         vertices,
         LineProgram::layoutVertex,


### PR DESCRIPTION
This fix avoids using a negative number to index the coordinates inside the "len" lambda in LineBucket::addGeometry().  It does an early return similar to the one on line ~90 for invalid geometry.