### PR TITLE
Fix instrumentation tests, attempt 2

### DIFF
--- a/.github/workflows/android-device-test.yml
+++ b/.github/workflows/android-device-test.yml
@@ -134,6 +134,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
+          role-duration-seconds: 14400
       
       - name: Run ${{ matrix.test.name }} on AWS Device Farm
         run: |

--- a/.github/workflows/ios-device-test.yml
+++ b/.github/workflows/ios-device-test.yml
@@ -49,6 +49,15 @@ jobs:
         with:
           files: "${{ matrix.test.xcTestFile }}, ${{ matrix.test.ipaFile }}"
 
+      - name: Configure AWS Credentials
+        if: env.run_device_test == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+          role-duration-seconds: 14400
+
       - name: Run ${{ matrix.test.name }} on AWS Device Farm
         if: steps.check_files.outputs.files_exists == 'true'
         run: |

--- a/scripts/aws-device-farm/aws-device-farm-run.sh
+++ b/scripts/aws-device-farm/aws-device-farm-run.sh
@@ -67,10 +67,10 @@ while ((max_checks--)); do
   status_test_package="$status_test_package"
 
   if [[ "$status_app" == "SUCCEEDED" && "$status_test_package" == "SUCCEEDED" ]]; then
-    echo "Uploads succeeded"  >&2
+    echo "Uploads succeeded" >&2
     break
   elif ((max_checks == 0)); then
-    echo "App or test package failed to upload"  >&2
+    echo "App or test package failed to upload" >&2
     exit 1
   fi
 
@@ -100,9 +100,9 @@ while true; do
   sleep 30
   result="$(aws devicefarm get-run --arn "$arn" --output text --query "run.result")"
   case $result in
-    FAILED|ERRORED|STOPPED) echo "Run $result" && exit 1 ;;
-    SKIPPED|PASSED) echo "Run $result" && exit 0 ;;
+    FAILED|ERRORED|STOPPED) echo "Run $result" >&2 && exit 1 ;;
+    SKIPPED|PASSED) echo "Run $result" >&2 && exit 0 ;;
     PENDING) continue ;;
-    *) echo "Unexpected run result $result" && exit 1 ;;
+    *) echo "Unexpected run result $result" >&2 && exit 1 ;;
   esac
 done


### PR DESCRIPTION
Follow-up to #3012

It printed 

> Error: Invalid format 'Run PASSED'

So it seems to work now, but I make sure I log to stderr, not stdout.

Also the AWS credential duration need to be extended.