### PR TITLE
Expose Android NativeMapView and move creation to the ModuleProvider

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/ModuleProvider.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/ModuleProvider.java
@@ -1,8 +1,13 @@
 package org.maplibre.android;
 
+import android.content.Context;
 import androidx.annotation.NonNull;
 
 import org.maplibre.android.http.HttpRequest;
+import org.maplibre.android.maps.NativeMap;
+import org.maplibre.android.maps.NativeMapView.ViewCallback;
+import org.maplibre.android.maps.NativeMapView.StateCallback; 
+import org.maplibre.android.maps.renderer.MapRenderer;
 
 /**
  * Injects concrete instances of configurable abstractions
@@ -25,4 +30,12 @@ public interface ModuleProvider {
   @NonNull
   LibraryLoaderProvider createLibraryLoaderProvider();
 
+  /**
+   * Create and return a new NativeMap view
+   * 
+   * @return a new instance implementing NativeMap
+   */
+  @NonNull
+  NativeMap createNativeMapView(Context context, float pixelRatio, boolean crossSourceCollisions,
+                                ViewCallback viewCallback, StateCallback stateCallback, MapRenderer mapRenderer);
 }

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/ModuleProvider.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/ModuleProvider.java
@@ -6,7 +6,7 @@ import androidx.annotation.NonNull;
 import org.maplibre.android.http.HttpRequest;
 import org.maplibre.android.maps.NativeMap;
 import org.maplibre.android.maps.NativeMapView.ViewCallback;
-import org.maplibre.android.maps.NativeMapView.StateCallback; 
+import org.maplibre.android.maps.NativeMapView.StateCallback;
 import org.maplibre.android.maps.renderer.MapRenderer;
 
 /**
@@ -32,7 +32,7 @@ public interface ModuleProvider {
 
   /**
    * Create and return a new NativeMap view
-   * 
+   *
    * @return a new instance implementing NativeMap
    */
   @NonNull

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/ModuleProviderImpl.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/ModuleProviderImpl.java
@@ -1,10 +1,16 @@
 package org.maplibre.android;
 
+import android.content.Context;
 import androidx.annotation.NonNull;
 
 import org.maplibre.android.http.HttpRequest;
 import org.maplibre.android.module.http.HttpRequestImpl;
 import org.maplibre.android.module.loader.LibraryLoaderProviderImpl;
+import org.maplibre.android.maps.NativeMap;
+import org.maplibre.android.maps.NativeMapView;
+import org.maplibre.android.maps.NativeMapView.ViewCallback;
+import org.maplibre.android.maps.NativeMapView.StateCallback; 
+import org.maplibre.android.maps.renderer.MapRenderer;
 
 public class ModuleProviderImpl implements ModuleProvider {
 
@@ -18,5 +24,12 @@ public class ModuleProviderImpl implements ModuleProvider {
   @Override
   public LibraryLoaderProvider createLibraryLoaderProvider() {
     return new LibraryLoaderProviderImpl();
+  }
+
+  @NonNull
+  @Override
+  public NativeMap createNativeMapView(Context context, float pixelRatio, boolean crossSourceCollisions,
+                                       ViewCallback viewCallback, StateCallback stateCallback, MapRenderer mapRenderer) {
+    return new NativeMapView(context, pixelRatio, crossSourceCollisions, viewCallback, stateCallback, mapRenderer);
   }
 }

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/ModuleProviderImpl.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/ModuleProviderImpl.java
@@ -9,7 +9,7 @@ import org.maplibre.android.module.loader.LibraryLoaderProviderImpl;
 import org.maplibre.android.maps.NativeMap;
 import org.maplibre.android.maps.NativeMapView;
 import org.maplibre.android.maps.NativeMapView.ViewCallback;
-import org.maplibre.android.maps.NativeMapView.StateCallback; 
+import org.maplibre.android.maps.NativeMapView.StateCallback;
 import org.maplibre.android.maps.renderer.MapRenderer;
 
 public class ModuleProviderImpl implements ModuleProvider {
@@ -29,7 +29,8 @@ public class ModuleProviderImpl implements ModuleProvider {
   @NonNull
   @Override
   public NativeMap createNativeMapView(Context context, float pixelRatio, boolean crossSourceCollisions,
-                                       ViewCallback viewCallback, StateCallback stateCallback, MapRenderer mapRenderer) {
+                                       ViewCallback viewCallback, StateCallback stateCallback,
+                                       MapRenderer mapRenderer) {
     return new NativeMapView(context, pixelRatio, crossSourceCollisions, viewCallback, stateCallback, mapRenderer);
   }
 }

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapView.java
@@ -311,10 +311,9 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
 
     addView(renderView, 0);
 
-    boolean crossSourceCollisions = options.getCrossSourceCollisions();
-    nativeMapView = new NativeMapView(
-            getContext(), getPixelRatio(), crossSourceCollisions, this, mapChangeReceiver, mapRenderer
-    );
+    boolean crossSourceCollisions = maplibreMapOptions.getCrossSourceCollisions();
+    nativeMapView = MapLibre.getModuleProvider().createNativeMapView(getContext(),
+      getPixelRatio(), crossSourceCollisions, this, mapChangeReceiver, mapRenderer);
   }
 
   private void onSurfaceCreated() {
@@ -518,6 +517,15 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   @UiThread
   public View getRenderView() {
     return renderView;
+  }
+
+  /**
+   * Returns the underlying native map instance.
+   * The type of NativeMap returned is determined by the ModuleProvider's
+   * `createNativeMapView` method.
+   */
+  public NativeMap getNativeMap() {
+    return nativeMapView;
   }
 
   @Override

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMap.java
@@ -25,7 +25,7 @@ import org.maplibre.android.style.sources.Source;
 
 import java.util.List;
 
-interface NativeMap {
+public interface NativeMap {
 
   //
   // Lifecycle API

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -44,7 +44,7 @@ import java.util.Arrays;
 import java.util.List;
 
 // Class that wraps the native methods for convenience
-final class NativeMapView implements NativeMap {
+public final class NativeMapView implements NativeMap {
 
   private static final String TAG = "Mbgl-NativeMapView";
 
@@ -1668,7 +1668,7 @@ final class NativeMapView implements NativeMap {
     void onDidFinishLoadingStyle();
   }
 
-  interface StateCallback extends StyleCallback {
+  public interface StateCallback extends StyleCallback {
     void onCameraWillChange(boolean animated);
 
     void onCameraIsChanging();


### PR DESCRIPTION
This PR exposes the NativeMapView implementation and delegates construction to the ModuleProvider via a new factory method. This allows an external library to implement a custom NativeMapView and replace it at runtime by implementing the ModuleProvider interface. This enables a much cleaner method of working with the native core layer of MapLibre in Android projects.

For existing users, nothing will change. Advanced users which already implement their own ModuleProvider will need to implement the new `createNativeMapView` method. The implementation of this method can be copied from the included `ModuleProviderImpl.java` file.