### PR TITLE
Add latency to surface updates

### DIFF
--- a/include/mbgl/vulkan/context.hpp
+++ b/include/mbgl/vulkan/context.hpp
@@ -146,7 +146,7 @@ public:
     void enqueueDeletion(std::function<void(Context&)>&& function);
     void submitOneTimeCommand(const std::function<void(const vk::UniqueCommandBuffer&)>& function) const;
 
-    void requestSurfaceUpdate() { surfaceUpdateRequested = true; }
+    void requestSurfaceUpdate();
 
 private:
     struct FrameResources {
@@ -197,6 +197,7 @@ private:
     uint8_t frameResourceIndex = 0;
     std::vector<FrameResources> frameResources;
     bool surfaceUpdateRequested{false};
+    int32_t surfaceUpdateLatency{0};
     int32_t currentFrameCount{0};
 
     struct {

--- a/include/mbgl/vulkan/context.hpp
+++ b/include/mbgl/vulkan/context.hpp
@@ -146,7 +146,7 @@ public:
     void enqueueDeletion(std::function<void(Context&)>&& function);
     void submitOneTimeCommand(const std::function<void(const vk::UniqueCommandBuffer&)>& function) const;
 
-    void requestSurfaceUpdate();
+    void requestSurfaceUpdate(bool useDelay = true);
 
 private:
     struct FrameResources {

--- a/src/mbgl/vulkan/context.cpp
+++ b/src/mbgl/vulkan/context.cpp
@@ -172,7 +172,7 @@ void Context::submitOneTimeCommand(const std::function<void(const vk::UniqueComm
 }
 
 void Context::requestSurfaceUpdate() {
-    if (surfaceUpdateLatency) {
+    if (surfaceUpdateRequested) {
         return;
     }
 

--- a/src/mbgl/vulkan/context.cpp
+++ b/src/mbgl/vulkan/context.cpp
@@ -171,6 +171,15 @@ void Context::submitOneTimeCommand(const std::function<void(const vk::UniqueComm
     }
 }
 
+void Context::requestSurfaceUpdate() {
+    if (surfaceUpdateLatency) {
+        return;
+    }
+
+    surfaceUpdateRequested = true;
+    surfaceUpdateLatency = backend.getMaxFrames() * 3;
+}
+
 void Context::waitFrame() const {
     MLN_TRACE_FUNC();
     const auto& device = backend.getDevice();
@@ -203,7 +212,7 @@ void Context::beginFrame() {
         }
     }
 
-    if (platformSurface && surfaceUpdateRequested) {
+    if (platformSurface && surfaceUpdateRequested && --surfaceUpdateLatency == 0) {
         renderableResource.recreateSwapchain();
 
         // we wait for an idle device to recreate the swapchain


### PR DESCRIPTION
Surface rotation events (and updated info) come a few frames later after 90 degree rotations. Adding a delay between the event and surface update fixes https://github.com/maplibre/maplibre-native/issues/2787#issuecomment-2488533005