### PR TITLE
Prevent exception SymbolLocationLayerRenderer with new style

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/SymbolLocationLayerRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/SymbolLocationLayerRenderer.java
@@ -319,6 +319,9 @@ final class SymbolLocationLayerRenderer implements LocationLayerRenderer {
   }
 
   private void refreshSource() {
+    // prevents exception when other style has been set with an update in flight
+    // https://github.com/maplibre/maplibre-native/issues/3348
+    if (!style.isFullyLoaded()) return;
     GeoJsonSource source = style.getSourceAs(LOCATION_SOURCE);
     if (source != null) {
       locationSource.setGeoJson(locationFeature);


### PR DESCRIPTION
Closes #3348

Prevents an exception from `getSource()` when a style is no longer loaded after a new style has been set.

Normally this doesn't happen because `MapLibreMap.setStyle()` calls `locationComponent.onStartLoadingMap()` (which stops/pauses the location layer) and then `locationComponent.onFinishLoadingStyle()` once the style has loaded. The LocationComponent then retrieves the new style from the map instance...

However in onLocationLayerStop() starts with this line:

```java
    if (!isComponentInitialized || !isLayerReady || !isComponentStarted) {
      return;
    }
```

Which means that if any of those are false, the `onCameraMoveListener` and `onCameraIdleListener` are not removed:

```java
    maplibreMap.removeOnCameraMoveListener(onCameraMoveListener);
    maplibreMap.removeOnCameraIdleListener(onCameraIdleListener);
```

which would trigger this issue.

I'm not exactly sure under what circumstances this can happen...