### PR TITLE
Fix the issue that the empty polyline cannot be updated

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/PolygonContainer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/PolygonContainer.java
@@ -27,12 +27,10 @@ class PolygonContainer implements Polygons {
   @Override
   public Polygon addBy(@NonNull PolygonOptions polygonOptions, @NonNull MapLibreMap maplibreMap) {
     Polygon polygon = polygonOptions.getPolygon();
-    if (!polygon.getPoints().isEmpty()) {
-      long id = nativeMap != null ? nativeMap.addPolygon(polygon) : 0;
-      polygon.setId(id);
-      polygon.setMapLibreMap(maplibreMap);
-      annotations.put(id, polygon);
-    }
+    long id = nativeMap != null ? nativeMap.addPolygon(polygon) : 0;
+    polygon.setId(id);
+    polygon.setMapLibreMap(maplibreMap);
+    annotations.put(id, polygon);
     return polygon;
   }
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/PolylineContainer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/PolylineContainer.java
@@ -27,12 +27,10 @@ class PolylineContainer implements Polylines {
   @Override
   public Polyline addBy(@NonNull PolylineOptions polylineOptions, @NonNull MapLibreMap maplibreMap) {
     Polyline polyline = polylineOptions.getPolyline();
-    if (!polyline.getPoints().isEmpty()) {
-      long id = nativeMap != null ? nativeMap.addPolyline(polyline) : 0;
-      polyline.setMapLibreMap(maplibreMap);
-      polyline.setId(id);
-      annotations.put(id, polyline);
-    }
+    long id = nativeMap != null ? nativeMap.addPolyline(polyline) : 0;
+    polyline.setMapLibreMap(maplibreMap);
+    polyline.setId(id);
+    annotations.put(id, polyline);
     return polyline;
   }
 

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/maps/AnnotationManagerTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/maps/AnnotationManagerTest.kt
@@ -8,35 +8,43 @@ import org.maplibre.android.annotations.MarkerOptions
 import org.maplibre.android.geometry.LatLng
 import org.junit.Assert
 import org.junit.Test
+import org.maplibre.android.annotations.PolygonOptions
+import org.maplibre.android.annotations.PolylineOptions
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 
 class AnnotationManagerTest {
+
+    private val aNativeMapView: NativeMap = Mockito.mock(NativeMapView::class.java)
+    private val aMapView = Mockito.mock(MapView::class.java)
+    private val annotationsArray = LongSparseArray<Annotation>()
+    private val aIconManager = Mockito.mock(
+        IconManager::class.java
+    )
+    private val aMapLibreMap = Mockito.mock(MapLibreMap::class.java)
+
+    private val annotations: Annotations = AnnotationContainer(aNativeMapView, annotationsArray)
+    private val markers: Markers = MarkerContainer(aNativeMapView, annotationsArray, aIconManager)
+    private val polygons: Polygons = PolygonContainer(aNativeMapView, annotationsArray)
+    private val polylines: Polylines = PolylineContainer(aNativeMapView, annotationsArray)
+    private val shapeAnnotations: ShapeAnnotations =
+        ShapeAnnotationContainer(aNativeMapView, annotationsArray)
+
+
+    private val annotationManager = AnnotationManager(
+        aMapView,
+        annotationsArray,
+        aIconManager,
+        annotations,
+        markers,
+        polygons,
+        polylines,
+        shapeAnnotations
+    )
+
     @Test
     @Throws(Exception::class)
     fun checksAddAMarker() {
-        val aNativeMapView: NativeMap = Mockito.mock(NativeMapView::class.java)
-        val aMapView = Mockito.mock(MapView::class.java)
-        val annotationsArray = LongSparseArray<Annotation>()
-        val aIconManager = Mockito.mock(
-            IconManager::class.java
-        )
-        val annotations: Annotations = AnnotationContainer(aNativeMapView, annotationsArray)
-        val markers: Markers = MarkerContainer(aNativeMapView, annotationsArray, aIconManager)
-        val polygons: Polygons = PolygonContainer(aNativeMapView, annotationsArray)
-        val polylines: Polylines = PolylineContainer(aNativeMapView, annotationsArray)
-        val shapeAnnotations: ShapeAnnotations =
-            ShapeAnnotationContainer(aNativeMapView, annotationsArray)
-        val annotationManager = AnnotationManager(
-            aMapView,
-            annotationsArray,
-            aIconManager,
-            annotations,
-            markers,
-            polygons,
-            polylines,
-            shapeAnnotations
-        )
         val aMarker = Mockito.mock(
             Marker::class.java
         )
@@ -55,28 +63,6 @@ class AnnotationManagerTest {
     @Test
     @Throws(Exception::class)
     fun checksAddMarkers() {
-        val aNativeMapView = Mockito.mock(NativeMapView::class.java)
-        val aMapView = Mockito.mock(MapView::class.java)
-        val annotationsArray = LongSparseArray<Annotation>()
-        val aIconManager = Mockito.mock(
-            IconManager::class.java
-        )
-        val annotations: Annotations = AnnotationContainer(aNativeMapView, annotationsArray)
-        val markers: Markers = MarkerContainer(aNativeMapView, annotationsArray, aIconManager)
-        val polygons: Polygons = PolygonContainer(aNativeMapView, annotationsArray)
-        val polylines: Polylines = PolylineContainer(aNativeMapView, annotationsArray)
-        val shapeAnnotations: ShapeAnnotations =
-            ShapeAnnotationContainer(aNativeMapView, annotationsArray)
-        val annotationManager = AnnotationManager(
-            aMapView,
-            annotationsArray,
-            aIconManager,
-            annotations,
-            markers,
-            polygons,
-            polylines,
-            shapeAnnotations
-        )
         val firstId = 1L
         val secondId = 2L
         val markerList: MutableList<BaseMarkerOptions<*, *>> = ArrayList()
@@ -100,5 +86,34 @@ class AnnotationManagerTest {
         Assert.assertEquals("second", (annotationManager.annotations[1] as Marker).title)
         Assert.assertEquals("first", (annotationManager.getAnnotation(firstId) as Marker).title)
         Assert.assertEquals("second", (annotationManager.getAnnotation(secondId) as Marker).title)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun checksAddEmptyPolygon() {
+        val pId = 5L
+        val polygonOptions = PolygonOptions()
+        val polygon = polygonOptions.polygon
+        Mockito.`when`(aNativeMapView.addPolygon(polygon)).thenReturn(pId)
+        val resultPolygon = annotationManager.addPolygon(polygonOptions, aMapLibreMap)
+        Assert.assertEquals(polygon, resultPolygon)
+        Assert.assertEquals(pId, resultPolygon.id)
+        Assert.assertEquals(1, annotationManager.annotations.size)
+        Assert.assertEquals(polygon, annotationManager.annotations[0])
+
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun checksAddEmptyPolyline() {
+        val pId = 5L
+        val polylineOptions = PolylineOptions()
+        val polyline = polylineOptions.polyline
+        Mockito.`when`(aNativeMapView.addPolyline(polyline)).thenReturn(pId)
+        val resultPolyline = annotationManager.addPolyline(polylineOptions, aMapLibreMap)
+        Assert.assertEquals(polyline, resultPolyline)
+        Assert.assertEquals(pId, resultPolyline.id)
+        Assert.assertEquals(1, annotationManager.annotations.size)
+        Assert.assertEquals(polyline, annotationManager.annotations[0])
     }
 }


### PR DESCRIPTION
An example code to reproduce the issue is 
```
Polyline line = mapLibreMap.addPolyline(new PolylineOptions());
// Anything to update the polyline will fail
line.setPoints(...);
line.setColor(...);
```
The reason is that PolylineContainer will ignore the empty polyline the first time.
