### PR TITLE
chore: add Rust CI and update cssparser dep and lock

### DIFF
--- a/.github/changed-files.yml
+++ b/.github/changed-files.yml
@@ -1,5 +1,6 @@
 linux:
   - 'src/**'
+  - 'rustutils/**'
   - 'test/**'
   - 'render-test/**'
   - 'expression-test/**'
@@ -12,6 +13,7 @@ linux:
   - 'BUILD.bazel'
   - '.bazelrc'
   - '.bazelversion'
+  - '!**/*.md'
 windows:
   - '.github/workflows/windows-ci.yml'
   - 'src/**'
@@ -24,11 +26,11 @@ windows:
   - 'metrics/**'
   - 'vendor/**'
   - '.gitmodules'
-  - '!**/*.md'
   - 'WORKSPACE'
   - 'BUILD.bazel'
   - '.bazelrc'
   - '.bazelversion'
+  - '!**/*.md'
 ios:
   - 'platform/ios/**'
   - 'platform/darwin/**'
@@ -44,12 +46,12 @@ ios:
   - 'test/**'
   - 'vendor/**'
   - '.gitmodules'
-  - '!**/*.md'
   - 'WORKSPACE'
   - 'BUILD.bazel'
   - '.bazelrc'
   - '.bazelversion'
   - 'pnpm-lock.yaml'
+  - '!**/*.md'
 android:
   - 'CMakeLists.txt'
   - 'platform/android/**'

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Read crate metadata
         id: metadata
-        run: echo "rust-version=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+        run: echo "rust-version=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> "$GITHUB_OUTPUT"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -17,38 +17,17 @@ jobs:
     name: Rust tests
     runs-on: ubuntu-latest
     steps:
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
       - uses: actions/checkout@v4
-      - name: Test rustutils
-        run: |
-          # Eventually this script should be moved to a justfile as a "ci-test" recipe
-          # rust-info:
-          rustc --version
-          cargo --version
-          #
-          # Test code formatting
-          # test-fmt:
-          cargo fmt --all -- --check
-          #
-          # Quick compile
-          # check:
-          RUSTFLAGS='-D warnings' cargo check --workspace --all-targets
-          #
-          # Run all tests
-          # test:
-          cargo test --workspace --all-targets
-          #
-          # Run cargo clippy
-          # clippy:
-          cargo clippy --workspace --all-targets -- -D warnings
-          #
-          # Test documentation
-          # test-doc:
-          RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+      - run: just -v ci-test
 
   msrv:
-    name: Rust tests MSRV
+    name: Rust tests MSRV (Minimal Supported Rust Version)
     runs-on: ubuntu-latest
     steps:
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
       - uses: actions/checkout@v4
       - name: Read crate metadata
         id: metadata
@@ -57,19 +36,4 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.metadata.outputs.rust-version }}
-          components: rustfmt
-      - name: Test rustutils
-        working-directory: rustutils/
-        run: |
-          # Eventually this script should be moved to a justfile as a "ci-test-msrv" recipe
-          # rust-info:
-          rustc --version
-          cargo --version
-          #
-          # Quick compile
-          # check:
-          RUSTFLAGS='-D warnings' cargo check --workspace --all-targets
-          #
-          # Run all tests
-          # test:
-          cargo test --workspace --all-targets
+      - run: just ci-test-msrv

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -1,0 +1,75 @@
+name: rust-ci
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+    working-directory: rustutils/
+
+jobs:
+  test:
+    name: Rust tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test rustutils
+        run: |
+          # Eventually this script should be moved to a justfile as a "ci-test" recipe
+          # rust-info:
+          rustc --version
+          cargo --version
+          #
+          # Test code formatting
+          # test-fmt:
+          cargo fmt --all -- --check
+          #
+          # Run cargo clippy
+          # clippy:
+          cargo clippy --workspace --all-targets -- -D warnings
+          #
+          # Quick compile
+          # check:
+          RUSTFLAGS='-D warnings' cargo check --workspace --all-targets
+          #
+          # Run all tests
+          # test:
+          cargo test --workspace --all-targets
+          #
+          # Test documentation
+          # test-doc:
+          RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+
+  msrv:
+    name: Rust tests MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read crate metadata
+        id: metadata
+        run: echo "rust-version=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.metadata.outputs.rust-version }}
+          components: rustfmt
+      - name: Test rustutils
+        working-directory: rustutils/
+        run: |
+          # Eventually this script should be moved to a justfile as a "ci-test-msrv" recipe
+          # rust-info:
+          rustc --version
+          cargo --version
+          #
+          # Quick compile
+          # check:
+          RUSTFLAGS='-D warnings' cargo check --workspace --all-targets
+          #
+          # Run all tests
+          # test:
+          cargo test --workspace --all-targets

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -29,10 +29,6 @@ jobs:
           # test-fmt:
           cargo fmt --all -- --check
           #
