### PR TITLE
Add documentation custom style layers

### DIFF
--- a/platform/darwin/src/MLNCustomStyleLayer.h
+++ b/platform/darwin/src/MLNCustomStyleLayer.h
@@ -16,42 +16,133 @@ NS_ASSUME_NONNULL_BEGIN
 @class MLNMapView;
 @class MLNStyle;
 
+/// A structure containing context needed to draw a frame in an ``MLNCustomStyleLayer``.
 typedef struct MLNStyleLayerDrawingContext {
+  /// The size of the drawable area, in points.
   CGSize size;
+  /// The center coordinate of the map view.
   CLLocationCoordinate2D centerCoordinate;
+  /// The current zoom level of the map view.
   double zoomLevel;
+  /// The heading (direction) in degrees clockwise from true north.
   CLLocationDirection direction;
+  /// The current pitch of the map view in degrees, measured from the map plane.
   CGFloat pitch;
+  /// The vertical field of view, in degrees, for the map’s perspective.
   CGFloat fieldOfView;
+  /// A 4×4 matrix representing the map view’s current projection state.
   MLNMatrix4 projectionMatrix;
 } MLNStyleLayerDrawingContext;
 
+/// A style layer that is rendered by Metal code that you provide.
+///
+/// By default, this class does nothing. You can subclass it to provide custom
+/// Metal drawing code that is run on each frame of the map.
+///
+/// You can access an existing ``MLNCustomStyleLayer`` using the
+/// ``MLNStyle/layerWithIdentifier:`` method if you know its identifier;
+/// otherwise, find it using the ``MLNStyle/layers`` property. You can also
+/// create a new ``MLNCustomStyleLayer`` and add it to the style using a method such as
+/// ``MLNStyle/addLayer:``.
+///
+/// - Warning: This API experimental. It may change
+///   at any time without notice.
 MLN_EXPORT
 @interface MLNCustomStyleLayer : MLNStyleLayer
 
+/// The style that currently contains the layer.
+///
+/// If the layer is not currently part of any style, this property is `nil`.
 @property (nonatomic, weak, readonly) MLNStyle *style;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 #if TARGET_OS_IPHONE
+/// The OpenGL ES rendering context used for drawing this layer.
+///
+/// This property is only valid when using the OpenGL-based rendering backend.
+/// If the Metal backend is in use, this property will be unavailable
+/// (or `nil`). This property is deprecated and will be removed in a future release.
+///
+/// - Warning: Deprecated and will be removed in a future release.
 @property (nonatomic, readonly) EAGLContext *context;
 #else
+/// The macOS CGL rendering context used for drawing this layer.
+///
+/// This property is only valid when using the OpenGL-based rendering backend.
+/// If the Metal backend is in use, this property will be `NULL`.
+/// This property is deprecated and may be removed in a future release.
+///
+/// - Warning: Deprecated and may be removed in a future release.
 @property (nonatomic, readonly) CGLContextObj context;
 #endif
+
 #pragma clang diagnostic pop
 
 #if MLN_RENDER_BACKEND_METAL
+/// The Metal render command encoder used for issuing Metal draw commands.
+///
+/// This property is only valid when using the Metal-based rendering backend.
+/// If the OpenGL backend is in use, this property will be `nil`.
 @property (nonatomic, weak) id<MTLRenderCommandEncoder> renderEncoder;
 #endif
 
+/// Returns an ``MLNCustomStyleLayer`` style layer object initialized with the given identifier.
+///
+/// After initializing and configuring the style layer, add it to a map view’s style
+/// using the ``MLNStyle/addLayer:`` or
+/// ``MLNStyle/insertLayer:belowLayer:`` method.
+///
+/// - Parameter identifier: A string that uniquely identifies the layer in the style
+///   to which it is added.
+/// - Returns: An initialized custom style layer.
 - (instancetype)initWithIdentifier:(NSString *)identifier;
 
+/// Called immediately after a layer is added to a map view’s style.
+///
+/// Override this method in a subclass to perform any setup work before the layer
+/// is used to draw a frame. For example, you might compile an OpenGL shader here.
+/// The default implementation of this method does nothing.
+///
+/// Any resource acquired in this method must be released in
+/// ``willMoveFromMapView:``.
+///
+/// - Parameter mapView: The map view to whose style the layer has been added.
 - (void)didMoveToMapView:(MLNMapView *)mapView;
 
