### PR TITLE
Add timeout-minutes to windows-ci workflow

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -103,6 +103,7 @@ jobs:
           CMAKE_CXX_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"
           RENDERER: "${{ matrix.renderer }}"
           RENDERING_MODE: "${{ matrix.rendering_mode }}"
+        timeout-minutes: 5
         run: |
           cmake --version
           & ${{ github.workspace }}\.github\scripts\windows-ci_configure_wrapper.ps1


### PR DESCRIPTION
This workflow step gets stuck for 6 hours right now. https://github.com/maplibre/maplibre-native/actions/runs/12811603515/job/35721558246

Add a timeout so it will time out quicker.