### PR TITLE
Fix std::bad_function_call in event handling

### DIFF
--- a/platform/qt/src/mbgl/run_loop.cpp
+++ b/platform/qt/src/mbgl/run_loop.cpp
@@ -113,7 +113,7 @@ void RunLoop::addWatch(int fd, Event event, std::function<void(int, Event)>&& cb
     if (event == Event::Read || event == Event::ReadWrite) {
         auto notifier = std::make_unique<QSocketNotifier>(fd, QSocketNotifier::Read);
         QObject::connect(notifier.get(), &QSocketNotifier::activated, impl.get(), &RunLoop::Impl::onReadEvent);
-        impl->readPoll[fd] = WatchPair(std::move(notifier), std::move(cb));
+        impl->readPoll[fd] = WatchPair(std::move(notifier), cb);
     }
 
     if (event == Event::Write || event == Event::ReadWrite) {


### PR DESCRIPTION
When calling RunLoop::addWatch with Event::ReadWrite, the callback was first moved into the list of read pollers. Then, when registering for writing, the callback is empty. When it gets triggered it results in an `std::bad_function_call`.

This is the simplest way to fix it now, at a small overhead when calling `RunLoop::addWatch` only for `Event::Read` (in that case we could've gotten away with moving it). I don't think that this overhead is significant, though.

