### PR TITLE
Fix scheduler test failure

### DIFF
--- a/src/mbgl/actor/scheduler.cpp
+++ b/src/mbgl/actor/scheduler.cpp
@@ -48,29 +48,22 @@ std::shared_ptr<Scheduler> Scheduler::GetBackground() {
 
 // static
 std::shared_ptr<Scheduler> Scheduler::GetSequenced() {
-    const std::size_t kSchedulersCount = 10;
+    constexpr std::size_t kSchedulersCount = 10;
     static std::vector<std::weak_ptr<Scheduler>> weaks(kSchedulersCount);
     static std::mutex mtx;
     static std::size_t lastUsedIndex = 0u;
 
-    std::lock_guard<std::mutex> lock(mtx);
+    std::lock_guard lock(mtx);
 
-    if (++lastUsedIndex == kSchedulersCount) lastUsedIndex = 0u;
+    lastUsedIndex = (lastUsedIndex + 1) % kSchedulersCount;
 
-    std::shared_ptr<Scheduler> result;
-    for (std::size_t i = 0; i < kSchedulersCount; ++i) {
-        auto& weak = weaks[i];
-        if (auto scheduler = weak.lock()) {
-            if (lastUsedIndex == i) result = scheduler;
-            continue;
-        }
-        result = std::make_shared<SequencedScheduler>();
-        weak = result;
-        lastUsedIndex = i;
-        break;
+    if (auto scheduler = weaks[lastUsedIndex].lock()) {
+        return scheduler;
+    } else {
+        auto result = std::make_shared<SequencedScheduler>();
+        weaks[lastUsedIndex] = result;
+        return result;
     }
-
-    return result;
 }
 
 } // namespace mbgl

--- a/test/util/async_task.test.cpp
+++ b/test/util/async_task.test.cpp
@@ -206,13 +206,25 @@ TEST(AsyncTask, SequencedScheduler) {
 }
 
 TEST(AsyncTask, MultipleSequencedSchedulers) {
-    std::vector<std::shared_ptr<Scheduler>> shedulers;
+    std::vector<std::shared_ptr<Scheduler>> schedulers;
 
-    for (int i = 0; i < 10; ++i) {
-        std::shared_ptr<Scheduler> scheduler = Scheduler::GetSequenced();
-        EXPECT_TRUE(std::none_of(
-            shedulers.begin(), shedulers.end(), [&scheduler](const auto &item) { return item == scheduler; }));
-        shedulers.emplace_back(std::move(scheduler));
+    // must match the value in the scheduler
+    constexpr std::size_t kSchedulersCount = 10;
+
+    for (std::size_t j = 0; j < kSchedulersCount; ++j) {
+        std::vector<std::shared_ptr<Scheduler>> refs(kSchedulersCount);
+        for (std::size_t i = 0; i < refs.size(); ++i) {
+            refs[i] = Scheduler::GetSequenced();
+        }
+        refs[j].reset();
+        
+        // Check that exactly N unique schedulers are produced.
+        // Note that this relies on no other threads requesting schedulers.
+        for (std::size_t i = 0; i < kSchedulersCount; ++i) {
+            auto scheduler = Scheduler::GetSequenced();
+            EXPECT_TRUE(std::ranges::find(schedulers, scheduler) == schedulers.end());
+            schedulers.emplace_back(std::move(scheduler));
+        }
+        EXPECT_EQ(schedulers.front(), Scheduler::GetSequenced());
     }
-    EXPECT_EQ(shedulers.front(), std::shared_ptr<Scheduler>(Scheduler::GetSequenced()));
 }

--- a/test/util/async_task.test.cpp
+++ b/test/util/async_task.test.cpp
@@ -217,7 +217,7 @@ TEST(AsyncTask, MultipleSequencedSchedulers) {
             refs[i] = Scheduler::GetSequenced();
         }
         refs[j].reset();
-        
+
         // Check that exactly N unique schedulers are produced.
         // Note that this relies on no other threads requesting schedulers.
         for (std::size_t i = 0; i < kSchedulersCount; ++i) {


### PR DESCRIPTION
Add a failing unit test to catch a rare case where `Scheduler::GetSequenced` cycles through the available items faster than expected, causing the test to fail.  Then simplify that method to fix the problem.