### PR TITLE
Prepare MapLibre Android 11.8.0 release

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog MapLibre Native for Android
 
+## 11.8.0
+
+> [!NOTE]  
+> We are now releasing OpenGL ES and Vulkan variants of MapLibre Android. See the [11.7.0 release notes](https://github.com/maplibre/maplibre-native/releases/tag/android-v11.7.0) for details.
+
+### ✨ Features and improvements
+
+- Add PMTiles support ([#2882](https://github.com/maplibre/maplibre-native/pull/2882)).
+- Consolidate UBOs ([#3089](https://github.com/maplibre/maplibre-native/pull/3089)).
+
+We have a new feature in the C++ Core to constrain the screen (instead of the center of the camera) to some bounds ([#2475](https://github.com/maplibre/maplibre-native/pull/2475)). This functionality still has to be exposed to Android. If you are interested in implementing this, see [this issue](https://github.com/maplibre/maplibre-native/issues/3128).
+
 ## 11.7.1
 
 > [!NOTE]  

--- a/platform/android/MapLibreAndroid/gradle.properties
+++ b/platform/android/MapLibreAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=11.7.1
+VERSION_NAME=11.8.0
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20

--- a/platform/android/MapLibreAndroid/src/cpp/http_file_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/http_file_source.cpp
@@ -161,7 +161,7 @@ void HTTPRequest::onResponse(jni::JNIEnv& env,
         response.expires = util::parseTimestamp(jni::Make<std::string>(env, expires).c_str());
     }
 
-    if (code == 200) {
+    if (code == 200 || code == 206) {
         if (body) {
             auto data = std::make_shared<std::string>(body.Length(env), char());
             jni::GetArrayRegion(env, *body, 0, data->size(), reinterpret_cast<jbyte*>(&(*data)[0]));

--- a/platform/android/docs/data/PMTiles.md
+++ b/platform/android/docs/data/PMTiles.md
@@ -1,0 +1,15 @@
+# PMTiles
+
+Starting MapLibre Android 11.7.0, using [PMTiles](https://docs.protomaps.com/pmtiles/) as a data source is supported. You can prefix your vector tile source with `pmtiles://` to load a PMTiles file. The rest of the URL continue with be `https://` to load a remote PMTiles file, `asset://` to load an asset or `file://` to load a local PMTiles file.
+
+Oliver Wipfli has made a style available that combines a [Protomaps]() basemap togehter with Foursquare's POI dataset. It is available in the [wipfli/foursquare-os-places-pmtiles](https://github.com/wipfli/foursquare-os-places-pmtiles) repository on GitHub. The style to use is
+
+```
+https://raw.githubusercontent.com/wipfli/foursquare-os-places-pmtiles/refs/heads/main/style.json
+```
+
+The neat thing about this style is that it only uses PMTiles vector sources. PMTiles can be hosted with a relatively simple file server (or file hosting service) instead of a more complex specialized tile server.
+
+<figure markdown="span">
+  ![Screenshot of PMTiles based style using Protomaps basemap with Foursquare POIs]({{ s3_url("pmtiles-demo.png") }}){ width="300" }
+</figure>


### PR DESCRIPTION
- Add some documentation for PMTiles feature.
- Update changelog.
- Bump version.
- Piggyback a small fix for PMTiles.