### PR TITLE
Encode the style URL in iOS

### DIFF
--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -226,8 +226,9 @@ BOOL isValidMapboxEndpoint(NSURL *url) {
 MLN_APPLE_EXPORT
 NSURL *resourceURL(const Resource& resource) {
     
-    NSURL *url = [NSURL URLWithString:@(resource.url.c_str())];
-
+    NSString *encodedUrlString = [@(resource.url.c_str()) stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
+    NSURL *url = [NSURL URLWithString:encodedUrlString];
+    
 #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
     if (isValidMapboxEndpoint(url)) {
         NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];

--- a/platform/darwin/test/MLNResourceTests.mm
+++ b/platform/darwin/test/MLNResourceTests.mm
@@ -86,4 +86,15 @@ namespace mbgl {
     [self internalTestOfflineQueryParameterIsAddedForOfflineResource:testURL];
 }
 
+- (void)testResourceURL {
+    using namespace mbgl;
+
+    // Test URL with characters requiring encoding
+    Resource resource(Resource::Kind::Unknown, "https://example.com/test?param1=a|b&param2=c|d");
+    NSURL *url = resourceURL(resource);
+
+    XCTAssertNotNil(url);
+    XCTAssertEqualObjects(url.absoluteString, @"https://example.com/test?param1=a%7Cb&param2=c%7Cd");
+}
+
 @end


### PR DESCRIPTION
For iOS versions under 17.0, `[NSURL URLWithString:]` cannot create an `NSURL` object with the url string that containing any characters that need to be encoded. Consequently, it cannot load the custom style correctly if the style file contains such a URL.