### PR TITLE
Allow android-ci to be run on free GitHub runnner

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -305,6 +305,12 @@ jobs:
         with:
           key: ${{ github.job }}
 
+      - name: Get CMake and Ninja
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 3.24.1
+          ninjaVersion: latest
+
       - uses: actions/setup-java@v4
         with:
           distribution: "temurin"

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -189,36 +189,6 @@ jobs:
             platform/android/InstrumentationTestApp.apk
             platform/android/InstrumentationTests.apk
 
-      - name: Create data.zip in assets directory
-        run: zip -r test/android/app/src/main/assets/data.zip -@ < test/android/app/src/main/assets/to_zip.txt
-        working-directory: .
-
-      - name: Build C++ Unit Tests App
-        working-directory: test/android
-        run: |
-          ./gradlew assembleDebug assembleAndroidTest
-          cp app/build/outputs/apk/debug/app-debug.apk .
-          cp app/build/outputs/apk/androidTest/release/app-release-androidTest.apk .
-
-      - name: Store C++ Unit Tests .apk files
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-cpp-tests
-          if-no-files-found: error
-          path: |
-            ./test/android/app-debug.apk
-            ./test/android/app-release-androidTest.apk
-
-      - name: Build and Upload Render Test APKs for OpenGL
-        uses: ./.github/actions/android-build-and-upload-render-test
-        with:
-          flavor: opengl
-
-      - name: Build and Upload Render Test APKs for Vulkan
-        uses: ./.github/actions/android-build-and-upload-render-test
-        with:
-          flavor: vulkan
-
   android-build-cpp-test:
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -35,7 +35,7 @@ jobs:
           files_yaml_from_source_file: .github/changed-files.yml
 
   android-build:
-    runs-on: [MapLibre_Native_Ubuntu_24_04_x84_16_core, ubuntu-24.04]
+    runs-on: ubuntu-24.04
     needs:
       - pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: npm install
         run: npm install --ignore-scripts
@@ -105,11 +105,11 @@ jobs:
           python3 -m venv venv
           source venv/bin/activate
           pip3 install pre-commit
-      
+
       - run: |
           source venv/bin/activate
           pre-commit run clang-format --all-files
-        continue-on-error: true  # this can mean files are modified, which is not an error
+        continue-on-error: true # this can mean files are modified, which is not an error
 
       - run: |
           source venv/bin/activate
@@ -162,7 +162,7 @@ jobs:
           cp MapLibreAndroidTestApp/build/outputs/apk/drawable/release/MapLibreAndroidTestApp-drawable-release.apk .
           cp MapLibreAndroidTestApp/build/outputs/apk/androidTest/drawable/release/MapLibreAndroidTestApp-drawable-release-androidTest.apk .
 
-      - name: Create artifact for benchmark APKs 
+      - name: Create artifact for benchmark APKs
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
@@ -213,11 +213,107 @@ jobs:
         uses: ./.github/actions/android-build-and-upload-render-test
         with:
           flavor: opengl
-    
+
       - name: Build and Upload Render Test APKs for Vulkan
         uses: ./.github/actions/android-build-and-upload-render-test
         with:
           flavor: vulkan
+
+  android-build-cpp-test:
+    runs-on: ubuntu-24.04
+
+    needs:
+      - pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+
+    defaults:
+      run:
+        working-directory: test/android
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Get CMake and Ninja
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 3.24.1
+          ninjaVersion: latest
+
+      - uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
+
+      - name: Create data.zip in assets directory
+        run: zip -r test/android/app/src/main/assets/data.zip -@ < test/android/app/src/main/assets/to_zip.txt
+        working-directory: .
+
+      - name: Build C++ Unit Tests App
+        run: |
+          ./gradlew assembleDebug assembleAndroidTest
+          cp app/build/outputs/apk/debug/app-debug.apk .
+          cp app/build/outputs/apk/androidTest/release/app-release-androidTest.apk .
+
+      - name: Store C++ Unit Tests .apk files
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-cpp-tests
+          if-no-files-found: error
+          path: |
+            ./test/android/app-debug.apk
+            ./test/android/app-release-androidTest.apk
+
+  android-build-render-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [opengl, vulkan]
+
+    runs-on: ubuntu-24.04
+
+    needs:
+      - pre_job
+
+    if: needs.pre_job.outputs.should_skip != 'true'
+
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        if: startsWith(runner.name, 'GitHub Actions')
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: false
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Build and Upload Render Test APKs (${{ matrix.flavor }})
+        uses: ./.github/actions/android-build-and-upload-render-test
+        with:
+          flavor: ${{ matrix.flavor }}
 
   android-ci-result:
     runs-on: ubuntu-latest
@@ -225,6 +321,8 @@ jobs:
     needs:
       - pre_job
       - android-build
+      - android-build-cpp-test
+      - android-build-render-test
     steps:
       - name: Mark result as failed
         if: needs.android-build.result != 'success'

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -35,7 +35,7 @@ jobs:
           files_yaml_from_source_file: .github/changed-files.yml
 
   android-build:
-    runs-on: MapLibre_Native_Ubuntu_24_04_x84_16_core
+    runs-on: [MapLibre_Native_Ubuntu_24_04_x84_16_core, ubuntu-24.04]
     needs:
       - pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
@@ -48,6 +48,18 @@ jobs:
       IS_LOCAL_DEVELOPMENT: false
       MLN_ANDROID_STL: c++_static
     steps:
+      - name: Free Disk Space (Ubuntu)
+        if: startsWith(runner.name, 'GitHub Actions')
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: false
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -43,7 +43,6 @@ jobs:
       run:
         working-directory: platform/android
     env:
-      JOBS: 8
       BUILDTYPE: Debug
       IS_LOCAL_DEVELOPMENT: false
       MLN_ANDROID_STL: c++_static

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: [MapLibre_Native_Ubuntu_24_04_x84_16_core, ubuntu-24.04]
     defaults:
       run:
         working-directory: platform/android

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       renderer:
-        description: 'Select renderering backend'
+        description: "Select renderering backend"
         required: true
-        default: 'OpenGL'
+        default: "OpenGL"
         type: choice
         options:
           - OpenGL
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: [MapLibre_Native_Ubuntu_24_04_x84_16_core, ubuntu-24.04]
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: platform/android


### PR DESCRIPTION
We ran into a spending limit. Unblock workflows by allowing free GitHub runners as a backup.