### PR TITLE
TextureViewRenderThread#eventQueue should be LinkedList

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/textureview/TextureViewRenderThread.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/textureview/TextureViewRenderThread.java
@@ -7,7 +7,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 
 /**
  * The render thread is responsible for managing the communication between the
@@ -24,7 +24,7 @@ abstract class TextureViewRenderThread extends Thread implements TextureView.Sur
   protected final Object lock = new Object();
 
   // Guarded by lock
-  protected final ArrayList<Runnable> eventQueue = new ArrayList<>();
+  protected final LinkedList<Runnable> eventQueue = new LinkedList<>();
   @Nullable
   protected SurfaceTexture surfaceTexture;
   protected boolean hasNativeSurface;


### PR DESCRIPTION
Every time `eventQueue.remove(0)` is called the whole array is being shifted left. Since only operations that are performed on the queue are `remove(0)` `add()` and `isEmpty()` LinkedList seems to be a perfect fit.