+/// Called immediately before a layer is removed from a map view’s style.
+///
+/// Override this method in a subclass to perform any teardown work once the
+/// layer has drawn its last frame and is about to be removed from the style.
+/// The default implementation of this method does nothing.
+///
+/// This method may be called even if ``didMoveToMapView:`` has not been called.
+///
+/// - Parameter mapView: The map view from whose style the layer is about to be removed.
 - (void)willMoveFromMapView:(MLNMapView *)mapView;
 
+/// Called each time the layer needs to draw a new frame in a map view.
+///
+/// Override this method in a subclass to draw the layer’s content. The default
+/// implementation of this method does nothing.
+///
+/// Your implementation should not make any assumptions about the OpenGL or Metal
+/// state, other than that the current context/encoder is active. You may make
+/// changes to the state as needed. You are not required to reset values such as
+/// the depth or stencil configuration to their original values.
+///
+/// Be sure to draw your fragments with a *z* value of 1 to take advantage of
+/// opaque fragment culling, in case the style contains any opaque layers above
+/// this layer.
+///
+/// - Parameters:
+///   - mapView: The map view to which the layer draws.
+///   - context: A context structure with information defining the frame to draw.
 - (void)drawInMapView:(MLNMapView *)mapView withContext:(MLNStyleLayerDrawingContext)context;
 
+/// Forces the map view associated with this style to redraw the receiving layer,
+/// causing the ``drawInMapView:withContext:`` method to be called again.
 - (void)setNeedsDisplay;
 
 @end

--- a/platform/darwin/src/MLNCustomStyleLayer.mm
+++ b/platform/darwin/src/MLNCustomStyleLayer.mm
@@ -19,56 +19,19 @@
 
 class MLNCustomLayerHost;
 
-/**
- An ``MLNCustomStyleLayer`` is a style layer that is rendered by OpenGL / Metal code that
- you provide.
-
- By default, this class does nothing. You can subclass this class to provide
- custom OpenGL or Metal drawing code that is run on each frame of the map. Your subclass
- should override the `-didMoveToMapView:`, `-willMoveFromMapView:`, and
- `-drawInMapView:withContext:` methods.
-
- You can access an existing MLNCustomStyleLayer using the
- ``MLNStyle/layerWithIdentifier:`` method if you know its identifier;
- otherwise, find it using the ``MLNStyle/layers`` property. You can also create a
- new MLNCustomStyleLayer and add it to the style using a method such as
- ``MLNStyle/addLayer:``.
-
- @warning This API is undocumented and therefore unsupported. It may change at
-    any time without notice.
- */
 @interface MLNCustomStyleLayer ()
-
 @property (nonatomic, readonly) mbgl::style::CustomLayer *rawLayer;
-
 @property (nonatomic, readonly, nullable) MLNMapView *mapView;
-
-/**
- The style currently containing the layer.
-
- If the layer is not currently part of any style, this property is
- set to `nil`.
- */
 @property (nonatomic, weak, readwrite) MLNStyle *style;
-
 @end
 
 @implementation MLNCustomStyleLayer
 
-/**
- Returns an MLNCustomStyleLayer style layer object initialized with the given identifier.
-
- After initializing and configuring the style layer, add it to a map view’s
- style using the ``MLNStyle/addLayer:`` or
- ``MLNStyle/insertLayer:belowLayer:`` method.
-
- @param identifier A string that uniquely identifies the layer in the style to
-    which it is added.
- @return An initialized OpenGL style layer.
- */
 - (instancetype)initWithIdentifier:(NSString *)identifier {
-    auto layer = std::make_unique<mbgl::style::CustomLayer>(identifier.UTF8String,
-                                                            std::make_unique<MLNCustomLayerHost>(self));
+    auto layer = std::make_unique<mbgl::style::CustomLayer>(
+        identifier.UTF8String,
+        std::make_unique<MLNCustomLayerHost>(self)
+    );
     return self = [super initWithPendingLayer:std::move(layer)];
 }
 
@@ -93,7 +56,6 @@ class MLNCustomLayerHost;
 }
 #endif
 
