### PR TITLE
Prevent rare crash when null values are passed to MapLibreAnimator

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponent.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponent.java
@@ -40,6 +40,7 @@ import org.maplibre.android.style.layers.SymbolLayer;
 import java.lang.ref.WeakReference;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -1259,7 +1260,17 @@ public final class LocationComponent {
    * @param location the latest user location
    */
   private void updateLocation(@Nullable final Location location, boolean fromLastLocation) {
-    updateLocation(location, null, fromLastLocation, false);
+    try {
+      updateLocation(location, null, fromLastLocation, false);
+    } catch (IllegalArgumentException ex) {
+      // ignore location update
+      // to prevent rare crash https://github.com/maplibre/maplibre-native/issues/3294
+      if (Objects.equals(ex.getMessage(), "MapLibreAnimator values cannot be null")) {
+        Logger.e(TAG, ex.getMessage());
+        return;
+      }
+      throw ex;
+    }
   }
 
   private void updateLocation(@Nullable final Location location, @Nullable List<Location> intermediatePoints,

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/MapLibreAnimator.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/MapLibreAnimator.java
@@ -9,8 +9,12 @@ import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Size;
 
+import org.maplibre.android.log.Logger;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Abstract class for all of the location component animators.
@@ -63,6 +67,9 @@ public abstract class MapLibreAnimator<K> extends ValueAnimator implements Value
 
   public MapLibreAnimator(@NonNull @Size(min = 2) K[] values, @NonNull AnimationsValueChangeListener<K> updateListener,
                    int maxAnimationFps) {
+    if (Arrays.stream(values).anyMatch(Objects::isNull)) {
+      throw new IllegalArgumentException("MapLibreAnimator values cannot be null");
+    }
     minUpdateInterval = 1E9 / maxAnimationFps;
     setObjectValues((Object[]) values);
     setEvaluator(provideEvaluator());


### PR DESCRIPTION
I added some logging, maybe we can understand why this is happening to fix the root cause.

For now this just skips an invalid location update to prevent a crash.

Closes #3294