### PR TITLE
Prepare MapLibre Android 11.7.1 release

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: MapLibre_Native_Ubuntu_24_04_x84_16_core
     defaults:
       run:
         working-directory: platform/android
@@ -18,8 +18,6 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-
-      - run: echo "cmake.dir=$(dirname "$(dirname "$(command -v cmake)")")" >> local.properties
 
       - uses: actions/setup-java@v4
         with:
@@ -47,6 +45,7 @@ jobs:
       - name: Update version name
         run: |
           RELEASE_VERSION="$( git describe --tags --match=android-v*.*.* --abbrev=0 | sed 's/^android-v//' )"
+          echo version="$RELEASE_VERSION" >> "$GITHUB_ENV"
           echo "Latest version from tag: $RELEASE_VERSION"
           if [ -n "$RELEASE_VERSION" ]; then
             sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${RELEASE_VERSION}/" MapLibreAndroid/gradle.properties
@@ -60,17 +59,6 @@ jobs:
           RENDERER=vulkan make apackage
           RENDERER=drawable make apackage
 
-      - name: Build release Test App
-        run: |
-          MAPLIBRE_DEVELOPER_CONFIG_XML='${{ secrets.MAPLIBRE_DEVELOPER_CONFIG_XML }}'
-          if [ -n "${MAPLIBRE_DEVELOPER_CONFIG_XML}" ]; then
-            echo "${MAPLIBRE_DEVELOPER_CONFIG_XML}" > MapLibreAndroidTestApp/src/main/res/values/developer-config.xml
-            make android
-          else
-            echo "No secrets.MAPLIBRE_DEVELOPER_CONFIG_XML variable set, skipping apk build..."
-          fi
-        shell: bash
-
       # create github release
       - name: Prepare release
         id: prepare_release
@@ -81,15 +69,15 @@ jobs:
           echo version_tag="$( git describe --tags --match=android-v*.*.* --abbrev=0 )" >> "$GITHUB_OUTPUT"
         shell: bash
 
-      - name: Check if version is valid semver
+      - name: Check if version is pre-release
         id: check_version
         run: |
-          version_tag="${{ steps.prepare_release.outputs.version_tag }}"
-          if [[ $version_tag =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Valid semver: $version_tag"
+          version="${{ env.version }}"
+          if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Valid semver: $version"
             echo "prerelease=false" >> "$GITHUB_ENV"
           else
-            echo "Invalid semver: $version_tag"
+            echo "Invalid semver: $version"
             echo "prerelease=true" >> "$GITHUB_ENV"
           fi
 

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog MapLibre Native for Android
 
+## 11.7.1
+
+> [!NOTE]  
+> We are now releasing OpenGL ES and Vulkan variants of MapLibre Android. See the [11.7.0 release notes](https://github.com/maplibre/maplibre-native/releases/tag/android-v11.7.0) for details.
+
+### ✨ Features and improvements
+
+- Batch up scheduling of deferred deletions ([#3030](https://github.com/maplibre/maplibre-native/pull/3030)).
+- Specify Vulkan version needed in AndroidManifest.xml ([#3095](https://github.com/maplibre/maplibre-native/pull/3095)).
+
+### 🐞 Bug fixes
+
+- Remove `Pass3D` ([#3077](https://github.com/maplibre/maplibre-native/pull/3077)).  
+      Fixes issue where filters applied to fill extrusion layers are not rendered unless a manual zoom is applied to the map ([#3039](https://github.com/maplibre/maplibre-native/issues/3039)).
+
 ## 11.7.0
 
 This release marks the official release of MapLibre Android with Vulkan support. [Vulkan](https://www.vulkan.org) is a modern graphics API which brings advantages such as improved performance, improved observability and better stability. Specifically, starting with this version we are releasing multiple versions of MapLibre Android:

--- a/platform/android/MapLibreAndroid/gradle.properties
+++ b/platform/android/MapLibreAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=11.7.0
+VERSION_NAME=11.7.1
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -18,7 +18,7 @@ function getTagLastVersion() {
     const lastVersion = fs
       .readFileSync(`platform/${platform}/CHANGELOG.md`, "utf-8")
       .split("\n")
-      .filter((line) => line.startsWith("## "))[1]
+      .filter((line) => line.startsWith("## "))[0]
       .slice(3);
     return `${platform}-v${lastVersion}`;
   }


### PR DESCRIPTION
- Use faster runner.
- Fix pre-release detection.
- Do not build test app as part of release workflow (tests run in separate workflow).
- Update changelog.