### PR TITLE
Use libuv run loop for macOS (CMake)

### DIFF
--- a/include/mbgl/util/run_loop.hpp
+++ b/include/mbgl/util/run_loop.hpp
@@ -50,7 +50,7 @@ public:
     void updateTime();
 
     /// Platform integration callback for platforms that do not have full
-    /// run loop integration or don't want to block at the Mapbox GL Native
+    /// run loop integration or don't want to block at the MapLibre Native
     /// loop. It will be called from any thread and is up to the platform
     /// to, after receiving the callback, call RunLoop::runOnce() from the
     /// same thread as the Map object lives.

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -10,29 +10,19 @@ endif()
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH[variant=Debug] "YES")
 
 set_target_properties(mbgl-core PROPERTIES XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES)
+find_package(PkgConfig REQUIRED)
+
+pkg_search_module(LIBUV libuv REQUIRED)
+
+if (NOT LIBUV_FOUND)
+    message(FATAL_ERROR "libuv not found! Install it via Homebrew: brew install libuv")
+endif()
 
 if(MLN_WITH_OPENGL)
-    find_package(OpenGL REQUIRED)
-
-    target_compile_definitions(
-        mbgl-core
-        PUBLIC GL_SILENCE_DEPRECATION
-    )
-    target_sources(
-        mbgl-core
-        PRIVATE
-            ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/gl/headless_backend.cpp
-            ${PROJECT_SOURCE_DIR}/platform/darwin/src/gl_functions.cpp ${PROJECT_SOURCE_DIR}/platform/darwin/src/headless_backend_cgl.mm
-    )
-    target_link_libraries(
-        mbgl-core
-        PRIVATE OpenGL::GL
-    )
+    message(FATAL_ERROR "OpenGL ES it not supported for macOS")
 endif()
 
 if(MLN_WITH_METAL)
-    find_package(OpenGL REQUIRED)
-
     target_sources(
         mbgl-core
         PRIVATE
@@ -63,7 +53,7 @@ endif()
 target_sources(
     mbgl-core
     PRIVATE
-        ${PROJECT_SOURCE_DIR}/platform/darwin/src/async_task.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/async_task.cpp
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/collator.mm
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/http_file_source.mm
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/image.mm
@@ -72,9 +62,9 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/native_apple_interface.m
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/nsthread.mm
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/number_format.mm
-        ${PROJECT_SOURCE_DIR}/platform/darwin/src/run_loop.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/run_loop.cpp
         ${PROJECT_SOURCE_DIR}/platform/darwin/src/string_nsstring.mm
-        ${PROJECT_SOURCE_DIR}/platform/darwin/src/timer.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/timer.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/gfx/headless_backend.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/gfx/headless_frontend.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/layermanager/layer_manager.cpp
@@ -114,6 +104,7 @@ target_include_directories(
     mbgl-core
     PRIVATE
         ${PROJECT_SOURCE_DIR}/platform/darwin/include ${PROJECT_SOURCE_DIR}/platform/darwin/src ${PROJECT_SOURCE_DIR}/platform/macos/src
+        ${LIBUV_INCLUDE_DIRS}
 )
 
 include(${PROJECT_SOURCE_DIR}/vendor/icu.cmake)
@@ -128,6 +119,7 @@ target_link_libraries(
         mbgl-vendor-icu
         sqlite3
         z
+        ${LIBUV_LINK_LIBRARIES}
 )
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/bin)


### PR DESCRIPTION
The CFRunLoop is crashing with GLFW on macOS.

I tried fixing it, but I am getting non-descriptive segfaults.

<details><summary>Stack trace</summary>

```
/Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSSharedPtr.hpp:219:16: runtime error: member call on null pointer of type 'NS::Referencing<MTL::Texture, MTL::Resource>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSSharedPtr.hpp:219:16 in 
/Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSObject.hpp:112:49: runtime error: member call on null pointer of type 'NS::Referencing<MTL::Texture, MTL::Resource> *'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSObject.hpp:112:49 in 
/Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSSharedPtr.hpp:219:16: runtime error: member call on null pointer of type 'NS::Referencing<MTL::DepthStencilState>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSSharedPtr.hpp:219:16 in 
/Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSObject.hpp:112:49: runtime error: member call on null pointer of type 'NS::Referencing<MTL::DepthStencilState> *'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSObject.hpp:112:49 in 
/Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSSharedPtr.hpp:219:16: runtime error: member call on null pointer of type 'NS::Referencing<MTL::Texture, MTL::Resource>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSSharedPtr.hpp:219:16 in 
/Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSObject.hpp:112:49: runtime error: member call on null pointer of type 'NS::Referencing<MTL::Texture, MTL::Resource> *'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSObject.hpp:112:49 in 
/Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSSharedPtr.hpp:219:16: runtime error: member call on null pointer of type 'NS::Referencing<MTL::SamplerState>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSSharedPtr.hpp:219:16 in 
/Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSObject.hpp:112:49: runtime error: member call on null pointer of type 'NS::Referencing<MTL::SamplerState> *'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/bart/src/maplibre-native/vendor/metal-cpp/Foundation/NSObject.hpp:112:49 in 
AddressSanitizer:DEADLYSIGNAL
=================================================================
==21109==ERROR: AddressSanitizer: SEGV on unknown address 0x000000010b20 (pc 0x000196424270 bp 0x00016d750a40 sp 0x00016d750a00 T0)
==21109==The signal is caused by a READ memory access.
    #0 0x196424270 in objc_release+0x10 (libobjc.A.dylib:arm64e+0x8270)
    #1 0x196428134 in objc_autoreleasePoolPop+0x100 (libobjc.A.dylib:arm64e+0xc134)
    #2 0x19689c7bc in _CFAutoreleasePoolPop+0x1c (CoreFoundation:arm64e+0x3c7bc)
    #3 0x1969af954 in __CFRunLoopPerCalloutARPEnd+0x2c (CoreFoundation:arm64e+0x14f954)
    #4 0x1968f7e44 in __CFRunLoopDoTimer+0x410 (CoreFoundation:arm64e+0x97e44)
    #5 0x1968f7934 in __CFRunLoopDoTimers+0x160 (CoreFoundation:arm64e+0x97934)
    #6 0x1968dd0ec in __CFRunLoopRun+0x73c (CoreFoundation:arm64e+0x7d0ec)
    #7 0x1968dc330 in CFRunLoopRunSpecific+0x238 (CoreFoundation:arm64e+0x7c330)
    #8 0x196957a0c in CFRunLoopRun+0x3c (CoreFoundation:arm64e+0xf7a0c)
    #9 0x102af0758 in mbgl::util::RunLoop::run() run_loop.cpp:38
    #10 0x1027c4cb0 in GLFWView::run() glfw_view.cpp:1119
    #11 0x1028ef6ac in main main.cpp:222
    #12 0x196474270  (<unknown module>)
```
</details>

This PR changes the CMake config to use the the libuv-based run loop on macOS instead, which seems to work fine.

```
cmake . -B build \                                                                               
            -G Ninja \
            -DCMAKE_BUILD_TYPE=Debug \
            -DCMAKE_CXX_COMPILER_LAUNCHER=/opt/homebrew/bin/ccache \
            -DMLN_WITH_OPENGL=OFF \
            -DMLN_WITH_METAL=ON \
            -DMLN_LEGACY_RENDERER=OFF \
            -DMLN_DRAWABLE_RENDERER=ON \
            -DMLN_WITH_WERROR=OFF
build/platform/glfw/mbgl-glfw --style "https://tiles.openfreemap.org/styles/liberty"
```