### PR TITLE
fix: Disable accessibility on hidden compass button

### DIFF
--- a/platform/ios/src/MLNCompassButton.mm
+++ b/platform/ios/src/MLNCompassButton.mm
@@ -124,6 +124,8 @@
 
 - (void)hideCompass:(BOOL)animated {
     animated ? [self animateToAlpha:0] : [self setAlpha:0];
+    self.isAccessibilityElement = NO;
+    self.accessibilityElementsHidden = YES;
 }
 
 - (void)animateToAlpha:(CGFloat)alpha {


### PR DESCRIPTION
Checking the [issue 3058](https://github.com/maplibre/maplibre-native/issues/3058), it might be solved by disabling the accessibility on the `hideCompass` function because if the compass is hidden there is no point in showing it for the accessibility.

Testing it fixes the problem, let me know if it's useful!

Also, you can check if on the other hand, the function `showCompass`, you can set the opposite

```
self.isAccessibilityElement = YES;
self.accessibilityElementsHidden = No;
```

but as they are the default values, maybe it is not needed, just mind a case of being forced to hide and show the compass button in the same instance. What do you think?