### PR TITLE
Remove legacy renderer from source, build files and CI

### DIFF
--- a/.github/scripts/windows-ci_configure_wrapper.ps1
+++ b/.github/scripts/windows-ci_configure_wrapper.ps1
@@ -12,12 +12,6 @@ switch ($env:RENDERER)
 	'osmesa' { $compile_flags += '-DMLN_WITH_OSMESA=ON'; break; }
 }
 
-switch ($env:RENDERING_MODE)
-{
-	'legacy'   { $compile_flags += '-DMLN_LEGACY_RENDERER=ON'  ; break; }
-	'drawable' { $compile_flags += '-DMLN_DRAWABLE_RENDERER=ON'; break; }
-}
-
 Write-Host 'Compile flags: ' $compile_flags
 
 & cmake -B build -G Ninja $($compile_flags)

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -187,9 +187,9 @@ jobs:
 
       - name: Build Instrumentation Tests, copy to platform/android
         run: |
-          ./gradlew assembleLegacyDebug assembleLegacyDebugAndroidTest -PtestBuildType=debug
-          cp MapLibreAndroidTestApp/build/outputs/apk/legacy/debug/MapLibreAndroidTestApp-legacy-debug.apk InstrumentationTestApp.apk
-          cp MapLibreAndroidTestApp/build/outputs/apk/androidTest/legacy/debug/MapLibreAndroidTestApp-legacy-debug-androidTest.apk InstrumentationTests.apk
+          ./gradlew assembleDrawableDebug assembleDrawableDebugAndroidTest -PtestBuildType=debug
+          cp MapLibreAndroidTestApp/build/outputs/apk/drawable/debug/MapLibreAndroidTestApp-drawable-debug.apk InstrumentationTestApp.apk
+          cp MapLibreAndroidTestApp/build/outputs/apk/androidTest/drawable/debug/MapLibreAndroidTestApp-drawable-debug-androidTest.apk InstrumentationTests.apk
 
       - name: Upload android-ui-test
         uses: actions/upload-artifact@v4

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        renderer: [legacy, drawable, vulkan, drawable-rust]
+        renderer: [vulkan, drawable-rust]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -79,19 +79,14 @@ jobs:
       - name: Install dependencies
         run: .github/scripts/install-linux-deps
 
-      - if: matrix.renderer == 'drawable'
-        run: echo renderer_flag_cmake=-DMLN_DRAWABLE_RENDERER=ON >> "$GITHUB_ENV"
 
       - if: matrix.renderer == 'drawable-rust'
         run: |
-          echo "renderer_flag_cmake=-DMLN_DRAWABLE_RENDERER=ON -DMLN_USE_RUST=ON" >> "$GITHUB_ENV"
+          echo "renderer_flag_cmake=-DMLN_USE_RUST=ON" >> "$GITHUB_ENV"
           cargo install cxxbridge-cmd
 
-      - if: matrix.renderer == 'legacy'
-        run: echo renderer_flag_cmake=-DMLN_LEGACY_RENDERER=ON >> "$GITHUB_ENV"
-
       - if: matrix.renderer == 'vulkan'
-        run: echo renderer_flag_cmake="-DMLN_DRAWABLE_RENDERER=ON -DMLN_LEGACY_RENDERER=OFF -DMLN_WITH_VULKAN=ON -DMLN_WITH_OPENGL=OFF" >> "$GITHUB_ENV"
+        run: echo renderer_flag_cmake="-DMLN_WITH_VULKAN=ON -DMLN_WITH_OPENGL=OFF" >> "$GITHUB_ENV"
 
       - name: Build MapLibre Native Core
         env:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        renderer: [vulkan, drawable-rust]
+        renderer: [vulkan, drawable]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -80,10 +80,9 @@ jobs:
         run: .github/scripts/install-linux-deps
 
 
-      - if: matrix.renderer == 'drawable-rust'
+      - if: matrix.renderer == 'drawable'
         run: |
-          echo "renderer_flag_cmake=-DMLN_USE_RUST=ON" >> "$GITHUB_ENV"
-          cargo install cxxbridge-cmd
+          echo "-DMLN_WITH_OPENGL=ON" >> "$GITHUB_ENV"
 
       - if: matrix.renderer == 'vulkan'
         run: echo renderer_flag_cmake="-DMLN_WITH_VULKAN=ON -DMLN_WITH_OPENGL=OFF" >> "$GITHUB_ENV"

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -136,7 +136,6 @@ jobs:
             libcurl4-openssl-dev \
             libglfw3-dev \
             libuv1-dev \
-            g++-12 \
             libjpeg-dev \
             libpng-dev \
             libwebp-dev
@@ -214,7 +213,6 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ env.BUILDTYPE }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_C_COMPILER=gcc-12 \
-            -DCMAKE_CXX_COMPILER=g++-12 \
             -DMLN_WITH_NODE=ON
 
       - name: "Create directory '${{ github.workspace }}/platform/windows/vendor/vcpkg/bincache' (Windows)"

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -181,8 +181,6 @@ jobs:
             -DMLN_WITH_NODE=ON \
             -DMLN_WITH_OPENGL=OFF \
             -DMLN_WITH_METAL=ON \
-            -DMLN_LEGACY_RENDERER=OFF \
-            -DMLN_DRAWABLE_RENDERER=ON \
             -DMLN_WITH_WERROR=OFF
 
       - name: Configure maplibre-native (Linux)

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -88,12 +88,6 @@ jobs:
     strategy:
       matrix:
         renderer: [opengl, egl, vulkan, osmesa]
-        rendering_mode: [legacy, drawable]
-        exclude:
-          - renderer: egl
-            rendering_mode: drawable
-          - renderer: vulkan
-            rendering_mode: legacy
     runs-on: windows-2022
     steps:
       - run: |
@@ -133,7 +127,6 @@ jobs:
           CMAKE_C_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"
           CMAKE_CXX_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"
           RENDERER: "${{ matrix.renderer }}"
-          RENDERING_MODE: "${{ matrix.rendering_mode }}"
         timeout-minutes: 60
         run: |
           cmake --version

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library", "js_run_binary")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "//bazel:core.bzl",
     "MLN_CORE_HEADERS",
