### PR TITLE
reset depth stencil state for render pass

### DIFF
--- a/include/mbgl/mtl/render_pass.hpp
+++ b/include/mbgl/mtl/render_pass.hpp
@@ -42,6 +42,13 @@ public:
 
     void endEncoding();
 
+    /// Resets the states and bindings of the render pass to deal
+    /// with situations where they are changed by calling the
+    /// underlying rendering API directly. Currently this happens
+    /// when a user changes one of these states or bindings
+    /// in a custom layer
+    void resetState();
+
     void addDebugSignpost(const char* name) override;
 
     void bindVertex(const BufferResource&, std::size_t offset, std::size_t index, std::size_t size = 0);

--- a/src/mbgl/gfx/drawable_custom_layer_host_tweaker.cpp
+++ b/src/mbgl/gfx/drawable_custom_layer_host_tweaker.cpp
@@ -8,6 +8,7 @@
 
 #if MLN_RENDER_BACKEND_METAL
 #include <mbgl/style/layers/mtl/custom_layer_render_parameters.hpp>
+#include <mbgl/mtl/render_pass.hpp>
 #endif
 
 #include <memory>
@@ -23,6 +24,9 @@ void DrawableCustomLayerHostTweaker::execute([[maybe_unused]] gfx::Drawable& dra
                        paintParameters.colorModeForRenderPass());
 
 #if MLN_RENDER_BACKEND_METAL
+    const auto& mtlRenderPass = static_cast<mtl::RenderPass*>(paintParameters.renderPass.get());
+    mtlRenderPass->resetState();
+
     style::mtl::CustomLayerRenderParameters parameters(paintParameters);
 #else
     style::CustomLayerRenderParameters parameters(paintParameters);

--- a/src/mbgl/mtl/render_pass.cpp
+++ b/src/mbgl/mtl/render_pass.cpp
@@ -72,6 +72,17 @@ void RenderPass::endEncoding() {
     }
 }
 
+void RenderPass::resetState() {
+    currentDepthStencilState.reset();
+    currentStencilReferenceValue = 0;
+    for (int i = 0; i < maxBinds; ++i) {
+        vertexBinds[i].reset();
+        fragmentBinds[i].reset();
+        fragmentTextureBindings[i].reset();
+        fragmentSamplerStates[i].reset();
+    }
+}
+
 namespace {
 constexpr auto missing = "<none>";
 NS::String* toNSString(const char* str) {


### PR DESCRIPTION
Because the depth stencil state of the render pass
is no reset correctly after the custom layer is drawn
we need to manually do this to ensure that we don't
write to the depth or stencil buffers when we shouldn't