-          # Run cargo clippy
-          # clippy:
-          cargo clippy --workspace --all-targets -- -D warnings
-          #
           # Quick compile
           # check:
           RUSTFLAGS='-D warnings' cargo check --workspace --all-targets
@@ -40,6 +36,10 @@ jobs:
           # Run all tests
           # test:
           cargo test --workspace --all-targets
+          #
+          # Run cargo clippy
+          # clippy:
+          cargo clippy --workspace --all-targets -- -D warnings
           #
           # Test documentation
           # test-doc:

--- a/docs/mdbook/src/rust.md
+++ b/docs/mdbook/src/rust.md
@@ -1,6 +1,6 @@
 # Rust
 
-We have added experimental support for intergrating Rust code into the source tree.
+We have added experimental support for integrating Rust code into the source tree.
 
 ## Rust Bridge
 
@@ -16,7 +16,7 @@ When building with CMake, need to have the correct Rust toolchain(s) installed. 
 
 You can use `rustup` to manage toolchains. Which toolchain you needs depends on your host platform and for what platform you are trying to build. If your host and target platform are the same, you probably have the correct toolchain installed after installing Rust. For example when building for **Android** and building on a **x84 Linux** host you would use the following command:
 
-```
+```shell
 rustup target add --toolchain stable-x86_64-unknown-linux-gnu aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 ```
 
@@ -24,7 +24,7 @@ See [Platform Support](https://doc.rust-lang.org/nightly/rustc/platform-support.
 
 You also need to have cxxbridge installed:
 
-```
+```shell
 cargo install cxxbridge-cmd
 ```
 
@@ -36,9 +36,18 @@ Pass the `--//:use_rust` flag to Bazel commands.
 
 Note that when [generating an Xcode project](./ios/README.md) you should not pass this option to Bazel directly, but as follows:
 
-```
+```shell
 bazel run //platform/ios:xcodeproj --@rules_xcodeproj//xcodeproj:extra_common_flags="--//:renderer=metal --//:use_rust"
 ```
+
+## Just
+
+For the Rust subproject, we suggest installing [just](https://github.com/casey/just#readme), a modern alternative to `make`. The `justfile` in the root directory contains a number of useful commands for building and testing the Rust code.  The same commands can be run directly, but `just` provides a more convenient interface.
+
+* Install `just` with `cargo install just`
+* Run `just` in the `/rustutils` dir to see a list of available commands
+* Some common commands: `just check`, `just test`, `just fmt`
+* To run the same steps as used by CI, run `just ci-test`
 
 ## Creating a new Module
 
@@ -47,15 +56,15 @@ To create a new module:
 1. Add a new source file to `rustutils/src/example.rs`.
 2. Implement it, see the [CXX documentation](https://cxx.rs/index.html) or see `rustutils/src/color.rs` for an example.
 3. Create a C++ source file that will use the generated C++ header. See `src/mbgl/util/color.rs.cpp` for an example. Import the generated header with
-    ```
+    ```cpp
     #include <rustutils/example.hpp>
     ```
 4. Conditionally include either the `*.rs.cpp` file or the `*.cpp` file it replaces in CMake and Bazel. Here is what it looks like for CMake:
