### PR TITLE
Apply clang-tidy fixes (mostly use designated initializers)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -113,7 +113,10 @@ Checks: [
     -performance-enum-size,
     -misc-include-cleaner,
     -readability-redundant-inline-specifier,
-    -readability-avoid-nested-conditional-operator
+    -readability-avoid-nested-conditional-operator,
+    -readability-math-missing-parentheses,
+    -readability-enum-initial-value,
+    -boost-use-ranges
 ]
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/include/mbgl/actor/established_actor.hpp
+++ b/include/mbgl/actor/established_actor.hpp
@@ -38,11 +38,9 @@ public:
     }
 
     // Construct the Object from a parameter pack `args` (i.e. `Object(args...)`)
-    template <typename U = Object,
-              class... Args,
-              typename std::enable_if_t<std::is_constructible_v<U, Args...> ||
-                                        std::is_constructible_v<U, ActorRef<U>, Args...>>* = nullptr>
+    template <typename U = Object, class... Args>
     EstablishedActor(const TaggedScheduler& scheduler, AspiringActor<Object>& parent_, Args&&... args)
+        requires(std::is_constructible_v<U, Args...> || std::is_constructible_v<U, ActorRef<U>, Args...>)
         : parent(parent_) {
         emplaceObject(std::forward<Args>(args)...);
         parent.mailbox->open(scheduler);
@@ -71,18 +69,18 @@ public:
 
 private:
     // Enabled for Objects with a constructor taking ActorRef<Object> as the first parameter
-    template <typename U = Object,
-              class... Args,
-              typename std::enable_if_t<std::is_constructible_v<U, ActorRef<U>, Args...>>* = nullptr>
-    void emplaceObject(Args&&... args_) {
+    template <typename U = Object, class... Args>
+    void emplaceObject(Args&&... args_)
+        requires(std::is_constructible_v<U, ActorRef<U>, Args...>)
+    {
         new (&parent.objectStorage) Object(parent.self(), std::forward<Args>(args_)...);
     }
 
     // Enabled for plain Objects
-    template <typename U = Object,
-              class... Args,
-              typename std::enable_if_t<std::is_constructible_v<U, Args...>>* = nullptr>
-    void emplaceObject(Args&&... args_) {
+    template <typename U = Object, class... Args>
+    void emplaceObject(Args&&... args_)
+        requires(std::is_constructible_v<U, Args...>)
+    {
         new (&parent.objectStorage) Object(std::forward<Args>(args_)...);
     }
 

--- a/include/mbgl/gfx/shader_group.hpp
+++ b/include/mbgl/gfx/shader_group.hpp
@@ -80,8 +80,10 @@ public:
     /// @tparam T Derived type, inheriting `gfx::Shader`
     /// @param shaderName The group name to look up
     /// @return T or nullptr if not found in the group
-    template <typename T, typename std::enable_if_t<is_shader_v<T>, bool>* = nullptr>
-    std::shared_ptr<T> get(const std::string& shaderName) noexcept {
+    template <typename T>
+    std::shared_ptr<T> get(const std::string& shaderName) noexcept
+        requires(is_shader_v<T>)
+    {
         auto shader = getShader(shaderName);
         if (!shader || shader->typeName() != T::Name) {
             return nullptr;
@@ -110,8 +112,10 @@ public:
     /// @param to Location to store the shader
     /// @param shaderName The group name to look up
     /// @return True if 'to' has a valid program object, false otherwise.
-    template <typename T, typename std::enable_if_t<is_shader_v<T>, bool>* = nullptr>
-    bool populate(std::shared_ptr<T>& to, const std::string& shaderName) noexcept {
+    template <typename T>
+    bool populate(std::shared_ptr<T>& to, const std::string& shaderName) noexcept
+        requires(is_shader_v<T>)
+    {
         if (to) {
             return true;
         }

--- a/include/mbgl/gfx/vertex_attribute.hpp
+++ b/include/mbgl/gfx/vertex_attribute.hpp
@@ -321,8 +321,7 @@ public:
 
     /// Indicates whether any values have changed
     bool isModifiedAfter(std::chrono::duration<double> time) const {
-        return std::any_of(
-            attrs.begin(), attrs.end(), [&](const auto& attr) { return attr && attr->isModifiedAfter(time); });
+        return std::ranges::any_of(attrs, [&](const auto& attr) { return attr && attr->isModifiedAfter(time); });
     }
 
     /// Clear the collection

--- a/include/mbgl/text/glyph.hpp
+++ b/include/mbgl/text/glyph.hpp
@@ -9,6 +9,7 @@
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/util.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <vector>
 #include <string>
@@ -113,9 +114,7 @@ public:
     float right = 0;
     WritingModeType writingMode;
     explicit operator bool() const {
-        return std::any_of(positionedLines.begin(), positionedLines.end(), [](const auto& line) {
-            return !line.positionedGlyphs.empty();
-        });
+        return std::ranges::any_of(positionedLines, [](const auto& line) { return !line.positionedGlyphs.empty(); });
     }
     // The y offset *should* be part of the font metadata.
     static constexpr int32_t yOffset = -17;

--- a/include/mbgl/util/event.hpp
+++ b/include/mbgl/util/event.hpp
@@ -53,6 +53,6 @@ constexpr Event disabledEvents[] = {
     Event(-1) // Avoid zero size array
 };
 
-constexpr EventPermutation disabledEventPermutations[] = {{EventSeverity::Debug, Event::Shader}};
+constexpr EventPermutation disabledEventPermutations[] = {{.severity = EventSeverity::Debug, .event = Event::Shader}};
 
 } // namespace mbgl

--- a/include/mbgl/util/immutable.hpp
+++ b/include/mbgl/util/immutable.hpp
@@ -84,7 +84,7 @@ public:
     Immutable(const Immutable&) = default;
 
     template <class S>
-    Immutable& operator=(Mutable<S>&& s) noexcept {
+    Immutable& operator=([[maybe_unused]] Mutable<S>&& s) noexcept {
         ptr = std::const_pointer_cast<const S>(std::move(s.ptr));
         return *this;
     }

--- a/include/mbgl/util/logging.hpp
+++ b/include/mbgl/util/logging.hpp
@@ -67,7 +67,7 @@ public:
     template <typename... Args>
     static void Record(EventSeverity severity, Event event, Args&&... args) noexcept {
         if (!includes(severity, disabledEventSeverities) && !includes(event, disabledEvents) &&
-            !includes({severity, event}, disabledEventPermutations)) {
+            !includes({.severity = severity, .event = event}, disabledEventPermutations)) {
             record(severity, event, ::std::forward<Args>(args)...);
         }
     }

--- a/src/mbgl/gfx/color_mode.hpp
+++ b/src/mbgl/gfx/color_mode.hpp
@@ -48,16 +48,24 @@ public:
 
     Mask mask;
 
-    static ColorMode disabled() { return {Replace{}, {}, {false, false, false, false}}; }
+    static ColorMode disabled() {
+        return {.blendFunction = Replace{}, .blendColor = {}, .mask = {.r = false, .g = false, .b = false, .a = false}};
+    }
 
-    static ColorMode unblended() { return {Replace{}, {}, {true, true, true, true}}; }
+    static ColorMode unblended() {
+        return {.blendFunction = Replace{}, .blendColor = {}, .mask = {.r = true, .g = true, .b = true, .a = true}};
+    }
 
     static ColorMode alphaBlended() {
-        return {Add{ColorBlendFactorType::One, ColorBlendFactorType::OneMinusSrcAlpha}, {}, {true, true, true, true}};
+        return {.blendFunction = Add{ColorBlendFactorType::One, ColorBlendFactorType::OneMinusSrcAlpha},
+                .blendColor = {},
+                .mask = {.r = true, .g = true, .b = true, .a = true}};
     }
 
     static ColorMode additive() {
-        return {Add{ColorBlendFactorType::One, ColorBlendFactorType::One}, {}, {true, true, true, true}};
+        return {.blendFunction = Add{ColorBlendFactorType::One, ColorBlendFactorType::One},
+                .blendColor = {},
+                .mask = {.r = true, .g = true, .b = true, .a = true}};
     }
 
     std::size_t hash() const {

--- a/src/mbgl/gfx/command_encoder.hpp
+++ b/src/mbgl/gfx/command_encoder.hpp
@@ -27,6 +27,7 @@ public:
     CommandEncoder& operator=(const CommandEncoder&) = delete;
 
     DebugGroup<CommandEncoder> createDebugGroup(const char* name) { return {*this, name}; }
+    // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
     DebugGroup<CommandEncoder> createDebugGroup(std::string_view name) { return createDebugGroup(name.data()); }
 
     virtual std::unique_ptr<UploadPass> createUploadPass(const char* name, Renderable&) = 0;

--- a/src/mbgl/gfx/cull_face_mode.hpp
+++ b/src/mbgl/gfx/cull_face_mode.hpp
@@ -11,9 +11,13 @@ public:
     CullFaceSideType side;
     CullFaceWindingType winding;
 
-    static CullFaceMode disabled() { return {false, CullFaceSideType::Back, CullFaceWindingType::CounterClockwise}; }
+    static CullFaceMode disabled() {
+        return {.enabled = false, .side = CullFaceSideType::Back, .winding = CullFaceWindingType::CounterClockwise};
+    }
 
-    static CullFaceMode backCCW() { return {true, CullFaceSideType::Back, CullFaceWindingType::CounterClockwise}; }
+    static CullFaceMode backCCW() {
+        return {.enabled = true, .side = CullFaceSideType::Back, .winding = CullFaceWindingType::CounterClockwise};
+    }
 };
 
 } // namespace gfx

--- a/src/mbgl/gfx/depth_mode.hpp
+++ b/src/mbgl/gfx/depth_mode.hpp
@@ -17,7 +17,9 @@ public:
 #if MLN_RENDER_BACKEND_OPENGL
     static DepthMode disabled() { return DepthMode{DepthFunctionType::Always, DepthMaskType::ReadOnly, {0.0, 1.0}}; }
 #else
-    static DepthMode disabled() { return DepthMode{DepthFunctionType::Always, DepthMaskType::ReadOnly}; }
+    static DepthMode disabled() {
+        return DepthMode{.func = DepthFunctionType::Always, .mask = DepthMaskType::ReadOnly};
+    }
 #endif
 };
 

--- a/src/mbgl/gfx/drawable_atlases_tweaker.cpp
+++ b/src/mbgl/gfx/drawable_atlases_tweaker.cpp
@@ -12,12 +12,13 @@ void DrawableAtlasesTweaker::setupTextures(gfx::Drawable& drawable, const bool l
     if (const auto& shader = drawable.getShader()) {
         if (glyphTextureId) {
             if (atlases) {
-                atlases->glyph->setSamplerConfiguration(
-                    {TextureFilterType::Linear, TextureWrapType::Clamp, TextureWrapType::Clamp});
+                atlases->glyph->setSamplerConfiguration({.filter = TextureFilterType::Linear,
+                                                         .wrapU = TextureWrapType::Clamp,
+                                                         .wrapV = TextureWrapType::Clamp});
                 atlases->icon->setSamplerConfiguration(
-                    {linearFilterForIcons ? TextureFilterType::Linear : TextureFilterType::Nearest,
-                     TextureWrapType::Clamp,
-                     TextureWrapType::Clamp});
+                    {.filter = linearFilterForIcons ? TextureFilterType::Linear : TextureFilterType::Nearest,
+                     .wrapU = TextureWrapType::Clamp,
+                     .wrapV = TextureWrapType::Clamp});
             }
             if (iconTextureId && shader->getSamplerLocation(*iconTextureId)) {
                 assert(*glyphTextureId != *iconTextureId);

--- a/src/mbgl/gfx/drawable_builder_impl.cpp
+++ b/src/mbgl/gfx/drawable_builder_impl.cpp
@@ -27,25 +27,25 @@ DrawableBuilder::Impl::LineLayoutVertex DrawableBuilder::Impl::layoutVertex(
      */
     static const int8_t extrudeScale = 63;
     return LineLayoutVertex{
-        {{static_cast<int16_t>((p.x * 2) | (round ? 1 : 0)), static_cast<int16_t>((p.y * 2) | (up ? 1 : 0))}},
-        {{// add 128 to store a byte in an unsigned byte
-          static_cast<uint8_t>(::round(extrudeScale * e.x) + 128),
-          static_cast<uint8_t>(::round(extrudeScale * e.y) + 128),
+        .a1 = {{static_cast<int16_t>((p.x * 2) | (round ? 1 : 0)), static_cast<int16_t>((p.y * 2) | (up ? 1 : 0))}},
+        .a2 = {{// add 128 to store a byte in an unsigned byte
+                static_cast<uint8_t>(::round(extrudeScale * e.x) + 128),
+                static_cast<uint8_t>(::round(extrudeScale * e.y) + 128),
 
-          // Encode the -1/0/1 direction value into the first two bits of .z
-          // of a_data. Combine it with the lower 6 bits of `linesofar`
-          // (shifted by 2 bites to make room for the direction value). The
-          // upper 8 bits of `linesofar` are placed in the `w` component.
-          // `linesofar` is scaled down by `LINE_DISTANCE_SCALE` so that we
-          // can store longer distances while sacrificing precision.
+                // Encode the -1/0/1 direction value into the first two bits of .z
+                // of a_data. Combine it with the lower 6 bits of `linesofar`
+                // (shifted by 2 bites to make room for the direction value). The
+                // upper 8 bits of `linesofar` are placed in the `w` component.
+                // `linesofar` is scaled down by `LINE_DISTANCE_SCALE` so that we
+                // can store longer distances while sacrificing precision.
 
-          // Encode the -1/0/1 direction value into .zw coordinates of
-          // a_data, which is normally covered by linesofar, so we need to
-          // merge them. The z component's first bit, as well as the sign
-          // bit is reserved for the direction, so we need to shift the
-          // linesofar.
-          static_cast<uint8_t>(((dir == 0 ? 0 : (dir < 0 ? -1 : 1)) + 1) | ((linesofar & 0x3F) << 2)),
-          static_cast<uint8_t>(linesofar >> 6)}}};
+                // Encode the -1/0/1 direction value into .zw coordinates of
+                // a_data, which is normally covered by linesofar, so we need to
+                // merge them. The z component's first bit, as well as the sign
+                // bit is reserved for the direction, so we need to shift the
+                // linesofar.
+                static_cast<uint8_t>(((dir == 0 ? 0 : (dir < 0 ? -1 : 1)) + 1) | ((linesofar & 0x3F) << 2)),
+                static_cast<uint8_t>(linesofar >> 6)}}};
 }
 
 void DrawableBuilder::Impl::addPolyline(gfx::DrawableBuilder& builder,
@@ -169,20 +169,20 @@ void DrawableBuilder::Impl::setupForWideVectors(gfx::Context& context, gfx::Draw
     // vertices
     if (!wideVectorVertices) {
         constexpr shaders::VertexTriWideVecB kWideVectorVertices[]{
-            {{0}, {0}, (0 << 16) + 0},
-            {{0}, {0}, (1 << 16) + 0},
-            {{0}, {0}, (2 << 16) + 0},
-            {{0}, {0}, (3 << 16) + 0},
+            {.screenPos = {0}, .color = {0}, .index = (0 << 16) + 0},
+            {.screenPos = {0}, .color = {0}, .index = (1 << 16) + 0},
+            {.screenPos = {0}, .color = {0}, .index = (2 << 16) + 0},
+            {.screenPos = {0}, .color = {0}, .index = (3 << 16) + 0},
 
-            {{0}, {0}, (4 << 16) + 1},
-            {{0}, {0}, (5 << 16) + 1},
-            {{0}, {0}, (6 << 16) + 1},
-            {{0}, {0}, (7 << 16) + 1},
+            {.screenPos = {0}, .color = {0}, .index = (4 << 16) + 1},
+            {.screenPos = {0}, .color = {0}, .index = (5 << 16) + 1},
+            {.screenPos = {0}, .color = {0}, .index = (6 << 16) + 1},
+            {.screenPos = {0}, .color = {0}, .index = (7 << 16) + 1},
 
-            {{0}, {0}, (8 << 16) + 2},
-            {{0}, {0}, (9 << 16) + 2},
-            {{0}, {0}, (10 << 16) + 2},
-            {{0}, {0}, (11 << 16) + 2},
+            {.screenPos = {0}, .color = {0}, .index = (8 << 16) + 2},
+            {.screenPos = {0}, .color = {0}, .index = (9 << 16) + 2},
+            {.screenPos = {0}, .color = {0}, .index = (10 << 16) + 2},
+            {.screenPos = {0}, .color = {0}, .index = (11 << 16) + 2},
         };
         wideVectorVertices = std::make_shared<gfx::VertexVector<shaders::VertexTriWideVecB>>();
         for (auto& v : kWideVectorVertices) {

--- a/src/mbgl/gfx/gpu_expression.cpp
+++ b/src/mbgl/gfx/gpu_expression.cpp
@@ -6,6 +6,8 @@
 #include <mbgl/style/expression/step.hpp>
 #include <mbgl/style/expression/value.hpp>
 
+#include <algorithm>
+
 namespace mbgl {
 namespace gfx {
 
@@ -53,7 +55,7 @@ auto addStop(UniqueGPUExpression& expr, GPUOutputType outType, std::size_t& inde
                     assert(value.is<Color>());
                     if (value.is<Color>()) {
                         const auto& color = attributeValue(value.get<Color>());
-                        std::copy(color.begin(), color.end(), &expr->stops.colors[2 * index++]);
+                        std::ranges::copy(color, &expr->stops.colors[2 * index++]);
                     } else {
                         // Evaluation error, cancel
                         expr.reset();

--- a/src/mbgl/gfx/stencil_mode.hpp
+++ b/src/mbgl/gfx/stencil_mode.hpp
@@ -40,7 +40,12 @@ public:
     StencilOpType pass;
 
     static StencilMode disabled() {
-        return StencilMode{Always(), 0, 0, StencilOpType::Keep, StencilOpType::Keep, StencilOpType::Keep};
+        return StencilMode{.test = Always(),
+                           .ref = 0,
+                           .mask = 0,
+                           .fail = StencilOpType::Keep,
+                           .depthFail = StencilOpType::Keep,
+                           .pass = StencilOpType::Keep};
     }
 };
 

--- a/src/mbgl/gfx/upload_pass.hpp
+++ b/src/mbgl/gfx/upload_pass.hpp
@@ -44,6 +44,7 @@ public:
     UploadPass& operator=(const UploadPass&) = delete;
 
     DebugGroup<UploadPass> createDebugGroup(const char* name) { return {*this, name}; }
+    // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
     DebugGroup<UploadPass> createDebugGroup(std::string_view name) { return createDebugGroup(name.data()); }
 
 #if MLN_DRAWABLE_RENDERER

--- a/src/mbgl/layout/pattern_layout.hpp
+++ b/src/mbgl/layout/pattern_layout.hpp
@@ -69,6 +69,7 @@ struct PatternFeatureInserter {
         const auto& sortKeyProperty = properties.template get<SortKeyPropertyType>();
         float sortKey = sortKeyProperty.evaluate(*feature, zoom, canonical, SortKeyPropertyType::defaultValue());
         PatternFeature patternFeature{index, std::move(feature), std::move(patternDependencyMap), sortKey};
+        // NOLINTNEXTLINE(modernize-use-ranges) C++26
         const auto lowerBound = std::lower_bound(features.cbegin(), features.cend(), patternFeature);
         features.insert(lowerBound, std::move(patternFeature));
     }
@@ -99,7 +100,8 @@ public:
             const std::string& layerId = layerProperties->baseImpl->id;
             const auto& evaluated = style::getEvaluated<LayerPropertiesType>(layerProperties);
             const auto& patternProperty = evaluated.template get<PatternPropertyType>();
-            const auto constantPattern = patternProperty.constantOr(Faded<style::expression::Image>{"", ""});
+            const auto constantPattern = patternProperty.constantOr(
+                Faded<style::expression::Image>{.from = "", .to = ""});
             // determine if layer group has any layers that use *-pattern
             // property and add constant pattern dependencies.
             if (!patternProperty.isConstant()) {

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -131,7 +131,11 @@ public:
         }
 
         const float unused = 0.0f;
-        return {isZoomConstant, true, unused, size, layoutSize};
+        return {.isZoomConstant = isZoomConstant,
+                .isFeatureConstant = true,
+                .sizeT = unused,
+                .size = size,
+                .layoutSize = layoutSize};
     }
 
     float layoutSize;
@@ -154,7 +158,8 @@ public:
 
     ZoomEvaluatedSize evaluateForZoom(float) const noexcept override {
         const float unused = 0.0f;
-        return {true, false, unused, unused, unused};
+        return {
+            .isZoomConstant = true, .isFeatureConstant = false, .sizeT = unused, .size = unused, .layoutSize = unused};
     }
 
     style::PropertyExpression<float> expression;
@@ -181,7 +186,11 @@ public:
             expression.interpolationFactor(coveringZoomStops, currentZoom), 0.0f, 1.0f);
 
         const float unused = 0.0f;
-        return {false, false, sizeInterpolationT, unused, unused};
+        return {.isZoomConstant = false,
+                .isFeatureConstant = false,
+                .sizeT = sizeInterpolationT,
+                .size = unused,
+                .layoutSize = unused};
     }
 
     style::PropertyExpression<float> expression;
@@ -261,6 +270,7 @@ public:
 
     std::unique_ptr<gfx::Program<Name>> program;
 
+    // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
     SymbolProgram([[maybe_unused]] const ProgramParameters& programParameters) {
         switch (gfx::Backend::GetType()) {
 #if MLN_RENDER_BACKEND_OPENGL
@@ -441,6 +451,7 @@ using SymbolSDFProgramUniforms = TypeList<uniforms::matrix,
                                           uniforms::is_halo>;
 
 template <class Name, shaders::BuiltIn ShaderSource, class PaintProperties>
+// NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
 class SymbolSDFProgram : public SymbolProgram<Name,
                                               ShaderSource,
                                               gfx::PrimitiveType::Triangle,

--- a/src/mbgl/renderer/layers/background_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/background_layer_tweaker.cpp
@@ -53,23 +53,23 @@ void BackgroundLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintPara
     auto& layerUniforms = layerGroup.mutableUniformBuffers();
 
     if (hasPattern) {
-        const BackgroundPatternPropsUBO propsUBO = {/* .pattern_tl_a = */ util::cast<float>(imagePosA->tl()),
-                                                    /* .pattern_br_a = */ util::cast<float>(imagePosA->br()),
-                                                    /* .pattern_tl_b = */ util::cast<float>(imagePosB->tl()),
-                                                    /* .pattern_br_b = */ util::cast<float>(imagePosB->br()),
-                                                    /* .pattern_size_a = */ imagePosA->displaySize(),
-                                                    /* .pattern_size_b = */ imagePosB->displaySize(),
-                                                    /* .scale_a = */ crossfade.fromScale,
-                                                    /* .scale_b = */ crossfade.toScale,
-                                                    /* .mix = */ crossfade.t,
-                                                    /* .opacity = */ evaluated.get<BackgroundOpacity>()};
+        const BackgroundPatternPropsUBO propsUBO = {.pattern_tl_a = util::cast<float>(imagePosA->tl()),
+                                                    .pattern_br_a = util::cast<float>(imagePosA->br()),
+                                                    .pattern_tl_b = util::cast<float>(imagePosB->tl()),
+                                                    .pattern_br_b = util::cast<float>(imagePosB->br()),
+                                                    .pattern_size_a = imagePosA->displaySize(),
+                                                    .pattern_size_b = imagePosB->displaySize(),
+                                                    .scale_a = crossfade.fromScale,
+                                                    .scale_b = crossfade.toScale,
+                                                    .mix = crossfade.t,
+                                                    .opacity = evaluated.get<BackgroundOpacity>()};
         layerUniforms.createOrUpdate(idBackgroundPropsUBO, &propsUBO, context);
     } else {
-        const BackgroundPropsUBO propsUBO = {/* .color = */ evaluated.get<BackgroundColor>(),
-                                             /* .opacity = */ evaluated.get<BackgroundOpacity>(),
-                                             /* .pad1 = */ 0,
-                                             /* .pad2 = */ 0,
-                                             /* .pad3 = */ 0};
+        const BackgroundPropsUBO propsUBO = {.color = evaluated.get<BackgroundColor>(),
+                                             .opacity = evaluated.get<BackgroundOpacity>(),
+                                             .pad1 = 0,
+                                             .pad2 = 0,
+                                             .pad3 = 0};
         layerUniforms.createOrUpdate(idBackgroundPropsUBO, &propsUBO, context);
     }
 
@@ -98,8 +98,9 @@ void BackgroundLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintPara
 
         if (hasPattern) {
             if (const auto& tex = parameters.patternAtlas.texture()) {
-                tex->setSamplerConfiguration(
-                    {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+                tex->setSamplerConfiguration({.filter = gfx::TextureFilterType::Linear,
+                                              .wrapU = gfx::TextureWrapType::Clamp,
+                                              .wrapV = gfx::TextureWrapType::Clamp});
                 drawable.setTexture(tex, idBackgroundImageTexture);
             }
 
@@ -115,13 +116,13 @@ void BackgroundLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintPara
 #else
             const BackgroundPatternDrawableUBO drawableUBO = {
 #endif
-                /* .matrix = */ util::cast<float>(matrix),
-                /* .pixel_coord_upper = */ {static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16)},
-                /* .pixel_coord_lower = */ {static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)},
-                /* .tile_units_to_pixels = */ (pixToTile != 0) ? 1.0f / pixToTile : 0.0f,
-                /* .pad1 = */ 0,
-                /* .pad2 = */ 0,
-                /* .pad3 = */ 0
+                .matrix = util::cast<float>(matrix),
+                .pixel_coord_upper = {static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16)},
+                .pixel_coord_lower = {static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)},
+                .tile_units_to_pixels = (pixToTile != 0) ? 1.0f / pixToTile : 0.0f,
+                .pad1 = 0,
+                .pad2 = 0,
+                .pad3 = 0
             };
 #if !MLN_UBO_CONSOLIDATION
             drawableUniforms.createOrUpdate(idBackgroundDrawableUBO, &drawableUBO, context);
@@ -133,7 +134,7 @@ void BackgroundLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintPara
 #else
             const BackgroundDrawableUBO drawableUBO = {
 #endif
-                /* .matrix = */ util::cast<float>(matrix)
+                util::cast<float>(matrix)
             };
 #if !MLN_UBO_CONSOLIDATION
             drawableUniforms.createOrUpdate(idBackgroundDrawableUBO, &drawableUBO, context);

--- a/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
@@ -42,16 +42,16 @@ void CircleLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
     // Updated only with evaluated properties
     if (!evaluatedPropsUniformBuffer || propertiesUpdated) {
         const CircleEvaluatedPropsUBO evaluatedPropsUBO = {
-            /* .color = */ constOrDefault<CircleColor>(evaluated),
-            /* .stroke_color = */ constOrDefault<CircleStrokeColor>(evaluated),
-            /* .radius = */ constOrDefault<CircleRadius>(evaluated),
-            /* .blur = */ constOrDefault<CircleBlur>(evaluated),
-            /* .opacity = */ constOrDefault<CircleOpacity>(evaluated),
-            /* .stroke_width = */ constOrDefault<CircleStrokeWidth>(evaluated),
-            /* .stroke_opacity = */ constOrDefault<CircleStrokeOpacity>(evaluated),
-            /* .scale_with_map = */ scaleWithMap,
-            /* .pitch_with_map = */ pitchWithMap,
-            /* .pad1 = */ 0};
+            .color = constOrDefault<CircleColor>(evaluated),
+            .stroke_color = constOrDefault<CircleStrokeColor>(evaluated),
+            .radius = constOrDefault<CircleRadius>(evaluated),
+            .blur = constOrDefault<CircleBlur>(evaluated),
+            .opacity = constOrDefault<CircleOpacity>(evaluated),
+            .stroke_width = constOrDefault<CircleStrokeWidth>(evaluated),
+            .stroke_opacity = constOrDefault<CircleStrokeOpacity>(evaluated),
+            .scale_with_map = scaleWithMap,
+            .pitch_with_map = pitchWithMap,
+            .pad1 = 0};
         context.emplaceOrUpdateUniformBuffer(evaluatedPropsUniformBuffer, &evaluatedPropsUBO);
         propertiesUpdated = false;
     }
@@ -93,19 +93,19 @@ void CircleLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
         const CircleDrawableUBO drawableUBO = {
 #endif
 
-            /* .matrix = */ util::cast<float>(matrix),
-            /* .extrude_scale = */ extrudeScale,
+            .matrix = util::cast<float>(matrix),
+            .extrude_scale = extrudeScale,
 
-            /* .color_t = */ std::get<0>(binders->get<CircleColor>()->interpolationFactor(zoom)),
-            /* .radius_t = */ std::get<0>(binders->get<CircleRadius>()->interpolationFactor(zoom)),
-            /* .blur_t = */ std::get<0>(binders->get<CircleBlur>()->interpolationFactor(zoom)),
-            /* .opacity_t = */ std::get<0>(binders->get<CircleOpacity>()->interpolationFactor(zoom)),
-            /* .stroke_color_t = */ std::get<0>(binders->get<CircleStrokeColor>()->interpolationFactor(zoom)),
-            /* .stroke_width_t = */ std::get<0>(binders->get<CircleStrokeWidth>()->interpolationFactor(zoom)),
-            /* .stroke_opacity_t = */ std::get<0>(binders->get<CircleStrokeOpacity>()->interpolationFactor(zoom)),
-            /* .pad1 = */ 0,
-            /* .pad2 = */ 0,
-            /* .pad3 = */ 0
+            .color_t = std::get<0>(binders->get<CircleColor>()->interpolationFactor(zoom)),
+            .radius_t = std::get<0>(binders->get<CircleRadius>()->interpolationFactor(zoom)),
+            .blur_t = std::get<0>(binders->get<CircleBlur>()->interpolationFactor(zoom)),
+            .opacity_t = std::get<0>(binders->get<CircleOpacity>()->interpolationFactor(zoom)),
+            .stroke_color_t = std::get<0>(binders->get<CircleStrokeColor>()->interpolationFactor(zoom)),
+            .stroke_width_t = std::get<0>(binders->get<CircleStrokeWidth>()->interpolationFactor(zoom)),
+            .stroke_opacity_t = std::get<0>(binders->get<CircleStrokeOpacity>()->interpolationFactor(zoom)),
+            .pad1 = 0,
+            .pad2 = 0,
+            .pad3 = 0
         };
 #if MLN_UBO_CONSOLIDATION
         drawable.setUBOIndex(i++);

--- a/src/mbgl/renderer/layers/collision_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/collision_layer_tweaker.cpp
@@ -61,9 +61,9 @@ void CollisionLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParam
         const CollisionDrawableUBO drawableUBO = {/* .matrix = */ util::cast<float>(matrix)};
 
         const CollisionTilePropsUBO tilePropsUBO = {
-            /* .extrude_scale = */ extrudeScale,
-            /* .overscale_factor = */ static_cast<float>(drawable.getTileID()->overscaleFactor()),
-            /* .pad1 = */ 0};
+            .extrude_scale = extrudeScale,
+            .overscale_factor = static_cast<float>(drawable.getTileID()->overscaleFactor()),
+            .pad1 = 0};
 
         auto& drawableUniforms = drawable.mutableUniformBuffers();
         drawableUniforms.createOrUpdate(idCollisionDrawableUBO, &drawableUBO, context);

--- a/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.cpp
@@ -42,26 +42,26 @@ void FillExtrusionLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintP
     // UBO depends on more than just evaluated properties, so we need to update every time,
     // but the resulting buffer can be shared across all the drawables from the layer.
     const FillExtrusionPropsUBO propsUBO = {
-        /* .color = */ constOrDefault<FillExtrusionColor>(evaluated),
-        /* .light_color = */ FillExtrusionProgram::lightColor(parameters.evaluatedLight),
-        /* .pad1 = */ 0,
-        /* .light_position = */ FillExtrusionProgram::lightPosition(parameters.evaluatedLight, state),
-        /* .base = */ constOrDefault<FillExtrusionBase>(evaluated),
-        /* .height = */ constOrDefault<FillExtrusionHeight>(evaluated),
-        /* .light_intensity = */ FillExtrusionProgram::lightIntensity(parameters.evaluatedLight),
-        /* .vertical_gradient = */ evaluated.get<FillExtrusionVerticalGradient>() ? 1.0f : 0.0f,
-        /* .opacity = */ evaluated.get<FillExtrusionOpacity>(),
-        /* .fade = */ crossfade.t,
-        /* .from_scale = */ crossfade.fromScale,
-        /* .to_scale = */ crossfade.toScale,
-        /* .pad2 = */ 0};
+        .color = constOrDefault<FillExtrusionColor>(evaluated),
+        .light_color = FillExtrusionProgram::lightColor(parameters.evaluatedLight),
+        .pad1 = 0,
+        .light_position = FillExtrusionProgram::lightPosition(parameters.evaluatedLight, state),
+        .base = constOrDefault<FillExtrusionBase>(evaluated),
+        .height = constOrDefault<FillExtrusionHeight>(evaluated),
+        .light_intensity = FillExtrusionProgram::lightIntensity(parameters.evaluatedLight),
+        .vertical_gradient = evaluated.get<FillExtrusionVerticalGradient>() ? 1.0f : 0.0f,
+        .opacity = evaluated.get<FillExtrusionOpacity>(),
+        .fade = crossfade.t,
+        .from_scale = crossfade.fromScale,
+        .to_scale = crossfade.toScale,
+        .pad2 = 0};
     auto& layerUniforms = layerGroup.mutableUniformBuffers();
     layerUniforms.createOrUpdate(idFillExtrusionPropsUBO, &propsUBO, context);
 
     propertiesUpdated = false;
 
     const auto zoom = static_cast<float>(parameters.state.getZoom());
-    const auto defPattern = mbgl::Faded<expression::Image>{"", ""};
+    const auto defPattern = mbgl::Faded<expression::Image>{.from = "", .to = ""};
     const auto fillPatternValue = evaluated.get<FillExtrusionPattern>().constantOr(defPattern);
 
 #if MLN_UBO_CONSOLIDATION
@@ -117,18 +117,18 @@ void FillExtrusionLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintP
 #else
         const FillExtrusionDrawableUBO drawableUBO = {
 #endif
-            /* .matrix = */ util::cast<float>(matrix),
-            /* .pixel_coord_upper = */ {static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16)},
-            /* .pixel_coord_lower = */ {static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)},
-            /* .height_factor = */ heightFactor,
-            /* .tile_ratio = */ tileRatio,
+            .matrix = util::cast<float>(matrix),
+            .pixel_coord_upper = {static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16)},
+            .pixel_coord_lower = {static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)},
+            .height_factor = heightFactor,
+            .tile_ratio = tileRatio,
 
-            /* .base_t = */ std::get<0>(binders->get<FillExtrusionBase>()->interpolationFactor(zoom)),
-            /* .height_t = */ std::get<0>(binders->get<FillExtrusionHeight>()->interpolationFactor(zoom)),
-            /* .color_t = */ std::get<0>(binders->get<FillExtrusionColor>()->interpolationFactor(zoom)),
-            /* .pattern_from_t = */ std::get<0>(binders->get<FillExtrusionPattern>()->interpolationFactor(zoom)),
-            /* .pattern_to_t = */ std::get<0>(binders->get<FillExtrusionPattern>()->interpolationFactor(zoom)),
-            /* .pad1 = */ 0
+            .base_t = std::get<0>(binders->get<FillExtrusionBase>()->interpolationFactor(zoom)),
+            .height_t = std::get<0>(binders->get<FillExtrusionHeight>()->interpolationFactor(zoom)),
+            .color_t = std::get<0>(binders->get<FillExtrusionColor>()->interpolationFactor(zoom)),
+            .pattern_from_t = std::get<0>(binders->get<FillExtrusionPattern>()->interpolationFactor(zoom)),
+            .pattern_to_t = std::get<0>(binders->get<FillExtrusionPattern>()->interpolationFactor(zoom)),
+            .pad1 = 0
         };
 
 #if MLN_UBO_CONSOLIDATION
@@ -136,11 +136,11 @@ void FillExtrusionLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintP
 #else
         const FillExtrusionTilePropsUBO tilePropsUBO = {
 #endif
-            /* .pattern_from = */ patternPosA ? util::cast<float>(patternPosA->tlbr()) : std::array<float, 4>{0},
-            /* .pattern_to = */ patternPosB ? util::cast<float>(patternPosB->tlbr()) : std::array<float, 4>{0},
-            /* .texsize = */ {static_cast<float>(textureSize.width), static_cast<float>(textureSize.height)},
-            /* .pad1 = */ 0,
-            /* .pad2 = */ 0
+            .pattern_from = patternPosA ? util::cast<float>(patternPosA->tlbr()) : std::array<float, 4>{0},
+            .pattern_to = patternPosB ? util::cast<float>(patternPosB->tlbr()) : std::array<float, 4>{0},
+            .texsize = {static_cast<float>(textureSize.width), static_cast<float>(textureSize.height)},
+            .pad1 = 0,
+            .pad2 = 0
         };
 
 #if MLN_UBO_CONSOLIDATION

--- a/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
@@ -39,12 +39,12 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 
     if (!evaluatedPropsUniformBuffer || propertiesUpdated) {
         const FillEvaluatedPropsUBO propsUBO = {
-            /* .color = */ evaluated.get<FillColor>().constantOr(FillColor::defaultValue()),
-            /* .outline_color = */ evaluated.get<FillOutlineColor>().constantOr(FillOutlineColor::defaultValue()),
-            /* .opacity = */ evaluated.get<FillOpacity>().constantOr(FillOpacity::defaultValue()),
-            /* .fade = */ crossfade.t,
-            /* .from_scale = */ crossfade.fromScale,
-            /* .to_scale = */ crossfade.toScale,
+            .color = evaluated.get<FillColor>().constantOr(FillColor::defaultValue()),
+            .outline_color = evaluated.get<FillOutlineColor>().constantOr(FillOutlineColor::defaultValue()),
+            .opacity = evaluated.get<FillOpacity>().constantOr(FillOpacity::defaultValue()),
+            .fade = crossfade.t,
+            .from_scale = crossfade.fromScale,
+            .to_scale = crossfade.toScale,
         };
         context.emplaceOrUpdateUniformBuffer(evaluatedPropsUniformBuffer, &propsUBO);
         propertiesUpdated = false;
@@ -77,7 +77,8 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
             return;
         }
 
-        const auto& fillPatternValue = evaluated.get<FillPattern>().constantOr(Faded<expression::Image>{"", ""});
+        const auto& fillPatternValue = evaluated.get<FillPattern>().constantOr(
+            Faded<expression::Image>{.from = "", .to = ""});
         const auto patternPosA = tile->getPattern(fillPatternValue.from.id());
         const auto patternPosB = tile->getPattern(fillPatternValue.to.id());
         binders->setPatternParameters(patternPosA, patternPosB, crossfade);
@@ -111,12 +112,12 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                 const FillDrawableUBO drawableUBO = {
 #endif
-                    /* .matrix = */ util::cast<float>(matrix),
+                    .matrix = util::cast<float>(matrix),
 
-                    /* .color_t = */ std::get<0>(binders->get<FillColor>()->interpolationFactor(zoom)),
-                    /* .opacity_t = */ std::get<0>(binders->get<FillOpacity>()->interpolationFactor(zoom)),
-                    /* .pad1 = */ 0,
-                    /* .pad2 = */ 0
+                    .color_t = std::get<0>(binders->get<FillColor>()->interpolationFactor(zoom)),
+                    .opacity_t = std::get<0>(binders->get<FillOpacity>()->interpolationFactor(zoom)),
+                    .pad1 = 0,
+                    .pad2 = 0
                 };
 
 #if !MLN_UBO_CONSOLIDATION
@@ -130,12 +131,12 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                 const FillOutlineDrawableUBO drawableUBO = {
 #endif
-                    /* .matrix=*/util::cast<float>(matrix),
+                    .matrix = util::cast<float>(matrix),
 
-                    /* .outline_color_t = */ std::get<0>(binders->get<FillOutlineColor>()->interpolationFactor(zoom)),
-                    /* .opacity_t = */ std::get<0>(binders->get<FillOpacity>()->interpolationFactor(zoom)),
-                    /* .pad1 = */ 0,
-                    /* .pad2 = */ 0
+                    .outline_color_t = std::get<0>(binders->get<FillOutlineColor>()->interpolationFactor(zoom)),
+                    .opacity_t = std::get<0>(binders->get<FillOpacity>()->interpolationFactor(zoom)),
+                    .pad1 = 0,
+                    .pad2 = 0
                 };
 
 #if !MLN_UBO_CONSOLIDATION
@@ -149,15 +150,15 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                 const FillPatternDrawableUBO drawableUBO = {
 #endif
-                    /* .matrix = */ util::cast<float>(matrix),
-                    /* .pixel_coord_upper = */ {static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16)},
-                    /* .pixel_coord_lower = */
-                    {static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)},
-                    /* .tile_ratio = */ tileRatio,
+                    .matrix = util::cast<float>(matrix),
+                    .pixel_coord_upper = {static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16)},
 
-                    /* .pattern_from_t = */ std::get<0>(binders->get<FillPattern>()->interpolationFactor(zoom)),
-                    /* .pattern_to_t = */ std::get<0>(binders->get<FillPattern>()->interpolationFactor(zoom)),
-                    /* .opacity_t = */ std::get<0>(binders->get<FillOpacity>()->interpolationFactor(zoom))
+                    .pixel_coord_lower = {static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)},
+                    .tile_ratio = tileRatio,
+
+                    .pattern_from_t = std::get<0>(binders->get<FillPattern>()->interpolationFactor(zoom)),
+                    .pattern_to_t = std::get<0>(binders->get<FillPattern>()->interpolationFactor(zoom)),
+                    .opacity_t = std::get<0>(binders->get<FillOpacity>()->interpolationFactor(zoom))
                 };
 
 #if MLN_UBO_CONSOLIDATION
@@ -165,14 +166,12 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                 const FillPatternTilePropsUBO tilePropsUBO = {
 #endif
-                    /* .pattern_from = */ patternPosA ? util::cast<float>(patternPosA->tlbr())
-                                                      : std::array<float, 4>{0},
-                        /* .pattern_to = */
-                        patternPosB ? util::cast<float>(patternPosB->tlbr()) : std::array<float, 4>{0},
-                        /* .texsize = */
-                        {static_cast<float>(textureSize.width), static_cast<float>(textureSize.height)},
-                        /* .pad1 = */ 0,
-                        /* .pad2 = */ 0
+                    .pattern_from = patternPosA ? util::cast<float>(patternPosA->tlbr()) : std::array<float, 4>{0},
+
+                    .pattern_to = patternPosB ? util::cast<float>(patternPosB->tlbr()) : std::array<float, 4>{0},
+
+                    .texsize = {static_cast<float>(textureSize.width), static_cast<float>(textureSize.height)},
+                    .pad1 = 0, .pad2 = 0
                 };
 
 #if !MLN_UBO_CONSOLIDATION
@@ -187,15 +186,15 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                 const FillOutlinePatternDrawableUBO drawableUBO = {
 #endif
-                    /* .matrix = */ util::cast<float>(matrix),
-                    /* .pixel_coord_upper = */ {static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16)},
-                    /* .pixel_coord_lower = */
-                    {static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)},
-                    /* .tile_ratio = */ tileRatio,
+                    .matrix = util::cast<float>(matrix),
+                    .pixel_coord_upper = {static_cast<float>(pixelX >> 16), static_cast<float>(pixelY >> 16)},
 
-                    /* .pattern_from_t = */ std::get<0>(binders->get<FillPattern>()->interpolationFactor(zoom)),
-                    /* .pattern_to_t = */ std::get<0>(binders->get<FillPattern>()->interpolationFactor(zoom)),
-                    /* .opacity_t = */ std::get<0>(binders->get<FillOpacity>()->interpolationFactor(zoom))
+                    .pixel_coord_lower = {static_cast<float>(pixelX & 0xFFFF), static_cast<float>(pixelY & 0xFFFF)},
+                    .tile_ratio = tileRatio,
+
+                    .pattern_from_t = std::get<0>(binders->get<FillPattern>()->interpolationFactor(zoom)),
+                    .pattern_to_t = std::get<0>(binders->get<FillPattern>()->interpolationFactor(zoom)),
+                    .opacity_t = std::get<0>(binders->get<FillOpacity>()->interpolationFactor(zoom))
                 };
 
 #if MLN_UBO_CONSOLIDATION
