### PR TITLE
Use the recommended actionlint hook in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
-    hooks:
-    -   id: check-yaml
-        args: [--allow-multiple-documents]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+  - id: check-yaml
+    args: [--allow-multiple-documents]
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v19.1.2
   hooks:
@@ -13,18 +13,16 @@ repos:
 - repo: https://github.com/keith/pre-commit-buildifier
   rev: 7.3.1
   hooks:
-    - id: buildifier
-- repo: https://github.com/Mateusz-Grzelinski/actionlint-py
-  rev: v1.7.3.17
+  - id: buildifier
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.3
   hooks:
-    - id: actionlint
-      additional_dependencies: [shellcheck-py]
+  - id: actionlint
 - repo: https://github.com/nicklockwood/SwiftFormat
   rev: "0.54.6"
   hooks:
-    - id: swiftformat
-      args: [--swiftversion, "5.8"]
+  - id: swiftformat
+    args: [--swiftversion, "5.8"]
 ci:
   # sometimes fails https://github.com/keith/pre-commit-buildifier/issues/13
   skip: [buildifier]
-  


### PR DESCRIPTION
Currently the pre-commit hooks uses actionlint hook, but it does not work well with shellcheck, specially PowerShell scripts in workflow flies. Looking at the [README](https://github.com/Mateusz-Grzelinski/actionlint-py?tab=readme-ov-file), it recommends another way to use this hook, so I changed it and then the pre-commit hooks are not complaining about incorrect PowerShell script parsing anymore. So I'm bringing this change to the project.