-    ```
+    ```cmake
     ${PROJECT_SOURCE_DIR}/src/mbgl/util/color$<IF:$<BOOL:${MLN_USE_RUST}>,.rs.cpp,.cpp>
     ```
     And here for Bazel:
-    ```
+    ```bazel
     select({
       "//:rust": [
           "src/mbgl/util/color.rs.cpp",

--- a/rustutils/Cargo.lock
+++ b/rustutils/Cargo.lock
@@ -132,7 +132,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rustutils"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "csscolorparser",
  "cxx",

--- a/rustutils/Cargo.lock
+++ b/rustutils/Cargo.lock
@@ -3,48 +3,115 @@
 version = 3
 
 [[package]]
-name = "cc"
-version = "1.1.6"
+name = "anstyle"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "cc"
+version = "1.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "csscolorparser"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+checksum = "46f9a16a848a7fb95dd47ce387ac1ee9a6df879ba784b815537fcd388a1a8288"
 dependencies = [
  "phf",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.124"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273dcfd3acd4e1e276af13ed2a43eea7001318823e7a726a6b3ed39b4acc0b82"
+checksum = "0fc894913dccfed0f84106062c284fa021c3ba70cb1d78797d6f5165d4492e45"
 dependencies = [
  "cc",
+ "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
+ "foldhash",
  "link-cplusplus",
 ]
 
 [[package]]
-name = "cxxbridge-flags"
-version = "1.0.124"
+name = "cxxbridge-cmd"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839fcd5e43464614ffaa989eaf1c139ef1f0c51672a1ed08023307fa1b909ccd"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.124"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2c1c1776b986979be68bb2285da855f8d8a35851a769fca8740df7c3d07877"
+checksum = "e0d2cb64a95b4b5a381971482235c4db2e0208302a962acdbe314db03cbbe2fb"
 dependencies = [
+ "clap",
+ "codespan-reporting",
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f797b0206463c9c2a68ed605ab28892cca784f1ef066050f4942e3de26ad885"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79010a2093848e65a3e0f7062d3f02fb2ef27f866416dfe436fccfa73d3bb59"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "link-cplusplus"
@@ -57,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -67,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand",
@@ -77,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -90,27 +157,27 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -139,16 +206,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
+name = "rustversion"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -156,7 +241,104 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.12"
+name = "termcolor"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/rustutils/Cargo.toml
+++ b/rustutils/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.78.0"
 crate-type = ["staticlib"]
 
 [dependencies]
-csscolorparser = "0.6.2"
+csscolorparser = "0.7.0"
 cxx = "1"
 
 [profile.release]

--- a/rustutils/Cargo.toml
+++ b/rustutils/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "rustutils"
-version = "0.1.0"
+version = "0.0.0"
+publish = false  # This crate is not intended to be published on crates.io
 authors = ["MapLibre contributors"]
 description = "Core Rust utilities for MapLibre Native"
 edition = "2021"
 license = "BSD-2-Clause"
 repository = "https://github.com/maplibre/maplibre-native"
+rust-version = "1.78.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/rustutils/justfile
+++ b/rustutils/justfile
@@ -58,7 +58,7 @@ rust-info:
     cargo --version
 
 # Run all tests as expected by CI
-ci-test: rust-info test-fmt clippy build test test-doc
+ci-test: rust-info clippy build test test-doc
 
 # Run minimal subset of tests to ensure compatibility with MSRV (Minimum Supported Rust Version). This assumes the default toolchain is already set to MSRV.
 ci-test-msrv: rust-info build test

--- a/rustutils/justfile
+++ b/rustutils/justfile
@@ -1,0 +1,64 @@
+#!/usr/bin/env just --justfile
+
+@_default:
+    just --list
+
+# Clean all build artifacts
+clean:
+    cargo clean
+
+# Update all dependencies, including the breaking changes. Requires nightly toolchain (install with `rustup install nightly`)
+update:
+    cargo +nightly -Z unstable-options update --breaking
+    cargo update
+
+# Quick compile without building a binary
+check:
+    RUSTFLAGS='-D warnings' cargo check --workspace --all-targets
+
+# Build the library
+build:
+    cargo build --workspace
+
+# Run cargo clippy to lint the code
+clippy:
+    cargo clippy --all-targets --workspace -- -D warnings
+
+# Test code formatting
+test-fmt:
+    cargo fmt --all -- --check
+
+# Reformat all code `cargo fmt`. If nightly is available, use it for better results
+fmt:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v cargo +nightly &> /dev/null; then
+        echo 'Reformatting Rust code using nightly Rust fmt to sort imports'
+        cargo +nightly fmt --all -- --config imports_granularity=Module,group_imports=StdExternalCrate
+    else
+        echo 'Reformatting Rust with the stable cargo fmt.  Install nightly with `rustup install nightly` for better results'
+        cargo fmt --all
+    fi
+
+# Run all tests
+test:
+    cargo test --all-targets --workspace
+
+# Test documentation
+test-doc:
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+
+# Build and open code documentation
+docs:
+    cargo doc --no-deps --open
+
+# Print Rust version information
+rust-info:
+    rustc --version
+    cargo --version
+
+# Run all tests as expected by CI
+ci-test: rust-info test-fmt clippy build test test-doc
+
+# Run minimal subset of tests to ensure compatibility with MSRV (Minimum Supported Rust Version). This assumes the default toolchain is already set to MSRV.
+ci-test-msrv: rust-info build test

--- a/rustutils/src/color.rs
+++ b/rustutils/src/color.rs
@@ -20,10 +20,10 @@ pub fn parse_css_color(css_str: &str) -> ffi::ParsedColor {
         .parse::<Color>()
         .map(|color| ffi::ParsedColor {
             success: true,
-            r: color.r as f32,
-            g: color.g as f32,
-            b: color.b as f32,
-            a: color.a as f32,
+            r: color.r,
+            g: color.g,
+            b: color.b,
+            a: color.a,
         })
         .unwrap_or_else(|_| ffi::ParsedColor {
             success: false,

--- a/rustutils/src/color.rs
+++ b/rustutils/src/color.rs
@@ -2,6 +2,9 @@ use csscolorparser::Color;
 
 #[cxx::bridge(namespace = "rustutils")]
 mod ffi {
+    // TODO: Use #[cfg_attr(test, derive(...))] once supported
+    // See https://github.com/dtolnay/cxx/issues/1022
+    #[derive(Debug, PartialEq)]
     struct ParsedColor {
         pub success: bool,
         pub r: f32,
@@ -32,4 +35,43 @@ pub fn parse_css_color(css_str: &str) -> ffi::ParsedColor {
             b: 0.0,
             a: 0.0,
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_css_color() {
+        assert_eq!(
+            parse_css_color("rgb(255, 0, 0)"),
+            ffi::ParsedColor {
+                success: true,
+                r: 1.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            }
+        );
+        assert_eq!(
+            parse_css_color("rgba(255, 0, 0, 0.5)"),
+            ffi::ParsedColor {
+                success: true,
+                r: 1.0,
+                g: 0.0,
+                b: 0.0,
+                a: 0.5,
+            }
+        );
+        assert_eq!(
+            parse_css_color("invalid"),
+            ffi::ParsedColor {
+                success: false,
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 0.0,
+            }
+        );
+    }
 }


### PR DESCRIPTION
* bump to https://github.com/mazznoer/csscolorparser-rs/releases/tag/v0.7.0 and fix related code
* update all lock file to latest with `cargo update`
* validate that the rustutils crate is valid
* add MSRV (tested with `cargo msrv find` + CI for it
* ensure rustutils crate is not published, and set version to 0.0.0 as it has no internal version