### PR TITLE
feat: add `getZoom` and `setZoom` function support for Android Auto

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMap.java
@@ -759,6 +759,24 @@ public final class MapLibreMap {
     nativeMapView.moveBy(x, y, duration);
   }
 
+  /**
+   * Returns the current zoom level.
+   */
+  public double getZoom() {
+    return nativeMapView.getZoom();
+  }
+
+  /**
+   * Zooms the camera to the specified level.
+   * @param zoom              The zoom level to which the camera should move.
+   * @param focalPoint        The point around which to zoom.
+   * @param duration          The duration for the zoom animation
+   */
+  public void setZoom(double zoom, @NonNull PointF focalPoint, long duration ) {
+    notifyDeveloperAnimationListeners();
+    nativeMapView.setZoom(zoom, focalPoint, duration);
+  }
+
   //
   //  Reset North
   //

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/maps/MapLibreMapTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/maps/MapLibreMapTest.kt
@@ -1,6 +1,7 @@
 package org.maplibre.android.maps
 
 import android.content.Context
+import android.graphics.PointF
 import org.maplibre.android.MapLibreInjector
 import org.maplibre.android.camera.CameraPosition
 import org.maplibre.android.camera.CameraUpdateFactory
@@ -243,5 +244,20 @@ class MapLibreMapTest {
         maplibreMap.setStyle(builder, onStyleLoadedListener)
         maplibreMap.onFinishLoadingStyle()
         verify(exactly = 1) { onStyleLoadedListener.onStyleLoaded(style) }
+    }
+
+    @Test
+    fun testGetZoom() {
+        maplibreMap.zoom
+        verify { nativeMapView.zoom }
+        assertEquals(maplibreMap.zoom, 0.0, 0.0)
+    }
+
+    @Test
+    fun testSetZoom() {
+        val target = PointF(100f, 100f)
+        maplibreMap.setZoom(2.0, target, 0)
+        verify { developerAnimationListener.onDeveloperAnimationStarted() }
+        verify { nativeMapView.setZoom(2.0, target, 0) }
     }
 }


### PR DESCRIPTION
- Added `getZoom` and `setZoom` methods to `MapLibreMap`, enabling handling of two-finger and double-click zoom gestures in the Android Auto Surface.  
