### PR TITLE
Add optional map mode argument to render

### DIFF
--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -38,7 +38,8 @@ int main(int argc, char* argv[]) {
     args::ValueFlag<uint32_t> widthValue(argumentParser, "pixels", "Image width", {'w', "width"});
     args::ValueFlag<uint32_t> heightValue(argumentParser, "pixels", "Image height", {'h', "height"});
 
-    args::ValueFlag<std::string> mapModeValue(argumentParser, "MapMode", "Map mode (e.g. 'static', 'tile', 'continuous')", {'m', "mode"});
+    args::ValueFlag<std::string> mapModeValue(
+        argumentParser, "MapMode", "Map mode (e.g. 'static', 'tile', 'continuous')", {'m', "mode"});
 
     try {
         argumentParser.ParseCLI(argc, argv);
@@ -88,21 +89,19 @@ int main(int argc, char* argv[]) {
             mapMode = MapMode::Tile;
         } else if (modeStr == "continuous") {
             mapMode = MapMode::Continuous;
-        } 
+        }
     }
 
     HeadlessFrontend frontend({width, height}, static_cast<float>(pixelRatio));
-    Map map(frontend,
-            MapObserver::nullObserver(),
-            MapOptions()
-                .withMapMode(mapMode)
-                .withSize(frontend.getSize())
-                .withPixelRatio(static_cast<float>(pixelRatio)),
-            ResourceOptions()
-                .withCachePath(cache_file)
-                .withAssetPath(asset_root)
-                .withApiKey(apikey)
-                .withTileServerOptions(mapTilerConfiguration));
+    Map map(
+        frontend,
+        MapObserver::nullObserver(),
+        MapOptions().withMapMode(mapMode).withSize(frontend.getSize()).withPixelRatio(static_cast<float>(pixelRatio)),
+        ResourceOptions()
+            .withCachePath(cache_file)
+            .withAssetPath(asset_root)
+            .withApiKey(apikey)
+            .withTileServerOptions(mapTilerConfiguration));
 
     if (style.find("://") == std::string::npos) {
         style = std::string("file://") + style;

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -38,6 +38,8 @@ int main(int argc, char* argv[]) {
     args::ValueFlag<uint32_t> widthValue(argumentParser, "pixels", "Image width", {'w', "width"});
     args::ValueFlag<uint32_t> heightValue(argumentParser, "pixels", "Image height", {'h', "height"});
 
+    args::ValueFlag<std::string> mapModeValue(argumentParser, "MapMode", "Map mode (e.g. 'static', 'tile', 'continuous')", {'m', "mode"});
+
     try {
         argumentParser.ParseCLI(argc, argv);
     } catch (const args::Help&) {
@@ -79,11 +81,21 @@ int main(int argc, char* argv[]) {
 
     util::RunLoop loop;
 
+    MapMode mapMode = MapMode::Static;
+    if (mapModeValue) {
+        const auto modeStr = args::get(mapModeValue);
+        if (modeStr == "tile") {
+            mapMode = MapMode::Tile;
+        } else if (modeStr == "continuous") {
+            mapMode = MapMode::Continuous;
+        } 
+    }
+
     HeadlessFrontend frontend({width, height}, static_cast<float>(pixelRatio));
     Map map(frontend,
             MapObserver::nullObserver(),
             MapOptions()
-                .withMapMode(MapMode::Static)
+                .withMapMode(mapMode)
                 .withSize(frontend.getSize())
                 .withPixelRatio(static_cast<float>(pixelRatio)),
             ResourceOptions()


### PR DESCRIPTION
# Label Clipping Prevention in mbgl-render

This PR adds the ability to use `MapMode::Tile` with `mbgl-render` to prevent label clipping at tile boundaries, which is particularly important for map tile generation.

## Changes
- Adds support for `MapMode::Tile` while maintaining `MapMode::Static` as the default
- No breaking changes to existing behavior
- Enables proper label placement across tile boundaries when explicitly using `MapMode::Tile`

## Technical Background
Label clipping occurs because `MapMode::Static` treats each tile in isolation, causing labels near tile edges to be truncated. `MapMode::Tile` mode considers neighboring tiles during label placement, ensuring continuous and properly placed labels across tile boundaries.

## Related Issues
- maplibre/maplibre-native#644 - Label clipping discussion
- maplibre/maplibre-native#284 (comment) - Technical explanation of tile modes