### PR TITLE
fix glfw platform feature state demo

### DIFF
--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -483,8 +483,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
                 auto &style = view->map->getStyle();
                 if (!style.getSource("states")) {
                     std::string url =
-                        "https://maplibre.org/maplibre-gl-js-docs/assets/"
-                        "us_states.geojson";
+                        "https://maplibre.org/maplibre-gl-js/docs/assets/us_states.geojson";
                     auto source = std::make_unique<GeoJSONSource>("states");
                     source->setURL(url);
                     style.addSource(std::move(source));

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -482,8 +482,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
 
                 auto &style = view->map->getStyle();
                 if (!style.getSource("states")) {
-                    std::string url =
-                        "https://maplibre.org/maplibre-gl-js/docs/assets/us_states.geojson";
+                    std::string url = "https://maplibre.org/maplibre-gl-js/docs/assets/us_states.geojson";
                     auto source = std::make_unique<GeoJSONSource>("states");
                     source->setURL(url);
                     style.addSource(std::move(source));


### PR DESCRIPTION
issue:

feature state demo for glfw platform doesn't work now

fix:

the `us_states.geojson` url in `glfw_view.cpp` is not available anymore, the [new link](https://maplibre.org/maplibre-gl-js/docs/assets/us_states.geojson) is from https://maplibre.org/maplibre-gl-js/docs/examples/hover-styles/, which works