### PR TITLE
Add Vector Tile Source example Android Docs & Example app

### DIFF
--- a/platform/android/MapLibreAndroidTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <application
         android:name=".MapLibreApplication"
         android:allowBackup="true"
+        android:debuggable="true"
         android:exported="true"
         android:fullBackupContent="true"
         android:icon="@drawable/icon"
@@ -14,7 +15,6 @@
         android:roundIcon="@drawable/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:debuggable="true"
         tools:ignore="HardcodedDebugMode">
         <activity
             android:name=".activity.FeatureOverviewActivity"
@@ -719,6 +719,18 @@
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity" />
+        </activity>
+        <activity
+            android:name=".activity.sources.VectorTileActivity"
+            android:description="@string/description_vector_tile"
+            android:exported="true"
+            android:label="@string/activity_vector_tile">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_data" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity" />
         </activity> <!-- Features -->
         <activity
             android:name=".activity.feature.QueryRenderedFeaturesPropertiesActivity"
@@ -878,10 +890,10 @@
                 android:value=".activity.FeatureOverviewActivity" />
         </activity> <!-- Events -->
         <activity
-            android:name="org.maplibre.android.testapp.activity.events.ObserverActivity"
+            android:name=".activity.events.ObserverActivity"
             android:description="@string/description_observer_activity"
             android:exported="true"
-            android:label="@string/activity_observer_activity" >
+            android:label="@string/activity_observer_activity">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_events" />
@@ -1259,13 +1271,11 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity" />
         </activity>
-
         <activity
             android:name=".activity.options.MapOptionsXmlActivity"
-            android:exported="true"
             android:description="@string/description_map_options_xml"
-            android:label="@string/activity_map_options_xml"
-            >
+            android:exported="true"
+            android:label="@string/activity_map_options_xml">
             <meta-data
                 android:name="@string/category"
                 android:value="@string/category_map_options" />
@@ -1273,7 +1283,6 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity" />
         </activity>
-
     </application>
 
 </manifest>

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/sources/VectorTileActivity.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/sources/VectorTileActivity.kt
@@ -1,0 +1,85 @@
+package org.maplibre.android.testapp.activity.sources
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import org.maplibre.android.camera.CameraUpdateFactory
+import org.maplibre.android.geometry.LatLngBounds
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.style.layers.LineLayer
+import org.maplibre.android.style.layers.PropertyFactory.lineColor
+import org.maplibre.android.style.layers.PropertyFactory.lineWidth
+import org.maplibre.android.style.sources.TileSet
+import org.maplibre.android.style.sources.VectorSource
+import org.maplibre.android.testapp.R
+import org.maplibre.android.testapp.styles.TestStyles
+
+
+class VectorTileActivity : AppCompatActivity() {
+    private lateinit var mapView: MapView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_vector_tile)
+        mapView = findViewById<MapView>(R.id.mapView)
+
+        mapView.getMapAsync {
+            it.animateCamera(
+                CameraUpdateFactory.newLatLngBounds(
+                    // z: 12, x: 2177, y: 1436 is one of the available tiles:
+                    // https://github.com/maplibre/demotiles/tree/gh-pages/tiles-omt/12/2177
+                    LatLngBounds.from(12, 2177, 1436),
+                    0
+                )
+            )
+            it.setStyle(TestStyles.PROTOMAPS_GRAYSCALE) { style ->
+                // --8<-- [start:addTileSet]
+                val tileset = TileSet(
+                    "openmaptiles",
+                    "https://demotiles.maplibre.org/tiles-omt/{z}/{x}/{y}.pbf"
+                )
+                val openmaptiles = VectorSource("openmaptiles", tileset)
+                style.addSource(openmaptiles)
+                val roadLayer = LineLayer("road", "openmaptiles").apply {
+                    setSourceLayer("transportation")
+                    setProperties(
+                        lineColor("red"),
+                        lineWidth(2.0f)
+                    )
+                }
+                // --8<-- [end:addTileSet]
+
+                style.addLayer(roadLayer)
+            }
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapView.onStart()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        mapView.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        mapView.onPause()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapView.onStop()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView.onLowMemory()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView.onDestroy()
+    }
+}

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_vector_tile.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/layout/activity_vector_tile.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activity.sources.VectorTileActivity">
+
+    <org.maplibre.android.maps.MapView
+        android:id="@id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</RelativeLayout>

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/values/descriptions.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/values/descriptions.xml
@@ -80,6 +80,7 @@
     <string name="description_overlay">Blend an overlay on a map</string>
     <string name="description_grid_source">Example Custom Geometry Source</string>
     <string name="description_no_style">Load a map without providing a style URI or JSON</string>
+    <string name="description_vector_tile">Load MVT data</string>
     <string name="description_local_glyph">Suzhou using Droid Sans for Chinese glyphs</string>
     <string name="description_hillshade">Example raster-dem source and hillshade layer</string>
     <string name="description_heatmaplayer">Use HeatmapLayer to visualise earthquakes</string>

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/values/strings.xml
@@ -8,4 +8,5 @@
     <string name="activity_benchmark_world_tour">World Tour Benchmark</string>
     <string name="description_world_tour_benchmark">Writes out avg. fps and 1% fps after world tour with .flyTo()</string>
     <string name="search">Search</string>
+    <string name="category_data">Data Sources</string>
 </resources>

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/values/titles.xml
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/values/titles.xml
@@ -76,6 +76,7 @@
     <string name="activity_overlay">Map overlay</string>
     <string name="activity_grid_source">Grid Source</string>
     <string name="activity_no_style">No Style URI/JSON</string>
+    <string name="activity_vector_tile">Vector Tile source</string>
     <string name="activity_local_glyph">Local CJK glyph generation</string>
     <string name="activity_hillshade">Hillshade</string>
     <string name="activity_heatmaplayer">Heatmap layer</string>

--- a/platform/android/docs/data/MVT.md
+++ b/platform/android/docs/data/MVT.md
@@ -1,0 +1,16 @@
+# Vector Tiles
+
+{{ activity_source_note("VectorTileActivity.kt") }}
+
+You can specify where to load MVTs (which sometimes have `.pbf` extension) by creating a `TileSet` object with template parameters (for example `{z}` which will be replaced with the zoom level).
+
+MapLibre has [a repo](https://github.com/maplibre/demotiles/tree/gh-pages/tiles-omt) with some example vector tiles with the OpenMapTiles schema around Innsbruck, Austria. In the example we load these MVTs and create a line layer for the road network.
+
+```kotlin
+--8<-- "MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/sources/VectorTileActivity.kt:addTileSet"
+```
+
+<figure markdown="span">
+  ![Screenshot of road overlay from vector tile source]({{ s3_url("vectortilesource.png") }}){ width="400" }
+  {{ openmaptiles_caption() }}
+</figure>


### PR DESCRIPTION
[A user](https://github.com/maplibre/maplibre-native/issues/3265) was asking about how to add vector tiles with the Android SDK. This PR adds a simple example to the docs.

<img width="2056" alt="image" src="https://github.com/user-attachments/assets/2e59f21b-54f2-465e-ae33-1ba22ac6463f" />