@@ -203,14 +202,12 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                 const FillOutlinePatternTilePropsUBO tilePropsUBO = {
 #endif
-                    /* .pattern_from = */ patternPosA ? util::cast<float>(patternPosA->tlbr())
-                                                      : std::array<float, 4>{0},
-                        /* .pattern_to = */
-                        patternPosB ? util::cast<float>(patternPosB->tlbr()) : std::array<float, 4>{0},
-                        /* .texsize = */
-                        {static_cast<float>(textureSize.width), static_cast<float>(textureSize.height)},
-                        /* .pad1 = */ 0,
-                        /* .pad2 = */ 0
+                    .pattern_from = patternPosA ? util::cast<float>(patternPosA->tlbr()) : std::array<float, 4>{0},
+
+                    .pattern_to = patternPosB ? util::cast<float>(patternPosB->tlbr()) : std::array<float, 4>{0},
+
+                    .texsize = {static_cast<float>(textureSize.width), static_cast<float>(textureSize.height)},
+                    .pad1 = 0, .pad2 = 0
                 };
 
 #if !MLN_UBO_CONSOLIDATION
@@ -225,11 +222,11 @@ void FillLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                 const FillOutlineTriangulatedDrawableUBO drawableUBO = {
 #endif
-                    /* .matrix = */ util::cast<float>(matrix),
-                    /* .ratio = */ 1.0f / tileID.pixelsToTileUnits(1.0f, parameters.state.getZoom()),
-                    /* .pad1 = */ 0,
-                    /* .pad2 = */ 0,
-                    /* .pad3 = */ 0
+                    .matrix = util::cast<float>(matrix),
+                    .ratio = 1.0f / tileID.pixelsToTileUnits(1.0f, parameters.state.getZoom()),
+                    .pad1 = 0,
+                    .pad2 = 0,
+                    .pad3 = 0
                 };
 
 #if !MLN_UBO_CONSOLIDATION

