### PR TITLE
Clarify padding order in the Java API

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMap.java
@@ -1546,7 +1546,7 @@ public final class MapLibreMap {
    * Get a camera position that fits a provided bounds and padding and the current camera tilt and bearing.
    *
    * @param latLngBounds the bounds to set the map with
-   * @param padding      the padding to apply to the bounds
+   * @param padding      the padding to apply to the bounds (in left, top, right, bottom order)
    * @return the camera position that fits the bounds and padding
    */
   @Nullable
@@ -1579,7 +1579,7 @@ public final class MapLibreMap {
    * Get a camera position that fits a provided bounds, padding, bearing and tilt.
    *
    * @param latLngBounds the bounds to set the map with
-   * @param padding      the padding to apply to the bounds
+   * @param padding      the padding to apply to the bounds (in left, top, right, bottom order)
    * @param bearing      the bearing to transform the camera position with
    * @param tilt         to transform the camera position with
    * @return the camera position that fits the bounds, bearing and tilt

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
@@ -55,6 +55,7 @@ interface NativeMap {
   @NonNull
   CameraPosition getCameraPosition();
 
+  // Note for implementors: the ordering of the padding is left, top, right, bottom
   CameraPosition getCameraForLatLngBounds(@NonNull LatLngBounds bounds, int[] padding, double bearing, double pitch);
 
   CameraPosition getCameraForGeometry(@NonNull Geometry geometry, int[] padding, double bearing, double pitch);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -284,6 +284,8 @@ final class NativeMapView implements NativeMap {
     if (checkState("getCameraForLatLngBounds")) {
       return null;
     }
+    // Note that we have to juggle things a bit to match the ordering of arguments
+    // to match the NativeMapView C++ interface.
     return nativeGetCameraForLatLngBounds(
       bounds,
       padding[1] / pixelRatio,


### PR DESCRIPTION
Pretty simple PR hopefully. When working on a bounding box camera for a Jetpack Compose wrapper, I realized that the padding order was nowhere to be found in the docs. So I drilled down to the C++, used that padding order, and was very confused 🙃

This should save others from such a fate.