### PR TITLE
Fix broken .geojson url

### DIFF
--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/style/HeatmapLayerActivity.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/style/HeatmapLayerActivity.kt
@@ -192,7 +192,7 @@ class HeatmapLayerActivity : AppCompatActivity() {
     // # --8<-- [start:constants]
     companion object {
         private const val EARTHQUAKE_SOURCE_URL =
-            "https://maplibre.org/maplibre-gl-js-docs/assets/earthquakes.geojson"
+            "https://maplibre.org/maplibre-gl-js/docs/assets/earthquakes.geojson"
         private const val EARTHQUAKE_SOURCE_ID = "earthquakes"
         private const val HEATMAP_LAYER_ID = "earthquakes-heat"
         private const val HEATMAP_LAYER_SOURCE = "earthquakes"


### PR DESCRIPTION
The path for MapLibre GL JS documentation assets appears to have changed, so the path in the test app needs updating to match.

Without this change, that url 404's.