### PR TITLE
Fix Typo

### DIFF
--- a/src/mbgl/gfx/upload_pass.hpp
+++ b/src/mbgl/gfx/upload_pass.hpp
@@ -22,7 +22,7 @@ namespace mbgl {
 namespace gfx {
 
 #if MLN_DRAWABLE_RENDERER
-class Conext;
+class Context;
 class Texture2D;
 class VertexAttributeArray;
 


### PR DESCRIPTION
I've noticed a small typo in src/mbgl/gfx/upload_pass.hpp. I think the typo doesn't affect the compilation of the project since it's not being used. However, I thought it would be nice to be corrected. 