### PR TITLE
Fix linking error in tests on MacOS

### DIFF
--- a/test/gl/gl_functions.test.cpp
+++ b/test/gl/gl_functions.test.cpp
@@ -253,8 +253,10 @@ TEST(GLFunctions, OpenGLES) {
     EXPECT_NE(glGetProgramBinary, nullptr);
     EXPECT_NE(glProgramBinary, nullptr);
     EXPECT_NE(glProgramParameteri, nullptr);
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
     EXPECT_NE(glInvalidateFramebuffer, nullptr);
     EXPECT_NE(glInvalidateSubFramebuffer, nullptr);
+#endif
     EXPECT_NE(glTexStorage2D, nullptr);
     EXPECT_NE(glTexStorage3D, nullptr);
     EXPECT_NE(glGetInternalformativ, nullptr);


### PR DESCRIPTION
This PR solves this error:

```
Undefined symbols for architecture arm64:
  "mbgl::platform::glInvalidateFramebuffer", referenced from:
      GLFunctions_OpenGLES_Test::TestBody() in libmbgl-test.a[125](gl_functions.test.cpp.o)
      GLFunctions_OpenGLES_Test::TestBody() in libmbgl-test.a[125](gl_functions.test.cpp.o)
  "mbgl::platform::glInvalidateSubFramebuffer", referenced from:
      GLFunctions_OpenGLES_Test::TestBody() in libmbgl-test.a[125](gl_functions.test.cpp.o)
      GLFunctions_OpenGLES_Test::TestBody() in libmbgl-test.a[125](gl_functions.test.cpp.o)
ld: symbol(s) not found for architecture arm64
```

I encountered this when building on MacOS with OpenGL like:

```
cmake . -B build \
            -G Ninja \
            -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
            -DCMAKE_C_COMPILER=cc \
            -DCMAKE_CXX_COMPILER=c++ \
            -DMLN_WITH_METAL=OFF \
            -DMLN_WITH_OPENGL=ON \
            -DMLN_LEGACY_RENDERER=ON \
            -DMLN_DRAWABLE_RENDERER=ON \
            -DMLN_WITH_WERROR=OFF
```

I recognize OPENGL on MacOS may be no longer maintained, and if so, please feel free to close. But since it almost works I wanted to provide this fix in case it is useful.