### PR TITLE
Add NSString initializer MLNVectorTileSource

### DIFF
--- a/platform/darwin/src/MLNVectorTileSource.h
+++ b/platform/darwin/src/MLNVectorTileSource.h
@@ -85,6 +85,30 @@ MLN_EXPORT
                   configurationURL:(NSURL *)configurationURL NS_DESIGNATED_INITIALIZER;
 
 /**
+ Returns a vector tile source initialized with an identifier and a
+ string-based configuration URL.
+
+ After initializing and configuring the source, add it to a map view’s style
+ using the ``MLNStyle/addSource:`` method.
+
+ The string may be a full HTTP or HTTPS URL or a canonical URL. The string should
+ point to a JSON file that conforms to the
+ <a href="https://github.com/mapbox/tilejson-spec/">TileJSON specification</a>.
+
+ This constructor can be used for URLs that cause problems with `NSURL`’s URL
+ parsing behavior. For example, URLs starting with `pmtiles://https://` were
+ not parsed correctly on iOS 17.
+
+ @param identifier A string that uniquely identifies the source in the style to
+    which it is added.
+ @param configurationURLString A string to a TileJSON configuration file
+    describing the source’s contents and other metadata.
+ @return An initialized vector tile source.
+ */
+- (instancetype)initWithIdentifier:(NSString *)identifier
+            configurationURLString:(NSString *)configurationURLString NS_DESIGNATED_INITIALIZER;
+
+/**
  Returns a vector tile source initialized an identifier, tile URL templates, and
  options.
 

--- a/platform/darwin/src/MLNVectorTileSource.mm
+++ b/platform/darwin/src/MLNVectorTileSource.mm
@@ -28,6 +28,17 @@
     return self = [super initWithPendingSource:std::move(source)];
 }
 
+- (instancetype)initWithIdentifier:(NSString *)identifier
+            configurationURLString:(NSString *)configurationURLString
+{
+    auto source = std::make_unique<mbgl::style::VectorSource>(
+        identifier.UTF8String,
+        configurationURLString.UTF8String
+    );
+    
+    return self = [super initWithPendingSource:std::move(source)];
+}
+
 - (instancetype)initWithIdentifier:(NSString *)identifier tileURLTemplates:(NSArray<NSString *> *)tileURLTemplates options:(nullable NSDictionary<MLNTileSourceOption, id> *)options {
     mbgl::Tileset tileSet = MLNTileSetFromTileURLTemplates(tileURLTemplates, options);
     auto source = std::make_unique<mbgl::style::VectorSource>(identifier.UTF8String, tileSet);

--- a/platform/ios/app/MBXViewController.mm
+++ b/platform/ios/app/MBXViewController.mm
@@ -108,6 +108,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsRuntimeStylingRows) {
 #if MLN_DRAWABLE_RENDERER
     MBXSettingsRuntimeStylingCustomDrawableLayer,
 #endif
+    MBXSettingsRuntimeStylingAddFoursquarePOIsPMTiles
 };
 
 typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
@@ -460,6 +461,7 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
 #if MLN_DRAWABLE_RENDERER
                 @"Add Custom Drawable Layer",
 #endif
+                @"Add FourSquare POIs PMTiles Layer"
             ]];
             break;
         case MBXSettingsMiscellaneous:
@@ -687,6 +689,9 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
                     [self addCustomDrawableLayer];
                     break;
 #endif
+                case MBXSettingsRuntimeStylingAddFoursquarePOIsPMTiles:
+                    [self addFoursquarePOIsPMTilesLayer];
+                    break;
                 default:
                     NSAssert(NO, @"All runtime styling setting rows should be implemented");
                     break;
@@ -1046,6 +1051,55 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
     [self.mapView addAnnotations:annotations];
 
     [self.mapView showAnnotations:annotations animated:YES];
+}
+
+// MARK: - Foursquare PMTiles Implementation
+/*
+  Add the new method that creates the PMTiles vector source and circle layer.
+*/
+- (void)addFoursquarePOIsPMTilesLayer {
+    MLNVectorTileSource *foursquareSource = [[MLNVectorTileSource alloc] initWithIdentifier:@"foursquare-10M" configurationURLString:@"pmtiles://https://oliverwipfli.ch/data/foursquare-os-places-10M-2024-11-20.pmtiles"];
+
+    // Also works
+    // MLNVectorTileSource *foursquareSource =
+    //   [[MLNVectorTileSource alloc] initWithIdentifier:@"foursquare-10M"
+    //                                  tileURLTemplates:@[@"pmtiles://https://oliverwipfli.ch/data/foursquare-os-places-10M-2024-11-20.pmtiles"]
+    //                                           options:nil];
+
+    // Add the source to the map style
+    [self.mapView.style addSource:foursquareSource];
+
+    // Initialize the circle style layer
+    MLNCircleStyleLayer *circleLayer = [[MLNCircleStyleLayer alloc] initWithIdentifier:@"foursquare-10M" source:foursquareSource];
+    circleLayer.sourceLayerIdentifier = @"place";
+    circleLayer.maximumZoomLevel = 11;
+
+    // Set the circle color
+    circleLayer.circleColor = [NSExpression expressionForConstantValue:[UIColor colorWithRed:0.8 green:0.2 blue:0.2 alpha:1.0]];
+    
+    // Set the circle opacity with interpolation
+    circleLayer.circleOpacity = [NSExpression expressionWithMLNJSONObject:@[
+        @"interpolate",
+        @[@"linear"],
+        @[@"zoom"],
+        @6, @0.5,
+        @11, @0.5,
+        @14, @1.0
+    ]];
+
+    // Set the circle radius with interpolation
+    circleLayer.circleRadius = [NSExpression expressionWithMLNJSONObject:@[
+        @"interpolate",
+        @[@"linear"],
+        @[@"zoom"],
+        @6, @1,
+        @11, @3,
+        @16, @4,
+        @18, @8
+    ]];
+
+    // Add the layer to the map style
+    [self.mapView.style addLayer:circleLayer];
 }
 
 - (void)styleBuildingExtrusions

