### PR TITLE
Use CMake 3.24.0+ for Android

### DIFF
--- a/platform/android/android.cmake
+++ b/platform/android/android.cmake
@@ -146,6 +146,14 @@ target_include_directories(
     ${PROJECT_SOURCE_DIR}/src
 )
 
+# this is needed because Android is not officially supported
+# https://discourse.cmake.org/t/error-when-crosscompiling-with-whole-archive-target-link/9394
+# https://cmake.org/cmake/help/latest/release/3.24.html#generator-expressions
+set(CMAKE_LINK_LIBRARY_USING_WHOLE_ARCHIVE 
+"-Wl,--whole-archive <LIBRARY> -Wl,--no-whole-archive"
+)
+set(CMAKE_LINK_LIBRARY_USING_WHOLE_ARCHIVE_SUPPORTED True)
+
 find_package(curl CONFIG)
 
 target_link_libraries(

--- a/platform/android/buildSrc/src/main/kotlin/Versions.kt
+++ b/platform/android/buildSrc/src/main/kotlin/Versions.kt
@@ -1,4 +1,4 @@
 object Versions {
-    const val ndkVersion ="27.0.12077973"
-    const val cmakeVersion = "3.18.1+"
+    const val ndkVersion = "27.0.12077973"
+    const val cmakeVersion = "3.24.0+"
 }

--- a/test/android/app/build.gradle.kts
+++ b/test/android/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
 
     externalNativeBuild {
         cmake {
-            version = "3.18.1+"
+            version = "3.24.0+"
             path = file("../../../CMakeLists.txt")
         }
     }


### PR DESCRIPTION
Android compilation will fail if an older CMake version is found.

So set CMake 3.24 which is needed after #2968.