--- a/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
@@ -36,10 +36,10 @@ void HeatmapLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamet
 
     if (!evaluatedPropsUniformBuffer || propertiesUpdated) {
         const HeatmapEvaluatedPropsUBO evaluatedPropsUBO = {
-            /* .weight = */ evaluated.get<HeatmapWeight>().constantOr(HeatmapWeight::defaultValue()),
-            /* .radius = */ evaluated.get<HeatmapRadius>().constantOr(HeatmapRadius::defaultValue()),
-            /* .intensity = */ evaluated.get<HeatmapIntensity>(),
-            /* .padding = */ 0};
+            .weight = evaluated.get<HeatmapWeight>().constantOr(HeatmapWeight::defaultValue()),
+            .radius = evaluated.get<HeatmapRadius>().constantOr(HeatmapRadius::defaultValue()),
+            .intensity = evaluated.get<HeatmapIntensity>(),
+            .padding = 0};
         parameters.context.emplaceOrUpdateUniformBuffer(evaluatedPropsUniformBuffer, &evaluatedPropsUBO);
         propertiesUpdated = false;
     }
@@ -75,12 +75,12 @@ void HeatmapLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamet
 #else
         const HeatmapDrawableUBO drawableUBO = {
 #endif
-            /* .matrix = */ util::cast<float>(matrix),
-            /* .extrude_scale = */ tileID.pixelsToTileUnits(1.0f, zoom),
+            .matrix = util::cast<float>(matrix),
+            .extrude_scale = tileID.pixelsToTileUnits(1.0f, zoom),
 
-            /* .weight_t = */ std::get<0>(binders->get<HeatmapWeight>()->interpolationFactor(zoom)),
-            /* .radius_t = */ std::get<0>(binders->get<HeatmapRadius>()->interpolationFactor(zoom)),
-            /* .pad1 = */ 0
+            .weight_t = std::get<0>(binders->get<HeatmapWeight>()->interpolationFactor(zoom)),
+            .radius_t = std::get<0>(binders->get<HeatmapRadius>()->interpolationFactor(zoom)),
+            .pad1 = 0
         };
 #if MLN_UBO_CONSOLIDATION
         drawable.setUBOIndex(i++);

