### PR TITLE
Fix rare crash LatLngAnimator

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationAnimatorCoordinator.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationAnimatorCoordinator.java
@@ -334,7 +334,7 @@ final class LocationAnimatorCoordinator {
     createNewCameraAdapterAnimator(ANIMATOR_TILT, new Float[] {previousTiltLevel, targetTilt}, cancelableCallback);
   }
 
-  private void createNewLatLngAnimator(@MapLibreAnimator.Type int animatorType, LatLng previous, LatLng target) {
+  private void createNewLatLngAnimator(@MapLibreAnimator.Type int animatorType, @NonNull LatLng previous, @NonNull LatLng target) {
     createNewLatLngAnimator(animatorType, new LatLng[] {previous, target});
   }
 
@@ -430,6 +430,8 @@ final class LocationAnimatorCoordinator {
 
     LatLng currentTarget = animator.getTarget();
     LatLng previousCameraTarget = currentCameraPosition.target;
+    if (previousCameraTarget == null) return false;
+
     createNewLatLngAnimator(ANIMATOR_CAMERA_LATLNG, previousCameraTarget, currentTarget);
 
     return immediateAnimation(projection, previousCameraTarget, currentTarget);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationAnimatorCoordinator.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationAnimatorCoordinator.java
@@ -334,7 +334,8 @@ final class LocationAnimatorCoordinator {
     createNewCameraAdapterAnimator(ANIMATOR_TILT, new Float[] {previousTiltLevel, targetTilt}, cancelableCallback);
   }
 
-  private void createNewLatLngAnimator(@MapLibreAnimator.Type int animatorType, @NonNull LatLng previous, @NonNull LatLng target) {
+  private void createNewLatLngAnimator(@MapLibreAnimator.Type int animatorType,
+                                       @NonNull LatLng previous, @NonNull LatLng target) {
     createNewLatLngAnimator(animatorType, new LatLng[] {previous, target});
   }
 
@@ -430,7 +431,9 @@ final class LocationAnimatorCoordinator {
 
     LatLng currentTarget = animator.getTarget();
     LatLng previousCameraTarget = currentCameraPosition.target;
-    if (previousCameraTarget == null) return false;
+    if (previousCameraTarget == null) {
+      return false;
+    }
 
     createNewLatLngAnimator(ANIMATOR_CAMERA_LATLNG, previousCameraTarget, currentTarget);
 

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/location/LocationAnimatorCoordinatorTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/location/LocationAnimatorCoordinatorTest.kt
@@ -583,6 +583,15 @@ class LocationAnimatorCoordinatorTest {
         assertFalse(locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_LATLNG].isStarted)
     }
 
+    // regression test for crash https://github.com/maplibre/maplibre-native/issues/3294
+    @Test
+    fun resetAllCameraAnimations_null_target() {
+        locationAnimatorCoordinator.feedNewLocation(Location(""), CameraPosition.DEFAULT, true)
+
+        val cameraPosition = CameraPosition.Builder().build()
+        locationAnimatorCoordinator.resetAllCameraAnimations(cameraPosition, false)
+    }
+
     @Test
     fun cancelZoomAnimators() {
         locationAnimatorCoordinator.feedNewZoomLevel(


### PR DESCRIPTION
Closes #3294

I am not 100% sure this resolves the crash, but I am pretty confident since `previousCameraTarget` can be null (which triggers the crash). Added a regression test.