### PR TITLE
Change runtime error to the nullptr returning

### DIFF
--- a/include/mbgl/shaders/mtl/shader_group.hpp
+++ b/include/mbgl/shaders/mtl/shader_group.hpp
@@ -70,7 +70,8 @@ public:
             assert(shader);
             if (!shader || !registerShader(shader, shaderName)) {
                 assert(false);
-                throw std::runtime_error("Failed to register " + shaderName + " with shader group!");
+                Log::Error(Event::Shader, "Failed to register " + shaderName + " with shader group!");
+                return nullptr;
             }
 
             using ShaderClass = shaders::ShaderSource<ShaderID, gfx::Backend::Type::Metal>;


### PR DESCRIPTION
- We are attempting to create shaders during the update of layers. It seems more appropriate to return a nullptr for a shader that fails to create, rather than stopping the app if one shader is not created (as exceptions are not caught).
- Proper handling is implemented in all callers when a shader is nullptr, so we should not experience inconsistent behavior in such cases.
- Most shader creation errors are related to low memory on iOS. Since we have lazy initialization for shaders, the behavior may be restored in the next level update if iOS frees the necessary memory.