### PR TITLE
Use MapLibre Android as attribution string across languages

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/res/values-bg/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-bg/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Иконка функции. Активирай, за да покажеш диалог функции.</string>
     <string name="maplibre_myLocationViewContentDescription">Изглед локация. Това показва местоположението ти на картата.</string>
     <string name="maplibre_mapActionDescription">Показва карта създадена с MapLibre. Скролни с два пръста. Мащабирай с два пръста.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Android SDK</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_offline_error_region_definition_invalid">Предоставените OfflineRegionDefinition не пасват в границите на света: %s</string>
 
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-ca/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-ca/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Icona d’atribució. Activa per mostrar el diàleg de l’atribució.</string>
     <string name="maplibre_myLocationViewContentDescription">Vista de posició. Mostra la teva posició al mapa.</string>
     <string name="maplibre_mapActionDescription">Mostrant un mapa creat amb MapLibre. Desplaça’t arrossegant amb dos dits. Fes zoom pessigant amb dos dits.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Android SDK</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_offline_error_region_definition_invalid">La OfflineRegionDefinition proporcionada no encaixa amb els límits del món: %s</string>
 
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-cs/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-cs/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Atributy. Zobrazit nastavení atributů.</string>
     <string name="maplibre_myLocationViewContentDescription">Zobrazení polohy. Zobrazit umístění na mapě.</string>
     <string name="maplibre_mapActionDescription">Zobrazení mapy vytvořené s MapLibre. Posunout tažením dvěma prsty. Změnit velikost roztažením dvou prstů.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK pro Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">Na zařízení není nainstalován webový prohlížeč, webovou stránku nelze zobrazit.</string>
     <string name="maplibre_offline_error_region_definition_invalid">Pokud OfflineRegionDefinition neodpovídá hranicím: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-es/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-es/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Ícono de atribución. Actívalo para mostrar el diálogo de atribución.</string>
     <string name="maplibre_myLocationViewContentDescription">Vista de ubicación. Muestra tu ubicación en el mapa.</string>
     <string name="maplibre_mapActionDescription">Se está mostrando un mapa creado con MapLibre. Arrastra dos dedos para desplazarte o pellizca para acercar.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK para Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">No puede abrir la página Web porque no hay un navegador Web en el dispositivo.</string>
     <string name="maplibre_offline_error_region_definition_invalid">El parámetro OfflineRegionDefinition que se ingresó no coincide con los límites mundiales: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-fr/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-fr/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Icône d’attribution. Activer pour afficher le dialogue d’attribution.</string>
     <string name="maplibre_myLocationViewContentDescription">Vue de géolocalisation. Ceci affiche votre localisation sur la carte.</string>
     <string name="maplibre_mapActionDescription">Affichage d’une carte créée avec MapLibre. Faites la glisser en traînant deux doigts. Zoomez ou dézoomez en écartant ou rapprochant deux doigts.</string>
-    <string name="maplibre_attributionsDialogTitle">SDK MapLibre Maps pour Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">Aucun navigateur web installé sur l’appareil, impossible d’ouvrir une page web.</string>
     <string name="maplibre_offline_error_region_definition_invalid">Le cadre OfflineRegionDefinition pour définir la région de navigation ne tient pas dans les limites du monde : %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-gl/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-gl/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Icona de atribución. Actívaa para amosar o diálogo de atribución.</string>
     <string name="maplibre_myLocationViewContentDescription">Vista de ubicación. Amosa a túa ubicación no mapa.</string>
     <string name="maplibre_mapActionDescription">Estase a amosar un mapa feito co MapLibre. Belisca dous dedos para desprazarte ou belisca para achegar.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK para o Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">Non podes abrir a páxina web porque non hai un navegador web no dispositivo.</string>
     <string name="maplibre_offline_error_region_definition_invalid">O parámetro OfflineRegionDefinition que se ingresou non coincide cos límites mundiais: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-he/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-he/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">סמל שיוך. הפעל כדי להציג תיבת דו-שיח של שיוך.</string>
     <string name="maplibre_myLocationViewContentDescription">סמן מיקום. מציג את המיקום הנוכחי שלך על המפה.</string>
     <string name="maplibre_mapActionDescription">מציג מפה שנוצרה עם MapLibre. גלול באמצעות גרירה עם שתי אצבעות, זום באמצעות צביטה עם שתי אצבעות.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK for Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">לא מותקן דפדפן אינטרנט במכשיר, לא ניתן לפתוח את דף האינטרנט.</string>
     <string name="maplibre_offline_error_region_definition_invalid">בתנאי ש- OfflineRegionDefinition אינו מתאים לגבולות העולם: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-hu/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-hu/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="maplibre_myLocationViewContentDescription">Hely nézet. Megmutatja, hol vagy a térképen.</string>
     <string name="maplibre_mapActionDescription">Egy MapLibre-szal készült térkép megjelenítése. Húzd két ujjadat a görgetéshez. Csippentsd össze a nagyításhoz.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK Androidhoz</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">Nincs webböngésző telepítve a készüléken, nem lehet megnyitni weboldalt.</string>
     <string name="maplibre_offline_error_region_definition_invalid">A megadott OfflineRegionDefinition nem fér bele a világ kereteibe: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-iw/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-iw/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">סמל שיוך. הפעל כדי להציג תיבת דו-שיח של שיוך.</string>
     <string name="maplibre_myLocationViewContentDescription">סמן מיקום. מציג את המיקום הנוכחי שלך על המפה.</string>
     <string name="maplibre_mapActionDescription">מציג מפה שנוצרה עם MapLibre. גלול באמצעות גרירה עם שתי אצבעות, זום באמצעות צביטה עם שתי אצבעות.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK for Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">לא מותקן דפדפן אינטרנט במכשיר, לא ניתן לפתוח את דף האינטרנט.</string>
     <string name="maplibre_offline_error_region_definition_invalid">בתנאי ש- OfflineRegionDefinition אינו מתאים לגבולות העולם: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-ko/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-ko/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">속성 정보. 속성 대화를 표시합니다.</string>
     <string name="maplibre_myLocationViewContentDescription">로케이션 뷰. 지도에서 현재 위치를 보여줍니다.</string>
     <string name="maplibre_mapActionDescription">맵박스로 생성된 지도 표시. 두 손가락으로 드래그하여 화면을 위 아래로 움직이세요. 두 손가락을 이용해 화면을 확대 축소 하세요.</string>
