### PR TITLE
Modify .bazelignore to allow reading git hash

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -3,7 +3,7 @@
 !.git/refs
 !.git/refs/heads
 !.git/packed-refs
-.git
+.git/*
 
 node_modules
 bazel-out

--- a/.bazelignore
+++ b/.bazelignore
@@ -1,4 +1,10 @@
+# ignore .git, but make sure we can get commit hash
+!.git/HEAD
+!.git/refs
+!.git/refs/heads
+!.git/packed-refs
 .git
+
 node_modules
 bazel-out
 bazel-bin


### PR DESCRIPTION
This was causing the iOS release to fail.