-// MARK: - Adding to and removing from a map view
 - (void)addToStyle:(MLNStyle *)style belowLayer:(MLNStyleLayer *)otherLayer {
     self.style = style;
     self.style.customLayers[self.identifier] = self;
@@ -106,66 +68,15 @@ class MLNCustomLayerHost;
     self.style = nil;
 }
 
-/**
- Called immediately after a layer is added to a map view’s style.
-
- This method is intended to be overridden in a subclass. You can use this method
- to perform any setup work before the layer is used to draw a frame. For
- example, you might use this method to compile an OpenGL shader. The default
- implementation of this method does nothing.
-
- Any resource acquired in this method must be released in
- `-willMoveFromMapView:`.
-
- @param mapView The map view to whose style the layer has been added.
- */
 - (void)didMoveToMapView:(MLNMapView *)mapView {
-
 }
 
-/**
- Called immediately before a layer is removed from a map view’s style.
-
- This method is intended to be overridden in a subclass. You can use this method
- to perform any teardown work once the layer has drawn its last frame and is
- about to be removed from the style. The default implementation of this method
- does nothing.
-
- This method may be called even if `-didMoveToMapView:` has not been called.
-
- @param mapView The map view from whose style the layer is about to be removed.
- */
 - (void)willMoveFromMapView:(MLNMapView *)mapView {
-
 }
 
-/**
- Called each time the layer needs to draw a new frame in a map view.
-
- This method is intended to be overridden in a subclass. You can use this method
- to draw the layer’s content. The default implementation of this method does
- nothing.
-
- Your implementation should not make any assumptions about the OpenGL state,
- other than that the current OpenGL context is active. It may make changes to
- the OpenGL state. It is not required to reset values such as the depth mask,
- stencil mask, or corresponding test flags to their original values.
-
- Be sure to draw your fragments with a <var>z</var> value of 1 to take advantage
- of the opaque fragment culling, in case the style contains any opaque layers
- above this layer.
-
- @param mapView The map view to which the layer draws.
- @param context A context structure with information defining the frame to draw.
- */
 - (void)drawInMapView:(MLNMapView *)mapView withContext:(MLNStyleLayerDrawingContext)context {
-
 }
 
-/**
- Forces the map view associated with this style to redraw the receiving layer,
- causing the `-drawInMapView:withContext:` method to be called.
- */
 - (void)setNeedsDisplay {
     [self.mapView setNeedsRerender];
 }
@@ -189,10 +100,11 @@ public:
     }
 
     void render(const mbgl::style::CustomLayerRenderParameters& parameters) {
-        if(!layer) return;
+        if (!layer) return;
 
 #if MLN_RENDER_BACKEND_METAL
-        MTL::RenderCommandEncoder* ptr = static_cast<const mbgl::style::mtl::CustomLayerRenderParameters&>(parameters).encoder.get();
+        MTL::RenderCommandEncoder* ptr =
+            static_cast<const mbgl::style::mtl::CustomLayerRenderParameters&>(parameters).encoder.get();
         id<MTLRenderCommandEncoder> encoder = (__bridge id<MTLRenderCommandEncoder>)ptr;
         layer.renderEncoder = encoder;
 #endif
@@ -206,12 +118,14 @@ public:
             .fieldOfView = static_cast<CGFloat>(parameters.fieldOfView),
             .projectionMatrix = MLNMatrix4Make(parameters.projectionMatrix)
         };
+
         if (layer.mapView) {
             [layer drawInMapView:layer.mapView withContext:drawingContext];
         }
     }
 
-    void contextLost() {}
+    void contextLost() {
+    }
 
     void deinitialize() {
         if (layer == nil) return;
@@ -222,6 +136,7 @@ public:
         layerRef = layer;
         layer = nil;
     }
+
 private:
     __weak MLNCustomStyleLayer * layerRef;
     MLNCustomStyleLayer * layer = nil;
@@ -234,4 +149,3 @@ MLNStyleLayer* CustomStyleLayerPeerFactory::createPeer(style::Layer* rawLayer) {
 }
 
 }  // namespace mbgl
-