-    <string name="maplibre_attributionsDialogTitle">안드로이드를 위한 맵박스 맵 SDK</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">웹 브라우저가 설치 되어 있지 않아, 웹 페이지를 열 수 없습니다.</string>
     <string name="maplibre_offline_error_region_definition_invalid">제공된 오프라인지역정의가 월드바운즈에 적합하지 않습니다: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-lt/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-lt/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Įnašo ikona. Paspausk norėdamas pamatyti dialogą su detalėmis</string>
     <string name="maplibre_myLocationViewContentDescription">Vartotojo vietos vaizdas. Nurodo tavo poziciją žemėlapyje</string>
     <string name="maplibre_mapActionDescription">Rodomas MapLibre kurtas žemėlapis. Naviguok tempdamas du pirštus. Valdyk žemėlapio pritraukimą suimdamas/atitolindamas du pirštus.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Android SDK</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_offline_error_region_definition_invalid">Pasirinktas OfflineRegionDefinition netalpa į rėžius:  %s</string>
 
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-nl/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-nl/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Attributie icoon. Activeer voor het tonen van het attributie dialoog. </string>
     <string name="maplibre_myLocationViewContentDescription">Locatie Element. Dit toont jouw locatie op de map.</string>
     <string name="maplibre_mapActionDescription">Toont een map gemaakt met MapLibre. Scroll door het slepen met twee vingers. Zoom door vingers te nijpen.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Android SDK</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_offline_error_region_definition_invalid">Aangeleverde OfflineRegionDefinition past niet in de wereld omtrek: %s</string>
 
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-pl/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-pl/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Atrybucja. Aktywuj, żeby pokazać więcej informacji.</string>
     <string name="maplibre_myLocationViewContentDescription">Widok lokalizacji. Pokazuje twoją pozycję na mapie.</string>
     <string name="maplibre_mapActionDescription">Pokazuje mapę stworzoną za pomocą biblioteki MapLibre. Przesuń mapę za pomocą przeciągnięcia dwoma palcami. Przybliż za pomocą uszczypnięcia dwoma palcami. </string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK dla Androida</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">Nie potrafię otworzyć strony, brak przeglądarki internetowej zainstalowanej na urządzeniu.</string>
     <string name="maplibre_offline_error_region_definition_invalid">Wymagany region nie mieści się w granicach świata: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-pt-rPT/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-pt-rPT/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Ícone de atribuição. Ativar para mostrar a janela de atribuição.</string>
     <string name="maplibre_myLocationViewContentDescription">Vista de localização. Isto mostra a sua localização no mapa.</string>
     <string name="maplibre_mapActionDescription">A mostrar um Mapa criado com MapLibre. Desloque arrastanto com 2 dedos. Zoom afastando ou aproximando os 2 dedos.</string>