@@ -76,32 +77,21 @@ cc_library(
     srcs = MLN_CORE_SOURCE +
            MLN_GENERATED_STYLE_SOURCE + select({
         ":drawable_renderer": MLN_OPENGL_SOURCE + MLN_DRAWABLES_SOURCE + MLN_DRAWABLES_GL_SOURCE,
-        ":legacy_renderer": MLN_OPENGL_SOURCE,
         ":metal_renderer": MLN_DRAWABLES_SOURCE + MLN_DRAWABLES_MTL_SOURCE,
         "//conditions:default": [],
     }),
     hdrs = MLN_CORE_HEADERS + select({
         ":drawable_renderer": MLN_OPENGL_HEADERS + MLN_DRAWABLES_HEADERS + MLN_DRAWABLES_GL_HEADERS,
-        ":legacy_renderer": MLN_OPENGL_HEADERS,
         ":metal_renderer": MLN_DRAWABLES_HEADERS + MLN_DRAWABLES_MTL_HEADERS,
         "//conditions:default": [],
     }),
     copts = CPP_FLAGS + MAPLIBRE_FLAGS,
     defines = select({
-        ":legacy_renderer": [
-            "MLN_RENDER_BACKEND_OPENGL=1",
-            "MLN_LEGACY_RENDERER=1",
-            "MLN_DRAWABLE_RENDERER=0",
-        ],
         ":drawable_renderer": [
             "MLN_RENDER_BACKEND_OPENGL=1",
-            "MLN_LEGACY_RENDERER=0",
-            "MLN_DRAWABLE_RENDERER=1",
         ],
         ":metal_renderer": [
             "MLN_RENDER_BACKEND_METAL=1",
-            "MLN_LEGACY_RENDERER=0",
-            "MLN_DRAWABLE_RENDERER=1",
         ],
     }) + select({
         "@platforms//os:ios": ["GLES_SILENCE_DEPRECATION=1"],
@@ -178,13 +168,6 @@ string_flag(
         "drawable",
         "metal",
     ],
-)
-
-config_setting(
-    name = "legacy_renderer",
-    flag_values = {
-        ":renderer": "legacy",
-    },
 )
 
 config_setting(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,9 +162,8 @@ genrule(
 
 string_flag(
     name = "renderer",
-    build_setting_default = "legacy",
+    build_setting_default = "drawable",
     values = [
-        "legacy",
         "drawable",
         "metal",
     ],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,19 @@ option(MLN_WITH_VULKAN "Build with Vulkan renderer" OFF)
 option(MLN_WITH_OSMESA "Build with OSMesa (Software) renderer" OFF)
 option(MLN_WITH_PMTILES "Build with PMTiles support" ON)
 option(MLN_WITH_WERROR "Make all compilation warnings errors" ON)
-option(MLN_LEGACY_RENDERER "Include the legacy rendering pathway" ON)
-option(MLN_DRAWABLE_RENDERER "Include the drawable rendering pathway" OFF)
 option(MLN_USE_UNORDERED_DENSE "Use ankerl dense containers for performance" ON)
 option(MLN_USE_TRACY "Enable Tracy instrumentation" OFF)
 option(MLN_USE_RUST "Use components in Rust" OFF)
 option(MLN_CORE_INCLUDE_DEPS "Include depdendencies in static build of core" OFF)
+
+if (MLN_LEGACY_RENDERER)
+    message(FATAL "The legacy renderer is no longer supported")
+endif()
+
+if (MLN_DRAWABLE_RENDERER)
+    message(FATAL "Do not pass MLN_DRAWABLE_RENDERER, the drawable renderer is now the default")
+endif()
+
 
 if (MLN_WITH_CLANG_TIDY)
     find_program(CLANG_TIDY_COMMAND NAMES clang-tidy)
@@ -63,10 +70,6 @@ add_library(
 )
 
 set(UBSAN_BLACKLIST ${PROJECT_SOURCE_DIR}/scripts/ubsan.blacklist)
-
-if (MLN_DRAWABLE_RENDERER)
-    set(MLN_LEGACY_RENDERER OFF)
-endif()
 
 target_compile_options(
     mbgl-compiler-options
@@ -146,82 +149,74 @@ else()
     add_library(mbgl-core STATIC)
 endif()
 
-if(MLN_DRAWABLE_RENDERER)
-    list(APPEND INCLUDE_FILES
-        ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/context.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable_data.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable_impl.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable_builder.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable_atlases_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable_custom_layer_host_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/gpu_expression.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/uniform_buffer.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/vertex_attribute.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/texture2d.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/renderer/change_request.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/renderer/layer_group.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/renderer/layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/renderer/render_target.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/shader_program_base.hpp
-        ${PROJECT_SOURCE_DIR}/include/mbgl/util/suppress_copies.hpp
-    )
-    list(APPEND SRC_FILES
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/drawable.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/drawable_builder.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/drawable_builder_impl.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/drawable_builder_impl.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/drawable_atlases_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/drawable_custom_layer_host_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/gpu_expression.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/hillshade_prepare_drawable_data.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/image_drawable_data.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/line_drawable_data.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/symbol_drawable_data.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/collision_drawable_data.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/uniform_buffer.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/vertex_attribute.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/render_target.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/change_request.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layer_group.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/tile_layer_group.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/background_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/background_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/circle_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/fill_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/heatmap_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/hillshade_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/hillshade_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/line_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/line_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/location_indicator_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/location_indicator_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/raster_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/raster_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/symbol_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/collision_layer_tweaker.cpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/collision_layer_tweaker.hpp
-        ${PROJECT_SOURCE_DIR}/src/mbgl/shaders/shader_program_base.cpp
-    )
-
-    target_compile_definitions(
-        mbgl-core
-        PUBLIC
-            "MLN_DRAWABLE_RENDERER=$<BOOL:${MLN_DRAWABLE_RENDERER}>"
-    )
-endif()
+list(APPEND INCLUDE_FILES
+    ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/context.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable_data.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable_impl.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable_builder.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable_atlases_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/drawable_custom_layer_host_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/gpu_expression.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/uniform_buffer.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/vertex_attribute.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/gfx/texture2d.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/renderer/change_request.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/renderer/layer_group.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/renderer/layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/renderer/render_target.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/shader_program_base.hpp
+    ${PROJECT_SOURCE_DIR}/include/mbgl/util/suppress_copies.hpp
+)
+list(APPEND SRC_FILES
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/drawable.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/drawable_builder.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/drawable_builder_impl.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/drawable_builder_impl.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/drawable_atlases_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/drawable_custom_layer_host_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/gpu_expression.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/hillshade_prepare_drawable_data.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/image_drawable_data.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/line_drawable_data.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/symbol_drawable_data.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/collision_drawable_data.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/uniform_buffer.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/gfx/vertex_attribute.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/render_target.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/change_request.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layer_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/tile_layer_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/background_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/background_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/circle_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/circle_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/fill_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/fill_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/fill_extrusion_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/heatmap_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/heatmap_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/heatmap_texture_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/hillshade_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/hillshade_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/hillshade_prepare_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/line_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/line_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/location_indicator_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/location_indicator_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/raster_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/raster_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/symbol_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/collision_layer_tweaker.cpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/collision_layer_tweaker.hpp
+    ${PROJECT_SOURCE_DIR}/src/mbgl/shaders/shader_program_base.cpp
+)
 
 list(APPEND INCLUDE_FILES
     ${PROJECT_SOURCE_DIR}/include/mbgl/actor/actor.hpp
@@ -1018,8 +1013,6 @@ if(MLN_WITH_OPENGL)
         mbgl-core
         PRIVATE MLN_RENDER_BACKEND_OPENGL=1
         PUBLIC
-            "MLN_LEGACY_RENDERER=$<BOOL:${MLN_LEGACY_RENDERER}>"
-            "MLN_DRAWABLE_RENDERER=$<BOOL:${MLN_DRAWABLE_RENDERER}>"
             "MLN_USE_UNORDERED_DENSE=$<BOOL:${MLN_USE_UNORDERED_DENSE}>"
     )
     list(APPEND
@@ -1141,50 +1134,48 @@ if(MLN_WITH_OPENGL)
             ${PROJECT_SOURCE_DIR}/src/mbgl/platform/gl_functions.cpp
     )
 
-    if(MLN_DRAWABLE_RENDERER)
-        list(APPEND INCLUDE_FILES
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/background_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/circle_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/collision_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/custom_drawable_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/debug_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/fill_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/fill_extrusion_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/heatmap_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/heatmap_texture_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/hillshade_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/hillshade_prepare_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/line_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/location_indicator_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/raster_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/shader_defines.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/symbol_layer_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/widevector_ubo.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/style/layers/custom_drawable_layer.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/layermanager/custom_drawable_layer_factory.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/shader_program_gl.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/gl/buffer_allocator.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/gl/drawable_gl.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/gl/drawable_gl_builder.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/gl/layer_group_gl.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/gl/uniform_buffer_gl.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/gl/vertex_attribute_gl.hpp
-            ${PROJECT_SOURCE_DIR}/include/mbgl/gl/texture2d.hpp
-        )
-        list(APPEND SRC_FILES
-            ${PROJECT_SOURCE_DIR}/src/mbgl/shaders/gl/shader_info.cpp
-            ${PROJECT_SOURCE_DIR}/src/mbgl/shaders/gl/shader_program_gl.cpp
-            ${PROJECT_SOURCE_DIR}/src/mbgl/gl/buffer_allocator.cpp
-            ${PROJECT_SOURCE_DIR}/src/mbgl/gl/drawable_gl.cpp
-            ${PROJECT_SOURCE_DIR}/src/mbgl/gl/drawable_gl_builder.cpp
-            ${PROJECT_SOURCE_DIR}/src/mbgl/gl/drawable_gl_impl.hpp
-            ${PROJECT_SOURCE_DIR}/src/mbgl/gl/layer_group_gl.cpp
-            ${PROJECT_SOURCE_DIR}/src/mbgl/gl/texture2d.cpp
-            ${PROJECT_SOURCE_DIR}/src/mbgl/gl/uniform_buffer_gl.cpp
-            ${PROJECT_SOURCE_DIR}/src/mbgl/gl/vertex_attribute_gl.cpp
-        )
-    endif()
+    list(APPEND INCLUDE_FILES
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/background_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/circle_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/collision_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/custom_drawable_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/debug_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/fill_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/fill_extrusion_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/heatmap_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/heatmap_texture_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/hillshade_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/hillshade_prepare_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/line_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/location_indicator_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/raster_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/shader_defines.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/symbol_layer_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/widevector_ubo.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/style/layers/custom_drawable_layer.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/layermanager/custom_drawable_layer_factory.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/shaders/gl/shader_program_gl.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/gl/buffer_allocator.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/gl/drawable_gl.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/gl/drawable_gl_builder.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/gl/layer_group_gl.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/gl/uniform_buffer_gl.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/gl/vertex_attribute_gl.hpp
+        ${PROJECT_SOURCE_DIR}/include/mbgl/gl/texture2d.hpp
+    )
+    list(APPEND SRC_FILES
+        ${PROJECT_SOURCE_DIR}/src/mbgl/shaders/gl/shader_info.cpp
+        ${PROJECT_SOURCE_DIR}/src/mbgl/shaders/gl/shader_program_gl.cpp
+        ${PROJECT_SOURCE_DIR}/src/mbgl/gl/buffer_allocator.cpp
+        ${PROJECT_SOURCE_DIR}/src/mbgl/gl/drawable_gl.cpp
+        ${PROJECT_SOURCE_DIR}/src/mbgl/gl/drawable_gl_builder.cpp
+        ${PROJECT_SOURCE_DIR}/src/mbgl/gl/drawable_gl_impl.hpp
+        ${PROJECT_SOURCE_DIR}/src/mbgl/gl/layer_group_gl.cpp
+        ${PROJECT_SOURCE_DIR}/src/mbgl/gl/texture2d.cpp
+        ${PROJECT_SOURCE_DIR}/src/mbgl/gl/uniform_buffer_gl.cpp
+        ${PROJECT_SOURCE_DIR}/src/mbgl/gl/vertex_attribute_gl.cpp
+    )
 endif()
 
 if(MLN_WITH_METAL)
@@ -1379,8 +1370,7 @@ if(MLN_WITH_VULKAN)
     )
 endif()
 
-if(MLN_DRAWABLE_RENDERER)
-    list(APPEND
+list(APPEND
     SRC_FILES
         ${PROJECT_SOURCE_DIR}/src/mbgl/layermanager/custom_drawable_layer_factory.cpp
         ${PROJECT_SOURCE_DIR}/src/mbgl/renderer/layers/render_custom_drawable_layer.cpp
@@ -1388,8 +1378,7 @@ if(MLN_DRAWABLE_RENDERER)
         ${PROJECT_SOURCE_DIR}/src/mbgl/style/layers/custom_drawable_layer_impl.cpp
         ${PROJECT_SOURCE_DIR}/src/mbgl/style/layers/custom_drawable_layer_impl.hpp
         ${PROJECT_SOURCE_DIR}/src/mbgl/style/layers/custom_drawable_layer.cpp
-    )
-endif()
+)
 
 target_sources(
     mbgl-core PRIVATE

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,8 +16,7 @@
         "CMAKE_SYSTEM_NAME": "iOS",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
         "MLN_WITH_METAL": "ON",
-        "MLN_WITH_OPENGL": "OFF",
-        "MLN_DRAWABLE_RENDERER": "ON"
+        "MLN_WITH_OPENGL": "OFF"
       }
     },
     {
@@ -29,8 +28,7 @@
         "CMAKE_SYSTEM_NAME": "Darwin",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
         "MLN_WITH_METAL": "ON",
-        "MLN_WITH_OPENGL": "OFF",
-        "MLN_DRAWABLE_RENDERER": "ON"
+        "MLN_WITH_OPENGL": "OFF"
       }
     },
     {
@@ -42,8 +40,7 @@
         "CMAKE_SYSTEM_NAME": "Darwin",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
         "MLN_WITH_VULKAN": "ON",
-        "MLN_WITH_OPENGL": "OFF",
-        "MLN_DRAWABLE_RENDERER": "ON"
+        "MLN_WITH_OPENGL": "OFF"
       }
     },
     {
@@ -72,7 +69,6 @@
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
         "MLN_WITH_METAL": "OFF",
         "MLN_WITH_OPENGL": "ON",
-        "MLN_DRAWABLE_RENDERER": "ON",
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++"
       }

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,6 +8,7 @@ bazel_dep(name = "rules_xcodeproj", version = "2.11.1")
 bazel_dep(name = "aspect_rules_js", version = "2.3.3")
 bazel_dep(name = "rules_nodejs", version = "6.3.4")
 bazel_dep(name = "libuv", version = "1.48.0")
+bazel_dep(name = "apple_support", version = "1.21.1", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,6 +8,7 @@ bazel_dep(name = "rules_xcodeproj", version = "2.11.1")
 bazel_dep(name = "aspect_rules_js", version = "2.3.3")
 bazel_dep(name = "rules_nodejs", version = "6.3.4")
 bazel_dep(name = "libuv", version = "1.48.0")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 node.toolchain(node_version = "20.14.0")
@@ -58,8 +59,8 @@ new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl"
 
 new_git_repository(
     name = "tinyobjloader",
-    remote = "https://github.com/tinyobjloader/tinyobjloader.git",
     branch = "release",
+    remote = "https://github.com/tinyobjloader/tinyobjloader.git",
 )
 
 darwin_config = use_repo_rule("//platform/darwin:bazel/darwin_config_repository_rule.bzl", "darwin_config")

--- a/bin/BUILD.bazel
+++ b/bin/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("//bazel:flags.bzl", "CPP_FLAGS", "MAPLIBRE_FLAGS")
 
 cc_binary(

--- a/docs/mdbook/src/profiling/tracy-profiling.md
+++ b/docs/mdbook/src/profiling/tracy-profiling.md
@@ -92,7 +92,7 @@ As an example, the glfw sample is used.
 With CMake, in MapLibre repository root do
 ~~~bash
 # generate project
-cmake -B build -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMLN_WITH_CLANG_TIDY=OFF -DMLN_WITH_COVERAGE=OFF -DMLN_DRAWABLE_RENDERER=ON -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DMLN_USE_TRACY=ON
+cmake -B build -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMLN_WITH_CLANG_TIDY=OFF -DMLN_WITH_COVERAGE=OFF -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DMLN_USE_TRACY=ON
 # build
 cmake --build build --target mbgl-glfw -j 8
 # run

--- a/expression-test/BUILD.bazel
+++ b/expression-test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bazel:flags.bzl", "CPP_FLAGS", "MAPLIBRE_FLAGS")
 
 cc_library(

--- a/include/mbgl/gfx/context.hpp
+++ b/include/mbgl/gfx/context.hpp
@@ -11,9 +11,7 @@
 #include <mbgl/gfx/texture.hpp>
 #include <mbgl/gfx/types.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/uniform_buffer.hpp>
-#endif
 
 #include <memory>
 #include <string>
@@ -23,21 +21,18 @@ namespace mbgl {
 class PaintParameters;
 class ProgramParameters;
 
-#if MLN_DRAWABLE_RENDERER
 class TileLayerGroup;
 class LayerGroup;
 class RenderTarget;
 using TileLayerGroupPtr = std::shared_ptr<TileLayerGroup>;
 using LayerGroupPtr = std::shared_ptr<LayerGroup>;
 using RenderTargetPtr = std::shared_ptr<RenderTarget>;
-#endif
 
 namespace gfx {
 
 class OffscreenTexture;
 class ShaderRegistry;
 
-#if MLN_DRAWABLE_RENDERER
 class Drawable;
 class DrawableBuilder;
 class ShaderProgramBase;
@@ -50,7 +45,6 @@ using Texture2DPtr = std::shared_ptr<Texture2D>;
 using UniformBufferPtr = std::shared_ptr<UniformBuffer>;
 using UniqueDrawableBuilder = std::unique_ptr<DrawableBuilder>;
 using VertexAttributeArrayPtr = std::shared_ptr<VertexAttributeArray>;
-#endif
 
 namespace {
 ContextObserver nullObserver;
@@ -114,7 +108,6 @@ public:
     /// Sets dirty state
     virtual void setDirtyState() = 0;
 
-#if MLN_DRAWABLE_RENDERER
     /// Create a new vertex attribute array
     virtual gfx::VertexAttributeArrayPtr createVertexAttributeArray() const = 0;
 
@@ -178,7 +171,6 @@ public:
 
     /// Unbind the global uniform buffers
     virtual void unbindGlobalUniformBuffers(gfx::RenderPass&) const noexcept = 0;
-#endif
 
 protected:
     virtual std::unique_ptr<TextureResource> createTextureResource(Size, TexturePixelType, TextureChannelDataType) = 0;

--- a/include/mbgl/gfx/gpu_expression.hpp
+++ b/include/mbgl/gfx/gpu_expression.hpp
@@ -5,8 +5,6 @@
 
 #include <optional>
 
-#if MLN_DRAWABLE_RENDERER
-
 namespace mbgl {
 namespace style {
 namespace expression {
@@ -104,5 +102,3 @@ inline auto GPUExpression::evaluate<float>(const float zoom) const {
 
 } // namespace gfx
 } // namespace mbgl
-
-#endif

--- a/include/mbgl/gfx/renderer_backend.hpp
+++ b/include/mbgl/gfx/renderer_backend.hpp
@@ -50,10 +50,8 @@ public:
     /// Returns a reference to the default surface that should be rendered on.
     virtual Renderable& getDefaultRenderable() = 0;
 
-#if MLN_DRAWABLE_RENDERER
     /// One-time shader initialization
     virtual void initShaders(gfx::ShaderRegistry&, const ProgramParameters&) = 0;
-#endif
     const mbgl::util::SimpleIdentity uniqueID;
 
 protected:

--- a/include/mbgl/gl/renderer_backend.hpp
+++ b/include/mbgl/gl/renderer_backend.hpp
@@ -23,10 +23,8 @@ public:
     /// Called prior to rendering to update the internally assumed OpenGL state.
     virtual void updateAssumedState() = 0;
 
-#if MLN_DRAWABLE_RENDERER
     /// One-time shader initialization
     void initShaders(gfx::ShaderRegistry&, const ProgramParameters& programParameters) override;
-#endif
 
 protected:
     std::unique_ptr<gfx::Context> createContext() override;

--- a/include/mbgl/renderer/renderer_frontend.hpp
+++ b/include/mbgl/renderer/renderer_frontend.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#if MLN_DRAWABLE_RENDERER
-#include <mbgl/gfx/drawable.hpp>
-#endif
-
-#include <mbgl/actor/scheduler.hpp>
 #include <memory>
+
+#include <mbgl/gfx/drawable.hpp>
+#include <mbgl/actor/scheduler.hpp>
 
 namespace mbgl {
 

--- a/include/mbgl/shaders/line_layer_ubo.hpp
+++ b/include/mbgl/shaders/line_layer_ubo.hpp
@@ -3,10 +3,7 @@
 #include <mbgl/shaders/layer_ubo.hpp>
 #include <mbgl/style/property_expression.hpp>
 #include <mbgl/util/bitmask_operations.hpp>
-
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/gpu_expression.hpp>
-#endif // MLN_DRAWABLE_RENDERER
 
 namespace mbgl {
 namespace shaders {

--- a/include/mbgl/style/property_expression.hpp
+++ b/include/mbgl/style/property_expression.hpp
@@ -7,10 +7,7 @@
 #include <mbgl/style/expression/find_zoom_curve.hpp>
 #include <mbgl/util/bitmask_operations.hpp>
 #include <mbgl/util/range.hpp>
-
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/gpu_expression.hpp>
-#endif // MLN_DRAWABLE_RENDERER
 
 #include <optional>
 
@@ -52,10 +49,8 @@ public:
     /// expression. May be removed if a better way of aggregation is found.
     std::shared_ptr<const Expression> getSharedExpression() const noexcept;
 
-#if MLN_DRAWABLE_RENDERER
     /// Build a cached GPU representation of the expression, with the same lifetime as this object.
     gfx::UniqueGPUExpression getGPUExpression(bool intZoom) const;
-#endif // MLN_DRAWABLE_RENDERER
 
     Dependency getDependencies() const noexcept { return expression ? expression->dependencies : Dependency::None; }
 

--- a/platform/BUILD.bazel
+++ b/platform/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("@rules_cc//cc:defs.bzl", "objc_library")
 load("//bazel:flags.bzl", "CPP_FLAGS", "MAPLIBRE_FLAGS", "WARNING_FLAGS")
 
 objc_library(
@@ -88,7 +89,6 @@ objc_library(
         "//platform/ios:ios_public_hdrs",
         "//platform/ios:ios_sdk_hdrs",
     ] + select({
-        "//:legacy_renderer": [],
         "//conditions:default": [
             "//platform/darwin:darwin_objcpp_custom_drawable_srcs",
         ],
@@ -288,7 +288,6 @@ objc_library(
     deps = [
         ":ios-sdk",
     ] + select({
-        "//:legacy_renderer": [],
         "//conditions:default": [
             ":app_custom_drawable_layer_objcpp_srcs",
         ],

--- a/platform/android/Makefile
+++ b/platform/android/Makefile
@@ -15,10 +15,9 @@ else
 endif
 
 ifeq ($(RENDERER), drawable)
-else ifeq ($(RENDERER), legacy)
 else ifeq ($(RENDERER), vulkan)
 else
-  $(error RENDERER must be 'legacy' (OpenGL), 'drawable' (OpenGL) or 'vulkan')
+  $(error RENDERER must be 'drawable' (OpenGL) or 'vulkan')
 endif
 
 buildtype := $(shell echo "$(BUILDTYPE)" | tr "[A-Z]" "[a-z]")
@@ -219,9 +218,9 @@ run-android-ui-test-%: run-android-ui-test-arm-v7-%
 # Run Java Unit tests on the JVM of the development machine executing this
 .PHONY: run-android-unit-test
 run-android-unit-test:
-	$(MLN_ANDROID_GRADLE) -Pmaplibre.abis=none :MapLibreAndroid:testLegacyDebugUnitTest --info
+	$(MLN_ANDROID_GRADLE) -Pmaplibre.abis=none :MapLibreAndroid:testDrawableDebugUnitTest --info
 run-android-unit-test-%:
-	$(MLN_ANDROID_GRADLE) -Pmaplibre.abis=none :MapLibreAndroid:testLegacyDebugUnitTest --info --tests "$*"
+	$(MLN_ANDROID_GRADLE) -Pmaplibre.abis=none :MapLibreAndroid:testDrawableDebugUnitTest --info --tests "$*"
 
 DEBUG_TAR_FILE_NAME := $(if $(findstring drawable,$(RENDERER)),debug-symbols-opengl.tar.gz,debug-symbols-$(RENDERER).tar.gz)
 

--- a/platform/android/MapLibreAndroid/build.gradle.kts
+++ b/platform/android/MapLibreAndroid/build.gradle.kts
@@ -70,29 +70,15 @@ android {
             "\"MapLibre Native/${project.property("VERSION_NAME")}\""
         )
         consumerProguardFiles("proguard-rules.pro")
-
-        externalNativeBuild {
-            cmake {
-                arguments("-DMLN_LEGACY_RENDERER=ON", "-DMLN_DRAWABLE_RENDERER=OFF")
-            }
-        }
     }
 
     flavorDimensions += "renderer"
     productFlavors {
-        create("legacy") {
-            dimension = "renderer"
-            externalNativeBuild {
-                cmake {
-                    arguments("-DMLN_LEGACY_RENDERER=ON", "-DMLN_DRAWABLE_RENDERER=OFF")
-                }
-            }
-        }
         create("drawable") {
             dimension = "renderer"
             externalNativeBuild {
                 cmake {
-                    arguments("-DMLN_LEGACY_RENDERER=OFF", "-DMLN_DRAWABLE_RENDERER=ON")
+                    arguments("-DMLN_LEGACY_RENDERER=OFF")
                 }
             }
         }
@@ -100,7 +86,7 @@ android {
             dimension = "renderer"
             externalNativeBuild {
                 cmake {
-                    arguments("-DMLN_LEGACY_RENDERER=OFF", "-DMLN_DRAWABLE_RENDERER=ON")
+                    arguments("-DMLN_LEGACY_RENDERER=OFF")
                     arguments("-DMLN_WITH_OPENGL=OFF", "-DMLN_WITH_VULKAN=ON")
                 }
             }
@@ -108,9 +94,6 @@ android {
     }
 
     sourceSets {
-        getByName("legacy") {
-            java.srcDirs("src/opengl/java/")
-        }
         getByName("drawable") {
             java.srcDirs("src/opengl/java/")
         }

--- a/platform/android/MapLibreAndroid/build.gradle.kts
+++ b/platform/android/MapLibreAndroid/build.gradle.kts
@@ -76,17 +76,11 @@ android {
     productFlavors {
         create("drawable") {
             dimension = "renderer"
-            externalNativeBuild {
-                cmake {
-                    arguments("-DMLN_LEGACY_RENDERER=OFF")
-                }
-            }
         }
         create("vulkan") {
             dimension = "renderer"
             externalNativeBuild {
                 cmake {
-                    arguments("-DMLN_LEGACY_RENDERER=OFF")
                     arguments("-DMLN_WITH_OPENGL=OFF", "-DMLN_WITH_VULKAN=ON")
                 }
             }

--- a/platform/darwin/BUILD.bazel
+++ b/platform/darwin/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library", "js_run_binary")
+load("@rules_cc//cc:defs.bzl", "cc_library", "objc_library")
 load(
     "@rules_swift//swift:swift.bzl",
     "swift_library",
@@ -337,7 +338,6 @@ js_library(
         ":generated_style_hdrs",
         ":generated_style_srcs",
     ] + select({
-        "//:legacy_renderer": [],
         "//conditions:default": [
             ":darwin_objcpp_custom_drawable_srcs",
         ],

--- a/platform/darwin/src/MLNStyleLayerManager.mm
+++ b/platform/darwin/src/MLNStyleLayerManager.mm
@@ -11,9 +11,7 @@
 #import "MLNSymbolStyleLayer_Private.h"
 #import "MLNCustomStyleLayer_Private.h"
 
-#if MLN_DRAWABLE_RENDERER
 #import "MLNCustomDrawableStyleLayer_Private.h"
-#endif
 
 #include <vector>
 
@@ -71,12 +69,10 @@ LayerManagerDarwin::LayerManagerDarwin() {
     addLayerType(std::make_unique<CustomStyleLayerPeerFactory>());
 #endif
 
-#if MLN_DRAWABLE_RENDERER
 #if defined(MLN_LAYER_CUSTOM_DRAWABLE_DISABLE_RUNTIME)
     addLayerTypeCoreOnly(std::make_unique<CustomDrawableLayerFactory>());
 #elif !defined(MLN_LAYER_CUSTOM_DRAWABLE_DISABLE_ALL)
     addLayerType(std::make_unique<CustomDrawableStyleLayerPeerFactory>());
-#endif
 #endif
 }
 

--- a/platform/default/BUILD.bazel
+++ b/platform/default/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//bazel:flags.bzl", "CPP_FLAGS", "MAPLIBRE_FLAGS")
 
 cc_library(

--- a/platform/default/src/mbgl/layermanager/layer_manager.cpp
+++ b/platform/default/src/mbgl/layermanager/layer_manager.cpp
@@ -12,10 +12,7 @@
 #include <mbgl/layermanager/raster_layer_factory.hpp>
 #include <mbgl/layermanager/symbol_layer_factory.hpp>
 #include <mbgl/util/logging.hpp>
-
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/layermanager/custom_drawable_layer_factory.hpp>
-#endif
 
 #include <map>
 #include <memory>
@@ -73,10 +70,8 @@ LayerManagerDefault::LayerManagerDefault() {
 #if !defined(MBGL_LAYER_LOCATION_INDICATOR_DISABLE_ALL)
     addLayerType(std::make_unique<LocationIndicatorLayerFactory>());
 #endif
-#if MLN_DRAWABLE_RENDERER
 #if !defined(MLN_LAYER_CUSTOM_DRAWABLE_DISABLE_ALL)
     addLayerType(std::make_unique<CustomDrawableLayerFactory>());
-#endif
 #endif
 }
 

--- a/platform/glfw/BUILD.bazel
+++ b/platform/glfw/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "objc_library")
 load("//bazel:flags.bzl", "CPP_FLAGS", "MAPLIBRE_FLAGS")
 
 objc_library(

--- a/platform/glfw/example_custom_drawable_style_layer.cpp
+++ b/platform/glfw/example_custom_drawable_style_layer.cpp
@@ -1,7 +1,5 @@
 #include "example_custom_drawable_style_layer.hpp"
 
-#if MLN_DRAWABLE_RENDERER
-
 #include <mbgl/style/layer.hpp>
 #include <mbgl/style/layers/custom_drawable_layer.hpp>
 #include <mbgl/util/io.hpp>
@@ -271,8 +269,9 @@ void ExampleCustomDrawableStyleLayerHost::createDrawables(Interface& interface) 
         Interface::SymbolOptions options;
         options.texture = interface.context.createTexture2D();
         options.texture->setImage(image);
-        options.texture->setSamplerConfiguration(
-            {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Repeat, gfx::TextureWrapType::Repeat});
+        options.texture->setSamplerConfiguration({.filter = gfx::TextureFilterType::Linear,
+                                                  .wrapU = gfx::TextureWrapType::Repeat,
+                                                  .wrapV = gfx::TextureWrapType::Repeat});
 
         const std::array<std::array<float, 2>, 2> textureCoordinates = {{{0.0f, 0.0f}, {10.0f, 10.0f}}};
         options.size = {static_cast<uint32_t>(image->size.width), static_cast<uint32_t>(image->size.height)};
@@ -300,8 +299,9 @@ void ExampleCustomDrawableStyleLayerHost::createDrawables(Interface& interface) 
         Interface::SymbolOptions options;
         options.texture = interface.context.createTexture2D();
         options.texture->setImage(image);
-        options.texture->setSamplerConfiguration(
-            {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+        options.texture->setSamplerConfiguration({.filter = gfx::TextureFilterType::Linear,
+                                                  .wrapU = gfx::TextureWrapType::Clamp,
+                                                  .wrapV = gfx::TextureWrapType::Clamp});
 
         options.size = {static_cast<uint32_t>(image->size.width), static_cast<uint32_t>(image->size.height)};
 
@@ -414,8 +414,9 @@ void ExampleCustomDrawableStyleLayerHost::generateGeometry(Interface& interface)
 
     options.texture = interface.context.createTexture2D();
     options.texture->setImage(image);
-    options.texture->setSamplerConfiguration(
-        {mbgl::gfx::TextureFilterType::Linear, mbgl::gfx::TextureWrapType::Clamp, mbgl::gfx::TextureWrapType::Clamp});
+    options.texture->setSamplerConfiguration({.filter = mbgl::gfx::TextureFilterType::Linear,
+                                              .wrapU = mbgl::gfx::TextureWrapType::Clamp,
+                                              .wrapV = mbgl::gfx::TextureWrapType::Clamp});
 
     const std::shared_ptr<VertexVector> sharedVertices = std::make_shared<VertexVector>();
     VertexVector& vertices = *sharedVertices;
@@ -426,7 +427,7 @@ void ExampleCustomDrawableStyleLayerHost::generateGeometry(Interface& interface)
     const unsigned long numVtxCircumference = 72;
     const float bearingStep = 360.0f / static_cast<float>(numVtxCircumference - 1);
 
-    vertices.emplace_back(Interface::GeometryVertex{{0.0f, 0.0f, 0.0f}, {0.5f, 0.5f}});
+    vertices.emplace_back(Interface::GeometryVertex{.position = {0.0f, 0.0f, 0.0f}, .texcoords = {0.5f, 0.5f}});
 
     for (unsigned long i = 1; i <= numVtxCircumference; ++i) {
         const float rad = mbgl::util::deg2radf((i - 1) * bearingStep);
@@ -596,11 +597,10 @@ mbgl::gfx::Texture2DPtr ExampleCustomDrawableStyleLayerHost::createCheckerboardT
     }
 
     auto texture = interface.context.createTexture2D();
-    texture->setSamplerConfiguration(
-        {mbgl::gfx::TextureFilterType::Linear, mbgl::gfx::TextureWrapType::Clamp, mbgl::gfx::TextureWrapType::Clamp});
+    texture->setSamplerConfiguration({.filter = mbgl::gfx::TextureFilterType::Linear,
+                                      .wrapU = mbgl::gfx::TextureWrapType::Clamp,
+                                      .wrapV = mbgl::gfx::TextureWrapType::Clamp});
     texture->setImage(std::move(image));
 
     return texture;
 }
-
-#endif

--- a/platform/glfw/example_custom_drawable_style_layer.hpp
+++ b/platform/glfw/example_custom_drawable_style_layer.hpp
@@ -2,8 +2,6 @@
 
 #include <mbgl/style/layers/custom_drawable_layer.hpp>
 
-#if MLN_DRAWABLE_RENDERER
-
 class ExampleCustomDrawableStyleLayerHost : public mbgl::style::CustomDrawableLayerHost {
 public:
     using VertexVector = mbgl::gfx::VertexVector<Interface::GeometryVertex>;
@@ -39,5 +37,3 @@ protected:
 protected:
     const std::string assetsPath;
 };
-
-#endif

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -28,7 +28,7 @@
 #include <mbgl/util/platform.hpp>
 #include <mbgl/util/string.hpp>
 
-#if !defined(MBGL_LAYER_CUSTOM_DISABLE_ALL) && MLN_DRAWABLE_RENDERER
+#if !defined(MBGL_LAYER_CUSTOM_DISABLE_ALL)
 #include "example_custom_drawable_style_layer.hpp"
 #endif
 
@@ -829,7 +829,7 @@ void GLFWView::popAnnotation() {
 }
 
 void GLFWView::toggleCustomDrawableStyle() {
-#if !defined(MBGL_LAYER_CUSTOM_DISABLE_ALL) && MLN_DRAWABLE_RENDERER
+#if !defined(MBGL_LAYER_CUSTOM_DISABLE_ALL)
     auto &style = map->getStyle();
 
     const std::string identifier = "ExampleCustomDrawableStyleLayer";

--- a/platform/ios/app/MBXViewController.mm
+++ b/platform/ios/app/MBXViewController.mm
@@ -17,9 +17,7 @@
 
 #import "CustomStyleLayerExample.h"
 
-#if MLN_DRAWABLE_RENDERER
 #import "ExampleCustomDrawableStyleLayer.h"
-#endif
 
 #import "MBXFrameTimeGraphView.h"
 #import "MLNMapView_Experimental.h"
@@ -105,9 +103,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsRuntimeStylingRows) {
     MBXSettingsRuntimeStylingDDSPolygon,
     MBXSettingsRuntimeStylingCustomLatLonGrid,
     MBXSettingsRuntimeStylingLineGradient,
-#if MLN_DRAWABLE_RENDERER
     MBXSettingsRuntimeStylingCustomDrawableLayer,
-#endif
     MBXSettingsRuntimeStylingAddFoursquarePOIsPMTiles
 };
 
@@ -458,9 +454,7 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
                 @"Dynamically Style Polygon",
                 @"Add Custom Lat/Lon Grid",
                 @"Style Route line with gradient",
-#if MLN_DRAWABLE_RENDERER
                 @"Add Custom Drawable Layer",
-#endif
                 @"Add FourSquare POIs PMTiles Layer"
             ]];
             break;
@@ -684,11 +678,9 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
                 case MBXSettingsRuntimeStylingLineGradient:
                     [self styleLineGradient];
                     break;
-#if MLN_DRAWABLE_RENDERER
                 case MBXSettingsRuntimeStylingCustomDrawableLayer:
                     [self addCustomDrawableLayer];
                     break;
-#endif
                 case MBXSettingsRuntimeStylingAddFoursquarePOIsPMTiles:
                     [self addFoursquarePOIsPMTilesLayer];
                     break;
@@ -1678,7 +1670,6 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
     [self.mapView.style addLayer:routeLayer];
 }
 
-#if MLN_DRAWABLE_RENDERER
 - (void)addCustomDrawableLayer
 {
     // Create a CustomLayer that uses the Drawable/Builder toolkit to generate and render geometry
@@ -1688,7 +1679,6 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
         [self.mapView.style addLayer:layer];
     }
 }
-#endif
 
 - (void)removeSource:(NSString*)ident
 {

--- a/platform/ios/test/BUILD.bazel
+++ b/platform/ios/test/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@rules_cc//cc:defs.bzl", "objc_library")
 load(
     "@rules_swift//swift:swift.bzl",
     "swift_library",

--- a/platform/ios/test/common/BUILD.bazel
+++ b/platform/ios/test/common/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@darwin_config//:config.bzl", "BUNDLE_ID_PREFIX")
 load("@rules_apple//apple:ios.bzl", "ios_application")
+load("@rules_cc//cc:defs.bzl", "cc_library", "objc_library")
 
 cc_library(
     name = "ios_test_runner_lib",

--- a/platform/ios/test/core/BUILD.bazel
+++ b/platform/ios/test/core/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@darwin_config//:config.bzl", "BUNDLE_ID_PREFIX")
 load("@rules_apple//apple:ios.bzl", "ios_application", "ios_unit_test")
 load("@rules_apple//apple:resources.bzl", "apple_resource_bundle")
+load("@rules_cc//cc:defs.bzl", "cc_library", "objc_library")
 load("//bazel:flags.bzl", "CPP_FLAGS", "MAPLIBRE_FLAGS")
 
 cc_library(

--- a/platform/ios/vendor/BUILD.bazel
+++ b/platform/ios/vendor/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "objc_library")
 load("//bazel:flags.bzl", "WARNING_FLAGS")
 
 # SMCalloutView

--- a/platform/linux/BUILD.bazel
+++ b/platform/linux/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//bazel:flags.bzl", "CPP_FLAGS", "MAPLIBRE_FLAGS")
 
 ICU_FLAGS = [

--- a/platform/linux/README.md
+++ b/platform/linux/README.md
@@ -33,7 +33,7 @@ See instructions in [docker/README.md](../../docker/README.md) to build in a doc
 
 ```bash
 # Run from the root of the project to init the build
-cmake -B build -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMLN_WITH_CLANG_TIDY=OFF -DMLN_WITH_COVERAGE=OFF -DMLN_DRAWABLE_RENDERER=ON -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
+cmake -B build -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMLN_WITH_CLANG_TIDY=OFF -DMLN_WITH_COVERAGE=OFF -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
 
 # Build mbgl-render using all available CPUs
 cmake --build build --target mbgl-render -j $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null)

--- a/platform/macos/app/BUILD.bazel
+++ b/platform/macos/app/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_apple//apple:macos.bzl", "macos_application")
+load("@rules_cc//cc:defs.bzl", "objc_library")
 
 objc_library(
     name = "macos_app_lib",

--- a/platform/node/DEVELOPING.md
+++ b/platform/node/DEVELOPING.md
@@ -51,7 +51,7 @@ To compile the Node.js bindings and install module dependencies, from the reposi
 #### MacOS
 
 ```bash
-cmake . -B build -G Ninja -DMLN_WITH_NODE=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DMLN_WITH_OPENGL=OFF -DMLN_WITH_METAL=ON -DMLN_LEGACY_RENDERER=OFF -DMLN_DRAWABLE_RENDERER=ON -DMLN_WITH_WERROR=OFF
+cmake . -B build -G Ninja -DMLN_WITH_NODE=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DMLN_WITH_OPENGL=OFF -DMLN_WITH_METAL=ON -DMLN_WITH_WERROR=OFF
 ```
 
 #### Linux

--- a/render-test/BUILD.bazel
+++ b/render-test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bazel:flags.bzl", "CPP_FLAGS", "MAPLIBRE_FLAGS")
 
 cc_library(

--- a/render-test/android/app/build.gradle.kts
+++ b/render-test/android/app/build.gradle.kts
@@ -35,7 +35,6 @@ android {
         externalNativeBuild {
             cmake {
                 arguments("-DANDROID_STL=c++_static")
-                arguments("-DMLN_LEGACY_RENDERER=OFF", "-DMLN_DRAWABLE_RENDERER=ON")
                 targets.add("mbgl-render-test-runner")
             }
         }

--- a/render-test/ios/BUILD.bazel
+++ b/render-test/ios/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@rules_apple//apple:resources.bzl", "apple_resource_bundle")
+load("@rules_cc//cc:defs.bzl", "objc_library")
 load("//bazel:flags.bzl", "CPP_FLAGS", "MAPLIBRE_FLAGS")
 
 apple_resource_bundle(

--- a/render-test/metadata.hpp
+++ b/render-test/metadata.hpp
@@ -152,11 +152,7 @@ struct TestMetadata {
     // error message: "Failed to find expectations for..., to prevent
     // unit test error by missing metric.json, can turn on 'ignoreProbing'
     // to prevent the unit test fail, and just verify the render result.
-#if MLN_LEGACY_RENDERER
-    bool ignoreProbing = false;
-#else
     bool ignoreProbing = true;
-#endif
 
     mbgl::Size size{512u, 512u};
     float pixelRatio = 1.0f;

--- a/rustutils/BUILD.bazel
+++ b/rustutils/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_rust//rust:defs.bzl", "rust_static_library")
 
 genrule(

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -207,7 +207,6 @@ DashPatternTexture::DashPatternTexture(const std::vector<float>& from_,
 }
 
 void DashPatternTexture::upload(gfx::UploadPass& uploadPass) {
-#if MLN_DRAWABLE_RENDERER
     if (std::holds_alternative<AlphaImage>(texture)) {
         auto tempTexture = uploadPass.getContext().createTexture2D();
         tempTexture->upload(std::get<AlphaImage>(texture));
@@ -215,41 +214,18 @@ void DashPatternTexture::upload(gfx::UploadPass& uploadPass) {
             {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Repeat, gfx::TextureWrapType::Clamp});
         texture = std::move(tempTexture);
     }
-#else
-    if (texture.is<AlphaImage>()) {
-        texture = uploadPass.createTexture(texture.get<AlphaImage>());
-    }
-#endif
 }
 
-#if MLN_LEGACY_RENDERER
-gfx::TextureBinding DashPatternTexture::textureBinding() const {
-    // The texture needs to have been uploaded already.
-    assert(texture.is<gfx::Texture>());
-    return {texture.get<gfx::Texture>().getResource(),
-            gfx::TextureFilterType::Linear,
-            gfx::TextureMipMapType::No,
-            gfx::TextureWrapType::Repeat,
-            gfx::TextureWrapType::Clamp};
-}
-#endif
-
-#if MLN_DRAWABLE_RENDERER
 static const gfx::Texture2DPtr noTexture;
 const std::shared_ptr<gfx::Texture2D>& DashPatternTexture::getTexture() const {
     return (std::holds_alternative<gfx::Texture2DPtr>(texture)) ? std::get<gfx::Texture2DPtr>(texture) : noTexture;
 }
-#endif
 
 Size DashPatternTexture::getSize() const {
-#if MLN_DRAWABLE_RENDERER
     if (std::holds_alternative<AlphaImage>(texture)) {
         return std::get<AlphaImage>(texture).size;
     }
     return std::get<gfx::Texture2DPtr>(texture)->getSize();
-#else
-    return texture.match([](const auto& obj) { return obj.size; });
-#endif
 }
 
 LineAtlas::LineAtlas() = default;

--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -3,15 +3,9 @@
 #include <mbgl/gfx/texture.hpp>
 #include <mbgl/gfx/context.hpp>
 #include <mbgl/util/image.hpp>
-
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/texture2d.hpp>
-#include <variant>
-#else
-#include <mbgl/util/variant.hpp>
-#include <optional>
-#endif
 
+#include <variant>
 #include <map>
 #include <memory>
 #include <vector>
@@ -51,11 +45,7 @@ public:
     void upload(gfx::UploadPass&);
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
-#if MLN_DRAWABLE_RENDERER
     const std::shared_ptr<gfx::Texture2D>& getTexture() const;
-#else
-    gfx::TextureBinding textureBinding() const;
-#endif
 
     // Returns the size of the texture image.
     Size getSize() const;
@@ -66,11 +56,7 @@ public:
 private:
     LinePatternPos from, to;
 
-#if MLN_DRAWABLE_RENDERER
     std::variant<AlphaImage, gfx::Texture2DPtr> texture;
-#else
-    variant<AlphaImage, gfx::Texture> texture;
-#endif
 };
 
 class LineAtlas {

--- a/src/mbgl/gfx/index_vector.hpp
+++ b/src/mbgl/gfx/index_vector.hpp
@@ -27,18 +27,13 @@ public:
         : v(other.v) {} // buffer is not copied
     IndexVectorBase(IndexVectorBase&& other)
         : v(std::move(other.v)),
-#if MLN_DRAWABLE_RENDERER
           buffer(std::move(other.buffer)),
-#endif // MLN_DRAWABLE_RENDERER
           dirty(other.dirty),
-          released(other.released) {
-    }
+          released(other.released) {}
     virtual ~IndexVectorBase() = default;
 
-#if MLN_DRAWABLE_RENDERER
     IndexBufferBase* getBuffer() const { return buffer.get(); }
     void setBuffer(std::unique_ptr<IndexBufferBase>&& value) { buffer = std::move(value); }
-#endif // MLN_DRAWABLE_RENDERER
 
     bool getDirty() const { return dirty; }
     void setDirty(bool value = true) { dirty = value; }
@@ -73,19 +68,15 @@ public:
     void clear() {
         dirty = true;
         v.clear();
-#if MLN_DRAWABLE_RENDERER
         buffer.reset();
-#endif // MLN_DRAWABLE_RENDERER
     }
 
     /// Indicate that this shared index vector will no longer be updated.
     void release() {
-#if MLN_DRAWABLE_RENDERER
         // If we've already created a buffer, we don't need the raw data any more.
         if (buffer) {
             v.clear();
         }
-#endif // MLN_DRAWABLE_RENDERER
         released = true;
     }
 
@@ -94,9 +85,7 @@ public:
     const std::vector<uint16_t>& vector() const { return v; }
 
 protected:
-#if MLN_DRAWABLE_RENDERER
     std::unique_ptr<IndexBufferBase> buffer;
-#endif // MLN_DRAWABLE_RENDERER
     bool dirty = true;
     bool released = false;
 };

--- a/src/mbgl/gfx/offscreen_texture.hpp
+++ b/src/mbgl/gfx/offscreen_texture.hpp
@@ -22,11 +22,7 @@ public:
 
     virtual PremultipliedImage readStillImage() = 0;
 
-#if MLN_LEGACY_RENDERER
-    virtual gfx::Texture& getTexture() = 0;
-#else
     virtual const gfx::Texture2DPtr& getTexture() = 0;
-#endif
 };
 
 } // namespace gfx

--- a/src/mbgl/gfx/polyline_generator.cpp
+++ b/src/mbgl/gfx/polyline_generator.cpp
@@ -3,12 +3,9 @@
 #include <mbgl/style/types.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/programs/line_program.hpp>
-
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/drawable_builder.hpp>
 #include <mbgl/gfx/drawable_builder_impl.hpp>
 #include <mbgl/gfx/drawable_impl.hpp>
-#endif
 
 #include <memory>
 #include <numbers>
@@ -637,10 +634,8 @@ void PolylineGenerator<PLV, PS>::addPieSliceVertex(const GeometryCoordinate& cur
     }
 }
 
-#if MLN_DRAWABLE_RENDERER
 template class PolylineGenerator<gfx::DrawableBuilder::Impl::LineLayoutVertex,
                                  std::unique_ptr<gfx::Drawable::DrawSegment>>;
-#endif
 
 template class PolylineGenerator<LineLayoutVertex, Segment<LineAttributes>>;
 

--- a/src/mbgl/gfx/upload_pass.hpp
+++ b/src/mbgl/gfx/upload_pass.hpp
@@ -10,9 +10,7 @@
 #include <mbgl/util/size.hpp>
 #include <mbgl/util/image.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/texture2d.hpp>
-#endif
 
 #include <optional>
 #include <string>
@@ -21,14 +19,12 @@
 namespace mbgl {
 namespace gfx {
 
-#if MLN_DRAWABLE_RENDERER
 class Conext;
 class Texture2D;
 class VertexAttributeArray;
 
 using AttributeBindingArray = std::vector<std::optional<gfx::AttributeBinding>>;
 using Texture2DPtr = std::shared_ptr<Texture2D>;
-#endif
 
 class UploadPass {
 protected:
@@ -47,10 +43,8 @@ public:
     // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
     DebugGroup<UploadPass> createDebugGroup(std::string_view name) { return createDebugGroup(name.data()); }
 
-#if MLN_DRAWABLE_RENDERER
     virtual Context& getContext() = 0;
     virtual const Context& getContext() const = 0;
-#endif
 
 public:
     template <class Vertex>
@@ -79,7 +73,6 @@ public:
         updateIndexBufferResource(buffer.getResource(), v.data(), v.bytes());
     }
 
-#if MLN_DRAWABLE_RENDERER
     virtual gfx::AttributeBindingArray buildAttributeBindings(
         const std::size_t vertexCount,
         const gfx::AttributeDataType vertexType,
@@ -90,7 +83,6 @@ public:
         gfx::BufferUsageType,
         const std::optional<std::chrono::duration<double>> lastUpdate,
         /*out*/ std::vector<std::unique_ptr<gfx::VertexBufferResource>>& outBuffers) = 0;
-#endif
 
 protected:
     virtual std::unique_ptr<VertexBufferResource> createVertexBufferResource(const void* data,

--- a/src/mbgl/gfx/vertex_vector.hpp
+++ b/src/mbgl/gfx/vertex_vector.hpp
@@ -18,23 +18,17 @@ public:
     VertexVectorBase() = default;
     VertexVectorBase(const VertexVectorBase&) {} // buffer is not copied
     VertexVectorBase(VertexVectorBase&& other)
-        :
-#if MLN_DRAWABLE_RENDERER
-          buffer(std::move(other.buffer)),
-#endif // MLN_DRAWABLE_RENDERER
+        : buffer(std::move(other.buffer)),
           dirty(other.dirty),
-          released(other.released) {
-    }
+          released(other.released) {}
     virtual ~VertexVectorBase() = default;
 
     virtual const void* getRawData() const = 0;
     virtual std::size_t getRawSize() const = 0;
     virtual std::size_t getRawCount() const = 0;
 
-#if MLN_DRAWABLE_RENDERER
     VertexBufferBase* getBuffer() const { return buffer.get(); }
     void setBuffer(std::unique_ptr<VertexBufferBase>&& value) { buffer = std::move(value); }
-#endif // MLN_DRAWABLE_RENDERER
 
     std::chrono::duration<double> getLastModified() const { return lastModified; }
     bool isModifiedAfter(std::chrono::duration<double> t) const { return t < lastModified; }
@@ -50,9 +44,7 @@ public:
     bool isReleased() const { return released; }
 
 protected:
-#if MLN_DRAWABLE_RENDERER
     std::unique_ptr<VertexBufferBase> buffer;
-#endif // MLN_DRAWABLE_RENDERER
     bool dirty = true;
     bool released = false;
 
@@ -113,12 +105,10 @@ public:
 
     /// Indicate that this shared vertex vector instance will no longer be updated.
     void release() {
-#if MLN_DRAWABLE_RENDERER
         // If we've already created a buffer, we don't need the raw data any more.
         if (buffer) {
             v.clear();
         }
-#endif // MLN_DRAWABLE_RENDERER
         released = true;
     }
 

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -19,7 +19,6 @@
 #include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/thread_pool.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gl/drawable_gl.hpp>
 #include <mbgl/gl/drawable_gl_builder.hpp>
 #include <mbgl/gl/layer_group_gl.hpp>
@@ -27,7 +26,6 @@
 #include <mbgl/gl/texture2d.hpp>
 #include <mbgl/renderer/render_target.hpp>
 #include <mbgl/shaders/gl/shader_program_gl.hpp>
-#endif
 
 #include <cstring>
 #include <iterator>
@@ -95,9 +93,7 @@ constexpr size_t renderBufferByteSize(const gfx::RenderbufferPixelType type, con
 Context::Context(RendererBackend& backend_)
     : gfx::Context(/*maximumVertexBindingCount=*/getMaxVertexAttribs()),
       backend(backend_) {
-#if MLN_DRAWABLE_RENDERER
     uboAllocator = std::make_unique<gl::UniformBufferAllocator>();
-#endif
 
     texturePool = std::make_unique<Texture2DPool>(this);
 }
@@ -123,7 +119,6 @@ void Context::beginFrame() {
 
     backend.getThreadPool().runRenderJobs();
 
-#if MLN_DRAWABLE_RENDERER
     frameInFlightFence = std::make_shared<gl::Fence>();
 
     // Run allocator defragmentation on this frame interval.
@@ -135,19 +130,16 @@ void Context::beginFrame() {
     } else {
         frameNum++;
     }
-#endif
 }
 
 void Context::endFrame() {
     MLN_TRACE_FUNC();
 
-#if MLN_DRAWABLE_RENDERER
     if (!frameInFlightFence) {
         return;
     }
 
     frameInFlightFence->insert();
-#endif
 }
 
 void Context::initializeExtensions(const std::function<gl::ProcAddress(const char*)>& getProcAddress) {
@@ -524,7 +516,6 @@ void Context::reset() {
     texturePool->shrink();
 }
 
-#if MLN_DRAWABLE_RENDERER
 void Context::resetState(gfx::DepthMode depthMode, gfx::ColorMode colorMode) {
     MLN_TRACE_FUNC();
     MLN_TRACE_FUNC_GL();
@@ -563,7 +554,6 @@ void Context::unbindGlobalUniformBuffers(gfx::RenderPass&) const noexcept {
 
     globalUniformBuffers.unbind();
 }
-#endif
 
 void Context::setDirtyState() {
     MLN_TRACE_FUNC();
@@ -604,7 +594,6 @@ void Context::setDirtyState() {
     globalVertexArrayState.setDirty();
 }
 
-#if MLN_DRAWABLE_RENDERER
 gfx::UniqueDrawableBuilder Context::createDrawableBuilder(std::string name) {
     MLN_TRACE_FUNC();
 
@@ -675,8 +664,6 @@ Framebuffer Context::createFramebuffer(const gfx::Texture2D& color) {
 gfx::VertexAttributeArrayPtr Context::createVertexAttributeArray() const {
     return std::make_shared<VertexAttributeArrayGL>();
 }
-
-#endif
 
 void Context::clear(std::optional<mbgl::Color> color, std::optional<float> depth, std::optional<int32_t> stencil) {
     MLN_TRACE_FUNC();
@@ -785,11 +772,9 @@ void Context::finish() {
     MBGL_CHECK_ERROR(glFinish());
 }
 
-#if MLN_DRAWABLE_RENDERER
 std::shared_ptr<gl::Fence> Context::getCurrentFrameFence() const {
     return frameInFlightFence;
 }
-#endif
 
 void Context::draw(const gfx::DrawMode& drawMode, std::size_t indexOffset, std::size_t indexLength) {
     MLN_TRACE_FUNC();

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -16,12 +16,10 @@
 #include <mbgl/platform/gl_functions.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gl/fence.hpp>
 #include <mbgl/gl/buffer_allocator.hpp>
 #include <mbgl/gfx/texture2d.hpp>
 #include <mbgl/gl/uniform_buffer_gl.hpp>
-#endif
 
 #include <array>
 #include <functional>
@@ -89,9 +87,7 @@ public:
 
     void finish();
 
-#if MLN_DRAWABLE_RENDERER
     std::shared_ptr<gl::Fence> getCurrentFrameFence() const;
-#endif
 
     // Actually remove the objects we marked as abandoned with the above methods.
     // Only call this while the OpenGL context is exclusive to this thread.
@@ -118,7 +114,6 @@ public:
 
     void setCleanupOnDestruction(bool cleanup) { cleanupOnDestruction = cleanup; }
 
-#if MLN_DRAWABLE_RENDERER
     gfx::UniqueDrawableBuilder createDrawableBuilder(std::string name) override;
     gfx::UniformBufferPtr createUniformBuffer(const void* data,
                                               std::size_t size,
@@ -159,7 +154,6 @@ public:
 
     /// Unbind the global uniform buffers
     void unbindGlobalUniformBuffers(gfx::RenderPass&) const noexcept override;
-#endif
 
     void setDirtyState() override;
 
@@ -170,12 +164,10 @@ private:
     bool cleanupOnDestruction = true;
 
     std::unique_ptr<extension::Debugging> debugging;
-#if MLN_DRAWABLE_RENDERER
     std::shared_ptr<gl::Fence> frameInFlightFence;
     std::unique_ptr<gl::UniformBufferAllocator> uboAllocator;
     size_t frameNum = 0;
     UniformBufferArrayGL globalUniformBuffers;
-#endif
 
 public:
     State<value::ActiveTextureUnit> activeTextureUnit;

--- a/src/mbgl/gl/offscreen_texture.cpp
+++ b/src/mbgl/gl/offscreen_texture.cpp
@@ -13,35 +13,28 @@ public:
           size(size_),
           type(type_) {
         assert(!size.isEmpty());
-#if MLN_DRAWABLE_RENDERER
         texture = context.createTexture2D();
         texture->setSize(size);
         texture->setFormat(gfx::TexturePixelType::RGBA, type);
-        texture->setSamplerConfiguration(
-            {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
-#endif
+        texture->setSamplerConfiguration({.filter = gfx::TextureFilterType::Linear,
+                                          .wrapU = gfx::TextureWrapType::Clamp,
+                                          .wrapV = gfx::TextureWrapType::Clamp});
     }
 
     ~OffscreenTextureResource() noexcept override = default;
 
     void bind() override {
         if (!framebuffer) {
-#if MLN_LEGACY_RENDERER
-            assert(!texture);
-            texture = context.createTexture(size, gfx::TexturePixelType::RGBA, type);
-            framebuffer = context.createFramebuffer(*texture);
-#else
             assert(texture);
             texture->create();
             framebuffer = context.createFramebuffer(*texture);
-#endif
         } else {
             context.bindFramebuffer = framebuffer->framebuffer;
         }
 
         context.activeTextureUnit = 0;
         context.scissorTest = false;
-        context.viewport = {0, 0, size};
+        context.viewport = {.x = 0, .y = 0, .size = size};
     }
 
     PremultipliedImage readStillImage() {
@@ -50,26 +43,15 @@ public:
         return context.readFramebuffer<PremultipliedImage>(size);
     }
 
-#if MLN_LEGACY_RENDERER
-    gfx::Texture& getTexture() {
-        assert(texture);
-        return *texture;
-    }
-#else
     gfx::Texture2DPtr& getTexture() {
         assert(texture);
         return texture;
     }
-#endif
 
 private:
     gl::Context& context;
     const Size size;
-#if MLN_LEGACY_RENDERER
-    std::optional<gfx::Texture> texture;
-#else
     gfx::Texture2DPtr texture;
-#endif
     const gfx::TextureChannelDataType type;
     std::optional<gl::Framebuffer> framebuffer;
 };
@@ -90,15 +72,9 @@ PremultipliedImage OffscreenTexture::readStillImage() {
     return getResource<OffscreenTextureResource>().readStillImage();
 }
 
-#if MLN_LEGACY_RENDERER
-gfx::Texture& OffscreenTexture::getTexture() {
-    return getResource<OffscreenTextureResource>().getTexture();
-}
-#else
 const gfx::Texture2DPtr& OffscreenTexture::getTexture() {
     return getResource<OffscreenTextureResource>().getTexture();
 }
-#endif
 
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/offscreen_texture.hpp
+++ b/src/mbgl/gl/offscreen_texture.hpp
@@ -17,12 +17,7 @@ public:
     bool isRenderable() override;
 
     PremultipliedImage readStillImage() override;
-
-#if MLN_LEGACY_RENDERER
-    gfx::Texture& getTexture() override;
-#else
     const gfx::Texture2DPtr& getTexture() override;
-#endif
 };
 
 } // namespace gl

--- a/src/mbgl/gl/renderer_backend.cpp
+++ b/src/mbgl/gl/renderer_backend.cpp
@@ -7,9 +7,7 @@
 #include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/logging.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/shaders/gl/shader_group_gl.hpp>
-#endif
 
 #include <cassert>
 
@@ -92,7 +90,6 @@ void RendererBackend::setScissorTest(bool enabled) {
 
 RendererBackend::~RendererBackend() = default;
 
-#if MLN_DRAWABLE_RENDERER
 /// @brief Register a list of types with a shader registry instance
 /// @tparam ...ShaderID Pack of BuiltIn:: shader IDs
 /// @param registry A shader registry instance
@@ -150,7 +147,6 @@ void RendererBackend::initShaders(gfx::ShaderRegistry& shaders, const ProgramPar
                   shaders::BuiltIn::SymbolSDFIconShader,
                   shaders::BuiltIn::SymbolTextAndIconShader>(shaders, programParameters);
 }
-#endif
 
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/upload_pass.cpp
+++ b/src/mbgl/gl/upload_pass.cpp
@@ -12,10 +12,8 @@
 #include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/logging.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gl/vertex_attribute_gl.hpp>
 #include <mbgl/gl/texture2d.hpp>
-#endif
 
 #include <algorithm>
 
@@ -140,7 +138,6 @@ struct VertexBufferGL : public gfx::VertexBufferBase {
     std::unique_ptr<gfx::VertexBufferResource> resource;
 };
 
-#if MLN_DRAWABLE_RENDERER
 namespace {
 const std::unique_ptr<gfx::VertexBufferResource> noBuffer;
 }
@@ -315,7 +312,6 @@ gfx::AttributeBindingArray UploadPass::buildAttributeBindings(
 
     return bindings;
 }
-#endif
 
 void UploadPass::pushDebugGroup(const char* name) {
     commandEncoder.pushDebugGroup(name);
@@ -325,7 +321,6 @@ void UploadPass::popDebugGroup() {
     commandEncoder.popDebugGroup();
 }
 
-#if MLN_DRAWABLE_RENDERER
 gfx::Context& UploadPass::getContext() {
     return commandEncoder.context;
 }
@@ -333,7 +328,6 @@ gfx::Context& UploadPass::getContext() {
 const gfx::Context& UploadPass::getContext() const {
     return commandEncoder.context;
 }
-#endif
 
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/upload_pass.hpp
+++ b/src/mbgl/gl/upload_pass.hpp
@@ -28,10 +28,8 @@ private:
     void popDebugGroup() override;
 
 public:
-#if MLN_DRAWABLE_RENDERER
     gfx::Context& getContext() override;
     const gfx::Context& getContext() const override;
-#endif
 
     std::unique_ptr<gfx::VertexBufferResource> createVertexBufferResource(const void* data,
                                                                           std::size_t size,
@@ -45,7 +43,6 @@ public:
                                                                         bool persistent) override;
     void updateIndexBufferResource(gfx::IndexBufferResource&, const void* data, std::size_t size) override;
 
-#if MLN_DRAWABLE_RENDERER
     const gfx::UniqueVertexBufferResource& getBuffer(const gfx::VertexVectorBasePtr&, gfx::BufferUsageType);
 
     gfx::AttributeBindingArray buildAttributeBindings(
@@ -58,7 +55,6 @@ public:
         gfx::BufferUsageType,
         const std::optional<std::chrono::duration<double>> lastUpdate,
         /*out*/ std::vector<std::unique_ptr<gfx::VertexBufferResource>>& outBuffers) override;
-#endif
 
 public:
     std::unique_ptr<gfx::TextureResource> createTextureResource(Size,

--- a/src/mbgl/programs/programs.cpp
+++ b/src/mbgl/programs/programs.cpp
@@ -40,38 +40,8 @@ void registerTypes(gfx::ShaderRegistry& registry, const ProgramParameters& progr
 }
 
 void Programs::registerWith(gfx::ShaderRegistry& registry) {
-#if MLN_LEGACY_RENDERER
-    /// The following types will be registered
-    registerTypes<BackgroundProgram,
-                  BackgroundPatternProgram,
-                  RasterProgram,
-                  HeatmapProgram,
-                  HeatmapTextureProgram,
-                  HillshadeProgram,
-                  HillshadePrepareProgram,
-                  FillProgram,
-                  FillPatternProgram,
-                  FillOutlineProgram,
-                  FillOutlinePatternProgram,
-                  FillExtrusionProgram,
-                  FillExtrusionPatternProgram,
-                  CircleProgram,
-                  LineProgram,
-                  LineGradientProgram,
-                  LineSDFProgram,
-                  LinePatternProgram,
-                  SymbolIconProgram,
-                  SymbolSDFIconProgram,
-                  SymbolSDFTextProgram,
-                  SymbolTextAndIconProgram,
-                  CollisionBoxProgram,
-                  CollisionCircleProgram,
-                  DebugProgram,
-                  ClippingMaskProgram>(registry, programParameters);
-#else
     /// The following types will be registered
     registerTypes<DebugProgram, ClippingMaskProgram>(registry, programParameters);
-#endif
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -6,9 +6,7 @@
 #include <mbgl/style/layer_impl.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/util/identity.hpp>
-#endif
 
 #include <atomic>
 
@@ -71,9 +69,7 @@ public:
     virtual void updateVertices(
         const Placement&, bool /*updateOpacities*/, const TransformState&, const RenderTile&, std::set<uint32_t>&) {}
 
-#if MLN_DRAWABLE_RENDERER
     const util::SimpleIdentity& getID() const { return bucketID; }
-#endif
 
 #if MLN_SYMBOL_GUARDS
     virtual bool check(std::source_location) { return true; }
@@ -88,9 +84,7 @@ protected:
     Bucket() = default;
     std::atomic<bool> uploaded{false};
 
-#if MLN_DRAWABLE_RENDERER
     util::SimpleIdentity bucketID;
-#endif
 
     std::optional<std::thread::id> renderThreadID;
 };

--- a/src/mbgl/renderer/buckets/circle_bucket.cpp
+++ b/src/mbgl/renderer/buckets/circle_bucket.cpp
@@ -26,17 +26,6 @@ CircleBucket::~CircleBucket() {
 }
 
 void CircleBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
-#if MLN_LEGACY_RENDERER
-    if (!uploaded) {
-        vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
-        indexBuffer = uploadPass.createIndexBuffer(std::move(triangles));
-    }
-
-    for (auto& pair : paintPropertyBinders) {
-        pair.second.upload(uploadPass);
-    }
-#endif // MLN_LEGACY_RENDERER
-
     uploaded = true;
 }
 

--- a/src/mbgl/renderer/buckets/circle_bucket.hpp
+++ b/src/mbgl/renderer/buckets/circle_bucket.hpp
@@ -40,11 +40,6 @@ public:
 
     SegmentVector<CircleAttributes> segments;
 
-#if MLN_LEGACY_RENDERER
-    std::optional<gfx::VertexBuffer<CircleLayoutVertex>> vertexBuffer;
-    std::optional<gfx::IndexBuffer> indexBuffer;
-#endif // MLN_LEGACY_RENDERER
-
     std::map<std::string, CircleProgram::Binders> paintPropertyBinders;
 
     const MapMode mode;

--- a/src/mbgl/renderer/buckets/debug_bucket.cpp
+++ b/src/mbgl/renderer/buckets/debug_bucket.cpp
@@ -5,7 +5,6 @@
 
 #include <cmath>
 #include <string>
-#include <vector>
 
 namespace mbgl {
 
@@ -70,18 +69,6 @@ DebugBucket::DebugBucket(const OverscaledTileID& id,
     segments.emplace_back(0, 0, vertices.elements(), indices.elements());
 }
 
-void DebugBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
-#if MLN_LEGACY_RENDERER
-    if (!vertices.empty()) {
-        vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
-        indexBuffer = uploadPass.createIndexBuffer(std::move(indices));
-    }
-    if (!texture) {
-        std::array<uint8_t, 4> data{{0, 0, 0, 0}};
-        static const PremultipliedImage emptyImage{Size(1, 1), data.data(), data.size()};
-        texture = uploadPass.createTexture(emptyImage);
-    }
-#endif // MLN_LEGACY_RENDERER
-}
+void DebugBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {}
 
 } // namespace mbgl

--- a/src/mbgl/renderer/buckets/fill_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_bucket.cpp
@@ -76,19 +76,6 @@ void FillBucket::addFeature(const GeometryTileFeature& feature,
 #endif // MLN_TRIANGULATE_FILL_OUTLINES
 
 void FillBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
-#if MLN_LEGACY_RENDERER
-    if (!uploaded) {
-        vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
-        lineIndexBuffer = uploadPass.createIndexBuffer(std::move(basicLines));
-        triangleIndexBuffer = triangles.empty() ? std::optional<gfx::IndexBuffer>{}
-                                                : uploadPass.createIndexBuffer(std::move(triangles));
-    }
-
-    for (auto& pair : paintPropertyBinders) {
-        pair.second.upload(uploadPass);
-    }
-#endif // MLN_LEGACY_RENDERER
-
     uploaded = true;
 }
 

--- a/src/mbgl/renderer/buckets/fill_bucket.hpp
+++ b/src/mbgl/renderer/buckets/fill_bucket.hpp
@@ -8,7 +8,6 @@
 #include <mbgl/programs/fill_program.hpp>
 #include <mbgl/style/layers/fill_layer_properties.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 /**
     Control how the fill outlines are being generated:
     MLN_TRIANGULATE_FILL_OUTLINES = 0 : Simple line primitives will be generated. Draw using gfx::Lines
@@ -16,16 +15,9 @@
  */
 #define MLN_TRIANGULATE_FILL_OUTLINES (MLN_RENDER_BACKEND_METAL)
 
-#else // MLN_DRAWABLE_RENDERER
-// Legacy Renderer is incompatible with triangulated lines
-#define MLN_TRIANGULATE_FILL_OUTLINES 0
-#endif // MLN_DRAWABLE_RENDERER
-
 #if MLN_TRIANGULATE_FILL_OUTLINES
 #include <mbgl/programs/line_program.hpp>
 #endif
-
-#include <vector>
 
 namespace mbgl {
 
@@ -84,12 +76,6 @@ public:
     TriangleIndexVector& triangles = *sharedTriangles;
 
     SegmentVector<FillAttributes> triangleSegments;
-
-#if MLN_LEGACY_RENDERER
-    std::optional<gfx::VertexBuffer<FillLayoutVertex>> vertexBuffer;
-    std::optional<gfx::IndexBuffer> lineIndexBuffer;
-    std::optional<gfx::IndexBuffer> triangleIndexBuffer;
-#endif // MLN_LEGACY_RENDERER
 
     std::map<std::string, FillProgram::Binders> paintPropertyBinders;
 };

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
@@ -172,17 +172,6 @@ void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature,
 }
 
 void FillExtrusionBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
-#if MLN_LEGACY_RENDERER
-    if (!uploaded) {
-        vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
-        indexBuffer = uploadPass.createIndexBuffer(std::move(triangles));
-    }
-
-    for (auto& pair : paintPropertyBinders) {
-        pair.second.upload(uploadPass);
-    }
-#endif // MLN_LEGACY_RENDERER
-
     uploaded = true;
 }
 

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.hpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.hpp
@@ -49,11 +49,6 @@ public:
 
     SegmentVector<FillExtrusionAttributes> triangleSegments;
 
-#if MLN_LEGACY_RENDERER
-    std::optional<gfx::VertexBuffer<FillExtrusionLayoutVertex>> vertexBuffer;
-    std::optional<gfx::IndexBuffer> indexBuffer;
-#endif // MLN_LEGACY_RENDERER
-
     std::unordered_map<std::string, FillExtrusionProgram::Binders> paintPropertyBinders;
 };
 

--- a/src/mbgl/renderer/buckets/heatmap_bucket.cpp
+++ b/src/mbgl/renderer/buckets/heatmap_bucket.cpp
@@ -26,15 +26,6 @@ HeatmapBucket::~HeatmapBucket() {
 }
 
 void HeatmapBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
-#if MLN_LEGACY_RENDERER
-    vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
-    indexBuffer = uploadPass.createIndexBuffer(std::move(triangles));
-
-    for (auto& pair : paintPropertyBinders) {
-        pair.second.upload(uploadPass);
-    }
-#endif // MLN_LEGACY_RENDERER
-
     uploaded = true;
 }
 

--- a/src/mbgl/renderer/buckets/heatmap_bucket.hpp
+++ b/src/mbgl/renderer/buckets/heatmap_bucket.hpp
@@ -40,11 +40,6 @@ public:
 
     SegmentVector<HeatmapAttributes> segments;
 
-#if MLN_LEGACY_RENDERER
-    std::optional<gfx::VertexBuffer<HeatmapLayoutVertex>> vertexBuffer;
-    std::optional<gfx::IndexBuffer> indexBuffer;
-#endif // MLN_LEGACY_RENDERER
-
     std::map<std::string, HeatmapProgram::Binders> paintPropertyBinders;
 
     const MapMode mode;

--- a/src/mbgl/renderer/buckets/hillshade_bucket.cpp
+++ b/src/mbgl/renderer/buckets/hillshade_bucket.cpp
@@ -31,27 +31,10 @@ void HillshadeBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
         return;
     }
 
-#if MLN_LEGACY_RENDERER
-    const PremultipliedImage* image = demdata.getImage();
-    dem = uploadPass.createTexture(*image);
-
-    if (!vertices.empty()) {
-        vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
-    }
-    if (!indices.empty()) {
-        indexBuffer = uploadPass.createIndexBuffer(std::move(indices));
-    }
-#endif // MLN_LEGACY_RENDERER
-
     uploaded = true;
 }
 
 void HillshadeBucket::clear() {
-#if MLN_LEGACY_RENDERER
-    vertexBuffer = {};
-    indexBuffer = {};
-#endif // MLN_LEGACY_RENDERER
-
     segments.clear();
     vertices.clear();
     indices.clear();

--- a/src/mbgl/renderer/buckets/hillshade_bucket.hpp
+++ b/src/mbgl/renderer/buckets/hillshade_bucket.hpp
@@ -30,10 +30,8 @@ public:
     std::optional<gfx::Texture> dem;
     std::optional<gfx::Texture> texture;
 
-#if MLN_DRAWABLE_RENDERER
     RenderTargetPtr renderTarget;
     bool renderTargetPrepared = false;
-#endif
 
     TileMask mask{{0, 0, 0}};
 
@@ -54,11 +52,6 @@ public:
     IndexVector& indices = *sharedIndices;
 
     SegmentVector<HillshadeAttributes> segments;
-
-#if MLN_LEGACY_RENDERER
-    std::optional<gfx::VertexBuffer<HillshadeLayoutVertex>> vertexBuffer;
-    std::optional<gfx::IndexBuffer> indexBuffer;
-#endif // MLN_LEGACY_RENDERER
 
 private:
     DEMData demdata;

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -127,17 +127,6 @@ void LineBucket::addGeometry(const GeometryCoordinates& coordinates,
 }
 
 void LineBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
-#if MLN_LEGACY_RENDERER
-    if (!uploaded) {
-        vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
-        indexBuffer = uploadPass.createIndexBuffer(std::move(triangles));
-    }
-
-    for (auto& pair : paintPropertyBinders) {
-        pair.second.upload(uploadPass);
-    }
-#endif // MLN_LEGACY_RENDERER
-
     uploaded = true;
 }
 

--- a/src/mbgl/renderer/buckets/line_bucket.hpp
+++ b/src/mbgl/renderer/buckets/line_bucket.hpp
@@ -8,8 +8,6 @@
 #include <mbgl/style/layers/line_layer_properties.hpp>
 #include <mbgl/style/image_impl.hpp>
 
-#include <vector>
-
 namespace mbgl {
 
 class BucketParameters;
@@ -51,11 +49,6 @@ public:
     TriangleIndexVector& triangles = *sharedTriangles;
 
     SegmentVector<LineAttributes> segments;
-
-#if MLN_LEGACY_RENDERER
-    std::optional<gfx::VertexBuffer<LineLayoutVertex>> vertexBuffer;
-    std::optional<gfx::IndexBuffer> indexBuffer;
-#endif // MLN_LEGACY_RENDERER
 
     std::map<std::string, LineProgram::Binders> paintPropertyBinders;
 

--- a/src/mbgl/renderer/buckets/raster_bucket.cpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.cpp
@@ -22,26 +22,10 @@ void RasterBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
     if (!hasData()) {
         return;
     }
-#if MLN_LEGACY_RENDERER
-    if (!texture) {
-        texture = uploadPass.createTexture(*image);
-    }
-    if (!vertices.empty()) {
-        vertexBuffer = uploadPass.createVertexBuffer(std::move(vertices));
-    }
-    if (!indices.empty()) {
-        indexBuffer = uploadPass.createIndexBuffer(std::move(indices));
-    }
-#endif // MLN_LEGACY_RENDERER
     uploaded = true;
 }
 
 void RasterBucket::clear() {
-#if MLN_LEGACY_RENDERER
-    vertexBuffer = {};
-    indexBuffer = {};
-#endif // MLN_LEGACY_RENDERER
-
     segments.clear();
     vertices.clear();
     indices.clear();

--- a/src/mbgl/renderer/buckets/raster_bucket.hpp
+++ b/src/mbgl/renderer/buckets/raster_bucket.hpp
@@ -48,11 +48,6 @@ public:
     TriangleIndexVector& indices = *sharedTriangles;
 
     SegmentVector<RasterAttributes> segments;
-
-#if MLN_LEGACY_RENDERER
-    std::optional<gfx::VertexBuffer<RasterLayoutVertex>> vertexBuffer;
-    std::optional<gfx::IndexBuffer> indexBuffer;
-#endif // MLN_LEGACY_RENDERER
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -52,132 +52,17 @@ SymbolBucket::SymbolBucket(Immutable<style::SymbolLayoutProperties::PossiblyEval
       placementModes(std::move(placementModes_)) {
     for (const auto& pair : paintProperties_) {
         const auto& evaluated = getEvaluated<SymbolLayerProperties>(pair.second);
-        paintProperties.emplace(
-            std::piecewise_construct,
-            std::forward_as_tuple(pair.first),
-            std::forward_as_tuple(PaintProperties{{RenderSymbolLayer::iconPaintProperties(evaluated), zoom},
-                                                  {RenderSymbolLayer::textPaintProperties(evaluated), zoom}}));
+        paintProperties.emplace(std::piecewise_construct,
+                                std::forward_as_tuple(pair.first),
+                                std::forward_as_tuple(PaintProperties{
+                                    .iconBinders = {RenderSymbolLayer::iconPaintProperties(evaluated), zoom},
+                                    .textBinders = {RenderSymbolLayer::textPaintProperties(evaluated), zoom}}));
     }
 }
 
 SymbolBucket::~SymbolBucket() = default;
 
 void SymbolBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
-#if MLN_LEGACY_RENDERER
-    if (hasTextData()) {
-        if (!staticUploaded) {
-            text.indexBuffer = uploadPass.createIndexBuffer(
-                std::move(text.triangles),
-                sortFeaturesByY ? gfx::BufferUsageType::StreamDraw : gfx::BufferUsageType::StaticDraw);
-            text.vertexBuffer = uploadPass.createVertexBuffer(text.vertices());
-            for (auto& pair : paintProperties) {
-                pair.second.textBinders.upload(uploadPass);
-            }
-        } else if (!sortUploaded) {
-            uploadPass.updateIndexBuffer(*text.indexBuffer, std::move(text.triangles));
-        }
-
-        if (!dynamicUploaded) {
-            if (!text.dynamicVertexBuffer) {
-                text.dynamicVertexBuffer = uploadPass.createVertexBuffer(text.dynamicVertices(),
-                                                                         gfx::BufferUsageType::StreamDraw);
-            } else {
-                uploadPass.updateVertexBuffer(*text.dynamicVertexBuffer, text.dynamicVertices());
-            }
-        }
-        if (!placementChangesUploaded) {
-            if (!text.opacityVertexBuffer) {
-                text.opacityVertexBuffer = uploadPass.createVertexBuffer(text.opacityVertices(),
-                                                                         gfx::BufferUsageType::StreamDraw);
-            } else {
-                uploadPass.updateVertexBuffer(*text.opacityVertexBuffer, text.opacityVertices());
-            }
-        }
-    }
-
-    auto updateIconBuffer = [&](Buffer& iconBuffer) {
-        if (!staticUploaded) {
-            iconBuffer.indexBuffer = uploadPass.createIndexBuffer(
-                std::move(iconBuffer.triangles),
-                sortFeaturesByY ? gfx::BufferUsageType::StreamDraw : gfx::BufferUsageType::StaticDraw);
-            iconBuffer.vertexBuffer = uploadPass.createVertexBuffer(iconBuffer.vertices());
-            for (auto& pair : paintProperties) {
-                pair.second.iconBinders.upload(uploadPass);
-            }
-        } else if (!sortUploaded) {
-            uploadPass.updateIndexBuffer(*iconBuffer.indexBuffer, std::move(iconBuffer.triangles));
-        }
-        if (!dynamicUploaded) {
-            if (!iconBuffer.dynamicVertexBuffer) {
-                iconBuffer.dynamicVertexBuffer = uploadPass.createVertexBuffer(iconBuffer.dynamicVertices(),
-                                                                               gfx::BufferUsageType::StreamDraw);
-            } else {
-                uploadPass.updateVertexBuffer(*iconBuffer.dynamicVertexBuffer, iconBuffer.dynamicVertices());
-            }
-        }
-        if (!placementChangesUploaded) {
-            if (!iconBuffer.opacityVertexBuffer) {
-                iconBuffer.opacityVertexBuffer = uploadPass.createVertexBuffer(iconBuffer.opacityVertices(),
-                                                                               gfx::BufferUsageType::StreamDraw);
-            } else {
-                uploadPass.updateVertexBuffer(*iconBuffer.opacityVertexBuffer, iconBuffer.opacityVertices());
-            }
-        }
-    };
-    if (hasIconData()) {
-        updateIconBuffer(icon);
-    }
-    if (hasSdfIconData()) {
-        updateIconBuffer(sdfIcon);
-    }
-
-    const auto updateCollisionBox = [&](CollisionBoxBuffer& collisionBox) {
-        if (!staticUploaded) {
-            collisionBox.indexBuffer = uploadPass.createIndexBuffer(std::move(collisionBox.lines));
-            collisionBox.vertexBuffer = uploadPass.createVertexBuffer(std::move(collisionBox.vertices()));
-        }
-        if (!placementChangesUploaded) {
-            if (!collisionBox.dynamicVertexBuffer) {
-                collisionBox.dynamicVertexBuffer = uploadPass.createVertexBuffer(
-                    std::move(collisionBox.dynamicVertices()), gfx::BufferUsageType::StreamDraw);
-            } else {
-                uploadPass.updateVertexBuffer(*collisionBox.dynamicVertexBuffer,
-                                              std::move(collisionBox.dynamicVertices()));
-            }
-        }
-    };
-    if (hasIconCollisionBoxData()) {
-        updateCollisionBox(*iconCollisionBox);
-    }
-
-    if (hasTextCollisionBoxData()) {
-        updateCollisionBox(*textCollisionBox);
-    }
-
-    const auto updateCollisionCircle = [&](CollisionCircleBuffer& collisionCircle) {
-        if (!staticUploaded) {
-            collisionCircle.indexBuffer = uploadPass.createIndexBuffer(std::move(collisionCircle.triangles));
-            collisionCircle.vertexBuffer = uploadPass.createVertexBuffer(std::move(collisionCircle.vertices()));
-        }
-        if (!placementChangesUploaded) {
-            if (!collisionCircle.dynamicVertexBuffer) {
-                collisionCircle.dynamicVertexBuffer = uploadPass.createVertexBuffer(
-                    std::move(collisionCircle.dynamicVertices()), gfx::BufferUsageType::StreamDraw);
-            } else {
-                uploadPass.updateVertexBuffer(*collisionCircle.dynamicVertexBuffer,
-                                              std::move(collisionCircle.dynamicVertices()));
-            }
-        }
-    };
-    if (hasIconCollisionCircleData()) {
-        updateCollisionCircle(*iconCollisionCircle);
-    }
-
-    if (hasTextCollisionCircleData()) {
-        updateCollisionCircle(*textCollisionCircle);
-    }
-#endif // MLN_LEGACY_RENDERER
-
     uploaded = true;
     staticUploaded = true;
     placementChangesUploaded = true;

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -182,13 +182,6 @@ public:
 
         SegmentVector<SymbolTextAttributes> segments;
         std::vector<PlacedSymbol> placedSymbols;
-
-#if MLN_LEGACY_RENDERER
-        std::optional<VertexBuffer> vertexBuffer;
-        std::optional<DynamicVertexBuffer> dynamicVertexBuffer;
-        std::optional<OpacityVertexBuffer> opacityVertexBuffer;
-        std::optional<gfx::IndexBuffer> indexBuffer;
-#endif // MLN_LEGACY_RENDERER
     } text;
 
     std::unique_ptr<SymbolSizeBinder> iconSizeBinder;
@@ -210,20 +203,12 @@ public:
         const CollisionDynamicVertexVector& dynamicVertices() const { return *sharedDynamicVertices; }
 
         SegmentVector<CollisionBoxProgram::AttributeList> segments;
-
-#if MLN_LEGACY_RENDERER
-        std::optional<gfx::VertexBuffer<gfx::Vertex<CollisionBoxLayoutAttributes>>> vertexBuffer;
-        std::optional<gfx::VertexBuffer<gfx::Vertex<CollisionBoxDynamicAttributes>>> dynamicVertexBuffer;
-#endif // MLN_LEGACY_RENDERER
     };
 
     struct CollisionBoxBuffer : public CollisionBuffer {
         using LineIndexVector = gfx::IndexVector<gfx::Lines>;
         const std::shared_ptr<LineIndexVector> sharedLines = std::make_shared<LineIndexVector>();
         LineIndexVector& lines = *sharedLines;
-#if MLN_LEGACY_RENDERER
-        std::optional<gfx::IndexBuffer> indexBuffer;
-#endif // MLN_LEGACY_RENDERER
     };
     std::unique_ptr<CollisionBoxBuffer> iconCollisionBox;
     std::unique_ptr<CollisionBoxBuffer> textCollisionBox;
@@ -242,9 +227,6 @@ public:
         using TriangleIndexVector = gfx::IndexVector<gfx::Triangles>;
         const std::shared_ptr<TriangleIndexVector> sharedTriangles = std::make_shared<TriangleIndexVector>();
         TriangleIndexVector& triangles = *sharedTriangles;
-#if MLN_LEGACY_RENDERER
-        std::optional<gfx::IndexBuffer> indexBuffer;
-#endif // MLN_LEGACY_RENDERER
     };
     std::unique_ptr<CollisionCircleBuffer> iconCollisionCircle;
     std::unique_ptr<CollisionCircleBuffer> textCollisionCircle;

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -15,16 +15,12 @@
 #include <mbgl/util/convert.hpp>
 #include <mbgl/util/logging.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/renderer/layers/background_layer_tweaker.hpp>
 #include <mbgl/gfx/drawable_builder.hpp>
 #include <mbgl/renderer/change_request.hpp>
 #include <mbgl/renderer/layer_group.hpp>
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/shaders/shader_program_base.hpp>
-#endif
-
-#include <unordered_set>
 
 namespace mbgl {
 
@@ -70,11 +66,9 @@ void RenderBackgroundLayer::evaluate(const PropertyEvaluationParameters& paramet
 
     evaluatedProperties = std::move(properties);
 
-#if MLN_DRAWABLE_RENDERER
     if (layerTweaker) {
         layerTweaker->updateProperties(evaluatedProperties);
     }
-#endif
 }
 
 bool RenderBackgroundLayer::hasTransition() const {
@@ -84,102 +78,6 @@ bool RenderBackgroundLayer::hasTransition() const {
 bool RenderBackgroundLayer::hasCrossfade() const {
     return getCrossfade<BackgroundLayerProperties>(evaluatedProperties).t != 1;
 }
-
-#if MLN_LEGACY_RENDERER
-void RenderBackgroundLayer::render(PaintParameters& parameters) {
-    // Note that for bottommost layers without a pattern, the background color
-    // is drawn with glClear rather than this method.
-
-    // Ensure programs are available
-    if (!parameters.shaders.getLegacyGroup().populate(backgroundProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(backgroundPatternProgram)) return;
-
-    const Properties<>::PossiblyEvaluated properties;
-    const BackgroundProgram::Binders paintAttributeData(properties, 0);
-
-    auto draw = [&](auto& program, auto&& uniformValues, const auto& textureBindings, const uint32_t id) {
-        const auto allUniformValues = program.computeAllUniformValues(
-            std::forward<decltype(uniformValues)>(uniformValues),
-            paintAttributeData,
-            properties,
-            static_cast<float>(parameters.state.getZoom()));
-        const auto allAttributeBindings = program.computeAllAttributeBindings(
-            *parameters.staticData.tileVertexBuffer, paintAttributeData, properties);
-
-        checkRenderability(parameters, program.activeBindingCount(allAttributeBindings));
-
-        program.draw(
-            parameters.context,
-            *parameters.renderPass,
-            gfx::Triangles(),
-            parameters.depthModeForSublayer(
-                0,
-                parameters.pass == RenderPass::Opaque ? gfx::DepthMaskType::ReadWrite : gfx::DepthMaskType::ReadOnly),
-            gfx::StencilMode::disabled(),
-            parameters.colorModeForRenderPass(),
-            gfx::CullFaceMode::disabled(),
-            *parameters.staticData.quadTriangleIndexBuffer,
-            segments,
-            allUniformValues,
-            allAttributeBindings,
-            textureBindings,
-            util::toString(id));
-    };
-
-    if (segments.empty()) {
-        segments = RenderStaticData::tileTriangleSegments();
-    }
-
-    const auto& evaluated = static_cast<const BackgroundLayerProperties&>(*evaluatedProperties).evaluated;
-    const auto& crossfade = static_cast<const BackgroundLayerProperties&>(*evaluatedProperties).crossfade;
-    if (!evaluated.get<BackgroundPattern>().to.empty()) {
-        std::optional<ImagePosition> imagePosA = parameters.patternAtlas.getPattern(
-            evaluated.get<BackgroundPattern>().from.id());
-        std::optional<ImagePosition> imagePosB = parameters.patternAtlas.getPattern(
-            evaluated.get<BackgroundPattern>().to.id());
-
-        if (!imagePosA || !imagePosB) return;
-
-        uint32_t i = 0;
-        for (const auto& tileID : util::tileCover(parameters.state, parameters.state.getIntegerZoom())) {
-            const UnwrappedTileID unwrappedTileID = tileID.toUnwrapped();
-            draw(*backgroundPatternProgram,
-                 BackgroundPatternProgram::layoutUniformValues(parameters.matrixForTile(unwrappedTileID),
-                                                               evaluated.get<BackgroundOpacity>(),
-                                                               parameters.patternAtlas.getPixelSize(),
-                                                               *imagePosA,
-                                                               *imagePosB,
-                                                               crossfade,
-                                                               unwrappedTileID,
-                                                               parameters.state),
-                 BackgroundPatternProgram::TextureBindings{
-                     textures::image::Value{parameters.patternAtlas.textureBinding()},
-                 },
-                 i++);
-        }
-    } else {
-        auto backgroundRenderPass = (evaluated.get<BackgroundColor>().a >= 1.0f &&
-                                     evaluated.get<BackgroundOpacity>() >= 1.0f &&
-                                     parameters.currentLayer >= parameters.opaquePassCutoff)
-                                        ? RenderPass::Opaque
-                                        : RenderPass::Translucent;
-        if (parameters.pass != backgroundRenderPass) {
-            return;
-        }
-        uint32_t i = 0;
-        for (const auto& tileID : util::tileCover(parameters.state, parameters.state.getIntegerZoom())) {
-            draw(*backgroundProgram,
-                 BackgroundProgram::LayoutUniformValues{
-                     uniforms::matrix::Value(parameters.matrixForTile(tileID.toUnwrapped())),
-                     uniforms::color::Value(evaluated.get<BackgroundColor>()),
-                     uniforms::opacity::Value(evaluated.get<BackgroundOpacity>()),
-                 },
-                 BackgroundProgram::TextureBindings{},
-                 i++);
-        }
-    }
-}
-#endif // MLN_LEGACY_RENDERER
 
 std::optional<Color> RenderBackgroundLayer::getSolidBackground() const {
     const auto& evaluated = getEvaluated<BackgroundLayerProperties>(evaluatedProperties);
@@ -210,7 +108,6 @@ void RenderBackgroundLayer::prepare(const LayerPrepareParameters& params) {
     }
 }
 
-#if MLN_DRAWABLE_RENDERER
 static constexpr std::string_view BackgroundPlainShaderName = "BackgroundShader";
 static constexpr std::string_view BackgroundPatternShaderName = "BackgroundPatternShader";
 
@@ -326,6 +223,5 @@ void RenderBackgroundLayer::update(gfx::ShaderRegistry& shaders,
         }
     }
 }
-#endif
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_background_layer.hpp
+++ b/src/mbgl/renderer/layers/render_background_layer.hpp
@@ -23,7 +23,6 @@ public:
     explicit RenderBackgroundLayer(Immutable<style::BackgroundLayer::Impl>);
     ~RenderBackgroundLayer() override;
 
-#if MLN_DRAWABLE_RENDERER
     /// Generate any changes needed by the layer
     void update(gfx::ShaderRegistry&,
                 gfx::Context&,
@@ -31,7 +30,6 @@ public:
                 const std::shared_ptr<UpdateParameters>&,
                 const RenderTree&,
                 UniqueChangeRequestVec&) override;
-#endif
 
 private:
     void transition(const TransitionParameters&) override;
@@ -40,26 +38,15 @@ private:
     bool hasCrossfade() const override;
     std::optional<Color> getSolidBackground() const override;
 
-#if MLN_LEGACY_RENDERER
-    void render(PaintParameters&) override;
-#endif
-
     void prepare(const LayerPrepareParameters&) override;
 
     // Paint properties
     style::BackgroundPaintProperties::Unevaluated unevaluated;
     SegmentVector<BackgroundAttributes> segments;
 
-#if MLN_LEGACY_RENDERER
-    // Programs
-    std::shared_ptr<BackgroundProgram> backgroundProgram;
-    std::shared_ptr<BackgroundPatternProgram> backgroundPatternProgram;
-#endif
-#if MLN_DRAWABLE_RENDERER
     // Drawable shaders
     gfx::ShaderProgramBasePtr plainShader;
     gfx::ShaderProgramBasePtr patternShader;
-#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -15,43 +15,18 @@
 #include <mbgl/util/intersection_tests.hpp>
 #include <mbgl/util/containers.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/drawable_builder.hpp>
 #include <mbgl/renderer/layers/circle_layer_tweaker.hpp>
 #include <mbgl/renderer/layer_group.hpp>
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/shaders/circle_layer_ubo.hpp>
 #include <mbgl/shaders/shader_program_base.hpp>
-#endif
 
 namespace mbgl {
 
 using namespace style;
 
 namespace {
-
-#if MLN_LEGACY_RENDERER
-struct RenderableSegment {
-    RenderableSegment(const Segment<CircleAttributes>& segment_,
-                      const RenderTile& tile_,
-                      const LayerRenderData* renderData_,
-                      float sortKey_)
-        : segment(segment_),
-          tile(tile_),
-          renderData(renderData_),
-          sortKey(sortKey_) {}
-
-    const Segment<CircleAttributes>& segment;
-    const RenderTile& tile;
-    const LayerRenderData* renderData;
-    const float sortKey;
-
-    friend bool operator<(const RenderableSegment& lhs, const RenderableSegment& rhs) {
-        if (lhs.sortKey == rhs.sortKey) return lhs.tile.id < rhs.tile.id;
-        return lhs.sortKey < rhs.sortKey;
-    }
-};
-#endif
 
 inline const style::CircleLayer::Impl& impl_cast(const Immutable<style::Layer::Impl>& impl) {
     assert(impl->getTypeInfo() == CircleLayer::Impl::staticTypeInfo());
@@ -89,11 +64,9 @@ void RenderCircleLayer::evaluate(const PropertyEvaluationParameters& parameters)
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 
-#if MLN_DRAWABLE_RENDERER
     if (layerTweaker) {
         layerTweaker->updateProperties(evaluatedProperties);
     }
-#endif // MLN_DRAWABLE_RENDERER
 }
 
 bool RenderCircleLayer::hasTransition() const {
@@ -103,88 +76,6 @@ bool RenderCircleLayer::hasTransition() const {
 bool RenderCircleLayer::hasCrossfade() const {
     return false;
 }
-
-#if MLN_LEGACY_RENDERER
-void RenderCircleLayer::render(PaintParameters& parameters) {
-    assert(renderTiles);
-
-    if (parameters.pass == RenderPass::Opaque) {
-        return;
-    }
-
-    if (!parameters.shaders.getLegacyGroup().populate(circleProgram)) return;
-
-    const auto drawTile = [&](const RenderTile& tile, const LayerRenderData* data, const auto& segments) {
-        auto& circleBucket = static_cast<CircleBucket&>(*data->bucket);
-        const auto& evaluated = getEvaluated<CircleLayerProperties>(data->layerProperties);
-        const bool scaleWithMap = evaluated.template get<CirclePitchScale>() == CirclePitchScaleType::Map;
-        const bool pitchWithMap = evaluated.template get<CirclePitchAlignment>() == AlignmentType::Map;
-        auto& paintPropertyBinders = circleBucket.paintPropertyBinders.at(getID());
-
-        using LayoutUniformValues = CircleProgram::LayoutUniformValues;
-        const auto& allUniformValues = CircleProgram::computeAllUniformValues(
-            LayoutUniformValues(
-                uniforms::matrix::Value(tile.translatedMatrix(evaluated.template get<CircleTranslate>(),
-                                                              evaluated.template get<CircleTranslateAnchor>(),
-                                                              parameters.state)),
-                uniforms::scale_with_map::Value(scaleWithMap),
-                uniforms::extrude_scale::Value(
-                    pitchWithMap ? std::array<float, 2>{{tile.id.pixelsToTileUnits(
-                                                             1.0f, static_cast<float>(parameters.state.getZoom())),
-                                                         tile.id.pixelsToTileUnits(
-                                                             1.0f, static_cast<float>(parameters.state.getZoom()))}}
-                                 : parameters.pixelsToGLUnits),
-                uniforms::device_pixel_ratio::Value(parameters.pixelRatio),
-                uniforms::camera_to_center_distance::Value(parameters.state.getCameraToCenterDistance()),
-                uniforms::pitch_with_map::Value(pitchWithMap)),
-            paintPropertyBinders,
-            evaluated,
-            static_cast<float>(parameters.state.getZoom()));
-        const auto& allAttributeBindings = CircleProgram::computeAllAttributeBindings(
-            *circleBucket.vertexBuffer, paintPropertyBinders, evaluated);
-
-        checkRenderability(parameters, CircleProgram::activeBindingCount(allAttributeBindings));
-
-        circleProgram->draw(parameters.context,
-                            *parameters.renderPass,
-                            gfx::Triangles(),
-                            parameters.depthModeForSublayer(0, gfx::DepthMaskType::ReadOnly),
-                            gfx::StencilMode::disabled(),
-                            parameters.colorModeForRenderPass(),
-                            gfx::CullFaceMode::disabled(),
-                            *circleBucket.indexBuffer,
-                            segments,
-                            allUniformValues,
-                            allAttributeBindings,
-                            CircleProgram::TextureBindings{},
-                            getID());
-    };
-
-    const bool sortFeaturesByKey = !impl_cast(baseImpl).layout.get<CircleSortKey>().isUndefined();
-    std::multiset<RenderableSegment> renderableSegments;
-
-    for (const RenderTile& renderTile : *renderTiles) {
-        const LayerRenderData* renderData = getRenderDataForPass(renderTile, parameters.pass);
-        if (!renderData) {
-            continue;
-        }
-        auto& bucket = static_cast<CircleBucket&>(*renderData->bucket);
-        if (!sortFeaturesByKey) {
-            drawTile(renderTile, renderData, bucket.segments);
-            continue;
-        }
-        for (auto& segment : bucket.segments) {
-            renderableSegments.emplace(segment, renderTile, renderData, segment.sortKey);
-        }
-    }
-
-    if (sortFeaturesByKey) {
-        for (const auto& renderable : renderableSegments) {
-            drawTile(renderable.tile, renderable.renderData, renderable.segment);
-        }
-    }
-}
-#endif // MLN_LEGACY_RENDERER
 
 GeometryCoordinate projectPoint(const GeometryCoordinate& p, const mat4& posMatrix, const Size& size) {
     vec4 pos = {{static_cast<double>(p.x), static_cast<double>(p.y), 0, 1}};
@@ -264,7 +155,6 @@ bool RenderCircleLayer::queryIntersectsFeature(const GeometryCoordinates& queryG
     return false;
 }
 
-#if MLN_DRAWABLE_RENDERER
 namespace {
 
 constexpr auto CircleShaderGroupName = "CircleShader";
@@ -403,6 +293,5 @@ void RenderCircleLayer::update(gfx::ShaderRegistry& shaders,
         }
     }
 }
-#endif
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_circle_layer.hpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.hpp
@@ -6,21 +6,14 @@
 
 namespace mbgl {
 
-#if MLN_LEGACY_RENDERER
-class CircleProgram;
-#endif // MLN_LEGACY_RENDERER
-
-#if MLN_DRAWABLE_RENDERER
 class CircleLayerTweaker;
 using CircleLayerTweakerPtr = std::shared_ptr<CircleLayerTweaker>;
-#endif // MLN_DRAWABLE_RENDERER
 
 class RenderCircleLayer final : public RenderLayer {
 public:
     explicit RenderCircleLayer(Immutable<style::CircleLayer::Impl>);
     ~RenderCircleLayer() final = default;
 
-#if MLN_DRAWABLE_RENDERER
     /// Generate any changes needed by the layer
     void update(gfx::ShaderRegistry&,
                 gfx::Context&,
@@ -28,7 +21,6 @@ public:
                 const std::shared_ptr<UpdateParameters>&,
                 const RenderTree&,
                 UniqueChangeRequestVec&) override;
-#endif
 
 private:
     void transition(const TransitionParameters&) override;
@@ -44,22 +36,11 @@ private:
                                 const mat4&,
                                 const FeatureState&) const override;
 
-#if MLN_LEGACY_RENDERER
-    void render(PaintParameters&) override;
-#endif // MLN_LEGACY_RENDERER
-
 private:
     // Paint properties
     style::CirclePaintProperties::Unevaluated unevaluated;
 
-#if MLN_LEGACY_RENDERER
-    // Programs
-    std::shared_ptr<CircleProgram> circleProgram;
-#endif
-
-#if MLN_DRAWABLE_RENDERER
     gfx::ShaderGroupPtr circleShaderGroup;
-#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_custom_drawable_layer.cpp
+++ b/src/mbgl/renderer/layers/render_custom_drawable_layer.cpp
@@ -9,11 +9,9 @@
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/util/mat4.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/context.hpp>
 #include <mbgl/renderer/layer_group.hpp>
 #include <mbgl/gfx/drawable_builder.hpp>
-#endif
 
 namespace mbgl {
 
@@ -54,11 +52,6 @@ bool RenderCustomDrawableLayer::hasCrossfade() const {
 
 void RenderCustomDrawableLayer::prepare(const LayerPrepareParameters&) {}
 
-#if MLN_LEGACY_RENDERER
-void RenderCustomDrawableLayer::render(PaintParameters&) {}
-#endif
-
-#if MLN_DRAWABLE_RENDERER
 void RenderCustomDrawableLayer::update(gfx::ShaderRegistry& shaders,
                                        gfx::Context& context,
                                        const TransformState& state,
@@ -83,7 +76,5 @@ void RenderCustomDrawableLayer::update(gfx::ShaderRegistry& shaders,
         host->update(interface);
     }
 }
-
-#endif
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_custom_drawable_layer.hpp
+++ b/src/mbgl/renderer/layers/render_custom_drawable_layer.hpp
@@ -10,7 +10,6 @@ public:
     explicit RenderCustomDrawableLayer(Immutable<style::CustomDrawableLayer::Impl>);
     ~RenderCustomDrawableLayer() override;
 
-#if MLN_DRAWABLE_RENDERER
     /// Generate any changes needed by the layer
     void update(gfx::ShaderRegistry&,
                 gfx::Context&,
@@ -18,7 +17,6 @@ public:
                 const std::shared_ptr<UpdateParameters>&,
                 const RenderTree&,
                 UniqueChangeRequestVec&) override;
-#endif
 
 private:
     void transition(const TransitionParameters&) override {}
@@ -26,10 +24,6 @@ private:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     void prepare(const LayerPrepareParameters&) override;
-
-#if MLN_LEGACY_RENDERER
-    void render(PaintParameters&) override;
-#endif
 
     std::shared_ptr<style::CustomDrawableLayerHost> host;
 };

--- a/src/mbgl/renderer/layers/render_custom_layer.hpp
+++ b/src/mbgl/renderer/layers/render_custom_layer.hpp
@@ -10,7 +10,6 @@ public:
     explicit RenderCustomLayer(Immutable<style::CustomLayer::Impl>);
     ~RenderCustomLayer() override;
 
-#if MLN_DRAWABLE_RENDERER
     /// Generate any changes needed by the layer
     void update(gfx::ShaderRegistry&,
                 gfx::Context&,
@@ -18,7 +17,6 @@ public:
                 const std::shared_ptr<UpdateParameters>&,
                 const RenderTree&,
                 UniqueChangeRequestVec&) override;
-#endif
 
 private:
     void transition(const TransitionParameters&) override {}
@@ -27,10 +25,6 @@ private:
     bool hasCrossfade() const override;
     void markContextDestroyed() override;
     void prepare(const LayerPrepareParameters&) override;
-
-#if MLN_LEGACY_RENDERER
-    void render(PaintParameters&) override;
-#endif
 
     bool contextDestroyed = false;
     std::shared_ptr<style::CustomLayerHost> host;

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.cpp
@@ -20,7 +20,6 @@
 #include <mbgl/util/intersection_tests.hpp>
 #include <mbgl/util/math.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/drawable_atlases_tweaker.hpp>
 #include <mbgl/gfx/drawable_builder.hpp>
 #include <mbgl/renderer/layer_group.hpp>
@@ -28,7 +27,6 @@
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/shaders/fill_extrusion_layer_ubo.hpp>
 #include <mbgl/shaders/shader_program_base.hpp>
-#endif // MLN_DRAWABLE_RENDERER
 
 namespace mbgl {
 
@@ -69,11 +67,9 @@ void RenderFillExtrusionLayer::evaluate(const PropertyEvaluationParameters& para
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 
-#if MLN_DRAWABLE_RENDERER
     if (layerTweaker) {
         layerTweaker->updateProperties(evaluatedProperties);
     }
-#endif // MLN_DRAWABLE_RENDERER
 }
 
 bool RenderFillExtrusionLayer::hasTransition() const {
@@ -87,165 +83,6 @@ bool RenderFillExtrusionLayer::hasCrossfade() const {
 bool RenderFillExtrusionLayer::is3D() const {
     return true;
 }
-
-#if MLN_LEGACY_RENDERER
-void RenderFillExtrusionLayer::render(PaintParameters& parameters) {
-    assert(renderTiles);
-    if (parameters.pass != RenderPass::Translucent) {
-        return;
-    }
-
-    if (!parameters.shaders.getLegacyGroup().populate(fillExtrusionProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(fillExtrusionPatternProgram)) return;
-
-    const auto& evaluated = static_cast<const FillExtrusionLayerProperties&>(*evaluatedProperties).evaluated;
-    const auto& crossfade = static_cast<const FillExtrusionLayerProperties&>(*evaluatedProperties).crossfade;
-    if (evaluatedProperties->renderPasses == mbgl::underlying_type(RenderPass::None)) {
-        return;
-    }
-
-    const auto depthMode = parameters.depthModeFor3D();
-
-    auto draw = [&](auto& programInstance,
-                    const auto& evaluated_,
-                    const auto& crossfade_,
-                    const gfx::StencilMode& stencilMode,
-                    const gfx::ColorMode& colorMode,
-                    auto& tileBucket,
-                    const auto& uniformValues,
-                    const std::optional<ImagePosition>& patternPositionA,
-                    const std::optional<ImagePosition>& patternPositionB,
-                    const auto& textureBindings,
-                    const std::string& uniqueName) {
-        auto& paintPropertyBinders = tileBucket.paintPropertyBinders.at(getID());
-        paintPropertyBinders.setPatternParameters(patternPositionA, patternPositionB, crossfade_);
-
-        const auto allUniformValues = programInstance.computeAllUniformValues(
-            uniformValues, paintPropertyBinders, evaluated_, static_cast<float>(parameters.state.getZoom()));
-        const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
-            *tileBucket.vertexBuffer, paintPropertyBinders, evaluated_);
-
-        checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
-
-        programInstance.draw(parameters.context,
-                             *parameters.renderPass,
-                             gfx::Triangles(),
-                             depthMode,
-                             stencilMode,
-                             colorMode,
-                             gfx::CullFaceMode::backCCW(),
-                             *tileBucket.indexBuffer,
-                             tileBucket.triangleSegments,
-                             allUniformValues,
-                             allAttributeBindings,
-                             textureBindings,
-                             getID() + "/" + uniqueName);
-    };
-
-    if (unevaluated.get<FillExtrusionPattern>().isUndefined()) {
-        // Draw solid color extrusions
-        auto drawTiles =
-            [&](const gfx::StencilMode& stencilMode_, const gfx::ColorMode& colorMode_, const std::string& name) {
-                for (const RenderTile& tile : *renderTiles) {
-                    const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
-                    if (!renderData) {
-                        continue;
-                    }
-                    auto& bucket = static_cast<FillExtrusionBucket&>(*renderData->bucket);
-                    draw(*fillExtrusionProgram,
-                         evaluated,
-                         crossfade,
-                         stencilMode_,
-                         colorMode_,
-                         bucket,
-                         FillExtrusionProgram::layoutUniformValues(
-                             tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),
-                                                       evaluated.get<FillExtrusionTranslateAnchor>(),
-                                                       parameters.state),
-                             parameters.state,
-                             evaluated.get<FillExtrusionOpacity>(),
-                             parameters.evaluatedLight,
-                             evaluated.get<FillExtrusionVerticalGradient>()),
-                         {},
-                         {},
-                         FillExtrusionProgram::TextureBindings{},
-                         name);
-                }
-            };
-
-        if (evaluated.get<FillExtrusionOpacity>() == 1) {
-            // Draw opaque extrusions
-            drawTiles(gfx::StencilMode::disabled(), parameters.colorModeForRenderPass(), "color");
-        } else {
-            // Draw transparent buildings in two passes so that only the closest
-            // surface is drawn. First draw all the extrusions into only the
-            // depth buffer. No colors are drawn.
-            drawTiles(gfx::StencilMode::disabled(), gfx::ColorMode::disabled(), "depth");
-
-            // Then draw all the extrusions a second time, only coloring
-            // fragments if they have the same depth value as the closest
-            // fragment in the previous pass. Use the stencil buffer to prevent
-            // the second draw in cases where we have coincident polygons.
-            drawTiles(parameters.stencilModeFor3D(), parameters.colorModeForRenderPass(), "color");
-        }
-    } else {
-        // Draw textured extrusions
-        const auto fillPatternValue = evaluated.get<FillExtrusionPattern>().constantOr(
-            mbgl::Faded<expression::Image>{"", ""});
-        auto drawTiles =
-            [&](const gfx::StencilMode& stencilMode_, const gfx::ColorMode& colorMode_, const std::string& name) {
-                for (const RenderTile& tile : *renderTiles) {
-                    const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
-                    if (!renderData) {
-                        continue;
-                    }
-                    auto& bucket = static_cast<FillExtrusionBucket&>(*renderData->bucket);
-                    const std::optional<ImagePosition> patternPosA = tile.getPattern(fillPatternValue.from.id());
-                    const std::optional<ImagePosition> patternPosB = tile.getPattern(fillPatternValue.to.id());
-                    const auto numTiles = std::pow(2, tile.id.canonical.z);
-                    const auto heightFactor = static_cast<float>(-numTiles / util::tileSize_D / 8.0);
-
-                    draw(*fillExtrusionPatternProgram,
-                         evaluated,
-                         crossfade,
-                         stencilMode_,
-                         colorMode_,
-                         bucket,
-                         FillExtrusionPatternProgram::layoutUniformValues(
-                             tile.translatedClipMatrix(evaluated.get<FillExtrusionTranslate>(),
-                                                       evaluated.get<FillExtrusionTranslateAnchor>(),
-                                                       parameters.state),
-                             tile.getIconAtlasTexture()->getSize(),
-                             crossfade,
-                             tile.id,
-                             parameters.state,
-                             evaluated.get<FillExtrusionOpacity>(),
-                             heightFactor,
-                             parameters.pixelRatio,
-                             parameters.evaluatedLight,
-                             evaluated.get<FillExtrusionVerticalGradient>()),
-                         patternPosA,
-                         patternPosB,
-                         FillExtrusionPatternProgram::TextureBindings{
-                             textures::image::Value{tile.getIconAtlasTextureBinding(gfx::TextureFilterType::Linear)},
-                         },
-                         name);
-                }
-            };
-
-        // Draw transparent buildings in two passes so that only the closest
-        // surface is drawn. First draw all the extrusions into only the depth
-        // buffer. No colors are drawn.
-        drawTiles(gfx::StencilMode::disabled(), gfx::ColorMode::disabled(), "depth");
-
-        // Then draw all the extrusions a second time, only coloring fragments
-        // if they have the same depth value as the closest fragment in the
-        // previous pass. Use the stencil buffer to prevent the second draw in
-        // cases where we have coincident polygons.
-        drawTiles(parameters.stencilModeFor3D(), parameters.colorModeForRenderPass(), "color");
-    }
-}
-#endif // MLN_LEGACY_RENDERER
 
 bool RenderFillExtrusionLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeometry,
                                                       const GeometryTileFeature& feature,
@@ -265,8 +102,6 @@ bool RenderFillExtrusionLayer::queryIntersectsFeature(const GeometryCoordinates&
     return util::polygonIntersectsMultiPolygon(translatedQueryGeometry.value_or(queryGeometry),
                                                feature.getGeometries());
 }
-
-#if MLN_DRAWABLE_RENDERER
 
 void RenderFillExtrusionLayer::update(gfx::ShaderRegistry& shaders,
                                       gfx::Context& context,
@@ -495,7 +330,5 @@ void RenderFillExtrusionLayer::update(gfx::ShaderRegistry& shaders,
         finish(*colorBuilder);
     }
 }
-
-#endif // MLN_DRAWABLE_RENDERER
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_extrusion_layer.hpp
@@ -7,11 +7,6 @@
 
 namespace mbgl {
 
-#if MLN_LEGACY_RENDERER
-class FillExtrusionProgram;
-class FillExtrusionPatternProgram;
-#endif // MLN_LEGACY_RENDERER
-
 class RenderFillExtrusionLayer final : public RenderLayer {
 public:
     explicit RenderFillExtrusionLayer(Immutable<style::FillExtrusionLayer::Impl>);
@@ -24,11 +19,6 @@ private:
     bool hasCrossfade() const override;
     bool is3D() const override;
 
-#if MLN_LEGACY_RENDERER
-    void render(PaintParameters&) override;
-#endif
-
-#if MLN_DRAWABLE_RENDERER
     /// Generate any changes needed by the layer
     void update(gfx::ShaderRegistry&,
                 gfx::Context&,
@@ -36,7 +26,6 @@ private:
                 const std::shared_ptr<UpdateParameters>&,
                 const RenderTree&,
                 UniqueChangeRequestVec&) override;
-#endif // MLN_DRAWABLE_RENDERER
 
     bool queryIntersectsFeature(const GeometryCoordinates&,
                                 const GeometryTileFeature&,
@@ -49,17 +38,8 @@ private:
     // Paint properties
     style::FillExtrusionPaintProperties::Unevaluated unevaluated;
 
-#if MLN_LEGACY_RENDERER
-    // Programs
-    std::shared_ptr<FillExtrusionProgram> fillExtrusionProgram;
-    std::shared_ptr<FillExtrusionPatternProgram> fillExtrusionPatternProgram;
-#endif
-
-#if MLN_DRAWABLE_RENDERER
     gfx::ShaderGroupPtr fillExtrusionGroup;
     gfx::ShaderGroupPtr fillExtrusionPatternGroup;
-#endif // MLN_DRAWABLE_RENDERER
-
     std::unique_ptr<gfx::OffscreenTexture> renderTexture;
 };
 

--- a/src/mbgl/renderer/layers/render_fill_layer.cpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.cpp
@@ -22,7 +22,6 @@
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/std.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/drawable_atlases_tweaker.hpp>
 #include <mbgl/gfx/drawable_builder.hpp>
 #include <mbgl/renderer/layers/fill_layer_tweaker.hpp>
@@ -30,7 +29,6 @@
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/shaders/fill_layer_ubo.hpp>
 #include <mbgl/shaders/shader_program_base.hpp>
-#endif
 
 namespace mbgl {
 
@@ -39,7 +37,6 @@ using namespace shaders;
 
 namespace {
 
-#if MLN_DRAWABLE_RENDERER
 constexpr auto FillShaderName = "FillShader";
 constexpr auto FillOutlineShaderName = "FillOutlineShader";
 constexpr auto FillPatternShaderName = "FillPatternShader";
@@ -47,7 +44,6 @@ constexpr auto FillOutlinePatternShaderName = "FillOutlinePatternShader";
 #if MLN_TRIANGULATE_FILL_OUTLINES
 constexpr auto FillOutlineTriangulatedShaderName = "FillOutlineTriangulatedShader";
 #endif
-#endif // MLN_DRAWABLE_RENDERER
 
 inline const FillLayer::Impl& impl_cast(const Immutable<style::Layer::Impl>& impl) {
     assert(impl->getTypeInfo() == FillLayer::Impl::staticTypeInfo());
@@ -91,11 +87,9 @@ void RenderFillLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 
-#if MLN_DRAWABLE_RENDERER
     if (layerTweaker) {
         layerTweaker->updateProperties(evaluatedProperties);
     }
-#endif
 }
 
 bool RenderFillLayer::hasTransition() const {
@@ -105,176 +99,6 @@ bool RenderFillLayer::hasTransition() const {
 bool RenderFillLayer::hasCrossfade() const {
     return getCrossfade<FillLayerProperties>(evaluatedProperties).t != 1;
 }
-
-#if MLN_LEGACY_RENDERER
-void RenderFillLayer::render(PaintParameters& parameters) {
-    assert(renderTiles);
-
-    if (!parameters.shaders.getLegacyGroup().populate(fillProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(fillPatternProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(fillOutlineProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(fillOutlinePatternProgram)) return;
-
-    if (unevaluated.get<FillPattern>().isUndefined()) {
-        parameters.renderTileClippingMasks(renderTiles);
-        for (const RenderTile& tile : *renderTiles) {
-            const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
-            if (!renderData) {
-                continue;
-            }
-            auto& bucket = static_cast<FillBucket&>(*renderData->bucket);
-            const auto& evaluated = getEvaluated<FillLayerProperties>(renderData->layerProperties);
-
-            auto draw = [&](auto& programInstance,
-                            const auto& drawMode,
-                            const auto& depthMode,
-                            const auto& indexBuffer,
-                            const auto& segments,
-                            auto&& textureBindings) {
-                auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
-
-                const auto allUniformValues = programInstance.computeAllUniformValues(
-                    FillProgram::LayoutUniformValues{
-                        uniforms::matrix::Value(tile.translatedMatrix(
-                            evaluated.get<FillTranslate>(), evaluated.get<FillTranslateAnchor>(), parameters.state)),
-                        uniforms::world::Value(parameters.backend.getDefaultRenderable().getSize()),
-                    },
-                    paintPropertyBinders,
-                    evaluated,
-                    static_cast<float>(parameters.state.getZoom()));
-                const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
-                    *bucket.vertexBuffer, paintPropertyBinders, evaluated);
-
-                checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
-
-                programInstance.draw(parameters.context,
-                                     *parameters.renderPass,
-                                     drawMode,
-                                     depthMode,
-                                     parameters.stencilModeForClipping(tile.id),
-                                     parameters.colorModeForRenderPass(),
-                                     gfx::CullFaceMode::disabled(),
-                                     indexBuffer,
-                                     segments,
-                                     allUniformValues,
-                                     allAttributeBindings,
-                                     std::forward<decltype(textureBindings)>(textureBindings),
-                                     getID());
-            };
-
-            auto fillRenderPass = (evaluated.get<FillColor>().constantOr(Color()).a >= 1.0f &&
-                                   evaluated.get<FillOpacity>().constantOr(0) >= 1.0f &&
-                                   parameters.currentLayer >= parameters.opaquePassCutoff)
-                                      ? RenderPass::Opaque
-                                      : RenderPass::Translucent;
-            if (bucket.triangleIndexBuffer && parameters.pass == fillRenderPass) {
-                draw(*fillProgram,
-                     gfx::Triangles(),
-                     parameters.depthModeForSublayer(1,
-                                                     parameters.pass == RenderPass::Opaque
-                                                         ? gfx::DepthMaskType::ReadWrite
-                                                         : gfx::DepthMaskType::ReadOnly),
-                     *bucket.triangleIndexBuffer,
-                     bucket.triangleSegments,
-                     FillProgram::TextureBindings{});
-            }
-
-            if (evaluated.get<FillAntialias>() && parameters.pass == RenderPass::Translucent) {
-                draw(*fillOutlineProgram,
-                     gfx::Lines{2.0f},
-                     parameters.depthModeForSublayer(unevaluated.get<FillOutlineColor>().isUndefined() ? 2 : 0,
-                                                     gfx::DepthMaskType::ReadOnly),
-                     *bucket.lineIndexBuffer,
-                     bucket.basicLineSegments,
-                     FillOutlineProgram::TextureBindings{});
-            }
-        }
-    } else {
-        if (parameters.pass != RenderPass::Translucent) {
-            return;
-        }
-
-        parameters.renderTileClippingMasks(renderTiles);
-
-        for (const RenderTile& tile : *renderTiles) {
-            const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
-            if (!renderData) {
-                continue;
-            }
-            auto& bucket = static_cast<FillBucket&>(*renderData->bucket);
-            const auto& evaluated = getEvaluated<FillLayerProperties>(renderData->layerProperties);
-            const auto& crossfade = getCrossfade<FillLayerProperties>(renderData->layerProperties);
-
-            const auto& fillPatternValue = evaluated.get<FillPattern>().constantOr(Faded<expression::Image>{"", ""});
-            std::optional<ImagePosition> patternPosA = tile.getPattern(fillPatternValue.from.id());
-            std::optional<ImagePosition> patternPosB = tile.getPattern(fillPatternValue.to.id());
-
-            auto draw = [&](auto& programInstance,
-                            const auto& drawMode,
-                            const auto& depthMode,
-                            const auto& indexBuffer,
-                            const auto& segments,
-                            auto&& textureBindings) {
-                auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
-                paintPropertyBinders.setPatternParameters(patternPosA, patternPosB, crossfade);
-
-                const auto allUniformValues = programInstance.computeAllUniformValues(
-                    FillPatternProgram::layoutUniformValues(
-                        tile.translatedMatrix(
-                            evaluated.get<FillTranslate>(), evaluated.get<FillTranslateAnchor>(), parameters.state),
-                        parameters.backend.getDefaultRenderable().getSize(),
-                        tile.getIconAtlasTexture()->getSize(),
-                        crossfade,
-                        tile.id,
-                        parameters.state,
-                        parameters.pixelRatio),
-                    paintPropertyBinders,
-                    evaluated,
-                    static_cast<float>(parameters.state.getZoom()));
-                const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
-                    *bucket.vertexBuffer, paintPropertyBinders, evaluated);
-
-                checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
-
-                programInstance.draw(parameters.context,
-                                     *parameters.renderPass,
-                                     drawMode,
-                                     depthMode,
-                                     parameters.stencilModeForClipping(tile.id),
-                                     parameters.colorModeForRenderPass(),
-                                     gfx::CullFaceMode::disabled(),
-                                     indexBuffer,
-                                     segments,
-                                     allUniformValues,
-                                     allAttributeBindings,
-                                     std::forward<decltype(textureBindings)>(textureBindings),
-                                     getID());
-            };
-
-            if (bucket.triangleIndexBuffer) {
-                draw(*fillPatternProgram,
-                     gfx::Triangles(),
-                     parameters.depthModeForSublayer(1, gfx::DepthMaskType::ReadWrite),
-                     *bucket.triangleIndexBuffer,
-                     bucket.triangleSegments,
-                     FillPatternProgram::TextureBindings{
-                         tile.getIconAtlasTextureBinding(gfx::TextureFilterType::Linear),
-                     });
-            }
-            if (evaluated.get<FillAntialias>() && unevaluated.get<FillOutlineColor>().isUndefined()) {
-                draw(*fillOutlinePatternProgram,
-                     gfx::Lines{2.0f},
-                     parameters.depthModeForSublayer(2, gfx::DepthMaskType::ReadOnly),
-                     *bucket.lineIndexBuffer,
-                     bucket.basicLineSegments,
-                     FillOutlinePatternProgram::TextureBindings{
-                         tile.getIconAtlasTextureBinding(gfx::TextureFilterType::Linear),
-                     });
-            }
-        }
-    }
-}
-#endif // MLN_LEGACY_RENDERER
 
 bool RenderFillLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeometry,
                                              const GeometryTileFeature& feature,
@@ -293,8 +117,6 @@ bool RenderFillLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeo
     return util::polygonIntersectsMultiPolygon(translatedQueryGeometry.value_or(queryGeometry),
                                                feature.getGeometries());
 }
-
-#if MLN_DRAWABLE_RENDERER
 
 void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
                              gfx::Context& context,
@@ -713,6 +535,5 @@ void RenderFillLayer::update(gfx::ShaderRegistry& shaders,
         }
     }
 }
-#endif
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_fill_layer.hpp
+++ b/src/mbgl/renderer/layers/render_fill_layer.hpp
@@ -16,10 +16,8 @@ class FillPatternProgram;
 class FillOutlineProgram;
 class FillOutlinePatternProgram;
 
-#if MLN_DRAWABLE_RENDERER
 class FillLayerTweaker;
 using FillLayerTweakerPtr = std::shared_ptr<FillLayerTweaker>;
-#endif // MLN_DRAWABLE_RENDERER
 
 class RenderFillLayer final : public RenderLayer {
 public:
@@ -36,7 +34,6 @@ public:
     explicit RenderFillLayer(Immutable<style::FillLayer::Impl>);
     ~RenderFillLayer() override;
 
-#if MLN_DRAWABLE_RENDERER
     /// Generate any changes needed by the layer
     void update(gfx::ShaderRegistry&,
                 gfx::Context&,
@@ -44,17 +41,12 @@ public:
                 const std::shared_ptr<UpdateParameters>&,
                 const RenderTree&,
                 UniqueChangeRequestVec&) override;
-#endif
 
 private:
     void transition(const TransitionParameters&) override;
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
-
-#if MLN_LEGACY_RENDERER
-    void render(PaintParameters&) override;
-#endif
 
     bool queryIntersectsFeature(const GeometryCoordinates&,
                                 const GeometryTileFeature&,
@@ -67,15 +59,6 @@ private:
     // Paint properties
     style::FillPaintProperties::Unevaluated unevaluated;
 
-#if MLN_LEGACY_RENDERER
-    // Programs
-    std::shared_ptr<FillProgram> fillProgram;
-    std::shared_ptr<FillPatternProgram> fillPatternProgram;
-    std::shared_ptr<FillOutlineProgram> fillOutlineProgram;
-    std::shared_ptr<FillOutlinePatternProgram> fillOutlinePatternProgram;
-#endif
-
-#if MLN_DRAWABLE_RENDERER
     gfx::ShaderGroupPtr fillShaderGroup;
     gfx::ShaderGroupPtr outlineShaderGroup;
     gfx::ShaderGroupPtr patternShaderGroup;
@@ -84,8 +67,6 @@ private:
 #if MLN_TRIANGULATE_FILL_OUTLINES
     gfx::ShaderGroupPtr outlineTriangulatedShaderGroup;
 #endif // MLN_TRIANGULATE_FILL_OUTLINES
-
-#endif // MLN_DRAWABLE_RENDERER
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -13,7 +13,6 @@
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/intersection_tests.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/renderer/layers/heatmap_layer_tweaker.hpp>
 #include <mbgl/renderer/layers/heatmap_texture_layer_tweaker.hpp>
 #include <mbgl/renderer/layer_group.hpp>
@@ -24,7 +23,6 @@
 #include <mbgl/gfx/drawable_builder.hpp>
 #include <mbgl/gfx/shader_group.hpp>
 #include <mbgl/gfx/shader_registry.hpp>
-#endif
 
 namespace mbgl {
 
@@ -54,14 +52,12 @@ void RenderHeatmapLayer::transition(const TransitionParameters& parameters) {
     updateColorRamp();
 }
 
-#if MLN_DRAWABLE_RENDERER
 void RenderHeatmapLayer::layerChanged(const TransitionParameters& parameters,
                                       const Immutable<style::Layer::Impl>& impl,
                                       UniqueChangeRequestVec& changes) {
     RenderLayer::layerChanged(parameters, impl, changes);
     textureTweaker.reset();
 }
-#endif
 
 void RenderHeatmapLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     const auto previousProperties = staticImmutableCast<HeatmapLayerProperties>(evaluatedProperties);
@@ -74,14 +70,12 @@ void RenderHeatmapLayer::evaluate(const PropertyEvaluationParameters& parameters
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 
-#if MLN_DRAWABLE_RENDERER
     if (layerTweaker) {
         layerTweaker->updateProperties(evaluatedProperties);
     }
     if (textureTweaker) {
         textureTweaker->updateProperties(evaluatedProperties);
     }
-#endif
 }
 
 bool RenderHeatmapLayer::hasTransition() const {
@@ -91,123 +85,6 @@ bool RenderHeatmapLayer::hasTransition() const {
 bool RenderHeatmapLayer::hasCrossfade() const {
     return false;
 }
-
-#if MLN_LEGACY_RENDERER
-void RenderHeatmapLayer::upload(gfx::UploadPass& uploadPass) {
-    if (!colorRampTexture) {
-        colorRampTexture = uploadPass.createTexture(*colorRamp, gfx::TextureChannelDataType::UnsignedByte);
-    }
-}
-
-void RenderHeatmapLayer::render(PaintParameters& parameters) {
-    assert(renderTiles);
-    if (parameters.pass == RenderPass::Opaque) {
-        return;
-    }
-
-    if (!parameters.shaders.getLegacyGroup().populate(heatmapProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(heatmapTextureProgram)) return;
-
-    if (parameters.pass == RenderPass::Pass3D) {
-        const auto& viewportSize = parameters.staticData.backendSize;
-        const auto size = Size{viewportSize.width / 4, viewportSize.height / 4};
-
-        assert(colorRampTexture);
-
-        if (!renderTexture || renderTexture->getSize() != size) {
-            renderTexture = parameters.context.createOffscreenTexture(size, gfx::TextureChannelDataType::HalfFloat);
-        }
-
-        auto renderPass = parameters.encoder->createRenderPass("heatmap texture",
-                                                               {*renderTexture, Color{0.0f, 0.0f, 0.0f, 1.0f}, {}, {}});
-
-        for (const RenderTile& tile : *renderTiles) {
-            const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
-            if (!renderData) {
-                continue;
-            }
-            auto& bucket = static_cast<HeatmapBucket&>(*renderData->bucket);
-            const auto& evaluated = getEvaluated<HeatmapLayerProperties>(renderData->layerProperties);
-
-            const auto extrudeScale = tile.id.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom()));
-
-            auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
-
-            const auto allUniformValues = HeatmapProgram::computeAllUniformValues(
-                HeatmapProgram::LayoutUniformValues{
-                    uniforms::intensity::Value(evaluated.get<style::HeatmapIntensity>()),
-                    uniforms::matrix::Value(tile.matrix),
-                    uniforms::heatmap::extrude_scale::Value(extrudeScale)},
-                paintPropertyBinders,
-                evaluated,
-                static_cast<float>(parameters.state.getZoom()));
-            const auto allAttributeBindings = HeatmapProgram::computeAllAttributeBindings(
-                *bucket.vertexBuffer, paintPropertyBinders, evaluated);
-
-            checkRenderability(parameters, HeatmapProgram::activeBindingCount(allAttributeBindings));
-
-            heatmapProgram->draw(parameters.context,
-                                 *renderPass,
-                                 gfx::Triangles(),
-                                 gfx::DepthMode::disabled(),
-                                 gfx::StencilMode::disabled(),
-                                 gfx::ColorMode::additive(),
-                                 gfx::CullFaceMode::disabled(),
-                                 *bucket.indexBuffer,
-                                 bucket.segments,
-                                 allUniformValues,
-                                 allAttributeBindings,
-                                 HeatmapProgram::TextureBindings{},
-                                 getID());
-        }
-
-    } else if (parameters.pass == RenderPass::Translucent) {
-        const auto& size = parameters.staticData.backendSize;
-
-        mat4 viewportMat;
-        matrix::ortho(viewportMat, 0, size.width, size.height, 0, 0, 1);
-
-        const Properties<>::PossiblyEvaluated properties;
-        const HeatmapTextureProgram::Binders paintAttributeData{properties, 0};
-
-        const auto allUniformValues = HeatmapTextureProgram::computeAllUniformValues(
-            HeatmapTextureProgram::LayoutUniformValues{
-                uniforms::matrix::Value(viewportMat),
-                uniforms::world::Value(size),
-                uniforms::opacity::Value(
-                    getEvaluated<HeatmapLayerProperties>(evaluatedProperties).get<HeatmapOpacity>())},
-            paintAttributeData,
-            properties,
-            static_cast<float>(parameters.state.getZoom()));
-        const auto allAttributeBindings = HeatmapTextureProgram::computeAllAttributeBindings(
-            *parameters.staticData.heatmapTextureVertexBuffer, paintAttributeData, properties);
-
-        checkRenderability(parameters, HeatmapTextureProgram::activeBindingCount(allAttributeBindings));
-
-        if (segments.empty()) {
-            // Copy over the segments so that we can create our own DrawScopes.
-            segments = RenderStaticData::heatmapTextureSegments();
-        }
-        heatmapTextureProgram->draw(
-            parameters.context,
-            *parameters.renderPass,
-            gfx::Triangles(),
-            gfx::DepthMode::disabled(),
-            gfx::StencilMode::disabled(),
-            parameters.colorModeForRenderPass(),
-            gfx::CullFaceMode::disabled(),
-            *parameters.staticData.quadTriangleIndexBuffer,
-            segments,
-            allUniformValues,
-            allAttributeBindings,
-            HeatmapTextureProgram::TextureBindings{
-                textures::image::Value{renderTexture->getTexture().getResource(), gfx::TextureFilterType::Linear},
-                textures::color_ramp::Value{colorRampTexture->getResource(), gfx::TextureFilterType::Linear},
-            },
-            getID());
-    }
-}
-#endif // MLN_LEGACY_RENDERER
 
 void RenderHeatmapLayer::updateColorRamp() {
     if (colorRamp) {
@@ -236,7 +113,6 @@ bool RenderHeatmapLayer::queryIntersectsFeature(const GeometryCoordinates& query
     return false;
 }
 
-#if MLN_DRAWABLE_RENDERER
 namespace {
 void activateRenderTarget(const RenderTargetPtr& renderTarget_, bool activate, UniqueChangeRequestVec& changes) {
     if (renderTarget_) {
@@ -505,8 +381,9 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
 
     std::shared_ptr<gfx::Texture2D> texture = context.createTexture2D();
     texture->setImage(colorRamp);
-    texture->setSamplerConfiguration(
-        {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+    texture->setSamplerConfiguration({.filter = gfx::TextureFilterType::Linear,
+                                      .wrapU = gfx::TextureWrapType::Clamp,
+                                      .wrapV = gfx::TextureWrapType::Clamp});
     heatmapTextureBuilder->setTexture(std::move(texture), idHeatmapColorRampTexture);
 
     heatmapTextureBuilder->flush(context);
@@ -517,6 +394,5 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
         ++stats.drawablesAdded;
     }
 }
-#endif // MLN_DRAWABLE_RENDERER
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_heatmap_layer.hpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.hpp
@@ -11,19 +11,16 @@
 
 namespace mbgl {
 
-#if MLN_DRAWABLE_RENDERER
 class HeatmapLayerTweaker;
 class HeatmapTextureLayerTweaker;
 using HeatmapLayerTweakerPtr = std::shared_ptr<HeatmapLayerTweaker>;
 using HeatmapTextureLayerTweakerPtr = std::shared_ptr<HeatmapTextureLayerTweaker>;
-#endif // MLN_DRAWABLE_RENDERER
 
 class RenderHeatmapLayer final : public RenderLayer {
 public:
     explicit RenderHeatmapLayer(Immutable<style::HeatmapLayer::Impl>);
     ~RenderHeatmapLayer() override;
 
-#if MLN_DRAWABLE_RENDERER
     void markLayerRenderable(bool willRender, UniqueChangeRequestVec& changes) override;
 
     /// Generate any changes needed by the layer
@@ -33,19 +30,12 @@ public:
                 const std::shared_ptr<UpdateParameters>&,
                 const RenderTree&,
                 UniqueChangeRequestVec&) override;
-#endif
 
 private:
     void transition(const TransitionParameters&) override;
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
-
-#if MLN_LEGACY_RENDERER
-    void upload(gfx::UploadPass&) override;
-    void render(PaintParameters&) override;
-#endif
-
     bool queryIntersectsFeature(const GeometryCoordinates&,
                                 const GeometryTileFeature&,
                                 float,
@@ -55,7 +45,6 @@ private:
                                 const FeatureState&) const override;
     void updateColorRamp();
 
-#if MLN_DRAWABLE_RENDERER
     void layerChanged(const TransitionParameters& parameters,
                       const Immutable<style::Layer::Impl>& impl,
                       UniqueChangeRequestVec& changes) override;
@@ -68,8 +57,6 @@ private:
     /// @return The number of drawables actually removed.
     std::size_t removeAllDrawables() override;
 
-#endif
-
     // Paint properties
     style::HeatmapPaintProperties::Unevaluated unevaluated;
     std::shared_ptr<PremultipliedImage> colorRamp;
@@ -77,13 +64,6 @@ private:
     std::optional<gfx::Texture> colorRampTexture;
     SegmentVector<HeatmapTextureAttributes> segments;
 
-#if MLN_LEGACY_RENDERER
-    // Programs
-    std::shared_ptr<HeatmapProgram> heatmapProgram;
-    std::shared_ptr<HeatmapTextureProgram> heatmapTextureProgram;
-#endif
-
-#if MLN_DRAWABLE_RENDERER
     gfx::ShaderGroupPtr heatmapShaderGroup;
     gfx::ShaderProgramBasePtr heatmapTextureShader;
     RenderTargetPtr renderTarget;
@@ -94,7 +74,6 @@ private:
     // This is the layer tweaker for applying the off-screen texture to the framebuffer.
     // The inherited layer tweaker is for applying tiles to the off-screen texture.
     LayerTweakerPtr textureTweaker;
-#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -13,7 +13,6 @@
 #include <mbgl/math/angles.hpp>
 #include <mbgl/util/geo.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/renderer/layers/hillshade_layer_tweaker.hpp>
 #include <mbgl/renderer/layers/hillshade_prepare_layer_tweaker.hpp>
 #include <mbgl/renderer/layer_group.hpp>
@@ -25,7 +24,6 @@
 #include <mbgl/gfx/hillshade_prepare_drawable_data.hpp>
 #include <mbgl/gfx/shader_group.hpp>
 #include <mbgl/gfx/shader_registry.hpp>
-#endif
 
 namespace mbgl {
 
@@ -68,14 +66,12 @@ void RenderHillshadeLayer::transition(const TransitionParameters& parameters) {
     styleDependencies = unevaluated.getDependencies();
 }
 
-#if MLN_DRAWABLE_RENDERER
 void RenderHillshadeLayer::layerChanged(const TransitionParameters& parameters,
                                         const Immutable<style::Layer::Impl>& impl,
                                         UniqueChangeRequestVec& changes) {
     RenderLayer::layerChanged(parameters, impl, changes);
     prepareLayerTweaker.reset();
 }
-#endif
 
 void RenderHillshadeLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     const auto previousProperties = staticImmutableCast<HillshadeLayerProperties>(evaluatedProperties);
@@ -88,14 +84,12 @@ void RenderHillshadeLayer::evaluate(const PropertyEvaluationParameters& paramete
                  : RenderPass::None;
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
-#if MLN_DRAWABLE_RENDERER
     if (layerTweaker) {
         layerTweaker->updateProperties(evaluatedProperties);
     }
     if (prepareLayerTweaker) {
         prepareLayerTweaker->updateProperties(evaluatedProperties);
     }
-#endif
 }
 
 bool RenderHillshadeLayer::hasTransition() const {
@@ -110,158 +104,9 @@ void RenderHillshadeLayer::prepare(const LayerPrepareParameters& params) {
     renderTiles = params.source->getRenderTiles();
     maxzoom = params.source->getMaxZoom();
 
-#if MLN_DRAWABLE_RENDERER
     updateRenderTileIDs();
-#endif // MLN_DRAWABLE_RENDERER
 }
 
-#if MLN_LEGACY_RENDERER
-void RenderHillshadeLayer::render(PaintParameters& parameters) {
-    assert(renderTiles);
-    if (parameters.pass != RenderPass::Translucent && parameters.pass != RenderPass::Pass3D) return;
-
-    if (!parameters.shaders.getLegacyGroup().populate(hillshadeProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(hillshadePrepareProgram)) return;
-
-    const auto& evaluated = static_cast<const HillshadeLayerProperties&>(*evaluatedProperties).evaluated;
-    auto draw = [&](const mat4& matrix,
-                    const auto& vertexBuffer,
-                    const auto& indexBuffer,
-                    const auto& segments,
-                    const UnwrappedTileID& id,
-                    const auto& textureBindings) {
-        const HillshadeProgram::Binders paintAttributeData{evaluated, 0};
-
-        const auto allUniformValues = HillshadeProgram::computeAllUniformValues(
-            HillshadeProgram::LayoutUniformValues{
-                uniforms::matrix::Value(matrix),
-                uniforms::highlight::Value(evaluated.get<HillshadeHighlightColor>()),
-                uniforms::shadow::Value(evaluated.get<HillshadeShadowColor>()),
-                uniforms::accent::Value(evaluated.get<HillshadeAccentColor>()),
-                uniforms::light::Value(getLight(parameters)),
-                uniforms::latrange::Value(getLatRange(id)),
-            },
-            paintAttributeData,
-            evaluated,
-            static_cast<float>(parameters.state.getZoom()));
-        const auto allAttributeBindings = HillshadeProgram::computeAllAttributeBindings(
-            vertexBuffer, paintAttributeData, evaluated);
-
-        checkRenderability(parameters, HillshadeProgram::activeBindingCount(allAttributeBindings));
-
-        hillshadeProgram->draw(parameters.context,
-                               *parameters.renderPass,
-                               gfx::Triangles(),
-                               parameters.depthModeForSublayer(0, gfx::DepthMaskType::ReadOnly),
-                               gfx::StencilMode::disabled(),
-                               parameters.colorModeForRenderPass(),
-                               gfx::CullFaceMode::disabled(),
-                               indexBuffer,
-                               segments,
-                               allUniformValues,
-                               allAttributeBindings,
-                               textureBindings,
-                               getID());
-    };
-
-    mat4 mat;
-    matrix::ortho(mat, 0, util::EXTENT, -util::EXTENT, 0, 0, 1);
-    matrix::translate(mat, mat, 0, -util::EXTENT, 0);
-
-    for (const RenderTile& tile : *renderTiles) {
-        auto* bucket_ = tile.getBucket(*baseImpl);
-        if (!bucket_) {
-            continue;
-        }
-        auto& bucket = static_cast<HillshadeBucket&>(*bucket_);
-
-        if (!bucket.hasData()) {
-            continue;
-        }
-
-        if (!bucket.isPrepared() && parameters.pass == RenderPass::Pass3D) {
-            assert(bucket.dem);
-            const uint16_t stride = bucket.getDEMData().stride;
-            const uint16_t tilesize = bucket.getDEMData().dim;
-            auto view = parameters.context.createOffscreenTexture({tilesize, tilesize},
-                                                                  gfx::TextureChannelDataType::UnsignedByte);
-
-            auto renderPass = parameters.encoder->createRenderPass("hillshade prepare",
-                                                                   {*view, Color{0.0f, 0.0f, 0.0f, 0.0f}, {}, {}});
-
-            const Properties<>::PossiblyEvaluated properties;
-            const HillshadePrepareProgram::Binders paintAttributeData{properties, 0};
-
-            const auto allUniformValues = HillshadePrepareProgram::computeAllUniformValues(
-                HillshadePrepareProgram::LayoutUniformValues{
-                    uniforms::matrix::Value(mat),
-                    uniforms::dimension::Value({{stride, stride}}),
-                    uniforms::zoom::Value(static_cast<float>(tile.id.canonical.z)),
-                    uniforms::maxzoom::Value(static_cast<float>(maxzoom)),
-                    uniforms::unpack::Value(bucket.getDEMData().getUnpackVector()),
-                },
-                paintAttributeData,
-                properties,
-                static_cast<float>(parameters.state.getZoom()));
-            const auto allAttributeBindings = HillshadePrepareProgram::computeAllAttributeBindings(
-                *parameters.staticData.rasterVertexBuffer, paintAttributeData, properties);
-
-            checkRenderability(parameters, HillshadePrepareProgram::activeBindingCount(allAttributeBindings));
-
-            // Copy over the segments so that we can create our own DrawScopes
-            // that get destroyed after this draw call.
-            auto segments = RenderStaticData::rasterSegments();
-            hillshadePrepareProgram->draw(parameters.context,
-                                          *renderPass,
-                                          gfx::Triangles(),
-                                          parameters.depthModeForSublayer(0, gfx::DepthMaskType::ReadOnly),
-                                          gfx::StencilMode::disabled(),
-                                          parameters.colorModeForRenderPass(),
-                                          gfx::CullFaceMode::disabled(),
-                                          *parameters.staticData.quadTriangleIndexBuffer,
-                                          segments,
-                                          allUniformValues,
-                                          allAttributeBindings,
-                                          HillshadePrepareProgram::TextureBindings{
-                                              textures::image::Value{bucket.dem->getResource()},
-                                          },
-                                          "prepare");
-            bucket.texture = std::move(view->getTexture());
-            bucket.setPrepared(true);
-        } else if (parameters.pass == RenderPass::Translucent) {
-            assert(bucket.texture);
-
-            if (bucket.vertexBuffer && bucket.indexBuffer) {
-                // Draw only the parts of the tile that aren't drawn by another tile in the layer.
-                draw(parameters.matrixForTile(tile.id, true),
-                     *bucket.vertexBuffer,
-                     *bucket.indexBuffer,
-                     bucket.segments,
-                     tile.id,
-                     HillshadeProgram::TextureBindings{
-                         textures::image::Value{bucket.texture->getResource(), gfx::TextureFilterType::Linear},
-                     });
-            } else {
-                // Draw the full tile.
-                if (bucket.segments.empty()) {
-                    // Copy over the segments so that we can create our own DrawScopes.
-                    bucket.segments = RenderStaticData::rasterSegments();
-                }
-                draw(parameters.matrixForTile(tile.id, true),
-                     *parameters.staticData.rasterVertexBuffer,
-                     *parameters.staticData.quadTriangleIndexBuffer,
-                     bucket.segments,
-                     tile.id,
-                     HillshadeProgram::TextureBindings{
-                         textures::image::Value{bucket.texture->getResource(), gfx::TextureFilterType::Linear},
-                     });
-            }
-        }
-    }
-}
-#endif // MLN_LEGACY_RENDERER
-
-#if MLN_DRAWABLE_RENDERER
 namespace {
 void activateRenderTarget(const RenderTargetPtr& renderTarget_, bool activate, UniqueChangeRequestVec& changes) {
     if (renderTarget_) {
@@ -434,8 +279,9 @@ void RenderHillshadeLayer::update(gfx::ShaderRegistry& shaders,
 
             std::shared_ptr<gfx::Texture2D> texture = context.createTexture2D();
             texture->setImage(bucket.getDEMData().getImagePtr());
-            texture->setSamplerConfiguration(
-                {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+            texture->setSamplerConfiguration({.filter = gfx::TextureFilterType::Linear,
+                                              .wrapU = gfx::TextureWrapType::Clamp,
+                                              .wrapV = gfx::TextureWrapType::Clamp});
             hillshadePrepareBuilder->setTexture(texture, idHillshadeImageTexture);
 
             hillshadePrepareBuilder->flush(context);
@@ -533,6 +379,5 @@ void RenderHillshadeLayer::update(gfx::ShaderRegistry& shaders,
         }
     }
 }
-#endif // MLN_DRAWABLE_RENDERER
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_hillshade_layer.hpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.hpp
@@ -9,17 +9,14 @@
 
 namespace mbgl {
 
-#if MLN_DRAWABLE_RENDERER
 class HillshadeLayerTweaker;
 using HillshadeLayerTweakerPtr = std::shared_ptr<HillshadeLayerTweaker>;
-#endif // MLN_DRAWABLE_RENDERER
 
 class RenderHillshadeLayer : public RenderLayer {
 public:
     explicit RenderHillshadeLayer(Immutable<style::HillshadeLayer::Impl>);
     ~RenderHillshadeLayer() override;
 
-#if MLN_DRAWABLE_RENDERER
     void markLayerRenderable(bool willRender, UniqueChangeRequestVec& changes) override;
 
     void layerRemoved(UniqueChangeRequestVec&) override;
@@ -31,7 +28,6 @@ public:
                 const std::shared_ptr<UpdateParameters>&,
                 const RenderTree&,
                 UniqueChangeRequestVec&) override;
-#endif
 
 private:
     void transition(const TransitionParameters&) override;
@@ -39,25 +35,16 @@ private:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
 
-#if MLN_LEGACY_RENDERER
-    void render(PaintParameters&) override;
-#endif
-
-#if MLN_DRAWABLE_RENDERER
     void updateLayerTweaker();
 
     void layerChanged(const TransitionParameters& parameters,
                       const Immutable<style::Layer::Impl>& impl,
                       UniqueChangeRequestVec& changes) override;
 
-#endif // MLN_DRAWABLE_RENDERER
-
     void prepare(const LayerPrepareParameters&) override;
 
-#if MLN_DRAWABLE_RENDERER
     void addRenderTarget(const RenderTargetPtr&, UniqueChangeRequestVec&);
     void removeRenderTargets(UniqueChangeRequestVec&);
-#endif
 
     // Paint properties
     style::HillshadePaintProperties::Unevaluated unevaluated;
@@ -66,13 +53,6 @@ private:
     std::array<float, 2> getLatRange(const UnwrappedTileID& id);
     std::array<float, 2> getLight(const PaintParameters& parameters);
 
-#if MLN_LEGACY_RENDERER
-    // Programs
-    std::shared_ptr<HillshadeProgram> hillshadeProgram;
-    std::shared_ptr<HillshadePrepareProgram> hillshadePrepareProgram;
-#endif
-
-#if MLN_DRAWABLE_RENDERER
     gfx::ShaderProgramBasePtr hillshadePrepareShader;
     gfx::ShaderProgramBasePtr hillshadeShader;
     std::vector<RenderTargetPtr> activatedRenderTargets;
@@ -81,7 +61,6 @@ private:
     std::shared_ptr<HillshadeVertexVector> staticDataSharedVertices;
 
     LayerTweakerPtr prepareLayerTweaker;
-#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_line_layer.cpp
+++ b/src/mbgl/renderer/layers/render_line_layer.cpp
@@ -21,7 +21,6 @@
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/math.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/drawable_atlases_tweaker.hpp>
 #include <mbgl/gfx/drawable_builder.hpp>
 #include <mbgl/gfx/line_drawable_data.hpp>
@@ -30,7 +29,6 @@
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/shaders/line_layer_ubo.hpp>
 #include <mbgl/shaders/shader_program_base.hpp>
-#endif
 
 namespace mbgl {
 
@@ -44,11 +42,7 @@ inline const LineLayer::Impl& impl_cast(const Immutable<style::Layer::Impl>& imp
     return static_cast<const LineLayer::Impl&>(*impl);
 }
 
-#if MLN_DRAWABLE_RENDERER
-
 const auto posNormalAttribName = "a_pos_normal";
-
-#endif // MLN_DRAWABLE_RENDERER
 
 } // namespace
 
@@ -88,14 +82,12 @@ void RenderLineLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 
-#if MLN_DRAWABLE_RENDERER
     if (auto* tweaker = static_cast<LineLayerTweaker*>(layerTweaker.get())) {
         tweaker->updateProperties(evaluatedProperties);
 #if MLN_RENDER_BACKEND_METAL
         tweaker->updateGPUExpressions(unevaluated, parameters.now);
 #endif // MLN_RENDER_BACKEND_METAL
     }
-#endif
 }
 
 bool RenderLineLayer::hasTransition() const {
@@ -123,134 +115,6 @@ void RenderLineLayer::prepare(const LayerPrepareParameters& params) {
             evaluated.get<LineDasharray>().from, evaluated.get<LineDasharray>().to, cap);
     }
 }
-
-#if MLN_LEGACY_RENDERER
-void RenderLineLayer::upload(gfx::UploadPass& uploadPass) {
-    if (!unevaluated.get<LineGradient>().getValue().isUndefined() && !colorRampTexture) {
-        colorRampTexture = uploadPass.createTexture(*colorRamp);
-    }
-}
-
-void RenderLineLayer::render(PaintParameters& parameters) {
-    assert(renderTiles);
-    if (parameters.pass == RenderPass::Opaque) {
-        return;
-    }
-
-    if (!parameters.shaders.getLegacyGroup().populate(lineProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(lineGradientProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(lineSDFProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(linePatternProgram)) return;
-
-    parameters.renderTileClippingMasks(renderTiles);
-
-    for (const RenderTile& tile : *renderTiles) {
-        const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
-        if (!renderData) {
-            continue;
-        }
-        auto& bucket = static_cast<LineBucket&>(*renderData->bucket);
-        const auto& evaluated = getEvaluated<LineLayerProperties>(renderData->layerProperties);
-        const auto& crossfade = getCrossfade<LineLayerProperties>(renderData->layerProperties);
-
-        auto draw = [&](auto& programInstance,
-                        auto&& uniformValues,
-                        const std::optional<ImagePosition>& patternPositionA,
-                        const std::optional<ImagePosition>& patternPositionB,
-                        auto&& textureBindings) {
-            auto& paintPropertyBinders = bucket.paintPropertyBinders.at(getID());
-
-            paintPropertyBinders.setPatternParameters(patternPositionA, patternPositionB, crossfade);
-
-            const auto allUniformValues = programInstance.computeAllUniformValues(
-                std::forward<decltype(uniformValues)>(uniformValues),
-                paintPropertyBinders,
-                evaluated,
-                static_cast<float>(parameters.state.getZoom()));
-            const auto allAttributeBindings = programInstance.computeAllAttributeBindings(
-                *bucket.vertexBuffer, paintPropertyBinders, evaluated);
-
-            checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
-
-            programInstance.draw(parameters.context,
-                                 *parameters.renderPass,
-                                 gfx::Triangles(),
-                                 parameters.depthModeForSublayer(0, gfx::DepthMaskType::ReadOnly),
-                                 parameters.stencilModeForClipping(tile.id),
-                                 parameters.colorModeForRenderPass(),
-                                 gfx::CullFaceMode::disabled(),
-                                 *bucket.indexBuffer,
-                                 bucket.segments,
-                                 allUniformValues,
-                                 allAttributeBindings,
-                                 std::forward<decltype(textureBindings)>(textureBindings),
-                                 getID());
-        };
-
-        if (!evaluated.get<LineDasharray>().from.empty()) {
-            const LinePatternCap cap = bucket.layout.get<LineCap>() == LineCapType::Round ? LinePatternCap::Round
-                                                                                          : LinePatternCap::Square;
-            const auto& dashPatternTexture = parameters.lineAtlas.getDashPatternTexture(
-                evaluated.get<LineDasharray>().from, evaluated.get<LineDasharray>().to, cap);
-
-            draw(*lineSDFProgram,
-                 LineSDFProgram::layoutUniformValues(evaluated,
-                                                     parameters.pixelRatio,
-                                                     tile,
-                                                     parameters.state,
-                                                     parameters.pixelsToGLUnits,
-                                                     dashPatternTexture.getFrom(),
-                                                     dashPatternTexture.getTo(),
-                                                     crossfade,
-                                                     static_cast<float>(dashPatternTexture.getSize().width)),
-                 {},
-                 {},
-                 LineSDFProgram::TextureBindings{
-                     dashPatternTexture.textureBinding(),
-                 });
-
-        } else if (!unevaluated.get<LinePattern>().isUndefined()) {
-            const auto& linePatternValue = evaluated.get<LinePattern>().constantOr(Faded<expression::Image>{"", ""});
-            const Size& texsize = tile.getIconAtlasTexture()->getSize();
-
-            std::optional<ImagePosition> posA = tile.getPattern(linePatternValue.from.id());
-            std::optional<ImagePosition> posB = tile.getPattern(linePatternValue.to.id());
-
-            draw(*linePatternProgram,
-                 LinePatternProgram::layoutUniformValues(evaluated,
-                                                         tile,
-                                                         parameters.state,
-                                                         parameters.pixelsToGLUnits,
-                                                         parameters.pixelRatio,
-                                                         texsize,
-                                                         crossfade),
-                 posA,
-                 posB,
-                 LinePatternProgram::TextureBindings{
-                     tile.getIconAtlasTextureBinding(gfx::TextureFilterType::Linear),
-                 });
-        } else if (!unevaluated.get<LineGradient>().getValue().isUndefined()) {
-            assert(colorRampTexture);
-
-            draw(*lineGradientProgram,
-                 LineGradientProgram::layoutUniformValues(
-                     evaluated, tile, parameters.state, parameters.pixelsToGLUnits, parameters.pixelRatio),
-                 {},
-                 {},
-                 LineGradientProgram::TextureBindings{
-                     textures::image::Value{colorRampTexture->getResource(), gfx::TextureFilterType::Linear},
-                 });
-        } else {
-            draw(*lineProgram,
-                 LineProgram::layoutUniformValues(
-                     evaluated, tile, parameters.state, parameters.pixelsToGLUnits, parameters.pixelRatio),
-                 {},
-                 {},
-                 LineProgram::TextureBindings{});
-        }
-    }
-}
-#endif // MLN_LEGACY_RENDERER
 
 namespace {
 
@@ -327,7 +191,6 @@ void RenderLineLayer::updateColorRamp() {
 
     colorRampTexture = std::nullopt;
 
-#if MLN_DRAWABLE_RENDERER
     if (colorRampTexture2D) {
         colorRampTexture2D.reset();
 
@@ -337,7 +200,6 @@ void RenderLineLayer::updateColorRamp() {
             layerGroup->clearDrawables();
         }
     }
-#endif
 }
 
 float RenderLineLayer::getLineWidth(const GeometryTileFeature& feature,
@@ -355,7 +217,6 @@ float RenderLineLayer::getLineWidth(const GeometryTileFeature& feature,
     }
 }
 
-#if MLN_DRAWABLE_RENDERER
 namespace {
 
 inline void setSegments(std::unique_ptr<gfx::DrawableBuilder>& builder, const LineBucket& bucket) {
@@ -603,8 +464,9 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
                 // create texture. to be reused for all the tiles of the layer
                 colorRampTexture2D = context.createTexture2D();
                 colorRampTexture2D->setImage(colorRamp);
-                colorRampTexture2D->setSamplerConfiguration(
-                    {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+                colorRampTexture2D->setSamplerConfiguration({.filter = gfx::TextureFilterType::Linear,
+                                                             .wrapU = gfx::TextureWrapType::Clamp,
+                                                             .wrapV = gfx::TextureWrapType::Clamp});
             }
 
             if (colorRampTexture2D) {
@@ -644,6 +506,5 @@ void RenderLineLayer::update(gfx::ShaderRegistry& shaders,
         }
     }
 }
-#endif
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_line_layer.hpp
+++ b/src/mbgl/renderer/layers/render_line_layer.hpp
@@ -13,14 +13,6 @@
 
 namespace mbgl {
 
-#if MLN_LEGACY_RENDERER
-class LineProgram;
-class LineGradientProgram;
-class LineSDFProgram;
-class LinePatternProgram;
-#endif
-
-#if MLN_DRAWABLE_RENDERER
 namespace gfx {
 class ShaderGroup;
 class UniformBuffer;
@@ -30,14 +22,12 @@ using UniformBufferPtr = std::shared_ptr<UniformBuffer>;
 
 class LineLayerTweaker;
 using LineLayerTweakerPtr = std::shared_ptr<LineLayerTweaker>;
-#endif
 
 class RenderLineLayer final : public RenderLayer {
 public:
     explicit RenderLineLayer(Immutable<style::LineLayer::Impl>);
     ~RenderLineLayer() override;
 
-#if MLN_DRAWABLE_RENDERER
     /// Generate any changes needed by the layer
     void update(gfx::ShaderRegistry&,
                 gfx::Context&,
@@ -45,7 +35,6 @@ public:
                 const std::shared_ptr<UpdateParameters>&,
                 const RenderTree&,
                 UniqueChangeRequestVec&) override;
-#endif
 
 private:
     void transition(const TransitionParameters&) override;
@@ -53,11 +42,6 @@ private:
     bool hasTransition() const override;
     bool hasCrossfade() const override;
     void prepare(const LayerPrepareParameters&) override;
-
-#if MLN_LEGACY_RENDERER
-    void upload(gfx::UploadPass&) override;
-    void render(PaintParameters&) override;
-#endif
 
     bool queryIntersectsFeature(const GeometryCoordinates&,
                                 const GeometryTileFeature&,
@@ -76,23 +60,12 @@ private:
     std::shared_ptr<PremultipliedImage> colorRamp;
     std::optional<gfx::Texture> colorRampTexture;
 
-#if MLN_DRAWABLE_RENDERER
     gfx::Texture2DPtr colorRampTexture2D;
-#endif
 
-#if MLN_LEGACY_RENDERER
-    // Programs
-    std::shared_ptr<LineProgram> lineProgram;
-    std::shared_ptr<LineGradientProgram> lineGradientProgram;
-    std::shared_ptr<LineSDFProgram> lineSDFProgram;
-    std::shared_ptr<LinePatternProgram> linePatternProgram;
-#endif
-#if MLN_DRAWABLE_RENDERER
     gfx::ShaderGroupPtr lineShaderGroup;
     gfx::ShaderGroupPtr lineGradientShaderGroup;
     gfx::ShaderGroupPtr lineSDFShaderGroup;
     gfx::ShaderGroupPtr linePatternShaderGroup;
-#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_raster_layer.cpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.cpp
@@ -13,7 +13,6 @@
 #include <mbgl/style/layers/raster_layer_impl.hpp>
 #include <mbgl/util/logging.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/renderer/layers/raster_layer_tweaker.hpp>
 #include <mbgl/gfx/image_drawable_data.hpp>
 #include <mbgl/gfx/drawable_impl.hpp>
@@ -21,7 +20,6 @@
 #include <mbgl/renderer/layer_group.hpp>
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/shaders/shader_program_base.hpp>
-#endif
 
 namespace mbgl {
 
@@ -60,11 +58,9 @@ void RenderRasterLayer::evaluate(const PropertyEvaluationParameters& parameters)
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 
-#if MLN_DRAWABLE_RENDERER
     if (layerTweaker) {
         layerTweaker->updateProperties(evaluatedProperties);
     }
-#endif
 }
 
 bool RenderRasterLayer::hasTransition() const {
@@ -75,163 +71,15 @@ bool RenderRasterLayer::hasCrossfade() const {
     return false;
 }
 
-#if MLN_LEGACY_RENDERER
-static float saturationFactor(float saturation) {
-    if (saturation > 0) {
-        return 1.f - 1.f / (1.001f - saturation);
-    } else {
-        return -saturation;
-    }
-}
-
-static float contrastFactor(float contrast) {
-    if (contrast > 0) {
-        return 1 / (1 - contrast);
-    } else {
-        return 1 + contrast;
-    }
-}
-
-static std::array<float, 3> spinWeights(float spin) {
-    spin = util::deg2radf(spin);
-    float s = std::sin(spin);
-    float c = std::cos(spin);
-    std::array<float, 3> spin_weights = {
-        {(2 * c + 1) / 3, (-std::sqrt(3.0f) * s - c + 1) / 3, (std::sqrt(3.0f) * s - c + 1) / 3}};
-    return spin_weights;
-}
-#endif
-
 void RenderRasterLayer::prepare(const LayerPrepareParameters& params) {
     renderTiles = params.source->getRenderTiles();
     imageData = params.source->getImageRenderData();
     // It is possible image data is not available until the source loads it.
     assert(renderTiles || imageData || !params.source->isEnabled());
 
-#if MLN_DRAWABLE_RENDERER
     updateRenderTileIDs();
-#endif // MLN_DRAWABLE_RENDERER
 }
 
-#if MLN_LEGACY_RENDERER
-void RenderRasterLayer::render(PaintParameters& parameters) {
-    if (parameters.pass != RenderPass::Translucent || (!renderTiles && !imageData)) {
-        return;
-    }
-
-    if (!parameters.shaders.getLegacyGroup().populate(rasterProgram)) return;
-
-    const auto& evaluated = static_cast<const RasterLayerProperties&>(*evaluatedProperties).evaluated;
-    RasterProgram::Binders paintAttributeData{evaluated, 0};
-
-    auto draw = [&](const mat4& matrix,
-                    const auto& vertexBuffer,
-                    const auto& indexBuffer,
-                    const auto& segments,
-                    const auto& textureBindings,
-                    const std::string& drawScopeID) {
-        const auto allUniformValues = RasterProgram::computeAllUniformValues(
-            RasterProgram::LayoutUniformValues{
-                uniforms::matrix::Value(matrix),
-                uniforms::opacity::Value(evaluated.get<RasterOpacity>()),
-                uniforms::fade_t::Value(1),
-                uniforms::brightness_low::Value(evaluated.get<RasterBrightnessMin>()),
-                uniforms::brightness_high::Value(evaluated.get<RasterBrightnessMax>()),
-                uniforms::saturation_factor::Value(saturationFactor(evaluated.get<RasterSaturation>())),
-                uniforms::contrast_factor::Value(contrastFactor(evaluated.get<RasterContrast>())),
-                uniforms::spin_weights::Value(spinWeights(evaluated.get<RasterHueRotate>())),
-                uniforms::buffer_scale::Value(1.0f),
-                uniforms::scale_parent::Value(1.0f),
-                uniforms::tl_parent::Value(std::array<float, 2>{{0.0f, 0.0f}}),
-            },
-            paintAttributeData,
-            evaluated,
-            static_cast<float>(parameters.state.getZoom()));
-        const auto allAttributeBindings = RasterProgram::computeAllAttributeBindings(
-            vertexBuffer, paintAttributeData, evaluated);
-
-        checkRenderability(parameters, RasterProgram::activeBindingCount(allAttributeBindings));
-
-        rasterProgram->draw(parameters.context,
-                            *parameters.renderPass,
-                            gfx::Triangles(),
-                            parameters.depthModeForSublayer(0, gfx::DepthMaskType::ReadOnly),
-                            gfx::StencilMode::disabled(),
-                            parameters.colorModeForRenderPass(),
-                            gfx::CullFaceMode::disabled(),
-                            indexBuffer,
-                            segments,
-                            allUniformValues,
-                            allAttributeBindings,
-                            textureBindings,
-                            getID() + "/" + drawScopeID);
-    };
-
-    const gfx::TextureFilterType filter = evaluated.get<RasterResampling>() == RasterResamplingType::Nearest
-                                              ? gfx::TextureFilterType::Nearest
-                                              : gfx::TextureFilterType::Linear;
-
-    if (imageData && !imageData->bucket->needsUpload()) {
-        RasterBucket& bucket = *imageData->bucket;
-        assert(bucket.texture);
-
-        size_t i = 0;
-        for (const auto& matrix_ : imageData->matrices) {
-            draw(matrix_,
-                 *bucket.vertexBuffer,
-                 *bucket.indexBuffer,
-                 bucket.segments,
-                 RasterProgram::TextureBindings{
-                     textures::image0::Value{bucket.texture->getResource(), filter},
-                     textures::image1::Value{bucket.texture->getResource(), filter},
-                 },
-                 std::to_string(i++));
-        }
-    } else if (renderTiles) {
-        for (const RenderTile& tile : *renderTiles) {
-            auto* bucket_ = tile.getBucket(*baseImpl);
-            if (!bucket_) {
-                continue;
-            }
-            auto& bucket = static_cast<RasterBucket&>(*bucket_);
-
-            if (!bucket.hasData()) continue;
-
-            assert(bucket.texture);
-            if (bucket.vertexBuffer && bucket.indexBuffer) {
-                // Draw only the parts of the tile that aren't drawn by another tile in the layer.
-                draw(parameters.matrixForTile(tile.id, !parameters.state.isChanging()),
-                     *bucket.vertexBuffer,
-                     *bucket.indexBuffer,
-                     bucket.segments,
-                     RasterProgram::TextureBindings{
-                         textures::image0::Value{bucket.texture->getResource(), filter},
-                         textures::image1::Value{bucket.texture->getResource(), filter},
-                     },
-                     "image");
-            } else {
-                // Draw the full tile.
-                if (bucket.segments.empty()) {
-                    // Copy over the segments so that we can create our own DrawScopes.
-                    bucket.segments = RenderStaticData::rasterSegments();
-                }
-                draw(parameters.matrixForTile(tile.id, !parameters.state.isChanging()),
-                     *parameters.staticData.rasterVertexBuffer,
-                     *parameters.staticData.quadTriangleIndexBuffer,
-                     bucket.segments,
-                     RasterProgram::TextureBindings{
-                         textures::image0::Value{bucket.texture->getResource(), filter},
-                         textures::image1::Value{bucket.texture->getResource(), filter},
-                     },
-                     "image");
-            }
-        }
-    }
-}
-
-#endif // MLN_LEGACY_RENDERER
-
-#if MLN_DRAWABLE_RENDERER
 void RenderRasterLayer::markLayerRenderable(bool willRender, UniqueChangeRequestVec& changes) {
     RenderLayer::markLayerRenderable(willRender, changes);
     if (imageLayerGroup) {
@@ -324,7 +172,7 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
                 const auto filter = nearest ? gfx::TextureFilterType::Nearest : gfx::TextureFilterType::Linear;
 
                 bucket.texture2d->setSamplerConfiguration(
-                    {filter, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+                    {.filter = filter, .wrapU = gfx::TextureWrapType::Clamp, .wrapV = gfx::TextureWrapType::Clamp});
 
                 builder->setTexture(bucket.texture2d, idRasterImage0Texture);
                 builder->setTexture(bucket.texture2d, idRasterImage1Texture);
@@ -520,6 +368,5 @@ void RenderRasterLayer::update(gfx::ShaderRegistry& shaders,
         }
     }
 }
-#endif // MLN_DRAWABLE_RENDERER
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_raster_layer.hpp
+++ b/src/mbgl/renderer/layers/render_raster_layer.hpp
@@ -16,7 +16,6 @@ public:
     explicit RenderRasterLayer(Immutable<style::RasterLayer::Impl>);
     ~RenderRasterLayer() override;
 
-#if MLN_DRAWABLE_RENDERER
     /// Generate any changes needed by the layer
     void update(gfx::ShaderRegistry&,
                 gfx::Context&,
@@ -24,10 +23,8 @@ public:
                 const std::shared_ptr<UpdateParameters>&,
                 const RenderTree&,
                 UniqueChangeRequestVec&) override;
-#endif
 
 protected:
-#if MLN_DRAWABLE_RENDERER
     /// @brief Called by the RenderOrchestrator during RenderTree construction.
     /// This event is run to indicate if the layer should render or not for the current frame.
     /// @param willRender Indicates if this layer should render or not
@@ -42,7 +39,6 @@ protected:
 
     /// Called when the style layer is removed
     void layerRemoved(UniqueChangeRequestVec&) override;
-#endif // MLN_DRAWABLE_RENDERER
 
 private:
     void transition(const TransitionParameters&) override;
@@ -51,20 +47,10 @@ private:
     bool hasCrossfade() const override;
     void prepare(const LayerPrepareParameters&) override;
 
-#if MLN_LEGACY_RENDERER
-    void render(PaintParameters&) override;
-#endif
-
     // Paint properties
     style::RasterPaintProperties::Unevaluated unevaluated;
     const ImageSourceRenderData* imageData = nullptr;
 
-#if MLN_LEGACY_RENDERER
-    // Programs
-    std::shared_ptr<RasterProgram> rasterProgram;
-#endif
-
-#if MLN_DRAWABLE_RENDERER
     gfx::ShaderProgramBasePtr rasterShader;
     LayerGroupPtr imageLayerGroup;
 
@@ -79,7 +65,6 @@ private:
     using RasterSegmentVector = SegmentVector<RasterAttributes>;
     using RasterSegmentVectorPtr = std::shared_ptr<RasterSegmentVector>;
     std::shared_ptr<RasterSegmentVector> staticDataSegments;
-#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -22,7 +22,6 @@
 #include <mbgl/util/convert.hpp>
 #include <mbgl/util/math.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/drawable_atlases_tweaker.hpp>
 #include <mbgl/gfx/drawable_builder.hpp>
 #include <mbgl/gfx/symbol_drawable_data.hpp>
@@ -33,9 +32,7 @@
 #include <mbgl/shaders/shader_program_base.hpp>
 #include <mbgl/shaders/symbol_layer_ubo.hpp>
 #include <mbgl/renderer/layers/collision_layer_tweaker.hpp>
-#endif // MLN_DRAWABLE_RENDERER
 
-#include <cmath>
 #include <set>
 
 namespace mbgl {
@@ -44,7 +41,6 @@ using namespace style;
 using namespace shaders;
 
 namespace {
-#if MLN_DRAWABLE_RENDERER
 
 constexpr std::string_view SymbolIconShaderName = "SymbolIconShader";
 constexpr std::string_view SymbolSDFIconShaderName = "SymbolSDFIconShader";
@@ -52,30 +48,30 @@ constexpr std::string_view SymbolTextAndIconShaderName = "SymbolTextAndIconShade
 constexpr std::string_view CollisionBoxShaderName = "CollisionBoxShader";
 constexpr std::string_view CollisionCircleShaderName = "CollisionCircleShader";
 
-#endif // MLN_DRAWABLE_RENDERER
-
 style::SymbolPropertyValues iconPropertyValues(const style::SymbolPaintProperties::PossiblyEvaluated& evaluated_,
                                                const style::SymbolLayoutProperties::PossiblyEvaluated& layout_) {
-    return style::SymbolPropertyValues{layout_.get<style::IconPitchAlignment>(),
-                                       layout_.get<style::IconRotationAlignment>(),
-                                       layout_.get<style::IconKeepUpright>(),
-                                       evaluated_.get<style::IconTranslate>(),
-                                       evaluated_.get<style::IconTranslateAnchor>(),
-                                       evaluated_.get<style::IconHaloColor>().constantOr(Color::black()).a > 0 &&
-                                           evaluated_.get<style::IconHaloWidth>().constantOr(1) != 0,
-                                       evaluated_.get<style::IconColor>().constantOr(Color::black()).a > 0};
+    return style::SymbolPropertyValues{
+        .pitchAlignment = layout_.get<style::IconPitchAlignment>(),
+        .rotationAlignment = layout_.get<style::IconRotationAlignment>(),
+        .keepUpright = layout_.get<style::IconKeepUpright>(),
+        .translate = evaluated_.get<style::IconTranslate>(),
+        .translateAnchor = evaluated_.get<style::IconTranslateAnchor>(),
+        .hasHalo = evaluated_.get<style::IconHaloColor>().constantOr(Color::black()).a > 0 &&
+                   evaluated_.get<style::IconHaloWidth>().constantOr(1) != 0,
+        .hasFill = evaluated_.get<style::IconColor>().constantOr(Color::black()).a > 0};
 }
 
 style::SymbolPropertyValues textPropertyValues(const style::SymbolPaintProperties::PossiblyEvaluated& evaluated_,
                                                const style::SymbolLayoutProperties::PossiblyEvaluated& layout_) {
-    return style::SymbolPropertyValues{layout_.get<style::TextPitchAlignment>(),
-                                       layout_.get<style::TextRotationAlignment>(),
-                                       layout_.get<style::TextKeepUpright>(),
-                                       evaluated_.get<style::TextTranslate>(),
-                                       evaluated_.get<style::TextTranslateAnchor>(),
-                                       evaluated_.get<style::TextHaloColor>().constantOr(Color::black()).a > 0 &&
-                                           evaluated_.get<style::TextHaloWidth>().constantOr(1) != 0,
-                                       evaluated_.get<style::TextColor>().constantOr(Color::black()).a > 0};
+    return style::SymbolPropertyValues{
+        .pitchAlignment = layout_.get<style::TextPitchAlignment>(),
+        .rotationAlignment = layout_.get<style::TextRotationAlignment>(),
+        .keepUpright = layout_.get<style::TextKeepUpright>(),
+        .translate = evaluated_.get<style::TextTranslate>(),
+        .translateAnchor = evaluated_.get<style::TextTranslateAnchor>(),
+        .hasHalo = evaluated_.get<style::TextHaloColor>().constantOr(Color::black()).a > 0 &&
+                   evaluated_.get<style::TextHaloWidth>().constantOr(1) != 0,
+        .hasFill = evaluated_.get<style::TextColor>().constantOr(Color::black()).a > 0};
 }
 
 using SegmentWrapper = std::reference_wrapper<const Segment<SymbolTextAttributes>>;
@@ -137,214 +133,6 @@ struct SegmentGroup {
     bool operator<(const SegmentGroup& other) const { return renderable < other.renderable; }
 };
 
-#if MLN_LEGACY_RENDERER
-
-template <typename DrawFn>
-void drawIcon(const RenderSymbolLayer::Programs& programs,
-              const DrawFn& draw,
-              const RenderTile& tile,
-              const LayerRenderData& renderData,
-              SegmentsWrapper iconSegments,
-              const SymbolBucket::PaintProperties& bucketPaintProperties,
-              const PaintParameters& parameters,
-              const bool sdfIcons) {
-    auto& bucket = static_cast<SymbolBucket&>(*renderData.bucket);
-    const auto& evaluated = getEvaluated<SymbolLayerProperties>(renderData.layerProperties);
-    const auto& layout = *bucket.layout;
-    auto values = iconPropertyValues(evaluated, layout);
-    const auto& paintPropertyValues = RenderSymbolLayer::iconPaintProperties(evaluated);
-
-    const bool alongLine = layout.get<SymbolPlacement>() != SymbolPlacementType::Point &&
-                           layout.get<IconRotationAlignment>() == AlignmentType::Map;
-
-    const bool iconScaled = layout.get<IconSize>().constantOr(1.0) != 1.0 || bucket.iconsNeedLinear;
-    const bool iconTransformed = values.rotationAlignment == AlignmentType::Map || parameters.state.getPitch() != 0;
-
-    const bool linear = sdfIcons || parameters.state.isChanging() || iconScaled || iconTransformed;
-    const auto filterType = linear ? gfx::TextureFilterType::Linear : gfx::TextureFilterType::Nearest;
-    const gfx::TextureBinding textureBinding = tile.getIconAtlasTextureBinding(filterType);
-
-    const Size& iconSize = tile.getIconAtlasTexture()->getSize();
-    const bool variablePlacedIcon = bucket.hasVariablePlacement && layout.get<IconTextFit>() != IconTextFitType::None;
-
-    if (sdfIcons) {
-        if (values.hasHalo) {
-            draw(*programs.symbolSDFIconProgram,
-                 SymbolSDFIconProgram::layoutUniformValues(/* isText = */ false,
-                                                           variablePlacedIcon,
-                                                           values,
-                                                           iconSize,
-                                                           parameters.pixelsToGLUnits,
-                                                           parameters.pixelRatio,
-                                                           alongLine,
-                                                           tile,
-                                                           parameters.state,
-                                                           parameters.symbolFadeChange,
-                                                           SymbolSDFPart::Halo),
-                 bucket.sdfIcon,
-                 iconSegments,
-                 bucket.iconSizeBinder,
-                 bucketPaintProperties.iconBinders,
-                 paintPropertyValues,
-                 SymbolSDFIconProgram::TextureBindings{textureBinding},
-                 "halo");
-        }
-
-        if (values.hasFill) {
-            draw(*programs.symbolSDFIconProgram,
-                 SymbolSDFIconProgram::layoutUniformValues(/* isText = */ false,
-                                                           variablePlacedIcon,
-                                                           values,
-                                                           iconSize,
-                                                           parameters.pixelsToGLUnits,
-                                                           parameters.pixelRatio,
-                                                           alongLine,
-                                                           tile,
-                                                           parameters.state,
-                                                           parameters.symbolFadeChange,
-                                                           SymbolSDFPart::Fill),
-                 bucket.sdfIcon,
-                 iconSegments,
-                 bucket.iconSizeBinder,
-                 bucketPaintProperties.iconBinders,
-                 paintPropertyValues,
-                 SymbolSDFIconProgram::TextureBindings{textureBinding},
-                 "fill");
-        }
-    } else {
-        draw(*programs.symbolIconProgram,
-             SymbolIconProgram::layoutUniformValues(/* isText = */ false,
-                                                    variablePlacedIcon,
-                                                    values,
-                                                    iconSize,
-                                                    parameters.pixelsToGLUnits,
-                                                    alongLine,
-                                                    tile,
-                                                    parameters.state,
-                                                    parameters.symbolFadeChange),
-             bucket.icon,
-             iconSegments,
-             bucket.iconSizeBinder,
-             bucketPaintProperties.iconBinders,
-             paintPropertyValues,
-             SymbolIconProgram::TextureBindings{textureBinding},
-             "icon");
-    }
-}
-
-template <typename DrawFn>
-void drawText(const RenderSymbolLayer::Programs& programs,
-              const DrawFn& draw,
-              const RenderTile& tile,
-              const LayerRenderData& renderData,
-              SegmentsWrapper textSegments,
-              const SymbolBucket::PaintProperties& bucketPaintProperties,
-              const PaintParameters& parameters) {
-    const auto& bucket = static_cast<SymbolBucket&>(*renderData.bucket);
-    const auto& evaluated = getEvaluated<SymbolLayerProperties>(renderData.layerProperties);
-    const auto& layout = *bucket.layout;
-
-    const auto values = textPropertyValues(evaluated, layout);
-    const auto& paintPropertyValues = RenderSymbolLayer::textPaintProperties(evaluated);
-
-    const bool alongLine = layout.get<SymbolPlacement>() != SymbolPlacementType::Point &&
-                           values.rotationAlignment == AlignmentType::Map;
-
-    const Size& glyphTexSize = tile.getGlyphAtlasTexture()->getSize();
-    const gfx::TextureBinding glyphTextureBinding = tile.getGlyphAtlasTextureBinding(gfx::TextureFilterType::Linear);
-
-    const auto drawGlyphs = [&](auto& program, const auto& uniforms, const auto& textures, SymbolSDFPart part) {
-        draw(program,
-             uniforms,
-             bucket.text,
-             textSegments,
-             bucket.textSizeBinder,
-             bucketPaintProperties.textBinders,
-             paintPropertyValues,
-             textures,
-             (part == SymbolSDFPart::Halo) ? "halo" : "fill");
-    };
-
-    if (bucket.iconsInText) {
-        const ZoomEvaluatedSize partiallyEvaluatedTextSize = bucket.textSizeBinder->evaluateForZoom(
-            static_cast<float>(parameters.state.getZoom()));
-        const bool transformed = values.rotationAlignment == AlignmentType::Map || parameters.state.getPitch() != 0;
-        const Size& iconTexSize = tile.getIconAtlasTexture()->getSize();
-        const bool linear = parameters.state.isChanging() || transformed || !partiallyEvaluatedTextSize.isZoomConstant;
-        const auto filterType = linear ? gfx::TextureFilterType::Linear : gfx::TextureFilterType::Nearest;
-        const gfx::TextureBinding iconTextureBinding = tile.getIconAtlasTextureBinding(filterType);
-        if (values.hasHalo) {
-            drawGlyphs(*programs.symbolTextAndIconProgram,
-                       SymbolTextAndIconProgram::layoutUniformValues(bucket.hasVariablePlacement,
-                                                                     values,
-                                                                     glyphTexSize,
-                                                                     iconTexSize,
-                                                                     parameters.pixelsToGLUnits,
-                                                                     parameters.pixelRatio,
-                                                                     alongLine,
-                                                                     tile,
-                                                                     parameters.state,
-                                                                     parameters.symbolFadeChange,
-                                                                     SymbolSDFPart::Halo),
-                       SymbolTextAndIconProgram::TextureBindings{glyphTextureBinding, iconTextureBinding},
-                       SymbolSDFPart::Halo);
-        }
-
-        if (values.hasFill) {
-            drawGlyphs(*programs.symbolTextAndIconProgram,
-                       SymbolTextAndIconProgram::layoutUniformValues(bucket.hasVariablePlacement,
-                                                                     values,
-                                                                     glyphTexSize,
-                                                                     iconTexSize,
-                                                                     parameters.pixelsToGLUnits,
-                                                                     parameters.pixelRatio,
-                                                                     alongLine,
-                                                                     tile,
-                                                                     parameters.state,
-                                                                     parameters.symbolFadeChange,
-                                                                     SymbolSDFPart::Fill),
-                       SymbolTextAndIconProgram::TextureBindings{glyphTextureBinding, iconTextureBinding},
-                       SymbolSDFPart::Fill);
-        }
-    } else {
-        if (values.hasHalo) {
-            drawGlyphs(*programs.symbolSDFTextProgram,
-                       SymbolSDFTextProgram::layoutUniformValues(/* isText = */ true,
-                                                                 bucket.hasVariablePlacement,
-                                                                 values,
-                                                                 glyphTexSize,
-                                                                 parameters.pixelsToGLUnits,
-                                                                 parameters.pixelRatio,
-                                                                 alongLine,
-                                                                 tile,
-                                                                 parameters.state,
-                                                                 parameters.symbolFadeChange,
-                                                                 SymbolSDFPart::Halo),
-                       SymbolSDFTextProgram::TextureBindings{glyphTextureBinding},
-                       SymbolSDFPart::Halo);
-        }
-
-        if (values.hasFill) {
-            drawGlyphs(*programs.symbolSDFTextProgram,
-                       SymbolSDFTextProgram::layoutUniformValues(/* isText = */ true,
-                                                                 bucket.hasVariablePlacement,
-                                                                 values,
-                                                                 glyphTexSize,
-                                                                 parameters.pixelsToGLUnits,
-                                                                 parameters.pixelRatio,
-                                                                 alongLine,
-                                                                 tile,
-                                                                 parameters.state,
-                                                                 parameters.symbolFadeChange,
-                                                                 SymbolSDFPart::Fill),
-                       SymbolSDFTextProgram::TextureBindings{glyphTextureBinding},
-                       SymbolSDFPart::Fill);
-        }
-    }
-}
-
-#endif // MLN_LEGACY_RENDERER
-
 inline const SymbolLayer::Impl& impl_cast(const Immutable<style::Layer::Impl>& impl) {
     assert(impl->getTypeInfo() == SymbolLayer::Impl::staticTypeInfo());
     return static_cast<const SymbolLayer::Impl&>(*impl);
@@ -392,13 +180,11 @@ void RenderSymbolLayer::evaluate(const PropertyEvaluationParameters& parameters)
     properties->renderPasses = mbgl::underlying_type(passes);
     evaluatedProperties = std::move(properties);
 
-#if MLN_DRAWABLE_RENDERER
     // The symbol tweaker supports updating properties.
     // When the style changes, it will be replaced in `RenderLayer::layerChanged`
     if (layerTweaker) {
         layerTweaker->updateProperties(evaluatedProperties);
     }
-#endif // MLN_DRAWABLE_RENDERER
 }
 
 bool RenderSymbolLayer::hasTransition() const {
@@ -408,258 +194,6 @@ bool RenderSymbolLayer::hasTransition() const {
 bool RenderSymbolLayer::hasCrossfade() const {
     return false;
 }
-
-#if MLN_LEGACY_RENDERER
-
-void RenderSymbolLayer::render(PaintParameters& parameters) {
-    assert(renderTiles);
-    if (parameters.pass == RenderPass::Opaque) {
-        return;
-    }
-
-    if (!parameters.shaders.getLegacyGroup().populate(programs.symbolIconProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(programs.symbolSDFIconProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(programs.symbolSDFTextProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(programs.symbolTextAndIconProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(programs.collisionBoxProgram)) return;
-    if (!parameters.shaders.getLegacyGroup().populate(programs.collisionCircleProgram)) return;
-
-    const bool sortFeaturesByKey = !impl_cast(baseImpl).layout.get<SymbolSortKey>().isUndefined();
-    std::multiset<RenderableSegment> renderableSegments;
-
-    const auto draw = [&parameters, this](auto& programInstance,
-                                          const auto& uniformValues,
-                                          const auto& buffers,
-                                          const auto& segments,
-                                          const auto& symbolSizeBinder,
-                                          const auto& binders,
-                                          const auto& paintProperties,
-                                          const auto& textureBindings,
-                                          const std::string& suffix) {
-        const auto allUniformValues = programInstance.computeAllUniformValues(
-            uniformValues, *symbolSizeBinder, binders, paintProperties, static_cast<float>(parameters.state.getZoom()));
-
-        const auto allAttributeBindings = programInstance.computeAllAttributeBindings(*buffers.vertexBuffer,
-                                                                                      *buffers.dynamicVertexBuffer,
-                                                                                      *buffers.opacityVertexBuffer,
-                                                                                      binders,
-                                                                                      paintProperties);
-
-        this->checkRenderability(parameters, programInstance.activeBindingCount(allAttributeBindings));
-
-        segments.match(
-            [&](const SegmentWrapper& segment) {
-                programInstance.draw(parameters.context,
-                                     *parameters.renderPass,
-                                     gfx::Triangles(),
-                                     parameters.depthModeForSublayer(0, gfx::DepthMaskType::ReadOnly),
-                                     gfx::StencilMode::disabled(),
-                                     parameters.colorModeForRenderPass(),
-                                     gfx::CullFaceMode::disabled(),
-                                     *buffers.indexBuffer,
-                                     segment,
-                                     allUniformValues,
-                                     allAttributeBindings,
-                                     textureBindings,
-                                     this->getID() + "/" + suffix);
-            },
-            [&](const SegmentVectorWrapper& segmentVector) {
-                programInstance.draw(parameters.context,
-                                     *parameters.renderPass,
-                                     gfx::Triangles(),
-                                     parameters.depthModeForSublayer(0, gfx::DepthMaskType::ReadOnly),
-                                     gfx::StencilMode::disabled(),
-                                     parameters.colorModeForRenderPass(),
-                                     gfx::CullFaceMode::disabled(),
-                                     *buffers.indexBuffer,
-                                     segmentVector,
-                                     allUniformValues,
-                                     allAttributeBindings,
-                                     textureBindings,
-                                     this->getID() + "/" + suffix);
-            });
-    };
-
-    for (const RenderTile& tile : *renderTiles) {
-        const LayerRenderData* renderData = getRenderDataForPass(tile, parameters.pass);
-        if (!renderData) {
-            continue;
-        }
-
-        auto& bucket = static_cast<SymbolBucket&>(*renderData->bucket);
-        assert(bucket.paintProperties.find(getID()) != bucket.paintProperties.end());
-        const auto& bucketPaintProperties = bucket.paintProperties.at(getID());
-
-        if (!static_cast<Bucket&>(bucket).check(SYM_GUARD_LOC)) {
-            continue;
-        }
-
-        // Prevent a flickering issue when a symbol is moved.
-        // bucket.justReloaded = false;
-
-        auto addRenderables =
-            [&renderableSegments, &tile, renderData, &bucketPaintProperties, it = renderableSegments.begin()](
-                auto& segments, const SymbolType type) mutable {
-                for (auto& segment : segments) {
-                    it = renderableSegments.emplace_hint(it,
-                                                         SegmentWrapper{std::ref(segment)},
-                                                         tile,
-                                                         *renderData,
-                                                         bucketPaintProperties,
-                                                         segment.sortKey,
-                                                         type);
-                }
-            };
-
-        if (bucket.hasIconData()) {
-            if (sortFeaturesByKey) {
-                addRenderables(bucket.icon.segments, SymbolType::IconRGBA);
-            } else {
-                drawIcon(programs,
-                         draw,
-                         tile,
-                         *renderData,
-                         std::cref(bucket.icon.segments),
-                         bucketPaintProperties,
-                         parameters,
-                         false /*sdfIcon*/
-                );
-            }
-        }
-
-        if (bucket.hasSdfIconData()) {
-            if (sortFeaturesByKey) {
-                addRenderables(bucket.sdfIcon.segments, SymbolType::IconSDF);
-            } else {
-                drawIcon(programs,
-                         draw,
-                         tile,
-                         *renderData,
-                         std::cref(bucket.sdfIcon.segments),
-                         bucketPaintProperties,
-                         parameters,
-                         true /*sdfIcon*/
-                );
-            }
-        }
-
-        if (bucket.hasTextData()) {
-            if (sortFeaturesByKey) {
-                addRenderables(bucket.text.segments, SymbolType::Text);
-            } else {
-                drawText(programs,
-                         draw,
-                         tile,
-                         *renderData,
-                         std::cref(bucket.text.segments),
-                         bucketPaintProperties,
-                         parameters);
-            }
-        }
-
-        const auto drawCollisonData = [&](const bool isText,
-                                          const bool hasCollisionBox,
-                                          const bool hasCollisionCircle) {
-            if (!hasCollisionBox && !hasCollisionCircle) return;
-
-            static const style::Properties<>::PossiblyEvaluated properties{};
-            static const CollisionBoxProgram::Binders paintAttributeData(properties, 0);
-            const auto pixelRatio = tile.id.pixelsToTileUnits(1.0f, static_cast<float>(parameters.state.getZoom()));
-            const auto scale = static_cast<float>(
-                std::pow(2, parameters.state.getZoom() - tile.getOverscaledTileID().overscaledZ));
-            std::array<float, 2> extrudeScale = {{parameters.pixelsToGLUnits[0] / (pixelRatio * scale),
-                                                  parameters.pixelsToGLUnits[1] / (pixelRatio * scale)}};
-            const auto& evaluated = getEvaluated<SymbolLayerProperties>(renderData->layerProperties);
-            const auto& layout = *bucket.layout;
-            const auto values = isText ? textPropertyValues(evaluated, layout) : iconPropertyValues(evaluated, layout);
-            const bool needTranslate = values.translate[0] != 0 || values.translate[1] != 0;
-
-            if (hasCollisionBox) {
-                const auto& collisionBox = isText ? bucket.textCollisionBox : bucket.iconCollisionBox;
-                programs.collisionBoxProgram->draw(
-                    parameters.context,
-                    *parameters.renderPass,
-                    gfx::Lines{1.0f},
-                    gfx::DepthMode::disabled(),
-                    gfx::StencilMode::disabled(),
-                    parameters.colorModeForRenderPass(),
-                    gfx::CullFaceMode::disabled(),
-                    CollisionBoxProgram::LayoutUniformValues{
-                        uniforms::matrix::Value(
-                            (needTranslate
-                                 ? tile.translatedMatrix(values.translate, values.translateAnchor, parameters.state)
-                                 : tile.matrix)),
-                        uniforms::extrude_scale::Value(extrudeScale),
-                        uniforms::camera_to_center_distance::Value(parameters.state.getCameraToCenterDistance())},
-                    *collisionBox->vertexBuffer,
-                    *collisionBox->dynamicVertexBuffer,
-                    *collisionBox->indexBuffer,
-                    collisionBox->segments,
-                    paintAttributeData,
-                    properties,
-                    CollisionBoxProgram::TextureBindings{},
-                    static_cast<float>(parameters.state.getZoom()),
-                    getID());
-            }
-            if (hasCollisionCircle) {
-                const auto& collisionCircle = isText ? bucket.textCollisionCircle : bucket.iconCollisionCircle;
-                programs.collisionCircleProgram->draw(
-                    parameters.context,
-                    *parameters.renderPass,
-                    gfx::Triangles(),
-                    gfx::DepthMode::disabled(),
-                    gfx::StencilMode::disabled(),
-                    parameters.colorModeForRenderPass(),
-                    gfx::CullFaceMode::disabled(),
-                    CollisionCircleProgram::LayoutUniformValues{
-                        uniforms::matrix::Value(
-                            (needTranslate
-                                 ? tile.translatedMatrix(values.translate, values.translateAnchor, parameters.state)
-                                 : tile.matrix)),
-                        uniforms::extrude_scale::Value(extrudeScale),
-                        uniforms::overscale_factor::Value(
-                            static_cast<float>(tile.getOverscaledTileID().overscaleFactor())),
-                        uniforms::camera_to_center_distance::Value(parameters.state.getCameraToCenterDistance())},
-                    *collisionCircle->vertexBuffer,
-                    *collisionCircle->dynamicVertexBuffer,
-                    *collisionCircle->indexBuffer,
-                    collisionCircle->segments,
-                    paintAttributeData,
-                    properties,
-                    CollisionCircleProgram::TextureBindings{},
-                    static_cast<float>(parameters.state.getZoom()),
-                    getID());
-            }
-        };
-        drawCollisonData(false /*isText*/, bucket.hasIconCollisionBoxData(), bucket.hasIconCollisionCircleData());
-        drawCollisonData(true /*isText*/, bucket.hasTextCollisionBoxData(), bucket.hasTextCollisionCircleData());
-    }
-
-    if (sortFeaturesByKey) {
-        for (auto& renderable : renderableSegments) {
-            if (renderable.type == SymbolType::Text) {
-                drawText(programs,
-                         draw,
-                         renderable.tile,
-                         renderable.renderData,
-                         renderable.segment,
-                         renderable.bucketPaintProperties,
-                         parameters);
-            } else {
-                drawIcon(programs,
-                         draw,
-                         renderable.tile,
-                         renderable.renderData,
-                         renderable.segment,
-                         renderable.bucketPaintProperties,
-                         parameters,
-                         renderable.type == SymbolType::IconSDF);
-            }
-        }
-    }
-}
-
-#endif // MLN_LEGACY_RENDERER
 
 // static
 style::IconPaintProperties::PossiblyEvaluated RenderSymbolLayer::iconPaintProperties(
@@ -688,10 +222,7 @@ style::TextPaintProperties::PossiblyEvaluated RenderSymbolLayer::textPaintProper
 void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
     renderTiles = params.source->getRenderTilesSortedByYPosition();
 
-#if MLN_DRAWABLE_RENDERER
     updateRenderTileIDs();
-#endif // MLN_DRAWABLE_RENDERER
-
     addRenderPassesFromTiles();
 
     placementData.clear();
@@ -710,7 +241,11 @@ void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
                 placementData.push_back({*bucket, renderTile, featureIndex, baseImpl->source, std::nullopt});
             } else {
                 for (const auto& sortKeyRange : bucket->sortKeyRanges) {
-                    BucketPlacementData layerData{*bucket, renderTile, featureIndex, baseImpl->source, sortKeyRange};
+                    BucketPlacementData layerData{.bucket = *bucket,
+                                                  .tile = renderTile,
+                                                  .featureIndex = featureIndex,
+                                                  .sourceId = baseImpl->source,
+                                                  .sortKeyRange = sortKeyRange};
                     auto sortPosition = std::upper_bound(
                         placementData.cbegin(), placementData.cend(), layerData, [](const auto& lhs, const auto& rhs) {
                             assert(lhs.sortKeyRange && rhs.sortKeyRange);
@@ -722,8 +257,6 @@ void RenderSymbolLayer::prepare(const LayerPrepareParameters& params) {
         }
     }
 }
-
-#if MLN_DRAWABLE_RENDERER
 
 namespace {
 const SegmentVector<SymbolTextAttributes> emptySegmentVector;
@@ -1112,13 +645,15 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
                 for (const auto& segment : buffer.segments) {
                     assert(segment.vertexOffset + segment.vertexLength <= buffer.vertices().elements());
                     renderableSegments.emplace(SegmentGroup{
-                        {segment, tile, renderData, bucketPaintProperties, segment.sortKey, type}, emptySegmentVector});
+                        .renderable = {segment, tile, renderData, bucketPaintProperties, segment.sortKey, type},
+                        .segments = emptySegmentVector});
                 }
             } else if (!buffer.segments.empty()) {
                 // Features can be rendered in the order produced, and as grouped by the bucket
                 const auto& firstSeg = buffer.segments.front();
-                renderableSegments.emplace(SegmentGroup{
-                    {firstSeg, tile, renderData, bucketPaintProperties, serialKey, type}, buffer.segments});
+                renderableSegments.emplace(
+                    SegmentGroup{.renderable = {firstSeg, tile, renderData, bucketPaintProperties, serialKey, type},
+                                 .segments = buffer.segments});
                 serialKey += 1.0;
             }
         };
@@ -1324,7 +859,5 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
         }
     }
 }
-
-#endif // MLN_DRAWABLE_RENDERER
 
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.hpp
@@ -6,9 +6,7 @@
 #include <mbgl/style/layers/symbol_layer_impl.hpp>
 #include <mbgl/style/layers/symbol_layer_properties.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <unordered_map>
-#endif // MLN_DRAWABLE_RENDERER
 
 namespace mbgl {
 
@@ -65,10 +63,8 @@ class SymbolTextAndIconProgram;
 class CollisionBoxProgram;
 class CollisionCircleProgram;
 
-#if MLN_DRAWABLE_RENDERER
 class SymbolLayerTweaker;
 using SymbolLayerTweakerPtr = std::shared_ptr<SymbolLayerTweaker>;
-#endif // MLN_DRAWABLE_RENDERER
 
 class RenderSymbolLayer final : public RenderLayer {
 public:
@@ -90,7 +86,6 @@ public:
     static style::TextPaintProperties::PossiblyEvaluated textPaintProperties(
         const style::SymbolPaintProperties::PossiblyEvaluated&);
 
-#if MLN_DRAWABLE_RENDERER
     /// Generate any changes needed by the layer
     void update(gfx::ShaderRegistry&,
                 gfx::Context&,
@@ -102,10 +97,7 @@ public:
     /// Remove all the drawables for tiles
     std::size_t removeAllDrawables() override;
 
-#endif // MLN_DRAWABLE_RENDERER
-
 protected:
-#if MLN_DRAWABLE_RENDERER
     /// @brief Called by the RenderOrchestrator during RenderTree construction.
     /// This event is run to indicate if the layer should render or not for the current frame.
     /// @param willRender Indicates if this layer should render or not
@@ -124,17 +116,11 @@ protected:
     /// Remove all drawables for the tile from the layer group
     std::size_t removeTile(RenderPass, const OverscaledTileID&) override;
 
-#endif // MLN_DRAWABLE_RENDERER
-
 private:
     void transition(const TransitionParameters&) override;
     void evaluate(const PropertyEvaluationParameters&) override;
     bool hasTransition() const override;
     bool hasCrossfade() const override;
-
-#if MLN_LEGACY_RENDERER
-    void render(PaintParameters&) override;
-#endif // MLN_LEGACY_RENDERER
 
     void prepare(const LayerPrepareParameters&) override;
 
@@ -147,12 +133,6 @@ private:
 
     bool hasFormatSectionOverrides = false;
 
-#if MLN_LEGACY_RENDERER
-    // Programs
-    Programs programs;
-#endif // MLN_LEGACY_RENDERER
-
-#if MLN_DRAWABLE_RENDERER
     gfx::ShaderGroupPtr symbolIconGroup;
     gfx::ShaderGroupPtr symbolSDFGroup;
     gfx::ShaderGroupPtr symbolTextAndIconGroup;
@@ -162,7 +142,6 @@ private:
     std::shared_ptr<TileLayerGroup> collisionTileLayerGroup;
 
     LayerTweakerPtr collisionLayerTweaker;
-#endif // MLN_DRAWABLE_RENDERER
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -120,13 +120,6 @@ public:
 
     virtual void updateVertexVector(std::size_t, std::size_t, const GeometryTileFeature&, const FeatureState&) = 0;
 
-#if MLN_LEGACY_RENDERER
-    virtual void upload(gfx::UploadPass&) = 0;
-
-    virtual std::tuple<ExpandToType<As, std::optional<gfx::AttributeBinding>>...> attributeBinding(
-        const PossiblyEvaluatedType& currentValue) const = 0;
-#endif // MLN_LEGACY_RENDERER
-
     virtual void setPatternParameters(const std::optional<ImagePosition>&,
                                       const std::optional<ImagePosition>&,
                                       const CrossfadeParameters&) = 0;
@@ -166,15 +159,6 @@ public:
                               const CanonicalTileID&,
                               const style::expression::Value&) override {}
     void updateVertexVector(std::size_t, std::size_t, const GeometryTileFeature&, const FeatureState&) override {}
-
-#if MLN_LEGACY_RENDERER
-    void upload(gfx::UploadPass&) override {}
-
-    std::tuple<std::optional<gfx::AttributeBinding>> attributeBinding(
-        const PossiblyEvaluatedPropertyValue<T>&) const override {
-        return {};
-    }
-#endif // MLN_LEGACY_RENDERER
 
     void setPatternParameters(const std::optional<ImagePosition>&,
                               const std::optional<ImagePosition>&,
@@ -218,15 +202,6 @@ public:
                               const CanonicalTileID&,
                               const style::expression::Value&) override {}
     void updateVertexVector(std::size_t, std::size_t, const GeometryTileFeature&, const FeatureState&) override {}
-
-#if MLN_LEGACY_RENDERER
-    void upload(gfx::UploadPass&) override {}
-
-    std::tuple<std::optional<gfx::AttributeBinding>, std::optional<gfx::AttributeBinding>> attributeBinding(
-        const PossiblyEvaluatedPropertyValue<Faded<T>>&) const override {
-        return {};
-    }
-#endif // MLN_LEGACY_RENDERER
 
     void setPatternParameters(const std::optional<ImagePosition>& posA,
                               const std::optional<ImagePosition>& posB,
@@ -331,19 +306,6 @@ public:
         vertexVector.updateModified();
     }
 
-#if MLN_LEGACY_RENDERER
-    void upload(gfx::UploadPass& uploadPass) override { vertexBuffer = uploadPass.createVertexBuffer(vertexVector); }
-
-    std::tuple<std::optional<gfx::AttributeBinding>> attributeBinding(
-        const PossiblyEvaluatedPropertyValue<T>& currentValue) const override {
-        if (currentValue.isConstant()) {
-            return {};
-        } else {
-            return std::tuple<std::optional<gfx::AttributeBinding>>{gfx::attributeBinding(*vertexBuffer)};
-        }
-    }
-#endif // MLN_LEGACY_RENDERER
-
     std::tuple<float> interpolationFactor(float) const override { return std::tuple<float>{0.0f}; }
 
     std::tuple<T> uniformValue(const PossiblyEvaluatedPropertyValue<T>& currentValue) const override {
@@ -370,10 +332,6 @@ private:
 
     gfx::VertexVectorPtr<BaseVertex> sharedVertexVector = std::make_shared<gfx::VertexVector<BaseVertex>>();
     gfx::VertexVector<BaseVertex>& vertexVector = *sharedVertexVector;
-
-#if MLN_LEGACY_RENDERER
-    std::optional<gfx::VertexBuffer<BaseVertex>> vertexBuffer;
-#endif // MLN_LEGACY_RENDERER
 
     FeatureVertexRangeMap featureMap;
 };
@@ -469,19 +427,6 @@ public:
         vertexVector.updateModified();
     }
 
-#if MLN_LEGACY_RENDERER
-    void upload(gfx::UploadPass& uploadPass) override { vertexBuffer = uploadPass.createVertexBuffer(vertexVector); }
-
-    std::tuple<std::optional<gfx::AttributeBinding>> attributeBinding(
-        const PossiblyEvaluatedPropertyValue<T>& currentValue) const override {
-        if (currentValue.isConstant()) {
-            return {};
-        } else {
-            return std::tuple<std::optional<gfx::AttributeBinding>>{gfx::attributeBinding(*vertexBuffer)};
-        }
-    }
-#endif // MLN_LEGACY_RENDERER
-
     std::tuple<float> interpolationFactor(float currentZoom) const override {
         const float possiblyRoundedZoom = expression.getUseIntegerZoom() ? std::floor(currentZoom) : currentZoom;
 
@@ -515,10 +460,6 @@ private:
 
     gfx::VertexVectorPtr<Vertex> sharedVertexVector = std::make_shared<gfx::VertexVector<Vertex>>();
     gfx::VertexVector<Vertex>& vertexVector = *sharedVertexVector;
-
-#if MLN_LEGACY_RENDERER
-    std::optional<gfx::VertexBuffer<Vertex>> vertexBuffer;
-#endif // MLN_LEGACY_RENDERER
 
     FeatureVertexRangeMap featureMap;
 };
@@ -586,36 +527,6 @@ public:
 
     void updateVertexVector(std::size_t, std::size_t, const GeometryTileFeature&, const FeatureState&) override {}
 
-#if MLN_LEGACY_RENDERER
-    void upload(gfx::UploadPass& uploadPass) override {
-        if (!patternToVertexVector.empty()) {
-            assert(!zoomInVertexVector.empty());
-            assert(!zoomOutVertexVector.empty());
-            patternToVertexBuffer = uploadPass.createVertexBuffer(patternToVertexVector);
-            zoomInVertexBuffer = uploadPass.createVertexBuffer(zoomInVertexVector);
-            zoomOutVertexBuffer = uploadPass.createVertexBuffer(zoomOutVertexVector);
-        }
-    }
-
-    std::tuple<std::optional<gfx::AttributeBinding>, std::optional<gfx::AttributeBinding>> attributeBinding(
-        const PossiblyEvaluatedPropertyValue<Faded<T>>& currentValue) const override {
-        if (currentValue.isConstant()) {
-            return {};
-        } else {
-            if (patternToVertexBuffer) {
-                assert(zoomInVertexBuffer);
-                assert(zoomOutVertexBuffer);
-                return std::tuple<std::optional<gfx::AttributeBinding>, std::optional<gfx::AttributeBinding>>{
-                    gfx::attributeBinding(*patternToVertexBuffer),
-                    gfx::attributeBinding(crossfade.fromScale == 2 ? *zoomInVertexBuffer : *zoomOutVertexBuffer)};
-            }
-
-            return std::tuple<std::optional<gfx::AttributeBinding>, std::optional<gfx::AttributeBinding>>{std::nullopt,
-                                                                                                          std::nullopt};
-        }
-    }
-#endif // MLN_LEGACY_RENDERER
-
     std::tuple<float, float> interpolationFactor(float) const override { return std::tuple<float, float>{0.0f, 0.0f}; }
 
     std::tuple<std::array<uint16_t, 4>, std::array<uint16_t, 4>> uniformValue(
@@ -647,12 +558,6 @@ private:
 
     gfx::VertexVector<Vertex2> zoomInVertexVector;
     gfx::VertexVector<Vertex2> zoomOutVertexVector;
-
-#if MLN_LEGACY_RENDERER
-    std::optional<gfx::VertexBuffer<Vertex>> patternToVertexBuffer;
-    std::optional<gfx::VertexBuffer<Vertex2>> zoomInVertexBuffer;
-    std::optional<gfx::VertexBuffer<Vertex2>> zoomOutVertexBuffer;
-#endif // MLN_LEGACY_RENDERER
 
     CrossfadeParameters crossfade;
 };
@@ -779,10 +684,6 @@ public:
                               const CrossfadeParameters& crossfade) {
         util::ignore({(binders.template get<Ps>()->setPatternParameters(posA, posB, crossfade), 0)...});
     }
-
-#if MLN_LEGACY_RENDERER
-    void upload(gfx::UploadPass& uploadPass) { util::ignore({(binders.template get<Ps>()->upload(uploadPass), 0)...}); }
-#endif // MLN_LEGACY_RENDERER
 
     template <class P>
     using ZoomInterpolatedAttributeList = typename Property<P>::ZoomInterpolatedAttributeList;

--- a/src/mbgl/renderer/pattern_atlas.cpp
+++ b/src/mbgl/renderer/pattern_atlas.cpp
@@ -1,9 +1,7 @@
 #include <mbgl/renderer/pattern_atlas.hpp>
 #include <mbgl/gfx/upload_pass.hpp>
 #include <mbgl/gfx/context.hpp>
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/texture2d.hpp>
-#endif
 
 namespace mbgl {
 
@@ -67,7 +65,7 @@ std::optional<ImagePosition> PatternAtlas::addPattern(const style::Image::Impl& 
 
     dirty = true;
 
-    return patterns.emplace(image.id, Pattern{bin, {*bin, image}}).first->second.position;
+    return patterns.emplace(image.id, Pattern{.bin = bin, .position = {*bin, image}}).first->second.position;
 }
 
 void PatternAtlas::removePattern(const std::string& id) {
@@ -90,7 +88,6 @@ Size PatternAtlas::getPixelSize() const {
 }
 
 void PatternAtlas::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
-#if MLN_DRAWABLE_RENDERER
     if (!atlasTexture2D) {
         atlasTexture2D = uploadPass.getContext().createTexture2D();
         if (atlasTexture2D) {
@@ -99,29 +96,11 @@ void PatternAtlas::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
     } else if (dirty) {
         atlasTexture2D->upload(atlasImage);
     }
-#else
-    if (!atlasTexture) {
-        atlasTexture = uploadPass.createTexture(atlasImage);
-    } else if (dirty) {
-        uploadPass.updateTexture(*atlasTexture, atlasImage);
-    }
-#endif
     dirty = false;
 }
 
-#if MLN_LEGACY_RENDERER
-// @note: Deprecated
-gfx::TextureBinding PatternAtlas::textureBinding() const {
-    assert(atlasTexture);
-    assert(!dirty);
-    return {atlasTexture->getResource(), gfx::TextureFilterType::Linear};
-}
-#endif
-
-#if MLN_DRAWABLE_RENDERER
 const std::shared_ptr<gfx::Texture2D>& PatternAtlas::texture() const {
     return atlasTexture2D;
 }
-#endif
 
 } // namespace mbgl

--- a/src/mbgl/renderer/pattern_atlas.hpp
+++ b/src/mbgl/renderer/pattern_atlas.hpp
@@ -15,9 +15,7 @@ template <class T>
 class Actor;
 
 namespace gfx {
-#if MLN_DRAWABLE_RENDERER
 class Texture2D;
-#endif
 class UploadPass;
 } // namespace gfx
 
@@ -32,11 +30,7 @@ public:
     std::optional<ImagePosition> addPattern(const style::Image::Impl&);
     void removePattern(const std::string&);
 
-#if MLN_DRAWABLE_RENDERER
     const std::shared_ptr<gfx::Texture2D>& texture() const;
-#else
-    gfx::TextureBinding textureBinding() const; // @TODO: Migrate
-#endif
 
     void upload(gfx::UploadPass&);
     Size getPixelSize() const;
@@ -53,11 +47,7 @@ private:
     mapbox::ShelfPack shelfPack;
     std::unordered_map<std::string, Pattern> patterns;
     PremultipliedImage atlasImage;
-#if MLN_DRAWABLE_RENDERER
     std::shared_ptr<gfx::Texture2D> atlasTexture2D{nullptr};
-#else
-    std::optional<gfx::Texture> atlasTexture;
-#endif
     bool dirty = true;
 };
 

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -11,9 +11,7 @@
 #include <mbgl/tile/tile.hpp>
 #include <mbgl/util/logging.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/renderer/layer_group.hpp>
-#endif
 
 namespace mbgl {
 
@@ -62,16 +60,13 @@ void RenderLayer::prepare(const LayerPrepareParameters& params) {
     renderTilesOwner = params.source->getRawRenderTiles();
     addRenderPassesFromTiles();
 
-#if MLN_DRAWABLE_RENDERER
     updateRenderTileIDs();
-#endif // MLN_DRAWABLE_RENDERER
 }
 
 std::optional<Color> RenderLayer::getSolidBackground() const {
     return std::nullopt;
 }
 
-#if MLN_DRAWABLE_RENDERER
 void RenderLayer::layerChanged(const TransitionParameters&,
                                const Immutable<style::Layer::Impl>&,
                                UniqueChangeRequestVec&) {
@@ -88,7 +83,6 @@ void RenderLayer::layerRemoved(UniqueChangeRequestVec& changes) {
     removeAllDrawables();
     activateLayerGroup(layerGroup, false, changes);
 }
-#endif
 
 void RenderLayer::markContextDestroyed() {
     // no-op
@@ -142,7 +136,6 @@ const LayerRenderData* RenderLayer::getRenderDataForPass(const RenderTile& tile,
     return nullptr;
 }
 
-#if MLN_DRAWABLE_RENDERER
 std::size_t RenderLayer::removeTile(RenderPass renderPass, const OverscaledTileID& tileID) {
     if (const auto tileGroup = static_cast<TileLayerGroup*>(layerGroup.get())) {
         const auto n = tileGroup->removeDrawables(renderPass, tileID).size();
@@ -238,7 +231,6 @@ void RenderLayer::activateLayerGroup(const LayerGroupBasePtr& layerGroup_,
         }
     }
 }
-#endif
 
 bool RenderLayer::applyColorRamp(const style::ColorRampPropertyValue& colorValue, PremultipliedImage& image) {
     if (colorValue.isUndefined()) {

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -6,12 +6,10 @@
 #include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/util/mat4.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/drawable.hpp>
 #include <mbgl/renderer/layer_group.hpp>
 #include <mbgl/renderer/change_request.hpp>
 #include <mbgl/util/tiny_unordered_map.hpp>
-#endif // MLN_DRAWABLE_RENDERER
 
 #include <list>
 #include <memory>
@@ -32,12 +30,10 @@ class TransitionParameters;
 class UpdateParameters;
 class UploadParameters;
 
-#if MLN_DRAWABLE_RENDERER
 class ChangeRequest;
 using LayerGroupBasePtr = std::shared_ptr<LayerGroupBase>;
 using UniqueChangeRequest = std::unique_ptr<ChangeRequest>;
 using UniqueChangeRequestVec = std::vector<UniqueChangeRequest>;
-#endif
 
 namespace gfx {
 class Context;
@@ -45,10 +41,8 @@ class ShaderGroup;
 class ShaderRegistry;
 using ShaderGroupPtr = std::shared_ptr<ShaderGroup>;
 
-#if MLN_DRAWABLE_RENDERER
 class UniformBuffer;
 using UniformBufferPtr = std::shared_ptr<UniformBuffer>;
-#endif
 } // namespace gfx
 
 namespace style {
@@ -161,7 +155,6 @@ public:
     // TODO: Only for background layers.
     virtual std::optional<Color> getSolidBackground() const;
 
-#if MLN_DRAWABLE_RENDERER
     /// Generate any changes needed by the layer
     virtual void update(gfx::ShaderRegistry&,
                         gfx::Context&,
@@ -194,7 +187,6 @@ public:
 
     /// Remove all the drawables for tiles
     virtual std::size_t removeAllDrawables();
-#endif
 
     using Dependency = style::expression::Dependency;
     Dependency getStyleDependencies() const { return styleDependencies; }
@@ -208,7 +200,6 @@ protected:
 
     const LayerRenderData* getRenderDataForPass(const RenderTile&, RenderPass) const;
 
-#if MLN_DRAWABLE_RENDERER
     void setLayerGroup(LayerGroupBasePtr, UniqueChangeRequestVec&);
 
     /// (Un-)Register the layer group with the orchestrator
@@ -268,8 +259,6 @@ protected:
     /// unchanged
     bool setRenderTileBucketID(const OverscaledTileID&, util::SimpleIdentity bucketID);
 
-#endif // MLN_DRAWABLE_RENDERER
-
     static bool applyColorRamp(const style::ColorRampPropertyValue&, PremultipliedImage&);
 
 protected:
@@ -285,7 +274,6 @@ protected:
 
     LayerPlacementData placementData;
 
-#if MLN_DRAWABLE_RENDERER
     // will need to be overriden to handle their activation.
     LayerGroupBasePtr layerGroup;
 
@@ -299,7 +287,6 @@ protected:
     using RenderTileIDMap = util::TinyUnorderedMap<OverscaledTileID, util::SimpleIdentity, LinearTileIDs>;
     RenderTileIDMap renderTileIDs;
     RenderTileIDMap newRenderTileIDs;
-#endif
 
     // Current layer index as specified by the layerIndexChanged event
     int32_t layerIndex{0};

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -2,9 +2,7 @@
 
 #include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/layermanager/layer_manager.hpp>
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/renderer/change_request.hpp>
-#endif
 #include <mbgl/renderer/renderer_observer.hpp>
 #include <mbgl/renderer/render_source.hpp>
 #include <mbgl/renderer/render_layer.hpp>
@@ -53,9 +51,7 @@ const std::string& LayerRenderItem::getName() const {
     return layer.get().getID();
 }
 
-#if MLN_DRAWABLE_RENDERER
 void LayerRenderItem::updateDebugDrawables(DebugLayerGroupMap&, PaintParameters&) const {};
-#endif
 
 namespace {
 
@@ -181,23 +177,24 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
     const TransitionOptions transitionOptions = isMapModeContinuous ? updateParameters->transitionOptions
                                                                     : TransitionOptions();
 
-    const TransitionParameters transitionParameters{updateParameters->timePoint, transitionOptions};
+    const TransitionParameters transitionParameters{.now = updateParameters->timePoint,
+                                                    .transition = transitionOptions};
     const auto transitionDuration = transitionOptions.duration.value_or(
         isMapModeContinuous ? util::DEFAULT_TRANSITION_DURATION : Duration::zero());
 
     PropertyEvaluationParameters evaluationParameters{zoomHistory, updateParameters->timePoint, transitionDuration};
     evaluationParameters.zoomChanged = zoomChanged;
 
-    const TileParameters tileParameters{updateParameters->pixelRatio,
-                                        updateParameters->debugOptions,
-                                        updateParameters->transformState,
-                                        updateParameters->fileSource,
-                                        updateParameters->mode,
-                                        updateParameters->annotationManager,
-                                        imageManager,
-                                        glyphManager,
-                                        updateParameters->prefetchZoomDelta,
-                                        threadPool};
+    const TileParameters tileParameters{.pixelRatio = updateParameters->pixelRatio,
+                                        .debugOptions = updateParameters->debugOptions,
+                                        .transformState = updateParameters->transformState,
+                                        .fileSource = updateParameters->fileSource,
+                                        .mode = updateParameters->mode,
+                                        .annotationManager = updateParameters->annotationManager,
+                                        .imageManager = imageManager,
+                                        .glyphManager = glyphManager,
+                                        .prefetchZoomDelta = updateParameters->prefetchZoomDelta,
+                                        .threadPool = threadPool};
 
     glyphManager->setURL(updateParameters->glyphURL);
 
@@ -246,18 +243,14 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
     layerImpls = updateParameters->layers;
     const bool layersAddedOrRemoved = !layerDiff.added.empty() || !layerDiff.removed.empty();
 
-#if MLN_DRAWABLE_RENDERER
     std::vector<std::unique_ptr<ChangeRequest>> changes;
-#endif
 
     // Remove render layers for removed layers.
     for (const auto& entry : layerDiff.removed) {
         MLN_TRACE_ZONE(remove layer);
         const auto hit = renderLayers.find(entry.first);
         if (hit != renderLayers.end()) {
-#if MLN_DRAWABLE_RENDERER
             hit->second->layerRemoved(changes);
-#endif
             renderLayers.erase(hit);
         }
     }
@@ -276,10 +269,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         if (const auto& renderLayer = renderLayers.at(entry.first)) {
             const auto& newLayer = entry.second.after;
 
-#if MLN_DRAWABLE_RENDERER
             renderLayer->layerChanged(transitionParameters, newLayer, changes);
-#endif // MLN_DRAWABLE_RENDERER
-
             renderLayer->transition(transitionParameters, newLayer);
         }
     }
@@ -293,10 +283,8 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
             assert(layer);
             orderedLayers.emplace_back(*layer);
 
-#if MLN_DRAWABLE_RENDERER
             // We're mutating the list of ordered layers and must notify them of their new assigned indices
             layer->layerIndexChanged(layerIndex++, changes);
-#endif
         }
     }
     assert(orderedLayers.size() == renderLayers.size());
@@ -364,10 +352,8 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         filteredLayersForSource.reserve(layerImpls->size());
     }
 
-#if MLN_DRAWABLE_RENDERER
     // Track which layers are flagged for rendering
     std::vector<bool> updateList(orderedLayers.size());
-#endif
 
     // Update all sources and initialize renderItems.
     for (const auto& sourceImpl : *sourceImpls) {
@@ -397,9 +383,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
                             sourceNeedsRendering = true;
                             renderItemsEmplaceHint = layerRenderItems.emplace_hint(
                                 renderItemsEmplaceHint, layer, source, static_cast<uint32_t>(index));
-#if MLN_DRAWABLE_RENDERER
                             updateList[index] = true;
-#endif
                         }
                     }
                 }
@@ -418,15 +402,12 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
                 }
                 renderItemsEmplaceHint = layerRenderItems.emplace_hint(
                     renderItemsEmplaceHint, layer, nullptr, static_cast<uint32_t>(index));
-#if MLN_DRAWABLE_RENDERER
                 updateList[index] = true;
-#endif
             }
         }
         source->update(sourceImpl, filteredLayersForSource, sourceNeedsRendering, sourceNeedsRelayout, tileParameters);
         filteredLayersForSource.clear();
 
-#if MLN_DRAWABLE_RENDERER
         // Update all layers with their new renderability status, if it changed.
         for (size_t i = 0; i < updateList.size(); i++) {
             if (orderedLayers[i].get().isLayerRenderable() != updateList[i]) {
@@ -434,7 +415,6 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
             }
         }
         addChanges(changes);
-#endif
     }
 
     renderTreeParameters->loaded = updateParameters->styleLoaded && isLoaded();
@@ -446,8 +426,9 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
     for (const auto& entry : renderSources) {
         MLN_TRACE_ZONE(prepare source);
         if (entry.second->isEnabled()) {
-            entry.second->prepare(
-                {renderTreeParameters->transformParams, updateParameters->debugOptions, *imageManager});
+            entry.second->prepare({.transform = renderTreeParameters->transformParams,
+                                   .debugOptions = updateParameters->debugOptions,
+                                   .imageManager = *imageManager});
         }
     }
 
@@ -457,8 +438,11 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         MLN_TRACE_ZONE(prepare layer);
         MLN_ZONE_STR(renderLayer.getID());
 
-        renderLayer.prepare(
-            {renderItem.source, *imageManager, *patternAtlas, *lineAtlas, updateParameters->transformState});
+        renderLayer.prepare({.source = renderItem.source,
+                             .imageManager = *imageManager,
+                             .patternAtlas = *patternAtlas,
+                             .lineAtlas = *lineAtlas,
+                             .state = updateParameters->transformState});
         if (renderLayer.needsPlacement()) {
             layersNeedPlacement.emplace_back(renderLayer);
         }
@@ -869,7 +853,6 @@ void RenderOrchestrator::clearData() {
     if (!layerImpls->empty()) layerImpls = makeMutable<std::vector<Immutable<style::Layer::Impl>>>();
     if (!imageImpls->empty()) imageImpls = makeMutable<std::vector<Immutable<style::Image::Impl>>>();
 
-#if MLN_DRAWABLE_RENDERER
     UniqueChangeRequestVec changes;
     for (const auto& entry : renderLayers) {
         entry.second->layerRemoved(changes);
@@ -877,7 +860,6 @@ void RenderOrchestrator::clearData() {
     addChanges(changes);
 
     debugLayerGroups.clear();
-#endif
 
     renderSources.clear();
     renderLayers.clear();
@@ -891,7 +873,6 @@ void RenderOrchestrator::clearData() {
     glyphManager->evict(fontStacks(*layerImpls));
 }
 
-#if MLN_DRAWABLE_RENDERER
 void RenderOrchestrator::addChanges(UniqueChangeRequestVec& changes) {
     pendingChanges.insert(
         pendingChanges.end(), std::make_move_iterator(changes.begin()), std::make_move_iterator(changes.end()));
@@ -1027,8 +1008,6 @@ void RenderOrchestrator::updateDebugLayerGroups(const RenderTree& renderTree, Pa
         item.updateDebugDrawables(debugLayerGroups, parameters);
     }
 }
-
-#endif // MLN_DRAWABLE_RENDERER
 
 void RenderOrchestrator::onGlyphsLoaded(const FontStack& fontStack, const GlyphRange& range) {
     observer->onGlyphsLoaded(fontStack, range);

--- a/src/mbgl/renderer/render_orchestrator.hpp
+++ b/src/mbgl/renderer/render_orchestrator.hpp
@@ -1,7 +1,6 @@
 #pragma once
-#if MLN_DRAWABLE_RENDERER
+
 #include <mbgl/renderer/layer_group.hpp>
-#endif
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/renderer/render_source_observer.hpp>
@@ -24,9 +23,7 @@
 #include <vector>
 
 namespace mbgl {
-#if MLN_DRAWABLE_RENDERER
 class ChangeRequest;
-#endif
 class RendererObserver;
 class RenderSource;
 class UpdateParameters;
@@ -42,10 +39,8 @@ class RenderTree;
 
 namespace gfx {
 class ShaderRegistry;
-#if MLN_DRAWABLE_RENDERER
 class Drawable;
 using DrawablePtr = std::shared_ptr<Drawable>;
-#endif
 } // namespace gfx
 
 namespace style {
@@ -106,7 +101,6 @@ public:
 
     void update(const std::shared_ptr<UpdateParameters>&);
 
-#if MLN_DRAWABLE_RENDERER
     bool addLayerGroup(LayerGroupBasePtr);
     bool removeLayerGroup(const LayerGroupBasePtr&);
     size_t numLayerGroups() const noexcept;
@@ -158,7 +152,6 @@ public:
             }
         }
     }
-#endif
 
     const ZoomHistory& getZoomHistory() const { return zoomHistory; }
 
@@ -193,10 +186,8 @@ private:
     void onStyleImageMissing(const std::string&, const std::function<void()>&) override;
     void onRemoveUnusedStyleImages(const std::vector<std::string>&) override;
 
-#if MLN_DRAWABLE_RENDERER
     /// Move changes into the pending set, clearing the provided collection
     void addChanges(UniqueChangeRequestVec&);
-#endif
 
     RendererObserver* observer;
 
@@ -236,7 +227,6 @@ private:
 
     TaggedScheduler threadPool;
 
-#if MLN_DRAWABLE_RENDERER
     std::vector<std::unique_ptr<ChangeRequest>> pendingChanges;
 
     using LayerGroupMap = std::multimap<int32_t, LayerGroupBasePtr>;
@@ -244,7 +234,6 @@ private:
 
     std::vector<RenderTargetPtr> renderTargets;
     RenderItem::DebugLayerGroupMap debugLayerGroups;
-#endif
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/render_static_data.cpp
+++ b/src/mbgl/renderer/render_static_data.cpp
@@ -91,11 +91,6 @@ void RenderStaticData::upload(gfx::UploadPass& uploadPass) {
             tileVertices(), gfx::BufferUsageType::StaticDraw, /*persistent=*/false);
         quadTriangleIndexBuffer = uploadPass.createIndexBuffer(
             quadTriangleIndices(), gfx::BufferUsageType::StaticDraw, /*persistent=*/false);
-#if MLN_LEGACY_RENDERER
-        rasterVertexBuffer = uploadPass.createVertexBuffer(rasterVertices());
-        heatmapTextureVertexBuffer = uploadPass.createVertexBuffer(heatmapTextureVertices());
-        tileBorderIndexBuffer = uploadPass.createIndexBuffer(tileLineStripIndices());
-#endif // MLN_LEGACY_RENDERER
         uploaded = true;
     }
 }

--- a/src/mbgl/renderer/render_tile.cpp
+++ b/src/mbgl/renderer/render_tile.cpp
@@ -96,7 +96,6 @@ std::optional<ImagePosition> RenderTile::getPattern(const std::string& pattern) 
     return renderData->getPattern(pattern);
 }
 
-#if MLN_DRAWABLE_RENDERER
 static const gfx::Texture2DPtr noTexture;
 
 bool RenderTile::hasGlyphAtlasTexture() const {
@@ -119,28 +118,6 @@ static const std::shared_ptr<TileAtlasTextures> noAtlas;
 const std::shared_ptr<TileAtlasTextures>& RenderTile::getAtlasTextures() const {
     return renderData ? renderData->getAtlasTextures() : noAtlas;
 }
-
-#else
-gfx::TextureBinding RenderTile::getGlyphAtlasTextureBinding(gfx::TextureFilterType filter) const {
-    assert(renderData);
-    return {getGlyphAtlasTexture()->getResource(), filter};
-}
-
-gfx::TextureBinding RenderTile::getIconAtlasTextureBinding(gfx::TextureFilterType filter) const {
-    assert(renderData);
-    return {getIconAtlasTexture()->getResource(), filter};
-}
-
-const gfx::Texture* RenderTile::getGlyphAtlasTexture() const {
-    assert(renderData);
-    return &renderData->getGlyphAtlasTexture();
-}
-
-const gfx::Texture* RenderTile::getIconAtlasTexture() const {
-    assert(renderData);
-    return &renderData->getIconAtlasTexture();
-}
-#endif
 
 void RenderTile::upload(gfx::UploadPass& uploadPass) const {
     assert(renderData);

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -14,10 +14,8 @@
 namespace mbgl {
 
 namespace gfx {
-#if MLN_DRAWABLE_RENDERER
 class Texture2D;
 using Texture2DPtr = std::shared_ptr<Texture2D>;
-#endif
 
 class UploadPass;
 } // namespace gfx
@@ -62,7 +60,6 @@ public:
     const LayerRenderData* getLayerRenderData(const style::Layer::Impl&) const;
     std::optional<ImagePosition> getPattern(const std::string& pattern) const;
 
-#if MLN_DRAWABLE_RENDERER
     bool hasGlyphAtlasTexture() const;
     const gfx::Texture2DPtr& getGlyphAtlasTexture() const;
 
@@ -72,13 +69,6 @@ public:
     const std::shared_ptr<TileAtlasTextures>& getAtlasTextures() const;
 
     bool getNeedsRendering() const { return needsRendering; };
-#else
-    gfx::TextureBinding getGlyphAtlasTextureBinding(gfx::TextureFilterType) const;
-    gfx::TextureBinding getIconAtlasTextureBinding(gfx::TextureFilterType) const;
-
-    const gfx::Texture* getGlyphAtlasTexture() const;
-    const gfx::Texture* getIconAtlasTexture() const;
-#endif
 
     void upload(gfx::UploadPass&) const;
     void prepare(const SourcePrepareParameters&);

--- a/src/mbgl/renderer/render_tree.hpp
+++ b/src/mbgl/renderer/render_tree.hpp
@@ -1,7 +1,5 @@
 #pragma once
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/drawable.hpp>
-#endif
 #include <mbgl/renderer/paint_parameters.hpp>
 #include <mbgl/util/monotonic_timer.hpp>
 
@@ -38,9 +36,7 @@ public:
     virtual void render(PaintParameters&) const = 0;
     virtual bool hasRenderPass(RenderPass) const = 0;
     virtual const std::string& getName() const = 0;
-#if MLN_DRAWABLE_RENDERER
     virtual void updateDebugDrawables(DebugLayerGroupMap&, PaintParameters&) const = 0;
-#endif
 };
 
 class RenderSource;
@@ -58,9 +54,7 @@ private:
     void upload(gfx::UploadPass& pass) const override;
     void render(PaintParameters& parameters) const override;
     const std::string& getName() const override;
-#if MLN_DRAWABLE_RENDERER
     void updateDebugDrawables(DebugLayerGroupMap&, PaintParameters&) const override;
-#endif
 };
 
 using RenderItems = std::vector<std::reference_wrapper<const RenderItem>>;

--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -19,13 +19,9 @@
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/instrumentation.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/drawable_tweaker.hpp>
 #include <mbgl/renderer/layer_tweaker.hpp>
 #include <mbgl/renderer/render_target.hpp>
-
-#include <limits>
-#endif // MLN_DRAWABLE_RENDERER
 
 #if MLN_RENDER_BACKEND_METAL
 #include <mbgl/mtl/renderer_backend.hpp>
@@ -38,9 +34,7 @@ constexpr auto CaptureFrameStart = 0; // frames are 0-based
 constexpr auto CaptureFrameCount = 1;
 #elif MLN_RENDER_BACKEND_OPENGL
 #include <mbgl/gl/defines.hpp>
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gl/drawable_gl.hpp>
-#endif // MLN_DRAWABLE_RENDERER
 #endif // !MLN_RENDER_BACKEND_METAL
 
 namespace mbgl {
@@ -169,11 +163,9 @@ void Renderer::Impl::render(const RenderTree& renderTree,
         // Initialize legacy shader programs
         staticData->programs.registerWith(*staticData->shaders);
 
-#if MLN_DRAWABLE_RENDERER
         // Initialize shaders for drawables
         const auto programParameters = ProgramParameters{pixelRatio, false};
         backend.initShaders(*staticData->shaders, programParameters);
-#endif
 
         // Notify post-shader registration
         observer->onRegisterShaders(*staticData->shaders);
@@ -206,11 +198,7 @@ void Renderer::Impl::render(const RenderTree& renderTree,
     parameters.opaquePassCutoff = renderTreeParameters.opaquePassCutOff;
     const auto& sourceRenderItems = renderTree.getSourceRenderItems();
 
-#if MLN_DRAWABLE_RENDERER
     const auto& layerRenderItems = renderTree.getLayerRenderItemMap();
-#else
-    const auto& layerRenderItems = renderTree.getLayerRenderItems();
-#endif
 
     // - UPLOAD PASS -------------------------------------------------------------------------------
     // Uploads all required buffers and images before we do any actual rendering.
@@ -233,7 +221,6 @@ void Renderer::Impl::render(const RenderTree& renderTree,
         renderTree.getPatternAtlas().upload(*uploadPass);
     }
 
-#if MLN_DRAWABLE_RENDERER
     // - LAYER GROUP UPDATE ------------------------------------------------------------------------
     // Updates all layer groups and process changes
     if (staticData && staticData->shaders) {
@@ -279,19 +266,18 @@ void Renderer::Impl::render(const RenderTree& renderTree,
     const Size atlasSize = parameters.patternAtlas.getPixelSize();
     const auto& worldSize = parameters.staticData.backendSize;
     const shaders::GlobalPaintParamsUBO globalPaintParamsUBO = {
-        /* .pattern_atlas_texsize = */ {static_cast<float>(atlasSize.width), static_cast<float>(atlasSize.height)},
-        /* .units_to_pixels = */ {1.0f / parameters.pixelsToGLUnits[0], 1.0f / parameters.pixelsToGLUnits[1]},
-        /* .world_size = */ {static_cast<float>(worldSize.width), static_cast<float>(worldSize.height)},
-        /* .camera_to_center_distance = */ parameters.state.getCameraToCenterDistance(),
-        /* .symbol_fade_change = */ parameters.symbolFadeChange,
-        /* .aspect_ratio = */ parameters.state.getSize().aspectRatio(),
-        /* .pixel_ratio = */ parameters.pixelRatio,
-        /* .map_zoom = */ static_cast<float>(parameters.state.getZoom()),
-        /* .pad1 = */ 0,
+        .pattern_atlas_texsize = {static_cast<float>(atlasSize.width), static_cast<float>(atlasSize.height)},
+        .units_to_pixels = {1.0f / parameters.pixelsToGLUnits[0], 1.0f / parameters.pixelsToGLUnits[1]},
+        .world_size = {static_cast<float>(worldSize.width), static_cast<float>(worldSize.height)},
+        .camera_to_center_distance = parameters.state.getCameraToCenterDistance(),
+        .symbol_fade_change = parameters.symbolFadeChange,
+        .aspect_ratio = parameters.state.getSize().aspectRatio(),
+        .pixel_ratio = parameters.pixelRatio,
+        .map_zoom = static_cast<float>(parameters.state.getZoom()),
+        .pad1 = 0,
     };
     auto& globalUniforms = context.mutableGlobalUniformBuffers();
     globalUniforms.createOrUpdate(shaders::idGlobalPaintParamsUBO, &globalPaintParamsUBO, context);
-#endif
 
     // - 3D PASS
     // -------------------------------------------------------------------------------------
@@ -315,7 +301,6 @@ void Renderer::Impl::render(const RenderTree& renderTree,
         }
     };
 
-#if MLN_DRAWABLE_RENDERER
     const auto drawable3DPass = [&] {
         const auto debugGroup(parameters.encoder->createDebugGroup("drawables-3d"));
         assert(parameters.pass == RenderPass::Pass3D);
@@ -329,30 +314,12 @@ void Renderer::Impl::render(const RenderTree& renderTree,
             }
         });
     };
-#endif // MLN_DRAWABLE_RENDERER
 
-#if MLN_LEGACY_RENDERER
-    const auto renderLayer3DPass = [&] {
-        const auto debugGroup(parameters.encoder->createDebugGroup("3d"));
-        int32_t i = static_cast<int32_t>(layerRenderItems.size()) - 1;
-        for (auto it = layerRenderItems.begin(); it != layerRenderItems.end() && i >= 0; ++it, --i) {
-            parameters.currentLayer = i;
-            const RenderItem& renderItem = it->get();
-            if (renderItem.hasRenderPass(parameters.pass)) {
-                const auto layerDebugGroup(parameters.encoder->createDebugGroup(renderItem.getName().c_str()));
-                renderItem.render(parameters);
-            }
-        }
-    };
-#endif // MLN_LEGACY_RENDERER
-
-#if MLN_DRAWABLE_RENDERER
     const auto drawableTargetsPass = [&] {
         // draw render targets
         orchestrator.visitRenderTargets(
             [&](RenderTarget& renderTarget) { renderTarget.render(orchestrator, renderTree, parameters); });
     };
-#endif
 
     const auto commonClearPass = [&] {
         // - CLEAR
@@ -367,12 +334,15 @@ void Renderer::Impl::render(const RenderTree& renderTree,
                 color = renderTreeParameters.backgroundColor;
             }
             parameters.renderPass = parameters.encoder->createRenderPass(
-                "main buffer", {parameters.backend.getDefaultRenderable(), color, 1.0f, 0});
+                "main buffer",
+                {.renderable = parameters.backend.getDefaultRenderable(),
+                 .clearColor = color,
+                 .clearDepth = 1.0f,
+                 .clearStencil = 0});
         }
     };
 
     // Actually render the layers
-#if MLN_DRAWABLE_RENDERER
     // Drawables
     const auto drawableOpaquePass = [&] {
         const auto debugGroup(parameters.renderPass->createDebugGroup("drawables-opaque"));
@@ -416,47 +386,7 @@ void Renderer::Impl::render(const RenderTree& renderTree,
             }
         }
     };
-#endif
 
-#if MLN_LEGACY_RENDERER
-    // Render everything top-to-bottom by using reverse iterators. Render opaque objects first.
-    const auto renderLayerOpaquePass = [&] {
-        const auto debugGroup(parameters.renderPass->createDebugGroup("opaque"));
-        parameters.pass = RenderPass::Opaque;
-        parameters.depthRangeSize = 1 - (layerRenderItems.size() + 2) * PaintParameters::numSublayers *
-                                            PaintParameters::depthEpsilon;
-
-        uint32_t i = 0;
-        for (auto it = layerRenderItems.rbegin(); it != layerRenderItems.rend(); ++it, ++i) {
-            parameters.currentLayer = i;
-            const RenderItem& renderItem = it->get();
-            if (renderItem.hasRenderPass(parameters.pass)) {
-                const auto layerDebugGroup(parameters.renderPass->createDebugGroup(renderItem.getName().c_str()));
-                renderItem.render(parameters);
-            }
-        }
-    };
-
-    // Make a second pass, rendering translucent objects. This time, we render bottom-to-top.
-    const auto renderLayerTranslucentPass = [&] {
-        const auto debugGroup(parameters.renderPass->createDebugGroup("translucent"));
-        parameters.pass = RenderPass::Translucent;
-        parameters.depthRangeSize = 1 - (layerRenderItems.size() + 2) * PaintParameters::numSublayers *
-                                            PaintParameters::depthEpsilon;
-
-        int32_t i = static_cast<int32_t>(layerRenderItems.size()) - 1;
-        for (auto it = layerRenderItems.begin(); it != layerRenderItems.end() && i >= 0; ++it, --i) {
-            parameters.currentLayer = i;
-            const RenderItem& renderItem = it->get();
-            if (renderItem.hasRenderPass(parameters.pass)) {
-                const auto layerDebugGroup(parameters.renderPass->createDebugGroup(renderItem.getName().c_str()));
-                renderItem.render(parameters);
-            }
-        }
-    };
-#endif // MLN_LEGACY_RENDERER
-
-#if MLN_DRAWABLE_RENDERER
     const auto drawableDebugOverlays = [&] {
         // Renders debug overlays.
         {
@@ -468,36 +398,7 @@ void Renderer::Impl::render(const RenderTree& renderTree,
             });
         }
     };
-#endif // MLN_DRAWABLE_RENDERER
 
-#if MLN_LEGACY_RENDERER
-    const auto renderDebugOverlays = [&] {
-        // Renders debug overlays.
-        {
-            const auto debugGroup(parameters.renderPass->createDebugGroup("debug"));
-
-            // Finalize the rendering, e.g. by calling debug render calls per tile.
-            // This guarantees that we have at least one function per tile called.
-            // When only rendering layers via the stylesheet, it's possible that we
-            // don't ever visit a tile during rendering.
-            for (const RenderItem& renderItem : sourceRenderItems) {
-                renderItem.render(parameters);
-            }
-        }
-
-#if !defined(NDEBUG)
-        if (parameters.debugOptions & MapDebugOptions::StencilClip) {
-            // Render tile clip boundaries, using stencil buffer to calculate fill color.
-            parameters.context.visualizeStencilBuffer();
-        } else if (parameters.debugOptions & MapDebugOptions::DepthBuffer) {
-            // Render the depth buffer.
-            parameters.context.visualizeDepthBuffer(parameters.depthRangeSize);
-        }
-#endif
-    };
-#endif // MLN_LEGACY_RENDERER
-
-#if (MLN_DRAWABLE_RENDERER && !MLN_LEGACY_RENDERER)
     if (parameters.staticData.has3D) {
         common3DPass();
         drawable3DPass();
@@ -508,24 +409,10 @@ void Renderer::Impl::render(const RenderTree& renderTree,
     drawableOpaquePass();
     drawableTranslucentPass();
     drawableDebugOverlays();
-#elif (MLN_LEGACY_RENDERER && !MLN_DRAWABLE_RENDERER)
-    if (parameters.staticData.has3D) {
-        common3DPass();
-        renderLayer3DPass();
-    }
-    commonClearPass();
-    renderLayerOpaquePass();
-    renderLayerTranslucentPass();
-    renderDebugOverlays();
-#else
-    static_assert(0, "Must define one of (MLN_DRAWABLE_RENDERER, MLN_LEGACY_RENDERER)");
-#endif // MLN_LEGACY_RENDERER
 
-#if MLN_DRAWABLE_RENDERER
     // Give the layers a chance to do cleanup
     orchestrator.visitLayerGroups([&](LayerGroupBase& layerGroup) { layerGroup.postRender(orchestrator, parameters); });
     context.unbindGlobalUniformBuffers(*parameters.renderPass);
-#endif
 
     // Ends the RenderPass
     parameters.renderPass.reset();

--- a/src/mbgl/renderer/sources/render_image_source.cpp
+++ b/src/mbgl/renderer/sources/render_image_source.cpp
@@ -24,14 +24,6 @@ void ImageSourceRenderData::upload(gfx::UploadPass& uploadPass) const {
     if (bucket && bucket->needsUpload()) {
         bucket->upload(uploadPass);
     }
-
-#if MLN_LEGACY_RENDERER
-    if (!debugTexture) {
-        std::array<uint8_t, 4> data{{0, 0, 0, 0}};
-        static const PremultipliedImage emptyImage{Size(1, 1), data.data(), data.size()};
-        debugTexture = uploadPass.createTexture(emptyImage);
-    }
-#endif
 }
 
 void ImageSourceRenderData::render(PaintParameters& parameters) const {
@@ -103,9 +95,6 @@ void RenderImageSource::prepare(const SourcePrepareParameters& parameters) {
         mat4& matrix = matrices[i];
         matrix::identity(matrix);
         transformParams.state.matrixFor(matrix, tileIds[i]);
-#if MLN_LEGACY_RENDERER
-        matrix::multiply(matrix, transformParams.alignedProjMatrix, matrix);
-#endif
     }
     renderData = std::make_unique<ImageSourceRenderData>(bucket, std::move(matrices), baseImpl->id);
 }

--- a/src/mbgl/renderer/sources/render_image_source.hpp
+++ b/src/mbgl/renderer/sources/render_image_source.hpp
@@ -25,9 +25,7 @@ private:
     bool hasRenderPass(RenderPass) const override { return false; }
     const std::string& getName() const override { return name; }
     std::string name;
-#if MLN_DRAWABLE_RENDERER
     void updateDebugDrawables(DebugLayerGroupMap&, PaintParameters&) const override {};
-#endif
     mutable std::optional<gfx::Texture> debugTexture;
 };
 

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -10,7 +10,6 @@
 #include <mbgl/util/instrumentation.hpp>
 #include <mbgl/util/math.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/cull_face_mode.hpp>
 #include <mbgl/gfx/drawable.hpp>
 #include <mbgl/gfx/drawable_builder.hpp>
@@ -27,14 +26,10 @@
 #include <mbgl/gfx/drawable_tweaker.hpp>
 #include <mbgl/renderer/layer_tweaker.hpp>
 
-#include <unordered_set>
-
 #if MLN_RENDER_BACKEND_METAL || (MLN_RENDER_BACKEND_VULKAN && defined(__ANDROID__))
 #define MLN_ENABLE_POLYLINE_DRAWABLES 1
 #else
 #define MLN_ENABLE_POLYLINE_DRAWABLES 0
-#endif
-
 #endif
 
 namespace mbgl {
@@ -54,8 +49,6 @@ void TileSourceRenderItem::render(PaintParameters& parameters) const {
     }
 }
 
-#if MLN_DRAWABLE_RENDERER
-
 #if MLN_ENABLE_POLYLINE_DRAWABLES
 class PolylineLayerImpl : public Layer::Impl {
 public:
@@ -66,13 +59,13 @@ public:
 
     const LayerTypeInfo* getTypeInfo() const noexcept final { return staticTypeInfo(); }
     static const LayerTypeInfo* staticTypeInfo() noexcept {
-        const static LayerTypeInfo typeInfo{"debugPolyline",
-                                            LayerTypeInfo::Source::NotRequired,
-                                            LayerTypeInfo::Pass3D::NotRequired,
-                                            LayerTypeInfo::Layout::NotRequired,
-                                            LayerTypeInfo::FadingTiles::NotRequired,
-                                            LayerTypeInfo::CrossTileIndex::NotRequired,
-                                            LayerTypeInfo::TileKind::NotRequired};
+        const static LayerTypeInfo typeInfo{.type = "debugPolyline",
+                                            .source = LayerTypeInfo::Source::NotRequired,
+                                            .pass3d = LayerTypeInfo::Pass3D::NotRequired,
+                                            .layout = LayerTypeInfo::Layout::NotRequired,
+                                            .fadingTiles = LayerTypeInfo::FadingTiles::NotRequired,
+                                            .crossTileIndex = LayerTypeInfo::CrossTileIndex::NotRequired,
+                                            .tileKind = LayerTypeInfo::TileKind::NotRequired};
         return &typeInfo;
     }
 };
@@ -457,7 +450,6 @@ void TileSourceRenderItem::updateDebugDrawables(DebugLayerGroupMap& debugLayerGr
         debugLayerGroups.erase(DebugType::Border);
     }
 }
-#endif
 
 RenderTileSource::RenderTileSource(Immutable<style::Source::Impl> impl_, const TaggedScheduler& threadPool_)
     : RenderSource(std::move(impl_)),

--- a/src/mbgl/renderer/sources/render_tile_source.hpp
+++ b/src/mbgl/renderer/sources/render_tile_source.hpp
@@ -6,9 +6,7 @@
 #include <mbgl/style/sources/vector_source_impl.hpp>
 #include <mbgl/renderer/render_tree.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/context.hpp>
-#endif
 
 namespace mbgl {
 
@@ -105,9 +103,7 @@ private:
     bool hasRenderPass(RenderPass) const override { return false; }
     const std::string& getName() const override { return name; }
 
-#if MLN_DRAWABLE_RENDERER
     void updateDebugDrawables(DebugLayerGroupMap&, PaintParameters&) const override;
-#endif
 
     Immutable<std::vector<RenderTile>> renderTiles;
     std::string name;

--- a/src/mbgl/renderer/tile_render_data.cpp
+++ b/src/mbgl/renderer/tile_render_data.cpp
@@ -9,7 +9,6 @@ TileRenderData::TileRenderData(std::shared_ptr<TileAtlasTextures> atlasTextures_
 
 TileRenderData::~TileRenderData() = default;
 
-#if MLN_DRAWABLE_RENDERER
 static gfx::Texture2DPtr noTexture;
 
 const gfx::Texture2DPtr& TileRenderData::getGlyphAtlasTexture() const {
@@ -19,19 +18,6 @@ const gfx::Texture2DPtr& TileRenderData::getGlyphAtlasTexture() const {
 const gfx::Texture2DPtr& TileRenderData::getIconAtlasTexture() const {
     return atlasTextures ? atlasTextures->icon : noTexture;
 }
-#else
-const gfx::Texture& TileRenderData::getGlyphAtlasTexture() const {
-    assert(atlasTextures);
-    assert(atlasTextures->glyph);
-    return *atlasTextures->glyph;
-}
-
-const gfx::Texture& TileRenderData::getIconAtlasTexture() const {
-    assert(atlasTextures);
-    assert(atlasTextures->icon);
-    return *atlasTextures->icon;
-}
-#endif
 
 std::optional<ImagePosition> TileRenderData::getPattern(const std::string&) const {
     assert(false);

--- a/src/mbgl/renderer/tile_render_data.hpp
+++ b/src/mbgl/renderer/tile_render_data.hpp
@@ -10,10 +10,8 @@
 namespace mbgl {
 
 namespace gfx {
-#if MLN_DRAWABLE_RENDERER
 class Texture2D;
 using Texture2DPtr = std::shared_ptr<gfx::Texture2D>;
-#endif
 
 class UploadPass;
 } // namespace gfx
@@ -24,26 +22,16 @@ class SourcePrepareParameters;
 
 class TileAtlasTextures {
 public:
-#if MLN_DRAWABLE_RENDERER
     gfx::Texture2DPtr glyph;
     gfx::Texture2DPtr icon;
-#else
-    std::optional<gfx::Texture> glyph;
-    std::optional<gfx::Texture> icon;
-#endif
 };
 
 class TileRenderData {
 public:
     virtual ~TileRenderData();
 
-#if MLN_DRAWABLE_RENDERER
     const gfx::Texture2DPtr& getGlyphAtlasTexture() const;
     const gfx::Texture2DPtr& getIconAtlasTexture() const;
-#else
-    const gfx::Texture& getGlyphAtlasTexture() const;
-    const gfx::Texture& getIconAtlasTexture() const;
-#endif
 
     const std::shared_ptr<TileAtlasTextures>& getAtlasTextures() const { return atlasTextures; }
     // To be implemented for concrete tile types.

--- a/src/mbgl/style/properties.hpp
+++ b/src/mbgl/style/properties.hpp
@@ -338,7 +338,6 @@ public:
             return result;
         }
 
-#if MLN_DRAWABLE_RENDERER
         using GPUExpressions = std::array<gfx::UniqueGPUExpression, UnevaluatedTypes::TypeCount>;
 
         /// Update the GPU expressions, if applicable, for each item in the tuple.
@@ -347,7 +346,6 @@ public:
             const auto results = util::to_array(std::make_tuple(updateGPUExpression<Ps>(exprs, now)...));
             return std::any_of(results.begin(), results.end(), [](bool x) { return x; });
         }
-#endif // MLN_DRAWABLE_RENDERER
 
     protected:
         // gather dependencies for each type that can appear in this tuple
@@ -362,7 +360,6 @@ public:
             return v.getValue().getDependencies();
         }
 
-#if MLN_DRAWABLE_RENDERER
         template <typename P>
         bool updateGPUExpression(Unevaluated::GPUExpressions& exprs, TimePoint now) const {
             constexpr auto index = TypeIndex<P, Ps...>::value;
@@ -407,7 +404,6 @@ public:
                                         bool) {
             return false;
         }
-#endif // MLN_DRAWABLE_RENDERER
     };
 
     class Transitionable : public Tuple<TransitionableTypes> {

--- a/src/mbgl/style/property_expression.cpp
+++ b/src/mbgl/style/property_expression.cpp
@@ -3,9 +3,7 @@
 #include <mbgl/renderer/paint_property_binder.hpp>
 #include <mbgl/util/convert.hpp>
 
-#if MLN_DRAWABLE_RENDERER
 #include <mbgl/gfx/gpu_expression.hpp>
-#endif // MLN_DRAWABLE_RENDERER
 
 namespace mbgl {
 namespace style {
@@ -72,12 +70,10 @@ PropertyExpressionBase& PropertyExpressionBase::operator=(const PropertyExpressi
     return *this;
 }
 
-#if MLN_DRAWABLE_RENDERER
 gfx::UniqueGPUExpression PropertyExpressionBase::getGPUExpression(bool intZoom) const {
     return isGPUCapable_ ? gfx::GPUExpression::create(*expression, zoomCurve, useIntegerZoom_ || intZoom)
                          : gfx::UniqueGPUExpression{};
 }
-#endif // MLN_DRAWABLE_RENDERER
 
 float PropertyExpressionBase::interpolationFactor(const Range<float>& inputLevels,
                                                   const float inputValue) const noexcept {

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -96,39 +96,25 @@ void GeometryTileRenderData::upload(gfx::UploadPass& uploadPass) {
     assert(atlasTextures);
 
     if (layoutResult->glyphAtlasImage && layoutResult->glyphAtlasImage->valid()) {
-#if MLN_DRAWABLE_RENDERER
         atlasTextures->glyph = uploadPass.getContext().createTexture2D();
-        atlasTextures->glyph->setSamplerConfiguration(
-            {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Clamp, gfx::TextureWrapType::Clamp});
+        atlasTextures->glyph->setSamplerConfiguration({.filter = gfx::TextureFilterType::Linear,
+                                                       .wrapU = gfx::TextureWrapType::Clamp,
+                                                       .wrapV = gfx::TextureWrapType::Clamp});
         atlasTextures->glyph->upload(*layoutResult->glyphAtlasImage);
-#else
-        atlasTextures->glyph = uploadPass.createTexture(*layoutResult->glyphAtlasImage);
-#endif
         layoutResult->glyphAtlasImage = {};
     }
 
     if (layoutResult->iconAtlas.image.valid()) {
-#if MLN_DRAWABLE_RENDERER
         atlasTextures->icon = uploadPass.getContext().createTexture2D();
         atlasTextures->icon->upload(layoutResult->iconAtlas.image);
-#else
-        atlasTextures->icon = uploadPass.createTexture(layoutResult->iconAtlas.image);
-#endif
         layoutResult->iconAtlas.image = {};
     }
 
     if (atlasTextures->icon && !imagePatches.empty()) {
         for (const auto& imagePatch : imagePatches) { // patch updated images.
-#if MLN_DRAWABLE_RENDERER
             atlasTextures->icon->uploadSubRegion(imagePatch.image->image,
                                                  imagePatch.paddedRect.x + ImagePosition::padding,
                                                  imagePatch.paddedRect.y + ImagePosition::padding);
-#else
-            uploadPass.updateTextureSub(*atlasTextures->icon,
-                                        imagePatch.image->image,
-                                        imagePatch.paddedRect.x + ImagePosition::padding,
-                                        imagePatch.paddedRect.y + ImagePosition::padding);
-#endif
         }
         imagePatches.clear();
     }

--- a/src/mbgl/tile/raster_dem_tile.cpp
+++ b/src/mbgl/tile/raster_dem_tile.cpp
@@ -133,9 +133,7 @@ void RasterDEMTile::backfillBorder(const RasterDEMTile& borderTile, const DEMTil
         // mark HillshadeBucket.prepared as false so it runs through the prepare
         // render pass with the new texture data we just backfilled
         bucket->setPrepared(false);
-#if MLN_DRAWABLE_RENDERER
         bucket->renderTargetPrepared = false;
-#endif
     }
 }
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//bazel:flags.bzl", "CPP_FLAGS", "MAPLIBRE_FLAGS")
 
 cc_library(

--- a/test/android/app/build.gradle.kts
+++ b/test/android/app/build.gradle.kts
@@ -33,8 +33,6 @@ android {
         externalNativeBuild {
             cmake {
                 arguments += listOf(
-                    "-DMLN_LEGACY_RENDERER=OFF",
-                    "-DMLN_DRAWABLE_RENDERER=ON",
                     "-DANDROID_STL=c++_static"
                 )
                 targets += "mbgl-test-runner"

--- a/test/api/custom_drawable_layer.test.cpp
+++ b/test/api/custom_drawable_layer.test.cpp
@@ -10,8 +10,6 @@
 #include <mbgl/util/mat4.hpp>
 #include <mbgl/util/run_loop.hpp>
 
-#if MLN_DRAWABLE_RENDERER
-
 #include <mbgl/style/layers/custom_drawable_layer.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/logging.hpp>
@@ -307,5 +305,3 @@ TEST(CustomDrawableLayer, SymbolIcon) {
     // render and test
     test::checkImage("test/fixtures/custom_drawable_layer/symbol_icon", frontend.render(map).image, 0.000657, 0.1);
 }
-
-#endif // MLN_DRAWABLE_RENDERER

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -1634,12 +1634,8 @@ TEST(Map, StencilOverflow) {
     test.map.jumpTo(CameraOptions().withZoom(5));
     auto result = test.frontend.render(test.map);
 
-    // In drawable builds, no drawables are built because no bucket/tiledata is available.
-#if MLN_DRAWABLE_RENDERER
+    // No drawables are built because no bucket/tiledata is available.
     ASSERT_LE(0, result.stats.stencilUpdates);
-#else
-    ASSERT_LT(0, result.stats.stencilClears);
-#endif // MLN_DRAWABLE_RENDERER
 
 #if !defined(NDEBUG)
     Log::Info(Event::General, result.stats.toString("\n"));

--- a/test/renderer/shader_registry.test.cpp
+++ b/test/renderer/shader_registry.test.cpp
@@ -207,11 +207,7 @@ TEST(ShaderRegistry, NamedReplace) {
 }
 
 // Test replacing an actual program instance with a similar instance
-#if MLN_LEGACY_RENDERER
-TEST(ShaderRegistry, GLSLReplacement_NoOp) {
-#else
 TEST(ShaderRegistry, DISABLED_GLSLReplacement_NoOp) {
-#endif
     MapInstance::ShaderAndStyleObserver observer;
     util::RunLoop runLoop;
     auto map = MapInstance(1.0f, observer);
@@ -237,11 +233,7 @@ TEST(ShaderRegistry, DISABLED_GLSLReplacement_NoOp) {
 
 // Test replacing an actual program with a similar instance using a different
 // fragment shader
-#if MLN_LEGACY_RENDERER
-TEST(ShaderRegistry, GLSLReplacement1) {
-#else
 TEST(ShaderRegistry, DISABLED_GLSLReplacement1) {
-#endif
     MapInstance::ShaderAndStyleObserver observer;
     util::RunLoop runLoop;
     auto map = MapInstance(1.0f, observer);
@@ -275,11 +267,7 @@ void main() {
 
 // Test replacing an actual program with a similar instance using a different
 // fragment shader
-#if MLN_LEGACY_RENDERER
-TEST(ShaderRegistry, GLSLReplacement2) {
-#else
 TEST(ShaderRegistry, DISABLED_GLSLReplacement2) {
-#endif
     MapInstance::ShaderAndStyleObserver observer;
     util::RunLoop runLoop;
     auto map = MapInstance(1.0f, observer);

--- a/test/util/offscreen_texture.test.cpp
+++ b/test/util/offscreen_texture.test.cpp
@@ -10,11 +10,7 @@
 #include <mbgl/gl/headless_backend.hpp>
 #include <mbgl/gl/offscreen_texture.hpp>
 
-#if MLN_LEGACY_RENDERER
-#include <mbgl/gl/texture.hpp>
-#else
 #include <mbgl/gl/texture2d.hpp>
-#endif
 
 using namespace mbgl;
 using namespace mbgl::platform;
@@ -173,13 +169,9 @@ void main() {
     test::checkImage("test/fixtures/offscreen_texture/render-to-fbo", image, 0, 0);
 
     // Now, composite the Framebuffer texture we've rendered to onto the main FBO.
-#if MLN_LEGACY_RENDERER
-    gl::bindTexture(context, 0, {offscreenTexture.getTexture().getResource(), gfx::TextureFilterType::Linear});
-    MBGL_CHECK_ERROR(glUniform1i(u_texture, 0));
-#else
     offscreenTexture.getTexture()->setSamplerConfiguration({gfx::TextureFilterType::Linear});
     std::static_pointer_cast<gl::Texture2D>(offscreenTexture.getTexture())->bind(u_texture, 0);
-#endif
+
     MBGL_CHECK_ERROR(glUseProgram(compositeShader.program));
     MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, viewportBuffer.buffer));
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(compositeShader.a_pos));

--- a/vendor/BUILD.bazel
+++ b/vendor/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "objc_library")
 load("//bazel:flags.bzl", "CPP_FLAGS")
 
 # vendor/mapbox-base-files.json

--- a/vendor/glfw.BUILD
+++ b/vendor/glfw.BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 cc_library(
     name = "glfw",
     hdrs = glob([


### PR DESCRIPTION
@alexcristici is working on https://github.com/maplibre/maplibre-native/pull/3198 which once it lands will offer greatly reduced peak memory usage. We have decided this is probably a good moment to get rid of the legacy renderer, because it is not worth it to backport the required changes to get that to compile as well.

We wanted to get rid of it for some time now, but thus far it hasn't really affected anyone's work and it was sometimes still useful to investigate regressions and performance. 

We are very dependent on the new rendering architecture to support different backends, the last round of testing indicated similar or better performance of the new drawable renderer and we want to move forward refactoring the codebase to be more aligned with the new rendering architecture.