--- a/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.cpp
@@ -33,11 +33,11 @@ void HeatmapTextureLayerTweaker::execute(LayerGroupBase& layerGroup, const Paint
     const auto& size = parameters.staticData.backendSize;
     matrix::ortho(matrix, 0, size.width, size.height, 0, -1, 1);
 
-    const HeatmapTexturePropsUBO propsUBO = {/* .matrix = */ util::cast<float>(matrix),
-                                             /* .opacity = */ evaluated.get<HeatmapOpacity>(),
-                                             /* .pad1 = */ 0,
-                                             /* .pad2 = */ 0,
-                                             /* .pad3 = */ 0};
+    const HeatmapTexturePropsUBO propsUBO = {.matrix = util::cast<float>(matrix),
+                                             .opacity = evaluated.get<HeatmapOpacity>(),
+                                             .pad1 = 0,
+                                             .pad2 = 0,
+                                             .pad3 = 0};
     auto& layerUniforms = layerGroup.mutableUniformBuffers();
     layerUniforms.createOrUpdate(idHeatmapTexturePropsUBO, &propsUBO, parameters.context);
 }

--- a/src/mbgl/renderer/layers/hillshade_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/hillshade_layer_tweaker.cpp
@@ -44,10 +44,9 @@ void HillshadeLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParam
 #endif
 
     if (!evaluatedPropsUniformBuffer || propertiesUpdated) {
-        const HillshadeEvaluatedPropsUBO evaluatedPropsUBO = {
-            /* .highlight = */ evaluated.get<HillshadeHighlightColor>(),
-            /* .shadow = */ evaluated.get<HillshadeShadowColor>(),
-            /* .accent = */ evaluated.get<HillshadeAccentColor>()};
+        const HillshadeEvaluatedPropsUBO evaluatedPropsUBO = {.highlight = evaluated.get<HillshadeHighlightColor>(),
+                                                              .shadow = evaluated.get<HillshadeShadowColor>(),
+                                                              .accent = evaluated.get<HillshadeAccentColor>()};
         parameters.context.emplaceOrUpdateUniformBuffer(evaluatedPropsUniformBuffer, &evaluatedPropsUBO);
         propertiesUpdated = false;
     }
