### PR TITLE
Put git configuration core.longpaths=true in Windows documentation

### DIFF
--- a/platform/windows/README.md
+++ b/platform/windows/README.md
@@ -15,9 +15,12 @@ To install the required Visual Studio components, open Visual Studio Installer a
 Open `x64 Native Tools Command Prompt for VS 2022` and then clone the repository:
 
 ```cmd
-git clone --recurse-submodules -j8 https://github.com/maplibre/maplibre-native.git
+git clone --config core.longpaths=true --recurse-submodules -j8 https://github.com/maplibre/maplibre-native.git
 cd maplibre-native
 ```
+
+> [!NOTE]
+> The `core.longpaths=true` config is necessary, because without it a lot of `Filename too long` messages will come. If you have this configuration set globally (`git config --system core.longpaths=true`), you can omit the `--config core.longpaths=true` portion of the clone command.
 
 ## Configuring
 


### PR DESCRIPTION
Update the Windows documentation, to avoid situations described by #3136.