### PR TITLE
Bind global uniform buffers at the end of the custom layer tweaker

### DIFF
--- a/include/mbgl/gfx/drawable_atlases_tweaker.hpp
+++ b/include/mbgl/gfx/drawable_atlases_tweaker.hpp
@@ -44,7 +44,7 @@ public:
 
     void init(Drawable&) override;
 
-    void execute(Drawable&, const PaintParameters&) override;
+    void execute(Drawable&, PaintParameters&) override;
 
 protected:
     void setupTextures(Drawable&, const bool);

--- a/include/mbgl/gfx/drawable_custom_layer_host_tweaker.hpp
+++ b/include/mbgl/gfx/drawable_custom_layer_host_tweaker.hpp
@@ -25,7 +25,7 @@ public:
 
     void init(Drawable&) override {};
 
-    void execute(Drawable&, const PaintParameters&) override;
+    void execute(Drawable&, PaintParameters&) override;
 
 protected:
     std::shared_ptr<style::CustomLayerHost> host;

--- a/include/mbgl/gfx/drawable_tweaker.hpp
+++ b/include/mbgl/gfx/drawable_tweaker.hpp
@@ -24,7 +24,7 @@ public:
     virtual void init(Drawable&) = 0;
 
     /// Called just before rendering
-    virtual void execute(Drawable&, const PaintParameters&) = 0;
+    virtual void execute(Drawable&, PaintParameters&) = 0;
 };
 
 using DrawableTweakerPtr = std::shared_ptr<DrawableTweaker>;

--- a/src/mbgl/gfx/drawable_atlases_tweaker.cpp
+++ b/src/mbgl/gfx/drawable_atlases_tweaker.cpp
@@ -34,7 +34,7 @@ void DrawableAtlasesTweaker::init(gfx::Drawable& drawable) {
     setupTextures(drawable, true);
 }
 
-void DrawableAtlasesTweaker::execute(gfx::Drawable& drawable, const PaintParameters& parameters) {
+void DrawableAtlasesTweaker::execute(gfx::Drawable& drawable, PaintParameters& parameters) {
     const bool transformed = rotationAlignment == style::AlignmentType::Map || parameters.state.getPitch() != 0;
     const bool linearFilterForIcons = isText ? (parameters.state.isChanging() || transformed || !textSizeIsZoomConstant)
                                              : (sdfIcons || parameters.state.isChanging() || iconScaled || transformed);

--- a/src/mbgl/gfx/drawable_custom_layer_host_tweaker.cpp
+++ b/src/mbgl/gfx/drawable_custom_layer_host_tweaker.cpp
@@ -16,7 +16,7 @@ namespace mbgl {
 namespace gfx {
 
 void DrawableCustomLayerHostTweaker::execute([[maybe_unused]] gfx::Drawable& drawable,
-                                             const mbgl::PaintParameters& paintParameters) {
+                                             mbgl::PaintParameters& paintParameters) {
     // custom drawing
     auto& context = paintParameters.context;
     context.resetState(paintParameters.depthModeForSublayer(0, gfx::DepthMaskType::ReadOnly),
@@ -35,6 +35,7 @@ void DrawableCustomLayerHostTweaker::execute([[maybe_unused]] gfx::Drawable& dra
     paintParameters.backend.getDefaultRenderable().getResource<gfx::RenderableResource>().bind();
 
     context.setDirtyState();
+    context.bindGlobalUniformBuffers(*paintParameters.renderPass);
 }
 
 } // namespace gfx

--- a/src/mbgl/style/layers/custom_drawable_layer.cpp
+++ b/src/mbgl/style/layers/custom_drawable_layer.cpp
@@ -95,7 +95,7 @@ public:
 
     void init(gfx::Drawable&) override {}
 
-    void execute(gfx::Drawable& drawable, const PaintParameters& parameters) override {
+    void execute(gfx::Drawable& drawable, PaintParameters& parameters) override {
         if (!drawable.getTileID().has_value()) {
             return;
         }
@@ -155,7 +155,7 @@ public:
 
     void init(gfx::Drawable&) override {}
 
-    void execute(gfx::Drawable& drawable, const PaintParameters& parameters) override {
+    void execute(gfx::Drawable& drawable, PaintParameters& parameters) override {
         if (!drawable.getTileID().has_value()) {
             return;
         }
@@ -222,7 +222,7 @@ public:
 
     void init(gfx::Drawable&) override {}
 
-    void execute(gfx::Drawable& drawable, const PaintParameters& parameters) override {
+    void execute(gfx::Drawable& drawable, PaintParameters& parameters) override {
         if (!drawable.getTileID().has_value()) {
             return;
         }
@@ -272,7 +272,7 @@ public:
 
     void init(gfx::Drawable&) override {}
 
-    void execute(gfx::Drawable& drawable, const PaintParameters& parameters) override {
+    void execute(gfx::Drawable& drawable, PaintParameters& parameters) override {
         if (!drawable.getTileID().has_value()) {
             return;
         }


### PR DESCRIPTION
- Convert the tweaker execute function's paint parameters to a mutable reference to be able to bind the global uniform buffers using the shared context.
- Bind the global uniform buffers at the end of the custom layer tweaker to deal with the case where something else gets bound to the first vertex buffer.