### PR TITLE
Strip punctuation from attribution

### DIFF
--- a/platform/darwin/src/MLNAttributionInfo.mm
+++ b/platform/darwin/src/MLNAttributionInfo.mm
@@ -104,9 +104,13 @@
             [attributedString removeAttribute:NSStrokeWidthAttributeName range:range];
         }
 
-        // Omit whitespace-only strings.
+        // Clean up strings by stripping punctuation and whitespace (often present for the web).
+        NSMutableCharacterSet *charset = [NSMutableCharacterSet whitespaceAndNewlineCharacterSet];
+        [charset formUnionWithCharacterSet:[NSCharacterSet punctuationCharacterSet]];
         NSAttributedString *title = [[attributedString attributedSubstringFromRange:range]
-                                     mgl_attributedStringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+                                     mgl_attributedStringByTrimmingCharactersInSet:charset];
+
+        // Omit strings that are empty after cleaning.
         if (!title.length) {
             return;
         }

--- a/platform/darwin/test/MLNAttributionInfoTests.m
+++ b/platform/darwin/test/MLNAttributionInfoTests.m
@@ -20,7 +20,7 @@
 - (void)testParsing {
     static NSString * const htmlStrings[] = {
         @"<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">&copy; Mapbox</a> "
-        @"<a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">©️ OpenStreetMap</a> "
+        @"<a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">©️ OpenStreetMap</a>, "
         @"CC&nbsp;BY-SA "
         @"<a class=\"mapbox-improve-map\" href=\"https://apps.mapbox.com/feedback/\" target=\"_blank\">Improve this map</a>",
     };


### PR DESCRIPTION
Punctuation like commas, semicolons, etc. are fairly common ways of formatting attribution on the web. However, this looks 

Example attribution string:

```html
<a href=\"https://stadiamaps.com/\" target=\"_blank\">&copy; Stadia Maps</a> &amp; <a href=\"https://stamen.com\" target=\"_blank\">&copy; Stamen Design</a>; <a href=\"https://openmaptiles.org/\" target=\"_blank\">&copy; OpenMapTiles</a>; <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">&copy; OpenStreetMap</a>.
```

Here's a pathological example of a rendering fail in MapLibre Native on iOS. I expect we'll need to do a similar fix on Android too.

![image](https://github.com/user-attachments/assets/7d93890b-5bc2-4d5a-b371-eff8943c65dd)

Thanks to @Archdoog for pointing this out!