### PR TITLE
More detail around Android test app, one minor typo.

### DIFF
--- a/docs/mdbook/src/platforms.md
+++ b/docs/mdbook/src/platforms.md
@@ -26,7 +26,7 @@ You can find an app that uses GLFW in [`platform/glfw`](https://github.com/mapli
 
 Originally the project only supported OpenGL 2.0. In 2023, the [renderer was modularized](https://github.com/maplibre/maplibre-native/blob/main/design-proposals/2022-10-27-rendering-modularization.md) allowing for the implementation of alternate rendering backends. The first alternate rendering backend that was implemented was [Metal](https://maplibre.org/news/2024-01-19-metal-support-for-maplibre-native-ios-is-here/), followed by [Vulkan](https://maplibre.org/news/2024-12-12-maplibre-android-vulkan/). In the future other rendering backends could be implemented such as WebGPU.
 
-What platfroms support which rendering backend can be found below.
+What platforms support which rendering backend can be found below.
 
 | Platform | OpenGL ES 3.0 | Vulkan 1.0 | Metal |
 |---|---|---|---|

--- a/platform/android/docs/getting-started.md
+++ b/platform/android/docs/getting-started.md
@@ -1,6 +1,8 @@
 # Quickstart
 
-1. Add bintray Maven repositories to your project-level Gradle file (usually `<project>/<app-module>/build.gradle`).
+To follow this example from scratch, in Android Studio create a new "Empty Views Activity" and then select "Kotlin" as the language.  Select "Groovy DSL" as the build configuration language.
+
+1. If you have an older project, you'll need to add bintray Maven repositories to your project-level Gradle file (usually `<project>/<app-module>/build.gradle`).  Add `mavenCentral()` to where repositories are already defined in that file, something like this:
 
     ```gradle
     allprojects {
@@ -11,13 +13,15 @@
     }
     ```
 
-2. Add the library as a dependency into your module Gradle file (usually `<project>/<app-module>/build.gradle`). Replace `<version>` with the [latest MapLibre Android version](https://github.com/maplibre/maplibre-native/releases?q=android-v11&expanded=true) (e.g.: `org.maplibre.gl:android-sdk:11.5.2`):
+   A newly-created app will likely already have `mavenCentral()` in a top-level `settings.gradle` file, and you won't need to add it.
+
+2. Add the library as a dependency into your module Gradle file (usually `<project>/<app-module>/build.gradle`). Replace `<version>` with the [latest MapLibre Android version](https://github.com/maplibre/maplibre-native/releases?q=android-v11&expanded=true) (e.g.: `org.maplibre.gl:android-sdk:11.8.0`):
 
     ```gradle
     dependencies {
         ...
         implementation 'org.maplibre.gl:android-sdk:<version>'
-        ...
+
     }
     ```
 
@@ -35,17 +39,16 @@
     ...
     ```
 
-5. Initialize the `MapView` in your `MainActivity` file by following the example below:
+5. Initialize the `MapView` in your `MainActivity` file by following the example below.  If modifying a newly-created "Empty Views Activity" example, it replaces all the Kotlin code after the "package" line.
 
     ```kotlin
     import androidx.appcompat.app.AppCompatActivity
     import android.os.Bundle
     import android.view.LayoutInflater
-    import org.maplibre.android.Maplibre
+    import org.maplibre.android.MapLibre
     import org.maplibre.android.camera.CameraPosition
     import org.maplibre.android.geometry.LatLng
     import org.maplibre.android.maps.MapView
-    import org.maplibre.android.testapp.R
 
     class MainActivity : AppCompatActivity() {
 


### PR DESCRIPTION
The changes to https://maplibre.org/maplibre-native/android/examples/getting-started/ were to give people starting from scratch a bit more of a clue and to fix a couple of typos (e.g. "MapLibre" for "maplibre" which caused an import to fail).  There's more detail that could be added, but this should get people started.

The other minor typo was "platfroms" in an unrelated document.