-    <string name="maplibre_attributionsDialogTitle">Mapas MapLibre SDK para Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">Não está nenhum navegador de Internet instalado no dispositivo. Não é possível abrir a página web.</string>
     <string name="maplibre_offline_error_region_definition_invalid">O OfflineRegionDefinition não cabe nos limites do mundo: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-ru/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-ru/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Значок атрибутов. Активируйте, чтобы показать диалог.</string>
     <string name="maplibre_myLocationViewContentDescription">Местоположение. Отображает вашу позицию на карте.</string>
     <string name="maplibre_mapActionDescription">Отображает карту, созданную при помощи MapLibre. Пролистывайте двумя пальцами. Меняйте масштаб сведением пальцев.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK для Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">На устройстве нет веб-браузера, нельзя показать веб-страницу.</string>
     <string name="maplibre_offline_error_region_definition_invalid">Запрошенный OfflineRegionDefinition не входит в допустимые границы: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-sv/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-sv/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Tillskrivningsikon. Aktivera för att visa tillskrivningsdialog.</string>
     <string name="maplibre_myLocationViewContentDescription">Positionsvy. Denna visar din position på kartan.</string>
     <string name="maplibre_mapActionDescription">Visar en karta skapad med MapLibre. Scrolla genom att dra med två fingrar. Zooma genom att nypa med två fingrar.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK for Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">Ingen webbläsare installerad på enheten. Kan inte visa sidan.</string>
     <string name="maplibre_offline_error_region_definition_invalid">Försedd OfflineRegionDefinition passar inte världens gränser: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-uk/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-uk/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Значок атрибуції. Натисніть, щоб показати діалог атрибуції.</string>
     <string name="maplibre_myLocationViewContentDescription">Визначення положення. Показує ваше місцеположення на мапі.</string>
     <string name="maplibre_mapActionDescription">Показує мапи створені за допомоги MapLibre. Пересувайте мапу двома пальцями. Змінюйте масштаб стуляючи/розводячи два пальці.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK для Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">Веб-оглядач відсутній на цьому пристрої, неможливо відкрити веб-сторінку</string>
     <string name="maplibre_offline_error_region_definition_invalid">Межі ділянки для оффлайнового користування даними за межами світу: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-vi/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-vi/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Biểu tượng ghi công. Kích hoạt để xem hộp thoại ghi công.</string>
     <string name="maplibre_myLocationViewContentDescription">Cái chỉ vị trí. Cái này chỉ vị trí của bạn trên bản đồ.</string>
     <string name="maplibre_mapActionDescription">Đang xem bản đồ được xây dựng dùng MapLibre. Kéo hai ngón tay để cuộn. Chụm các ngón tay lại để phóng to. Tách các ngón tay ra để thu nhỏ.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK cho Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">Không thể mở trang Web vì thiết bị thiếu trình duyệt.</string>
     <string name="maplibre_offline_error_region_definition_invalid">OfflineRegionDefinition được cung cấp không vừa thế giới: %s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-zh-rCN/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-zh-rCN/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Attribution图标，点击以显示attribution对话框。</string>
     <string name="maplibre_myLocationViewContentDescription">定位视图，在地图上显示当前位置。</string>
     <string name="maplibre_mapActionDescription">显示由MapLibre创建的地图，通过拖动两个手指来滚动，捏两个手指来放大。</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK for Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">设备中未安装任何浏览器，不能打开该网页</string>
     <string name="maplibre_offline_error_region_definition_invalid">提供的OfflineRegionDefinition不符合标准地理范围：%s</string>
 </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-zh-rHK/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-zh-rHK/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Attribution圖標，點擊以顯示attribution對話框。</string>
     <string name="maplibre_myLocationViewContentDescription">定位視圖，在地圖上顯示當前位置。</string>
     <string name="maplibre_mapActionDescription">顯示由MapLibre創建的地圖，通過拖動兩個手指來滾動，捏兩個手指來放大。</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK for Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">設備中未安裝任何瀏覽器，不能打開該網頁</string>
     <string name="maplibre_offline_error_region_definition_invalid">提供的OfflineRegionDefinition不符合標準地理範圍：%s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values-zh-rTW/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values-zh-rTW/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Attribution圖標，點擊以顯示attribution對話框。</string>
     <string name="maplibre_myLocationViewContentDescription">定位視圖，在地圖上顯示當前位置。</string>
     <string name="maplibre_mapActionDescription">顯示由MapLibre創建的地圖，通過拖動兩個手指來滾動，捏兩個手指來放大。</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK for Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">設備中未安裝任何瀏覽器，不能打開該網頁</string>
     <string name="maplibre_offline_error_region_definition_invalid">提供的OfflineRegionDefinition不符合標準地理範圍：%s</string>
     </resources>

--- a/platform/android/MapLibreAndroid/src/main/res/values/strings.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="maplibre_attributionsIconContentDescription">Attribution icon. Activate to show attribution dialog.</string>
     <string name="maplibre_myLocationViewContentDescription">Location View. This shows your location on the map.</string>
     <string name="maplibre_mapActionDescription">Showing a Map created with MapLibre. Scroll by dragging two fingers. Zoom by pinching two fingers.</string>
-    <string name="maplibre_attributionsDialogTitle">MapLibre Maps SDK for Android</string>
+    <string name="maplibre_attributionsDialogTitle">MapLibre Android</string>
     <string name="maplibre_attributionErrorNoBrowser">No web browser installed on device, can\'t open web page.</string>
     <string name="maplibre_offline_error_region_definition_invalid">Provided OfflineRegionDefinition doesn\'t fit the world bounds: %s</string>
 </resources>


### PR DESCRIPTION
Since we tend to drop the 'SDK' and also the 'for', and just call the library 'MapLibre Android', I updated the attribution strings to match this across languages.

For Korean  안드로이드를 위한 맵박스 맵 SDK was used (translates to Mapbox Map SDK for Android). @ianthetechie recommended dropping the transliteration as MapLibre Android is more recognizable.