@@ -83,8 +82,8 @@ void HillshadeLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParam
 #else
         const HillshadeTilePropsUBO tilePropsUBO = {
 #endif
-            /* .latrange = */ getLatRange(tileID),
-            /* .light = */ getLight(parameters, evaluated)
+            .latrange = getLatRange(tileID),
+            .light = getLight(parameters, evaluated)
         };
 
 #if MLN_UBO_CONSOLIDATION

--- a/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.cpp
@@ -52,10 +52,10 @@ void HillshadePrepareLayerTweaker::execute(LayerGroupBase& layerGroup, const Pai
 
         const HillshadePrepareDrawableUBO drawableUBO = {/* .matrix = */ util::cast<float>(matrix)};
         const HillshadePrepareTilePropsUBO tilePropsUBO = {
-            /* .unpack = */ getUnpackVector(drawableData.encoding),
-            /* .dimension = */ {static_cast<float>(drawableData.stride), static_cast<float>(drawableData.stride)},
-            /* .zoom = */ static_cast<float>(tileID.canonical.z),
-            /* .maxzoom = */ static_cast<float>(drawableData.maxzoom)};
+            .unpack = getUnpackVector(drawableData.encoding),
+            .dimension = {static_cast<float>(drawableData.stride), static_cast<float>(drawableData.stride)},
+            .zoom = static_cast<float>(tileID.canonical.z),
+            .maxzoom = static_cast<float>(drawableData.maxzoom)};
 
         auto& drawableUniforms = drawable.mutableUniformBuffers();
         drawableUniforms.createOrUpdate(idHillshadePrepareDrawableUBO, &drawableUBO, parameters.context);

--- a/src/mbgl/renderer/layers/line_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.cpp
@@ -74,7 +74,8 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
     const auto& evaluated = static_cast<const LineLayerProperties&>(*evaluatedProperties).evaluated;
     const auto& crossfade = static_cast<const LineLayerProperties&>(*evaluatedProperties).crossfade;
 
-    const auto& linePatternValue = evaluated.get<LinePattern>().constantOr(Faded<expression::Image>{"", ""});
+    const auto& linePatternValue = evaluated.get<LinePattern>().constantOr(
+        Faded<expression::Image>{.from = "", .to = ""});
 
     const auto zoom = static_cast<float>(parameters.state.getZoom());
     const auto intZoom = parameters.state.getIntegerZoom();