--- a/platform/ios/app/MBXViewController.mm
+++ b/platform/ios/app/MBXViewController.mm
@@ -1066,18 +1066,12 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
     //                                  tileURLTemplates:@[@"pmtiles://https://oliverwipfli.ch/data/foursquare-os-places-10M-2024-11-20.pmtiles"]
     //                                           options:nil];
 
-    // Add the source to the map style
     [self.mapView.style addSource:foursquareSource];
 
-    // Initialize the circle style layer
     MLNCircleStyleLayer *circleLayer = [[MLNCircleStyleLayer alloc] initWithIdentifier:@"foursquare-10M" source:foursquareSource];
     circleLayer.sourceLayerIdentifier = @"place";
     circleLayer.maximumZoomLevel = 11;
-
-    // Set the circle color
     circleLayer.circleColor = [NSExpression expressionForConstantValue:[UIColor colorWithRed:0.8 green:0.2 blue:0.2 alpha:1.0]];
-    
-    // Set the circle opacity with interpolation
     circleLayer.circleOpacity = [NSExpression expressionWithMLNJSONObject:@[
         @"interpolate",
         @[@"linear"],
@@ -1086,8 +1080,6 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
         @11, @0.5,
         @14, @1.0
     ]];
-
-    // Set the circle radius with interpolation
     circleLayer.circleRadius = [NSExpression expressionWithMLNJSONObject:@[
         @"interpolate",
         @[@"linear"],
@@ -1097,8 +1089,6 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
         @16, @4,
         @18, @8
     ]];
-
-    // Add the layer to the map style
     [self.mapView.style addLayer:circleLayer];
 }
 


### PR DESCRIPTION
Resolves #3151. On iOS 17 NSURL URL parsing behavior does not work with `pmtiles://https://...` URLs. This PR allows creating a `MLNVectorTileSource` from an `NSString` instead.

Also adds an example to the Objective-C based example app that uses PMTiles.

cc @KiwiKilian