### PR TITLE
Update vcpkg to 2025.01.13

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -51,9 +51,40 @@ jobs:
         run: |
           Write-Host "Changed file(s): ${{ steps.changed-files.outputs.windows_all_changed_files }}"
 
-  windows-build-and-test:
+  windows-get-or-build-dependencies:
     if: needs.pre-job.outputs.should_skip != 'true'
     needs: pre-job
+    runs-on: windows-2022
+    steps:
+      - run: |
+          git config --system core.longpaths true
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Acquire/Build Maplibre Native Core Dependencies
+        env:
+          CI: 1
+          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+        timeout-minutes: 60
+        run: |
+          & ${{ github.workspace }}\platform\windows\Get-VendorPackages.ps1 -Triplet ${{ env.VSCMD_ARG_TGT_ARCH }}-windows -Renderer All
+
+
+  windows-build-and-test:
+#    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: windows-get-or-build-dependencies
     strategy:
       matrix:
         renderer: [opengl, egl, vulkan, osmesa]
@@ -98,7 +129,7 @@ jobs:
         env:
           CI: 1
           VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-          VCPKG_KEEP_ENV_VARS: "CMAKE_CXX_COMPILER_LAUNCHER;CMAKE_C_COMPILER_LAUNCHER"
+#          VCPKG_KEEP_ENV_VARS: "CMAKE_CXX_COMPILER_LAUNCHER;CMAKE_C_COMPILER_LAUNCHER"
           CMAKE_C_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"
           CMAKE_CXX_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"
           RENDERER: "${{ matrix.renderer }}"

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -103,7 +103,7 @@ jobs:
           CMAKE_CXX_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"
           RENDERER: "${{ matrix.renderer }}"
           RENDERING_MODE: "${{ matrix.rendering_mode }}"
-        timeout-minutes: 5
+        timeout-minutes: 60
         run: |
           cmake --version
           & ${{ github.workspace }}\.github\scripts\windows-ci_configure_wrapper.ps1

--- a/platform/windows/Get-VendorPackages.ps1
+++ b/platform/windows/Get-VendorPackages.ps1
@@ -25,6 +25,7 @@ switch($Renderer)
     'OSMesa' { $renderer_packages = @();                         break }
     'OpenGL' { $renderer_packages = @('opengl-registry');        break }
 	'Vulkan' { $renderer_packages = @();                         break }
+	'All'    { $renderer_packages = @('egl', 'opengl-registry'); break }
 }
 
 if(-not (Test-Path ('{0}\vcpkg.exe' -f $vcpkg_temp_dir)))


### PR DESCRIPTION
Update `vcpkg` to 2025.01.13 commit tag. Hopefully this will reduce the timeouts in `Windows CI` workflow.