### PR TITLE
Use bazel_dep for libuv

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,6 +8,7 @@ bazel_dep(name = "rules_swift", version = "2.2.3", repo_name = "build_bazel_rule
 bazel_dep(name = "rules_xcodeproj", version = "2.8.1")
 bazel_dep(name = "aspect_rules_js", version = "2.1.0")
 bazel_dep(name = "rules_nodejs", version = "6.3.2")
+bazel_dep(name = "libuv", version = "1.48.0")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 node.toolchain(node_version = "20.14.0")
@@ -52,14 +53,6 @@ http_archive(
     integrity = "sha256-tewASycS/Qjohh3CcUKPBId1IAot9xnM9XUUO6dJo+k=",
     strip_prefix = "glfw-3.4",
     urls = ["https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.zip"],
-)
-
-new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
-
-new_local_repository(
-    name = "libuv",
-    build_file = "@//vendor:libuv.BUILD",
-    path = "/opt/homebrew/opt/libuv",
 )
 
 darwin_config = use_repo_rule("//platform/darwin:bazel/darwin_config_repository_rule.bzl", "darwin_config")

--- a/vendor/libuv.BUILD
+++ b/vendor/libuv.BUILD
@@ -1,6 +1,0 @@
-cc_library(
-    name = "libuv",
-    hdrs = glob(["include/**/*.h"]),
-    includes = ["include"],
-    visibility = ["//visibility:public"],
-)


### PR DESCRIPTION
Use `bazel_dep` instead of relying on Homebrew installed libuv.

```
bazel run //platform/glfw:glfw_app --//:renderer=metal -- --style https://raw.githubusercontent.com/maplibre/demotiles/gh-pages/style.json
```

cc @bdon