### PR TITLE
Fix crash on unsupported attribute type conversion

### DIFF
--- a/src/mbgl/gl/upload_pass.cpp
+++ b/src/mbgl/gl/upload_pass.cpp
@@ -271,7 +271,9 @@ gfx::AttributeBindingArray UploadPass::buildAttributeBindings(
             return;
         }
 
-        overrideAttr->setDirty(false);
+        if (overrideAttr) {
+            overrideAttr->setDirty(false);
+        }
 
         bindings[index] = {
             /*.attribute = */ {defaultAttr.getDataType(), offset},

--- a/src/mbgl/gl/vertex_attribute_gl.cpp
+++ b/src/mbgl/gl/vertex_attribute_gl.cpp
@@ -169,7 +169,7 @@ const std::vector<std::uint8_t>& VertexAttributeGL::getRaw(gfx::VertexAttribute&
             for (std::size_t i = 0; i < count; ++i) {
                 if (!get(attr.get(i), type, outPtr)) {
                     // missing type conversion
-                    assert(false);
+                    std::fill(outPtr, outPtr + stride_, 0);
                 }
                 outPtr += stride_;
             }


### PR DESCRIPTION
Check matched attribute before trying to clear its dirty flag, preventing a crash when there is no match.

Remove assertion to avoid killing debug builds while attempting to set up the attribute.

Resolves #3042
