### PR TITLE
Use Issue Templates for iOS and Android

### DIFF
--- a/.github/ISSUE_TEMPLATE/android-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/android-bug-report.yml
@@ -44,6 +44,21 @@ body:
     validations:
       required: true
   - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Explain how the issue can be reproduced.
+    validations:
+      required: true
+  - type: dropdown
+    id: renderer
+    attributes:
+      label: What renderer do you see the problem with?
+      multiple: true
+      options:
+        - OpenGL (choose this if you are unsure)
+        - Vulkan
+  - type: textarea
     id: logs
     attributes:
       label: Relevant log output

--- a/.github/ISSUE_TEMPLATE/android-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/android-bug-report.yml
@@ -14,7 +14,6 @@ body:
       placeholder: e.g. 11.6.2
     validations:
       required: true
-    description: What [version](https://github.com/maplibre/maplibre-native/releases?q=android&expanded=true) are you experiencing this issue with?
   - type: input
     id: android-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/android-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/android-bug-report.yml
@@ -34,7 +34,6 @@ body:
     attributes:
       label: What happened?
       description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/android-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/android-bug-report.yml
@@ -43,13 +43,6 @@ body:
       description: Explain how the issue can be reproduced.
     validations:
       required: true
-  - type: textarea
-    id: repro
-    attributes:
-      label: Steps to reproduce
-      description: Explain how the issue can be reproduced.
-    validations:
-      required: true
   - type: dropdown
     id: renderer
     attributes:

--- a/.github/ISSUE_TEMPLATE/android-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/android-bug-report.yml
@@ -1,0 +1,60 @@
+name: MapLibre Android Bug Report
+description: Report a bug you encountered with MapLibre Android.
+labels: ["android"]
+type: "bug"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: version
+    attributes:
+      label: MapLibre Android Version
+      description: MapLibre iOS Version
+      placeholder: e.g. 11.6.2
+    validations:
+      required: true
+  - type: input
+    id: android-version
+    attributes:
+      label: Android SDK Version
+      placeholder: e.g. Android 10
+    validations:
+      required: true
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      description: Enter the device that you encountered the issue on.
+      placeholder: Google Pixel 7 Pro
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Explain how the issue can be reproduced.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Additional context such as screenshots or videos that are helpful.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/android-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/android-bug-report.yml
@@ -14,6 +14,7 @@ body:
       placeholder: e.g. 11.6.2
     validations:
       required: true
+    description: What [version](https://github.com/maplibre/maplibre-native/releases?q=android&expanded=true) are you experiencing this issue with?
   - type: input
     id: android-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/android-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/android-bug-report.yml
@@ -46,11 +46,12 @@ body:
   - type: dropdown
     id: renderer
     attributes:
-      label: What renderer do you see the problem with?
+      label: Renderer
       multiple: true
       options:
         - OpenGL (choose this if you are unsure)
         - Vulkan
+      description: Mostly relevant for rendering issues.
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/android-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/android-bug-report.yml
@@ -11,7 +11,6 @@ body:
     id: version
     attributes:
       label: MapLibre Android Version
-      description: MapLibre iOS Version
       placeholder: e.g. 11.6.2
     validations:
       required: true
@@ -26,7 +25,7 @@ body:
     id: device
     attributes:
       label: Device
-      description: Enter the device that you encountered the issue on.
+      description: "Enter the device that you encountered the issue on or enter 'Simulator' if you only see this issue in a simulator."
       placeholder: Google Pixel 7 Pro
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,16 +1,20 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: General Bug report
+about: Create a report to help us improve.
 title: ''
-labels: bug
+type: bug
 assignees: ''
 
 ---
 
+<!-- If your issue is about MapLibre iOS or MapLibre Android, please use the corresponding template. -->
+
 **Describe the bug**
+
 A clear and concise description of what the bug is.
 
 **To Reproduce**
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
@@ -18,16 +22,19 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
+
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
+
 If applicable, add screenshots to help explain your problem.
 
 **Platform information (please complete the following information):**
- - OS: [e.g. iOS]
- - Platform [e.g. Qt, Node.js, iOS]
- - Version [e.g. 22]
 
+ - Operating System:
+ - Platform (e.g. Node.js, Qt):
+ - Version:
 
 **Additional context**
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/ios-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/ios-bug-report.yml
@@ -1,6 +1,7 @@
 name: MapLibre iOS Bug Report
 description: Report a bug you encountered with MapLibre iOS.
 labels: ["ios"]
+type: "bug"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/ios-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/ios-bug-report.yml
@@ -16,7 +16,7 @@ body:
     validations:
       required: true
   - type: input
-    id: version
+    id: ios-version
     attributes:
       label: iOS Version
       description: MapLibre iOS Version

--- a/.github/ISSUE_TEMPLATE/ios-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/ios-bug-report.yml
@@ -25,7 +25,7 @@ body:
     id: device
     attributes:
       label: Device
-      description: Enter the device that you encountered the issue on.
+      description: "Enter the device that you encountered the issue on or enter 'Simulator' if you only see this issue in a simulator."
       placeholder: iPhone 15 Pro
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/ios-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/ios-bug-report.yml
@@ -34,7 +34,6 @@ body:
     attributes:
       label: What happened?
       description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/ios-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/ios-bug-report.yml
@@ -53,6 +53,7 @@ body:
   - type: textarea
     id: context
     attributes:
-      label: Additional context (screenshots, videos)
+      label: Additional context
+      description: Additional context such as screenshots or videos that are helpful.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/ios-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/ios-bug-report.yml
@@ -1,0 +1,55 @@
+name: MapLibre iOS Bug Report
+description: Report a bug you encountered with MapLibre iOS.
+labels: ["ios"]
+type: "bug"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: version
+    attributes:
+      label: MapLibre iOS Version
+      description: MapLibre iOS Version
+      placeholder: e.g. 6.8.1
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: iOS Version
+      description: MapLibre iOS Version
+      placeholder: e.g. 6.8.1
+    validations:
+      required: true
+  - type: input
+    id: device
+    attributes:
+      label: device
+      description: Device
+      placeholder: iPhone 15 Pro
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/ios-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/ios-bug-report.yml
@@ -26,8 +26,8 @@ body:
   - type: input
     id: device
     attributes:
-      label: device
-      description: Device
+      label: Device
+      description: Enter the device that you encountered the issue on.
       placeholder: iPhone 15 Pro
     validations:
       required: true
@@ -42,9 +42,8 @@ body:
   - type: textarea
     id: repro
     attributes:
-      label: What happened?
-      description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
+      label: Steps to reproduce
+      description: Explain how the issue can be reproduced.
     validations:
       required: true
   - type: textarea
@@ -53,3 +52,9 @@ body:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
       render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context (screenshots, videos)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/ios-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/ios-bug-report.yml
@@ -11,7 +11,6 @@ body:
     id: version
     attributes:
       label: MapLibre iOS Version
-      description: MapLibre iOS Version
       placeholder: e.g. 6.8.1
     validations:
       required: true
@@ -19,7 +18,6 @@ body:
     id: ios-version
     attributes:
       label: iOS Version
-      description: MapLibre iOS Version
       placeholder: e.g. 6.8.1
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/ios-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/ios-bug-report.yml
@@ -1,7 +1,6 @@
 name: MapLibre iOS Bug Report
 description: Report a bug you encountered with MapLibre iOS.
 labels: ["ios"]
-type: "bug"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
I noticed that quite a few bug reports are missing information (e.g. device used, iOS version).

So I will try using an issue template for iOS and Android specifically. There are some slight differences, enough to warrant a separate template for each I think.

I want keep the old Markdown based bug report template as well for now.

Preview here: https://github.com/maplibre/maplibre-native/blob/ios-bug-report-template/.github/ISSUE_TEMPLATE/ios-bug-report.yml