--- a/platform/ios/MapLibre.docc/BuildingLightExample.md
+++ b/platform/ios/MapLibre.docc/BuildingLightExample.md
@@ -77,7 +77,7 @@ class BuildingLightExample: UIViewController, MLNMapViewDelegate {
     }
 
     func addFillExtrusionLayer(style: MLNStyle) {
-        // Access the OpenMapTiles source and use it to create a `MLNFillExtrusionStyleLayer`. The source identifier is `openmaptiles`. Use the `sources` property on a style to verify source identifiers.
+        // Access the OpenMapTiles source and use it to create a ``MLNFillExtrusionStyleLayer``. The source identifier is `openmaptiles`. Use the `sources` property on a style to verify source identifiers.
         guard let source = style.source(withIdentifier: "openmaptiles") else {
             print("Could not find source openmaptiles")
             return

--- a/platform/ios/MapLibre.docc/CustomStyleLayerExample.md
+++ b/platform/ios/MapLibre.docc/CustomStyleLayerExample.md
@@ -1,10 +1,16 @@
-import Foundation
-import MapLibre
-import MetalKit
-import SwiftUI
-import UIKit
+# Custom Style Layers (Metal API)
 
-// #-example-code(CustomStyleLayerExample)
+Creating a Custom Style Layer with Metal
+
+Custom style layers allow you to draw directly with Metal, enabling you to render specialized shapes, custom geometry, or apply advanced visual effects that go beyond what is possible with standard style layers.
+
+Below you can find an example of how to create a custom style layer with ``MLNCustomStyleLayer``. In this implementation, a SwiftUI view wraps an ``MLNMapView`` and appends a subclassed custom style layer once the map loads. The layer’s ``MLNCustomStyleLayer/didMoveToMapView:`` method handles initialization, including compiling Metal shaders and creating a [`MTLRenderPipelineState`](https://developer.apple.com/documentation/metal/mtlrenderpipelinestate?language=objc) for subsequent draw operations. The ``MLNCustomStyleLayer/willMoveFromMapView:`` method provides a place to release or invalidate resources when the layer is removed from the map, while the ``MLNCustomStyleLayer/drawInMapView:withContext:`` method encodes the drawing commands using a [`MTLRenderCommandEncoder`](https://developer.apple.com/documentation/metal/mtlrendercommandencoder) and the map’s projection matrix. By projecting latitude/longitude coordinates into a normalized 0–1 space and then transforming them into tile coordinates, the layer ensures that rendered geometry aligns correctly with the base map.
+
+![](CustomStyleLayerExample.png)
+
+<!-- include-example(CustomStyleLayerExample) -->
+
+```swift
 struct CustomStyleLayerExample: UIViewRepresentable {
     func makeCoordinator() -> CustomStyleLayerExample.Coordinator {
         Coordinator(self)
@@ -183,5 +189,4 @@ class CustomStyleLayer: MLNCustomStyleLayer {
         )
     }
 }
-
-// #-end-example-code
+```

--- a/platform/ios/MapLibre.docc/ManageOfflineRegionsExample.md
+++ b/platform/ios/MapLibre.docc/ManageOfflineRegionsExample.md
@@ -174,7 +174,7 @@ private extension MLNOfflinePackProgress {
             return 0
         }
 
-        let percentage = Float((countOfResourcesCompleted / countOfResourcesExpected) * 100)
+        let percentage = Float(countOfResourcesCompleted) / Float(countOfResourcesExpected) * 100
         return percentage
     }
 

--- a/platform/ios/MapLibre.docc/MapLibre.md
+++ b/platform/ios/MapLibre.docc/MapLibre.md
@@ -49,6 +49,10 @@ Powerful, free and open-source mapping toolkit with full control over data sourc
 - <doc:OfflinePackExample>
 - <doc:ManageOfflineRegionsExample>
 
+### Advanced
+
+- <doc:CustomStyleLayerExample>
+
 ### Other Articles
 
 - <doc:Customizing_Fonts>


### PR DESCRIPTION
Follow-up to #3154 from @christian-boks.

- Moves the documentation comments to the header so they show up in the documentation. I think Mapbox decided to not make this public because they didn't want to officially support it.
- Makes some tweaks to the custom style layer so the triangle stays in place when you rotate the map.
- Adds documentation page for custom style layer.

Please help me check if ChatGPT did a good job. 😄 

<img width="3200" alt="image" src="https://github.com/user-attachments/assets/70825f8c-065a-449f-bf25-e6f3f8408888" />

<img width="3200" alt="image" src="https://github.com/user-attachments/assets/d1709cdc-4f19-4c9e-8d92-0d80f70407b2" />
