### PR TITLE
Fix 16K alignment for Android build

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -162,6 +162,12 @@ jobs:
           cp MapLibreAndroidTestApp/build/outputs/apk/drawable/release/MapLibreAndroidTestApp-drawable-release.apk .
           cp MapLibreAndroidTestApp/build/outputs/apk/androidTest/drawable/release/MapLibreAndroidTestApp-drawable-release-androidTest.apk .
 
+      # https://developer.android.com/guide/practices/page-sizes
+      - name: Check alignment of .apk
+        run: |
+          unzip -o MapLibreAndroidTestApp/build/outputs/apk/drawable/release/MapLibreAndroidTestApp-drawable-release.apk -d /tmp/my_apk_out
+          scripts/check-alignment.sh /tmp/my_apk_out
+
       - name: Create artifact for benchmark APKs
         uses: actions/upload-artifact@v4
         with:

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## 11.6.1
 
+### 🐞 Bug fixes
+
+- Fix 16K alignment Android builds ([#2995](https://github.com/maplibre/maplibre-native/issues/2995)).
+
 ### ✨ Features and improvements
 
 - Allow configuring a `Call.Factory` instead of a `OkHttpClient` ([https://github.com/maplibre/maplibre-native/pull/2987](#2987)). Since an `OkHttpClient` can be assigned to a `Call.Factory` this should not cause any issues.

--- a/platform/android/MapLibreAndroid/build.gradle.kts
+++ b/platform/android/MapLibreAndroid/build.gradle.kts
@@ -48,6 +48,8 @@ tasks.withType<DokkaTask> {
 }
 
 android {
+    ndkVersion = Versions.ndkVersion
+
     defaultConfig {
         compileSdk = 34
         minSdk = 21

--- a/platform/android/MapLibreAndroidTestApp/build.gradle.kts
+++ b/platform/android/MapLibreAndroidTestApp/build.gradle.kts
@@ -19,6 +19,8 @@ fun obtainTestBuildType(): String {
 }
 
 android {
+    ndkVersion = Versions.ndkVersion
+
     compileSdk = 34
 
     defaultConfig {

--- a/platform/android/scripts/check-alignment.sh
+++ b/platform/android/scripts/check-alignment.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# usage: alignment.sh path to search for *.so files
+
+dir="$1"
+
+matches="$(find $dir -name "*.so" -type f)"
+IFS=$'\n'
+
+err=0
+
+for match in $matches; do
+  res="$(objdump -p ${match} | grep LOAD | awk '{ print $NF }' | head -1)"
+  if [[ $res =~ "2**14" ]] || [[ $res =~ "2**16" ]]; then
+    echo -e "${match}: ALIGNED ($res)"
+  else
+    if [[ "$match" == *"x86_64"* || "$match" == *"arm64-v8a"* ]]; then
+      echo "ERROR:"
+      err=1
+    fi
+    echo -e "${match}: UNALIGNED ($res)"
+  fi
+done
+
+exit $err


### PR DESCRIPTION
- Make sure correct NDK version is used. Using the system NDK version caused alignment issues on new devices with 16K pages.
- Add alignment check to `android-ci.yml`.

Closes https://github.com/maplibre/maplibre-native/issues/2995