### PR TITLE
Deploy DocC docs from Ubuntu workflow

### DIFF
--- a/.github/workflows/gh-pages-docc.yml
+++ b/.github/workflows/gh-pages-docc.yml
@@ -1,0 +1,74 @@
+name: gh-pages-docc
+
+permissions:
+  id-token: write
+  pages: write
+  contents: write
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - ios-ci
+    types:
+      - completed
+
+jobs:
+  gh-pages-docc-build:
+    if: ${{ github.ref_name == 'main' }}
+    name: Build DocC Docs
+    runs-on: macos-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
+      - name: Build DocC documentation
+        working-directory: .
+        run: |
+          HOSTING_BASE_PATH="maplibre-native/ios/latest" platform/ios/scripts/docc.sh
+
+      # workaround since colons in filenames are not allowed in artifacts
+      # https://github.com/actions/upload-artifact/issues/333
+      - name: Create ZIP archive
+        run: |
+          cd build
+          zip -r docs.zip docs/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docc-docs
+          path: build/docs.zip
+
+  gh-pages-docc-deploy:
+    needs: gh-pages-docc-build
+    name: Deploy DocC Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Download DocC docs artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: docc-docs
+          path: build
+
+      - name: Unzip documentation
+        run: |
+          cd build
+          unzip docs.zip
+          rm docs.zip
+
+      - name: Deploy DocC documentation (main) 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.7.2
+        with:
+          branch: gh-pages
+          folder: build/docs
+          target-folder: ios/latest/

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -29,7 +29,6 @@ on:
 permissions:
   id-token: write         # needed for AWS
   contents: write         # allow making a release
-  pages: write
 
 jobs:
   pre_job:
@@ -199,15 +198,6 @@ jobs:
         working-directory: .
         run: |
           HOSTING_BASE_PATH="maplibre-native/ios/latest" platform/ios/scripts/docc.sh
-
-      - name: Deploy DocC documentation (main) 🚀
-        if: github.ref == 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@v4.7.2
-        continue-on-error: true
-        with:
-          branch: gh-pages
-          folder: build/docs
-          target-folder: ios/latest/
 
   ios-release:
     runs-on: macos-14


### PR DESCRIPTION
Running the deploy action on macOS is not officially supported, so DocC deployment was failing.

In this PR I split the deployment out in a new workflow. Has been tested an seems to work again.

Closes #3132