### PR TITLE
Fix warnings, ignore new CMake build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ local.properties
 .cache
 compile_commands.json
 /build
+/build-*
 **/.idea
 **/.clwb
 /new_offline.db

--- a/platform/darwin/core/local_glyph_rasterizer.mm
+++ b/platform/darwin/core/local_glyph_rasterizer.mm
@@ -266,8 +266,8 @@ PremultipliedImage drawGlyphBitmap(GlyphID glyphID, CTFontRef font, GlyphMetrics
     CFArrayRef glyphRuns = CTLineGetGlyphRuns(*line);
     CTRunRef glyphRun = (CTRunRef)CFArrayGetValueAtIndex(glyphRuns, 0);
     CFRange wholeRunRange = CFRangeMake(0, CTRunGetGlyphCount(glyphRun));
-    CGSize advances[wholeRunRange.length];
-    CTRunGetAdvances(glyphRun, wholeRunRange, advances);
+    std::vector<CGSize> advances(wholeRunRange.length);
+    CTRunGetAdvances(glyphRun, wholeRunRange, advances.data());
     metrics.advance = std::round(advances[0].width);
 
     // Mimic glyph PBF metrics.

--- a/src/mbgl/mtl/buffer_resource.cpp
+++ b/src/mbgl/mtl/buffer_resource.cpp
@@ -184,7 +184,7 @@ void BufferResource::updateVertexBindOffset(const MTLRenderCommandEncoderPtr& en
     // The documentation for `setVertexBufferOffset` indicates that it should work for buffers
     // assigned using `setVertexBytes` but, in practice, it produces a validation failure:
     // `Set Vertex Buffer Offset Validation index(1) must have an existing buffer.`
-    if (const auto* mtlBuf = buffer.get()) {
+    if (buffer.get()) {
         encoder->setVertexBufferOffset(offset, index);
     } else {
         bindVertex(encoder, offset, index, size_);
@@ -195,7 +195,7 @@ void BufferResource::updateFragmentBindOffset(const MTLRenderCommandEncoderPtr& 
                                               std::size_t offset,
                                               std::size_t index,
                                               std::size_t size_) const noexcept {
-    if (const auto* mtlBuf = buffer.get()) {
+    if (buffer.get()) {
         encoder->setFragmentBufferOffset(offset, index);
     } else {
         bindFragment(encoder, offset, index, size_);

--- a/src/mbgl/mtl/context.cpp
+++ b/src/mbgl/mtl/context.cpp
@@ -605,12 +605,12 @@ MTLDepthStencilStatePtr Context::makeDepthStencilState(const gfx::DepthMode& dep
         // `Draw Errors Validation MTLDepthStencilDescriptor sets depth test but MTLRenderPassDescriptor has a nil
         // depthAttachment texture`
         if (auto* depthTarget = rpd->depthAttachment()) {
-            if (auto* tex = depthTarget->texture()) {
+            if (depthTarget->texture()) {
                 applyDepthMode(depthMode, depthStencilDescriptor.get());
             }
         }
         if (auto* stencilTarget = rpd->stencilAttachment()) {
-            if (auto* tex = stencilTarget->texture()) {
+            if (stencilTarget->texture()) {
                 auto stencilDescriptor = NS::TransferPtr(MTL::StencilDescriptor::alloc()->init());
                 if (!stencilDescriptor) {
                     return {};


### PR DESCRIPTION
With Xcode 16.3 on a new system, using `cmake --preset ios`, I get several warnings which are treated as errors.

Also adds a git ignore for the new `build-*` pattern used in `CMakePresets`.

```
$ /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang --version
Apple clang version 17.0.0 (clang-1700.0.13.3)
Target: arm64-apple-darwin24.4.0
```