@@ -84,13 +85,13 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
         const bool enableEval = gfx::Backend::getEnableGPUExpressionEval();
         if (!expressionUniformBuffer || (gpuExpressionsUpdated && enableEval)) {
             LineExpressionUBO exprUBO = {
-                /* color = */ enableEval ? gpuExpressions[propertyIndex<LineColor>()].get() : nullptr,
-                /* blur = */ enableEval ? gpuExpressions[propertyIndex<LineBlur>()].get() : nullptr,
-                /* opacity = */ enableEval ? gpuExpressions[propertyIndex<LineOpacity>()].get() : nullptr,
-                /* gapwidth = */ enableEval ? gpuExpressions[propertyIndex<LineGapWidth>()].get() : nullptr,
-                /* offset = */ enableEval ? gpuExpressions[propertyIndex<LineOffset>()].get() : nullptr,
-                /* width = */ enableEval ? gpuExpressions[propertyIndex<LineWidth>()].get() : nullptr,
-                /* floorWidth = */ enableEval ? gpuExpressions[propertyIndex<LineFloorWidth>()].get() : nullptr,
+                .color = enableEval ? gpuExpressions[propertyIndex<LineColor>()].get() : nullptr,
+                .blur = enableEval ? gpuExpressions[propertyIndex<LineBlur>()].get() : nullptr,
+                .opacity = enableEval ? gpuExpressions[propertyIndex<LineOpacity>()].get() : nullptr,
+                .gapwidth = enableEval ? gpuExpressions[propertyIndex<LineGapWidth>()].get() : nullptr,
+                .offset = enableEval ? gpuExpressions[propertyIndex<LineOffset>()].get() : nullptr,
+                .width = enableEval ? gpuExpressions[propertyIndex<LineWidth>()].get() : nullptr,
+                .floorWidth = enableEval ? gpuExpressions[propertyIndex<LineFloorWidth>()].get() : nullptr,
             };
             context.emplaceOrUpdateUniformBuffer(expressionUniformBuffer, &exprUBO);
             gpuExpressionsUpdated = false;
@@ -116,26 +117,28 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
                    (gpuExpressions[propertyIndex<LineFloorWidth>()] ? LineExpressionMask::FloorWidth
                                                                     : LineExpressionMask::None));
         const LineEvaluatedPropsUBO propsUBO{
-            /*color =*/(expressionMask & LineExpressionMask::Color) ? LineColor::defaultValue()
-                                                                    : evaluate<LineColor>(parameters),
-            /*blur =*/
-            (expressionMask & LineExpressionMask::Blur) ? LineBlur::defaultValue() : evaluate<LineBlur>(parameters),
-            /*opacity =*/
-            (expressionMask & LineExpressionMask::Opacity) ? LineOpacity::defaultValue()
-                                                           : evaluate<LineOpacity>(parameters),
-            /*gapwidth =*/
-            (expressionMask & LineExpressionMask::GapWidth) ? LineGapWidth::defaultValue()
-                                                            : evaluate<LineGapWidth>(parameters),
-            /*offset =*/
-            (expressionMask & LineExpressionMask::Offset) ? LineOffset::defaultValue()
-                                                          : evaluate<LineOffset>(parameters),
-            /*width =*/
-            (expressionMask & LineExpressionMask::Width) ? LineWidth::defaultValue() : evaluate<LineWidth>(parameters),
-            /*floorwidth =*/
-            (expressionMask & LineExpressionMask::FloorWidth) ? LineFloorWidth::defaultValue()
-                                                              : evaluate<LineFloorWidth>(parameters),
-            expressionMask,
-            0};
+            .color = (expressionMask & LineExpressionMask::Color) ? LineColor::defaultValue()
+                                                                  : evaluate<LineColor>(parameters),
+
+            .blur = (expressionMask & LineExpressionMask::Blur) ? LineBlur::defaultValue()
+                                                                : evaluate<LineBlur>(parameters),
+
+            .opacity = (expressionMask & LineExpressionMask::Opacity) ? LineOpacity::defaultValue()
+                                                                      : evaluate<LineOpacity>(parameters),
+
+            .gapwidth = (expressionMask & LineExpressionMask::GapWidth) ? LineGapWidth::defaultValue()
+                                                                        : evaluate<LineGapWidth>(parameters),
+
+            .offset = (expressionMask & LineExpressionMask::Offset) ? LineOffset::defaultValue()
+                                                                    : evaluate<LineOffset>(parameters),
+
+            .width = (expressionMask & LineExpressionMask::Width) ? LineWidth::defaultValue()
+                                                                  : evaluate<LineWidth>(parameters),
+
+            .floorwidth = (expressionMask & LineExpressionMask::FloorWidth) ? LineFloorWidth::defaultValue()
+                                                                            : evaluate<LineFloorWidth>(parameters),
+            .expressionMask = expressionMask,
+            .pad1 = 0};
 #else
         const LineEvaluatedPropsUBO propsUBO{/*color =*/evaluate<LineColor>(parameters),
                                              /*blur =*/evaluate<LineBlur>(parameters),
@@ -201,16 +204,16 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                 const LineDrawableUBO drawableUBO = {
 #endif
-                    /* .matrix = */ util::cast<float>(matrix),
-                    /* .ratio = */ 1.0f / tileID.pixelsToTileUnits(1.0f, static_cast<float>(zoom)),
+                    .matrix = util::cast<float>(matrix),
+                    .ratio = 1.0f / tileID.pixelsToTileUnits(1.0f, static_cast<float>(zoom)),
 
-                    /* .color_t = */ std::get<0>(binders->get<LineColor>()->interpolationFactor(zoom)),
-                    /* .blur_t = */ std::get<0>(binders->get<LineBlur>()->interpolationFactor(zoom)),
-                    /* .opacity_t = */ std::get<0>(binders->get<LineOpacity>()->interpolationFactor(zoom)),
-                    /* .gapwidth_t = */ std::get<0>(binders->get<LineGapWidth>()->interpolationFactor(zoom)),
-                    /* .offset_t = */ std::get<0>(binders->get<LineOffset>()->interpolationFactor(zoom)),
-                    /* .width_t = */ std::get<0>(binders->get<LineWidth>()->interpolationFactor(zoom)),
-                    /* .pad1 = */ 0
+                    .color_t = std::get<0>(binders->get<LineColor>()->interpolationFactor(zoom)),
+                    .blur_t = std::get<0>(binders->get<LineBlur>()->interpolationFactor(zoom)),
+                    .opacity_t = std::get<0>(binders->get<LineOpacity>()->interpolationFactor(zoom)),
+                    .gapwidth_t = std::get<0>(binders->get<LineGapWidth>()->interpolationFactor(zoom)),
+                    .offset_t = std::get<0>(binders->get<LineOffset>()->interpolationFactor(zoom)),
+                    .width_t = std::get<0>(binders->get<LineWidth>()->interpolationFactor(zoom)),
+                    .pad1 = 0
                 };
 
 #if !MLN_UBO_CONSOLIDATION
@@ -225,16 +228,16 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                 const LineGradientDrawableUBO drawableUBO = {
 #endif
-                    /* .matrix = */ util::cast<float>(matrix),
-                    /* .ratio = */ 1.0f / tileID.pixelsToTileUnits(1.0f, static_cast<float>(zoom)),
+                    .matrix = util::cast<float>(matrix),
+                    .ratio = 1.0f / tileID.pixelsToTileUnits(1.0f, static_cast<float>(zoom)),
 
-                    /* .blur_t = */ std::get<0>(binders->get<LineBlur>()->interpolationFactor(zoom)),
-                    /* .opacity_t = */ std::get<0>(binders->get<LineOpacity>()->interpolationFactor(zoom)),
-                    /* .gapwidth_t = */ std::get<0>(binders->get<LineGapWidth>()->interpolationFactor(zoom)),
-                    /* .offset_t = */ std::get<0>(binders->get<LineOffset>()->interpolationFactor(zoom)),
-                    /* .width_t = */ std::get<0>(binders->get<LineWidth>()->interpolationFactor(zoom)),
-                    /* .pad1 = */ 0,
-                    /* .pad2 = */ 0
+                    .blur_t = std::get<0>(binders->get<LineBlur>()->interpolationFactor(zoom)),
+                    .opacity_t = std::get<0>(binders->get<LineOpacity>()->interpolationFactor(zoom)),
+                    .gapwidth_t = std::get<0>(binders->get<LineGapWidth>()->interpolationFactor(zoom)),
+                    .offset_t = std::get<0>(binders->get<LineOffset>()->interpolationFactor(zoom)),
+                    .width_t = std::get<0>(binders->get<LineWidth>()->interpolationFactor(zoom)),
+                    .pad1 = 0,
+                    .pad2 = 0
                 };
 
 #if !MLN_UBO_CONSOLIDATION
@@ -252,16 +255,16 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                 const LinePatternDrawableUBO drawableUBO = {
 #endif
-                    /* .matrix = */ util::cast<float>(matrix),
-                    /* .ratio = */ 1.0f / tileID.pixelsToTileUnits(1.0f, static_cast<float>(zoom)),
+                    .matrix = util::cast<float>(matrix),
+                    .ratio = 1.0f / tileID.pixelsToTileUnits(1.0f, static_cast<float>(zoom)),
 
-                    /* .blur_t = */ std::get<0>(binders->get<LineBlur>()->interpolationFactor(zoom)),
-                    /* .opacity_t = */ std::get<0>(binders->get<LineOpacity>()->interpolationFactor(zoom)),
-                    /* .offset_t = */ std::get<0>(binders->get<LineOffset>()->interpolationFactor(zoom)),
-                    /* .gapwidth_t = */ std::get<0>(binders->get<LineGapWidth>()->interpolationFactor(zoom)),
-                    /* .width_t = */ std::get<0>(binders->get<LineWidth>()->interpolationFactor(zoom)),
-                    /* .pattern_from_t = */ std::get<0>(binders->get<LinePattern>()->interpolationFactor(zoom)),
-                    /* .pattern_to_t = */ std::get<1>(binders->get<LinePattern>()->interpolationFactor(zoom))
+                    .blur_t = std::get<0>(binders->get<LineBlur>()->interpolationFactor(zoom)),
+                    .opacity_t = std::get<0>(binders->get<LineOpacity>()->interpolationFactor(zoom)),
+                    .gapwidth_t = std::get<0>(binders->get<LineOffset>()->interpolationFactor(zoom)),
+                    .offset_t = std::get<0>(binders->get<LineGapWidth>()->interpolationFactor(zoom)),
+                    .width_t = std::get<0>(binders->get<LineWidth>()->interpolationFactor(zoom)),
+                    .pattern_from_t = std::get<0>(binders->get<LinePattern>()->interpolationFactor(zoom)),
+                    .pattern_to_t = std::get<1>(binders->get<LinePattern>()->interpolationFactor(zoom))
                 };
 
 #if MLN_UBO_CONSOLIDATION
@@ -269,19 +272,17 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                 const LinePatternTilePropsUBO tilePropsUBO = {
 #endif
-                    /* .pattern_from = */ patternPosA ? util::cast<float>(patternPosA->tlbr())
-                                                      : std::array<float, 4>{0},
-                        /* .pattern_to = */
-                        patternPosB ? util::cast<float>(patternPosB->tlbr()) : std::array<float, 4>{0},
-                        /* .scale = */
-                        {parameters.pixelRatio,
-                         1 / tileID.pixelsToTileUnits(1, intZoom),
-                         crossfade.fromScale,
-                         crossfade.toScale},
-                        /* .texsize = */
-                        {static_cast<float>(textureSize.width), static_cast<float>(textureSize.height)},
-                        /* .fade = */ crossfade.t,
-                        /* .pad1 = */ 0
+                    .pattern_from = patternPosA ? util::cast<float>(patternPosA->tlbr()) : std::array<float, 4>{0},
+
+                    .pattern_to = patternPosB ? util::cast<float>(patternPosB->tlbr()) : std::array<float, 4>{0},
+
+                    .scale = {parameters.pixelRatio,
+                              1 / tileID.pixelsToTileUnits(1, intZoom),
+                              crossfade.fromScale,
+                              crossfade.toScale},
+
+                    .texsize = {static_cast<float>(textureSize.width), static_cast<float>(textureSize.height)},
+                    .fade = crossfade.t, .pad1 = 0
                 };
 
 #if !MLN_UBO_CONSOLIDATION
@@ -317,22 +318,22 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                     const LineSDFDrawableUBO drawableUBO = {
 #endif
-                        /* .matrix = */ util::cast<float>(matrix),
-                        /* .patternscale_a = */ {1.0f / tileID.pixelsToTileUnits(widthA, intZoom), -posA.height / 2.0f},
-                        /* .patternscale_b = */ {1.0f / tileID.pixelsToTileUnits(widthB, intZoom), -posB.height / 2.0f},
-                        /* .tex_y_a = */ posA.y,
-                        /* .tex_y_b = */ posB.y,
-                        /* .ratio = */ 1.0f / tileID.pixelsToTileUnits(1.0f, zoom),
+                        .matrix = util::cast<float>(matrix),
+                        .patternscale_a = {1.0f / tileID.pixelsToTileUnits(widthA, intZoom), -posA.height / 2.0f},
+                        .patternscale_b = {1.0f / tileID.pixelsToTileUnits(widthB, intZoom), -posB.height / 2.0f},
+                        .tex_y_a = posA.y,
+                        .tex_y_b = posB.y,
+                        .ratio = 1.0f / tileID.pixelsToTileUnits(1.0f, zoom),
 
-                        /* .color_t = */ std::get<0>(binders->get<LineColor>()->interpolationFactor(zoom)),
-                        /* .blur_t = */ std::get<0>(binders->get<LineBlur>()->interpolationFactor(zoom)),
-                        /* .opacity_t = */ std::get<0>(binders->get<LineOpacity>()->interpolationFactor(zoom)),
-                        /* .gapwidth_t = */ std::get<0>(binders->get<LineGapWidth>()->interpolationFactor(zoom)),
-                        /* .offset_t = */ std::get<0>(binders->get<LineOffset>()->interpolationFactor(zoom)),
-                        /* .width_t = */ std::get<0>(binders->get<LineWidth>()->interpolationFactor(zoom)),
-                        /* .floorwidth_t = */ std::get<0>(binders->get<LineFloorWidth>()->interpolationFactor(zoom)),
-                        /* .pad1 = */ 0,
-                        /* .pad2 = */ 0
+                        .color_t = std::get<0>(binders->get<LineColor>()->interpolationFactor(zoom)),
+                        .blur_t = std::get<0>(binders->get<LineBlur>()->interpolationFactor(zoom)),
+                        .opacity_t = std::get<0>(binders->get<LineOpacity>()->interpolationFactor(zoom)),
+                        .gapwidth_t = std::get<0>(binders->get<LineGapWidth>()->interpolationFactor(zoom)),
+                        .offset_t = std::get<0>(binders->get<LineOffset>()->interpolationFactor(zoom)),
+                        .width_t = std::get<0>(binders->get<LineWidth>()->interpolationFactor(zoom)),
+                        .floorwidth_t = std::get<0>(binders->get<LineFloorWidth>()->interpolationFactor(zoom)),
+                        .pad1 = 0,
+                        .pad2 = 0
                     };
 
 #if MLN_UBO_CONSOLIDATION
@@ -340,11 +341,9 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 #else
                     const LineSDFTilePropsUBO tilePropsUBO = {
 #endif
-                        /* .sdfgamma = */ static_cast<float>(dashPatternTexture.getSize().width) /
-                            (std::min(widthA, widthB) * 256.0f * parameters.pixelRatio) / 2.0f,
-                            /* .mix = */ crossfade.t,
-                            /* .pad1 = */ 0,
-                            /* .pad2 = */ 0
+                        .sdfgamma = static_cast<float>(dashPatternTexture.getSize().width) /
+                                    (std::min(widthA, widthB) * 256.0f * parameters.pixelRatio) / 2.0f,
+                        .mix = crossfade.t, .pad1 = 0, .pad2 = 0
                     };
 
 #if !MLN_UBO_CONSOLIDATION

--- a/src/mbgl/renderer/layers/location_indicator_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/location_indicator_layer_tweaker.cpp
@@ -27,16 +27,15 @@ void LocationIndicatorLayerTweaker::execute(LayerGroupBase& layerGroup, const Pa
 
         switch (static_cast<RenderLocationIndicatorLayer::LocationIndicatorComponentType>(drawable.getType())) {
             case RenderLocationIndicatorLayer::LocationIndicatorComponentType::Circle: {
-                LocationIndicatorDrawableUBO drawableUBO = {/* .matrix = */ util::cast<float>(projectionCircle),
-                                                            /* .color = */ props.evaluated.get<AccuracyRadiusColor>()};
+                LocationIndicatorDrawableUBO drawableUBO = {.matrix = util::cast<float>(projectionCircle),
+                                                            .color = props.evaluated.get<AccuracyRadiusColor>()};
                 drawableUniforms.createOrUpdate(idLocationIndicatorDrawableUBO, &drawableUBO, params.context);
                 break;
             }
 
             case RenderLocationIndicatorLayer::LocationIndicatorComponentType::CircleOutline: {
-                LocationIndicatorDrawableUBO drawableUBO = {
-                    /* .matrix = */ util::cast<float>(projectionCircle),
-                    /* .color = */ props.evaluated.get<AccuracyRadiusBorderColor>()};
+                LocationIndicatorDrawableUBO drawableUBO = {.matrix = util::cast<float>(projectionCircle),
+                                                            .color = props.evaluated.get<AccuracyRadiusBorderColor>()};
                 drawableUniforms.createOrUpdate(idLocationIndicatorDrawableUBO, &drawableUBO, params.context);
                 break;
             }
@@ -46,8 +45,8 @@ void LocationIndicatorLayerTweaker::execute(LayerGroupBase& layerGroup, const Pa
             case RenderLocationIndicatorLayer::LocationIndicatorComponentType::Puck:
                 [[fallthrough]];
             case RenderLocationIndicatorLayer::LocationIndicatorComponentType::PuckHat: {
-                const LocationIndicatorDrawableUBO drawableUBO = {/* .matrix = */ util::cast<float>(projectionPuck),
-                                                                  /* .color = */ Color::black()};
+                const LocationIndicatorDrawableUBO drawableUBO = {.matrix = util::cast<float>(projectionPuck),
+                                                                  .color = Color::black()};
                 drawableUniforms.createOrUpdate(idLocationIndicatorDrawableUBO, &drawableUBO, params.context);
                 break;
             }

--- a/src/mbgl/renderer/layers/raster_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/raster_layer_tweaker.cpp
@@ -51,18 +51,18 @@ void RasterLayerTweaker::execute([[maybe_unused]] LayerGroupBase& layerGroup,
 
     if (!evaluatedPropsUniformBuffer || propertiesUpdated) {
         const RasterEvaluatedPropsUBO propsUBO = {
-            /* .spin_weigths = */ spinWeights(evaluated.get<RasterHueRotate>()),
-            /* .tl_parent = */ {{0.0f, 0.0f}},
-            /* .scale_parent = */ 1.0f,
-            /* .buffer_scale = */ 1.0f,
-            /* .fade_t = */ 1.0f,
-            /* .opacity = */ evaluated.get<RasterOpacity>(),
-            /* .brightness_low = */ evaluated.get<RasterBrightnessMin>(),
-            /* .brightness_high = */ evaluated.get<RasterBrightnessMax>(),
-            /* .saturation_factor = */ saturationFactor(evaluated.get<RasterSaturation>()),
-            /* .contrast_factor = */ contrastFactor(evaluated.get<RasterContrast>()),
-            /* .pad1 = */ 0,
-            /* .pad2 = */ 0};
+            .spin_weights = spinWeights(evaluated.get<RasterHueRotate>()),
+            .tl_parent = {{0.0f, 0.0f}},
+            .scale_parent = 1.0f,
+            .buffer_scale = 1.0f,
+            .fade_t = 1.0f,
+            .opacity = evaluated.get<RasterOpacity>(),
+            .brightness_low = evaluated.get<RasterBrightnessMin>(),
+            .brightness_high = evaluated.get<RasterBrightnessMax>(),
+            .saturation_factor = saturationFactor(evaluated.get<RasterSaturation>()),
+            .contrast_factor = contrastFactor(evaluated.get<RasterContrast>()),
+            .pad1 = 0,
+            .pad2 = 0};
         parameters.context.emplaceOrUpdateUniformBuffer(evaluatedPropsUniformBuffer, &propsUBO);
         propertiesUpdated = false;
     }

--- a/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
@@ -69,19 +69,19 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
     const auto zoom = static_cast<float>(state.getZoom());
 
     if (!evaluatedPropsUniformBuffer || propertiesUpdated) {
-        const SymbolEvaluatedPropsUBO propsUBO = {/* .text_fill_color = */ constOrDefault<TextColor>(evaluated),
-                                                  /* .text_halo_color = */ constOrDefault<TextHaloColor>(evaluated),
-                                                  /* .text_opacity = */ constOrDefault<TextOpacity>(evaluated),
-                                                  /* .text_halo_width = */ constOrDefault<TextHaloWidth>(evaluated),
-                                                  /* .text_halo_blur = */ constOrDefault<TextHaloBlur>(evaluated),
-                                                  /* .pad1 */ 0,
+        const SymbolEvaluatedPropsUBO propsUBO = {.text_fill_color = constOrDefault<TextColor>(evaluated),
+                                                  .text_halo_color = constOrDefault<TextHaloColor>(evaluated),
+                                                  .text_opacity = constOrDefault<TextOpacity>(evaluated),
+                                                  .text_halo_width = constOrDefault<TextHaloWidth>(evaluated),
+                                                  .text_halo_blur = constOrDefault<TextHaloBlur>(evaluated),
+                                                  .pad1 = 0,
 
-                                                  /* .icon_fill_color = */ constOrDefault<IconColor>(evaluated),
-                                                  /* .icon_halo_color = */ constOrDefault<IconHaloColor>(evaluated),
-                                                  /* .icon_opacity = */ constOrDefault<IconOpacity>(evaluated),
-                                                  /* .icon_halo_width = */ constOrDefault<IconHaloWidth>(evaluated),
-                                                  /* .icon_halo_blur = */ constOrDefault<IconHaloBlur>(evaluated),
-                                                  /* .pad2 */ 0};
+                                                  .icon_fill_color = constOrDefault<IconColor>(evaluated),
+                                                  .icon_halo_color = constOrDefault<IconHaloColor>(evaluated),
+                                                  .icon_opacity = constOrDefault<IconOpacity>(evaluated),
+                                                  .icon_halo_width = constOrDefault<IconHaloWidth>(evaluated),
+                                                  .icon_halo_blur = constOrDefault<IconHaloBlur>(evaluated),
+                                                  .pad2 = 0};
         context.emplaceOrUpdateUniformBuffer(evaluatedPropsUniformBuffer, &propsUBO);
         propertiesUpdated = false;
     }
@@ -157,27 +157,27 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
 #else
         const SymbolDrawableUBO drawableUBO = {
 #endif
-            /* .matrix = */ util::cast<float>(matrix),
-            /* .label_plane_matrix = */ util::cast<float>(labelPlaneMatrix),
-            /* .coord_matrix = */ util::cast<float>(glCoordMatrix),
+            .matrix = util::cast<float>(matrix),
+            .label_plane_matrix = util::cast<float>(labelPlaneMatrix),
+            .coord_matrix = util::cast<float>(glCoordMatrix),
 
-            /* .texsize = */ toArray(getTexSize(drawable, idSymbolImageTexture)),
-            /* .texsize_icon = */ toArray(getTexSize(drawable, idSymbolImageIconTexture)),
+            .texsize = toArray(getTexSize(drawable, idSymbolImageTexture)),
+            .texsize_icon = toArray(getTexSize(drawable, idSymbolImageIconTexture)),
 
-            /* .is_text_prop = */ isText,
-            /* .rotate_symbol = */ rotateInShader,
-            /* .pitch_with_map = */ (symbolData.pitchAlignment == style::AlignmentType::Map),
-            /* .is_size_zoom_constant = */ size.isZoomConstant,
-            /* .is_size_feature_constant = */ size.isFeatureConstant,
+            .is_text_prop = isText,
+            .rotate_symbol = rotateInShader,
+            .pitch_with_map = (symbolData.pitchAlignment == style::AlignmentType::Map),
+            .is_size_zoom_constant = size.isZoomConstant,
+            .is_size_feature_constant = size.isFeatureConstant,
 
-            /* .size_t = */ size.sizeT,
-            /* .size = */ size.size,
+            .size_t = size.sizeT,
+            .size = size.size,
 
-            /* .fill_color_t = */ getInterpFactor<TextColor, IconColor, 0>(paintProperties, isText, zoom),
-            /* .halo_color_t = */ getInterpFactor<TextHaloColor, IconHaloColor, 0>(paintProperties, isText, zoom),
-            /* .opacity_t = */ getInterpFactor<TextOpacity, IconOpacity, 0>(paintProperties, isText, zoom),
-            /* .halo_width_t = */ getInterpFactor<TextHaloWidth, IconHaloWidth, 0>(paintProperties, isText, zoom),
-            /* .halo_blur_t = */ getInterpFactor<TextHaloBlur, IconHaloBlur, 0>(paintProperties, isText, zoom),
+            .fill_color_t = getInterpFactor<TextColor, IconColor, 0>(paintProperties, isText, zoom),
+            .halo_color_t = getInterpFactor<TextHaloColor, IconHaloColor, 0>(paintProperties, isText, zoom),
+            .opacity_t = getInterpFactor<TextOpacity, IconOpacity, 0>(paintProperties, isText, zoom),
+            .halo_width_t = getInterpFactor<TextHaloWidth, IconHaloWidth, 0>(paintProperties, isText, zoom),
+            .halo_blur_t = getInterpFactor<TextHaloBlur, IconHaloBlur, 0>(paintProperties, isText, zoom),
         };
 
 #if MLN_UBO_CONSOLIDATION
@@ -185,10 +185,10 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
 #else
         const SymbolTilePropsUBO tilePropsUBO = {
 #endif
-            /* .is_text = */ isText,
-            /* .is_halo = */ symbolData.isHalo,
-            /* .gamma_scale= */ gammaScale,
-            /* .pad1 = */ 0,
+            .is_text = isText,
+            .is_halo = symbolData.isHalo,
+            .gamma_scale = gammaScale,
+            .pad1 = 0,
         };
 
 #if MLN_UBO_CONSOLIDATION

--- a/src/mbgl/renderer/property_evaluation_parameters.hpp
+++ b/src/mbgl/renderer/property_evaluation_parameters.hpp
@@ -33,8 +33,9 @@ public:
                             ? std::min((now - zoomHistory.lastIntegerZoomTime) / d, 1.0f)
                             : 1.0f;
 
-        return z > zoomHistory.lastIntegerZoom ? CrossfadeParameters{2.0f, 1.0f, fraction + (1.0f - fraction) * t}
-                                               : CrossfadeParameters{0.5f, 1.0f, 1 - (1 - t) * fraction};
+        return z > zoomHistory.lastIntegerZoom
+                   ? CrossfadeParameters{.fromScale = 2.0f, .toScale = 1.0f, .t = fraction + (1.0f - fraction) * t}
+                   : CrossfadeParameters{.fromScale = 0.5f, .toScale = 1.0f, .t = 1 - (1 - t) * fraction};
     }
 
     float z;

--- a/src/mbgl/renderer/render_target.cpp
+++ b/src/mbgl/renderer/render_target.cpp
@@ -65,8 +65,11 @@ void RenderTarget::upload(gfx::UploadPass& uploadPass) {
 }
 
 void RenderTarget::render(RenderOrchestrator& orchestrator, const RenderTree& renderTree, PaintParameters& parameters) {
-    parameters.renderPass = parameters.encoder->createRenderPass(
-        "render target", {*offscreenTexture, Color{0.0f, 0.0f, 0.0f, 1.0f}, {}, {}});
+    parameters.renderPass = parameters.encoder->createRenderPass("render target",
+                                                                 {.renderable = *offscreenTexture,
+                                                                  .clearColor = Color{0.0f, 0.0f, 0.0f, 1.0f},
+                                                                  .clearDepth = {},
+                                                                  .clearStencil = {}});
 
     // Run layer tweakers to update any dynamic elements
     parameters.currentLayer = 0;

--- a/src/mbgl/renderer/tile_layer_group.cpp
+++ b/src/mbgl/renderer/tile_layer_group.cpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/gfx/upload_pass.hpp>
 
+#include <algorithm>
 #include <unordered_map>
 #include <set>
 
@@ -40,7 +41,7 @@ std::vector<gfx::UniqueDrawable> TileLayerGroup::removeDrawables(mbgl::RenderPas
             return std::move(pair.second);
         });
     drawablesByTile.erase(range.first, range.second);
-    std::for_each(result.begin(), result.end(), [&](const auto& item) {
+    std::ranges::for_each(result, [&](const auto& item) {
         const auto hit = sortedDrawables.find(item.get());
         assert(hit != sortedDrawables.end());
         if (hit != sortedDrawables.end()) {
@@ -56,7 +57,8 @@ void TileLayerGroup::addDrawable(mbgl::RenderPass pass, const OverscaledTileID& 
         LayerGroupBase::addDrawable(drawable);
         [[maybe_unused]] const auto result = sortedDrawables.insert(drawable.get());
         assert(result.second);
-        drawablesByTile.insert(std::make_pair(TileLayerGroupTileKey{pass, id}, std::move(drawable)));
+        drawablesByTile.insert(
+            std::make_pair(TileLayerGroupTileKey{.renderPass = pass, .tileID = id}, std::move(drawable)));
     }
 }
 

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -21,16 +21,15 @@ namespace style {
 
 // static
 const LayerTypeInfo* BackgroundLayer::Impl::staticTypeInfo() noexcept {
-    const static LayerTypeInfo typeInfo{"background",
-                                        LayerTypeInfo::Source::NotRequired,
-                                        LayerTypeInfo::Pass3D::NotRequired,
-                                        LayerTypeInfo::Layout::NotRequired,
-                                        LayerTypeInfo::FadingTiles::NotRequired,
-                                        LayerTypeInfo::CrossTileIndex::NotRequired,
-                                        LayerTypeInfo::TileKind::NotRequired};
+    const static LayerTypeInfo typeInfo{.type="background",
+                                        .source=LayerTypeInfo::Source::NotRequired,
+                                        .pass3d=LayerTypeInfo::Pass3D::NotRequired,
+                                        .layout=LayerTypeInfo::Layout::NotRequired,
+                                        .fadingTiles=LayerTypeInfo::FadingTiles::NotRequired,
+                                        .crossTileIndex=LayerTypeInfo::CrossTileIndex::NotRequired,
+                                        .tileKind=LayerTypeInfo::TileKind::NotRequired};
     return &typeInfo;
 }
-
 
 BackgroundLayer::BackgroundLayer(const std::string& layerID)
     : Layer(makeMutable<Impl>(layerID, std::string())) {

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -21,16 +21,15 @@ namespace style {
 
 // static
 const LayerTypeInfo* CircleLayer::Impl::staticTypeInfo() noexcept {
-    const static LayerTypeInfo typeInfo{"circle",
-                                        LayerTypeInfo::Source::Required,
-                                        LayerTypeInfo::Pass3D::NotRequired,
-                                        LayerTypeInfo::Layout::Required,
-                                        LayerTypeInfo::FadingTiles::NotRequired,
-                                        LayerTypeInfo::CrossTileIndex::NotRequired,
-                                        LayerTypeInfo::TileKind::Geometry};
+    const static LayerTypeInfo typeInfo{.type="circle",
+                                        .source=LayerTypeInfo::Source::Required,
+                                        .pass3d=LayerTypeInfo::Pass3D::NotRequired,
+                                        .layout=LayerTypeInfo::Layout::Required,
+                                        .fadingTiles=LayerTypeInfo::FadingTiles::NotRequired,
+                                        .crossTileIndex=LayerTypeInfo::CrossTileIndex::NotRequired,
+                                        .tileKind=LayerTypeInfo::TileKind::Geometry};
     return &typeInfo;
 }
-
 
 CircleLayer::CircleLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(layerID, sourceID)) {

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -21,16 +21,15 @@ namespace style {
 
 // static
 const LayerTypeInfo* FillExtrusionLayer::Impl::staticTypeInfo() noexcept {
-    const static LayerTypeInfo typeInfo{"fill-extrusion",
-                                        LayerTypeInfo::Source::Required,
-                                        LayerTypeInfo::Pass3D::Required,
-                                        LayerTypeInfo::Layout::Required,
-                                        LayerTypeInfo::FadingTiles::NotRequired,
-                                        LayerTypeInfo::CrossTileIndex::NotRequired,
-                                        LayerTypeInfo::TileKind::Geometry};
+    const static LayerTypeInfo typeInfo{.type="fill-extrusion",
+                                        .source=LayerTypeInfo::Source::Required,
+                                        .pass3d=LayerTypeInfo::Pass3D::Required,
+                                        .layout=LayerTypeInfo::Layout::Required,
+                                        .fadingTiles=LayerTypeInfo::FadingTiles::NotRequired,
+                                        .crossTileIndex=LayerTypeInfo::CrossTileIndex::NotRequired,
+                                        .tileKind=LayerTypeInfo::TileKind::Geometry};
     return &typeInfo;
 }
-
 
 FillExtrusionLayer::FillExtrusionLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(layerID, sourceID)) {

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -21,16 +21,15 @@ namespace style {
 
 // static
 const LayerTypeInfo* FillLayer::Impl::staticTypeInfo() noexcept {
-    const static LayerTypeInfo typeInfo{"fill",
-                                        LayerTypeInfo::Source::Required,
-                                        LayerTypeInfo::Pass3D::NotRequired,
-                                        LayerTypeInfo::Layout::Required,
-                                        LayerTypeInfo::FadingTiles::NotRequired,
-                                        LayerTypeInfo::CrossTileIndex::NotRequired,
-                                        LayerTypeInfo::TileKind::Geometry};
+    const static LayerTypeInfo typeInfo{.type="fill",
+                                        .source=LayerTypeInfo::Source::Required,
+                                        .pass3d=LayerTypeInfo::Pass3D::NotRequired,
+                                        .layout=LayerTypeInfo::Layout::Required,
+                                        .fadingTiles=LayerTypeInfo::FadingTiles::NotRequired,
+                                        .crossTileIndex=LayerTypeInfo::CrossTileIndex::NotRequired,
+                                        .tileKind=LayerTypeInfo::TileKind::Geometry};
     return &typeInfo;
 }
-
 
 FillLayer::FillLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(layerID, sourceID)) {

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -21,16 +21,15 @@ namespace style {
 
 // static
 const LayerTypeInfo* HeatmapLayer::Impl::staticTypeInfo() noexcept {
-    const static LayerTypeInfo typeInfo{"heatmap",
-                                        LayerTypeInfo::Source::Required,
-                                        LayerTypeInfo::Pass3D::Required,
-                                        LayerTypeInfo::Layout::NotRequired,
-                                        LayerTypeInfo::FadingTiles::NotRequired,
-                                        LayerTypeInfo::CrossTileIndex::NotRequired,
-                                        LayerTypeInfo::TileKind::Geometry};
+    const static LayerTypeInfo typeInfo{.type="heatmap",
+                                        .source=LayerTypeInfo::Source::Required,
+                                        .pass3d=LayerTypeInfo::Pass3D::Required,
+                                        .layout=LayerTypeInfo::Layout::NotRequired,
+                                        .fadingTiles=LayerTypeInfo::FadingTiles::NotRequired,
+                                        .crossTileIndex=LayerTypeInfo::CrossTileIndex::NotRequired,
+                                        .tileKind=LayerTypeInfo::TileKind::Geometry};
     return &typeInfo;
 }
-
 
 HeatmapLayer::HeatmapLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(layerID, sourceID)) {

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -21,16 +21,15 @@ namespace style {
 
 // static
 const LayerTypeInfo* HillshadeLayer::Impl::staticTypeInfo() noexcept {
-    const static LayerTypeInfo typeInfo{"hillshade",
-                                        LayerTypeInfo::Source::Required,
-                                        LayerTypeInfo::Pass3D::Required,
-                                        LayerTypeInfo::Layout::NotRequired,
-                                        LayerTypeInfo::FadingTiles::NotRequired,
-                                        LayerTypeInfo::CrossTileIndex::NotRequired,
-                                        LayerTypeInfo::TileKind::RasterDEM};
+    const static LayerTypeInfo typeInfo{.type="hillshade",
+                                        .source=LayerTypeInfo::Source::Required,
+                                        .pass3d=LayerTypeInfo::Pass3D::Required,
+                                        .layout=LayerTypeInfo::Layout::NotRequired,
+                                        .fadingTiles=LayerTypeInfo::FadingTiles::NotRequired,
+                                        .crossTileIndex=LayerTypeInfo::CrossTileIndex::NotRequired,
+                                        .tileKind=LayerTypeInfo::TileKind::RasterDEM};
     return &typeInfo;
 }
-
 
 HillshadeLayer::HillshadeLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(layerID, sourceID)) {

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -3,6 +3,16 @@
   const layoutProperties = locals.layoutProperties;
   const paintProperties = locals.paintProperties;
   const allProperties = paintProperties.concat(layoutProperties);
+
+  // Define the mapping from capability keys to struct member names
+  const memberMap = {
+    'Source': 'source',
+    'Pass3D': 'pass3d',
+    'Layout': 'layout',
+    'FadingTiles': 'fadingTiles',
+    'CrossTileIndex': 'crossTileIndex',
+    'TileKind': 'tileKind'
+  };
 -%>
 // clang-format off
 
@@ -97,11 +107,13 @@ const split120Line = line => {
 %>
 // static
 const LayerTypeInfo* <%- camelize(type) %>Layer::Impl::staticTypeInfo() noexcept {
-    const static LayerTypeInfo typeInfo{"<%- type %>",
-                                        <%-`${layerCapabilities[type].map(cap => `LayerTypeInfo::${cap}`).join(',\n                                        ')}` %>};
+    const static LayerTypeInfo typeInfo{.type="<%- type %>",
+                                        <%- layerCapabilities[type].map(cap => {
+                                            const key = cap.split('::')[0];
+                                            return `.${memberMap[key]}=LayerTypeInfo::${cap}`;
+                                        }).join(',\n                                        ') %>};
     return &typeInfo;
 }
-
 
 <% if ((type === 'background') || (type === 'location-indicator')) { -%>
 <%- camelize(type) %>Layer::<%- camelize(type) %>Layer(const std::string& layerID)

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -21,16 +21,15 @@ namespace style {
 
 // static
 const LayerTypeInfo* LineLayer::Impl::staticTypeInfo() noexcept {
-    const static LayerTypeInfo typeInfo{"line",
-                                        LayerTypeInfo::Source::Required,
-                                        LayerTypeInfo::Pass3D::NotRequired,
-                                        LayerTypeInfo::Layout::Required,
-                                        LayerTypeInfo::FadingTiles::NotRequired,
-                                        LayerTypeInfo::CrossTileIndex::NotRequired,
-                                        LayerTypeInfo::TileKind::Geometry};
+    const static LayerTypeInfo typeInfo{.type="line",
+                                        .source=LayerTypeInfo::Source::Required,
+                                        .pass3d=LayerTypeInfo::Pass3D::NotRequired,
+                                        .layout=LayerTypeInfo::Layout::Required,
+                                        .fadingTiles=LayerTypeInfo::FadingTiles::NotRequired,
+                                        .crossTileIndex=LayerTypeInfo::CrossTileIndex::NotRequired,
+                                        .tileKind=LayerTypeInfo::TileKind::Geometry};
     return &typeInfo;
 }
-
 
 LineLayer::LineLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(layerID, sourceID)) {

--- a/src/mbgl/style/layers/location_indicator_layer.cpp
+++ b/src/mbgl/style/layers/location_indicator_layer.cpp
@@ -21,16 +21,15 @@ namespace style {
 
 // static
 const LayerTypeInfo* LocationIndicatorLayer::Impl::staticTypeInfo() noexcept {
-    const static LayerTypeInfo typeInfo{"location-indicator",
-                                        LayerTypeInfo::Source::NotRequired,
-                                        LayerTypeInfo::Pass3D::NotRequired,
-                                        LayerTypeInfo::Layout::NotRequired,
-                                        LayerTypeInfo::FadingTiles::NotRequired,
-                                        LayerTypeInfo::CrossTileIndex::NotRequired,
-                                        LayerTypeInfo::TileKind::NotRequired};
+    const static LayerTypeInfo typeInfo{.type="location-indicator",
+                                        .source=LayerTypeInfo::Source::NotRequired,
+                                        .pass3d=LayerTypeInfo::Pass3D::NotRequired,
+                                        .layout=LayerTypeInfo::Layout::NotRequired,
+                                        .fadingTiles=LayerTypeInfo::FadingTiles::NotRequired,
+                                        .crossTileIndex=LayerTypeInfo::CrossTileIndex::NotRequired,
+                                        .tileKind=LayerTypeInfo::TileKind::NotRequired};
     return &typeInfo;
 }
-
 
 LocationIndicatorLayer::LocationIndicatorLayer(const std::string& layerID)
     : Layer(makeMutable<Impl>(layerID, std::string())) {

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -21,16 +21,15 @@ namespace style {
 
 // static
 const LayerTypeInfo* RasterLayer::Impl::staticTypeInfo() noexcept {
-    const static LayerTypeInfo typeInfo{"raster",
-                                        LayerTypeInfo::Source::Required,
-                                        LayerTypeInfo::Pass3D::NotRequired,
-                                        LayerTypeInfo::Layout::NotRequired,
-                                        LayerTypeInfo::FadingTiles::NotRequired,
-                                        LayerTypeInfo::CrossTileIndex::NotRequired,
-                                        LayerTypeInfo::TileKind::Raster};
+    const static LayerTypeInfo typeInfo{.type="raster",
+                                        .source=LayerTypeInfo::Source::Required,
+                                        .pass3d=LayerTypeInfo::Pass3D::NotRequired,
+                                        .layout=LayerTypeInfo::Layout::NotRequired,
+                                        .fadingTiles=LayerTypeInfo::FadingTiles::NotRequired,
+                                        .crossTileIndex=LayerTypeInfo::CrossTileIndex::NotRequired,
+                                        .tileKind=LayerTypeInfo::TileKind::Raster};
     return &typeInfo;
 }
-
 
 RasterLayer::RasterLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(layerID, sourceID)) {

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -21,16 +21,15 @@ namespace style {
 
 // static
 const LayerTypeInfo* SymbolLayer::Impl::staticTypeInfo() noexcept {
-    const static LayerTypeInfo typeInfo{"symbol",
-                                        LayerTypeInfo::Source::Required,
-                                        LayerTypeInfo::Pass3D::NotRequired,
-                                        LayerTypeInfo::Layout::Required,
-                                        LayerTypeInfo::FadingTiles::Required,
-                                        LayerTypeInfo::CrossTileIndex::Required,
-                                        LayerTypeInfo::TileKind::Geometry};
+    const static LayerTypeInfo typeInfo{.type="symbol",
+                                        .source=LayerTypeInfo::Source::Required,
+                                        .pass3d=LayerTypeInfo::Pass3D::NotRequired,
+                                        .layout=LayerTypeInfo::Layout::Required,
+                                        .fadingTiles=LayerTypeInfo::FadingTiles::Required,
+                                        .crossTileIndex=LayerTypeInfo::CrossTileIndex::Required,
+                                        .tileKind=LayerTypeInfo::TileKind::Geometry};
     return &typeInfo;
 }
-
 
 SymbolLayer::SymbolLayer(const std::string& layerID, const std::string& sourceID)
     : Layer(makeMutable<Impl>(layerID, sourceID)) {
@@ -648,7 +647,6 @@ void SymbolLayer::setTextTransform(const PropertyValue<TextTransformType>& value
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-
 PropertyValue<std::vector<TextVariableAnchorType>> SymbolLayer::getDefaultTextVariableAnchor() {
     return TextVariableAnchor::defaultValue();
 }
@@ -664,7 +662,6 @@ void SymbolLayer::setTextVariableAnchor(const PropertyValue<std::vector<TextVari
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-
 PropertyValue<VariableAnchorOffsetCollection> SymbolLayer::getDefaultTextVariableAnchorOffset() {
     return TextVariableAnchorOffset::defaultValue();
 }
@@ -680,7 +677,6 @@ void SymbolLayer::setTextVariableAnchorOffset(const PropertyValue<VariableAnchor
     baseImpl = std::move(impl_);
     observer->onLayerChanged(*this);
 }
-
 PropertyValue<std::vector<TextWritingModeType>> SymbolLayer::getDefaultTextWritingMode() {
     return TextWritingMode::defaultValue();
 }

--- a/src/mbgl/util/tile_coordinate.hpp
+++ b/src/mbgl/util/tile_coordinate.hpp
@@ -21,7 +21,7 @@ public:
 
     static TileCoordinate fromLatLng(double zoom, const LatLng& latLng) {
         const double scale = std::pow(2.0, zoom);
-        return {Projection::project(latLng, scale) / util::tileSize_D, zoom};
+        return {.p = Projection::project(latLng, scale) / util::tileSize_D, .z = zoom};
     }
 
     static TileCoordinate fromScreenCoordinate(const TransformState& state,
@@ -32,12 +32,12 @@ public:
 
     TileCoordinate zoomTo(double zoom) const {
         const double scaleDiff = std::pow(2.0, zoom - z);
-        return {p * scaleDiff, zoom};
+        return {.p = p * scaleDiff, .z = zoom};
     }
 
     static GeometryCoordinate toGeometryCoordinate(const UnwrappedTileID& tileID, const TileCoordinatePoint& point) {
         const double scale = std::pow(2.0, tileID.canonical.z);
-        auto zoomed = TileCoordinate{point, 0}.zoomTo(tileID.canonical.z);
+        auto zoomed = TileCoordinate{.p = point, .z = 0}.zoomTo(tileID.canonical.z);
         return {int16_t(util::clamp<int64_t>(
                     static_cast<int64_t>((zoomed.p.x - tileID.canonical.x - tileID.wrap * scale) * util::EXTENT),
                     std::numeric_limits<int16_t>::min(),


### PR DESCRIPTION
Went over some of the issues reported by clang-tidy. They added a lot of checks in recent versions.

```
cmake --preset macos -DMLN_WITH_CLANG_TIDY=ON
cmake --build build-macos
```