### PR TITLE
Restore Rust build, fix cxx-bridge version

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        renderer: [vulkan, drawable]
+        renderer: [vulkan, drawable, drawable-rust]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -79,6 +79,10 @@ jobs:
       - name: Install dependencies
         run: .github/scripts/install-linux-deps
 
+      - if: matrix.renderer == 'drawable-rust'
+        run: |
+          echo "renderer_flag_cmake=DMLN_WITH_OPENGL=ON -DMLN_USE_RUST=ON" >> "$GITHUB_ENV"
+          cargo install cxxbridge-cmd --version 1.0.154 --locked
 
       - if: matrix.renderer == 'drawable'
         run: |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -71,10 +71,10 @@ darwin_config(
 )
 
 bazel_dep(name = "rules_rust", version = "0.59.2")
-bazel_dep(name = "cxx.rs", version = "1.0.136")
+bazel_dep(name = "cxx.rs", version = "1.0.154")
 git_override(
     module_name = "cxx.rs",
-    commit = "dfb54b4a6b2c60de54431ae97c2014aee96c162c",
+    commit = "204d76f53ab2380dd9d532795781beb51c953520",  # 1.0.154
     remote = "https://github.com/dtolnay/cxx.git",
 )
 

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -44,7 +44,8 @@ fi
 
 if ! command -v cxxbridge > /dev/null; then
     echo "Installing cxxbridge..."
-    cargo install cxxbridge-cmd
+    # Attention: v1.0.154 was the last one was not causing &str passing issues
+    cargo install cxxbridge-cmd@1.0.154 --locked
 fi
 
 

--- a/docs/mdbook/src/rust.md
+++ b/docs/mdbook/src/rust.md
@@ -25,7 +25,7 @@ See [Platform Support](https://doc.rust-lang.org/nightly/rustc/platform-support.
 You also need to have cxxbridge installed:
 
 ```shell
-cargo install cxxbridge-cmd
+cargo install cxxbridge-cmd@1.0.154 --locked
 ```
 
 Set `-DMLN_USE_RUST=ON` when generating a configuration with CMake.

--- a/rustutils/Cargo.lock
+++ b/rustutils/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.157"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6354e975ea4ec28033ec3a36fa9baa1a02e3eb22ad740eeb4929370d4f5ba8"
+checksum = "76751bca18309cbce06f9821698d6c05b3af5c3fde8af5caf57f11611729397b"
 dependencies = [
  "cc",
  "cxxbridge-cmd",
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.157"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31860c98f69fc14da5742c5deaf78983e846c7b27804ca8c8319e32eef421bde"
+checksum = "78ce717e582fc3b56bd2f1eb3cda9916e9b4629721e4c2ce637ac5e7d4beef11"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -92,15 +92,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.157"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0402a66013f3b8d3d9f2d7c9994656cc81e671054822b0728d7454d9231892f"
+checksum = "aa7fdd4b264a3335a8b21221092bd2fbfba35c3606bd50feb28d22ba3fb0a6e5"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.157"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c0b38f32d68f3324a981645ee39b2d686af36d03c98a386df3716108c9feae"
+checksum = "c36a0a2b78ff9232a3dc584340471d4fa1751a81026cf62f3661a06d5a8bae17"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rustutils/Cargo.lock
+++ b/rustutils/Cargo.lock
@@ -45,10 +45,11 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
  "unicode-width",
 ]
@@ -64,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.137"
+version = "1.0.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc894913dccfed0f84106062c284fa021c3ba70cb1d78797d6f5165d4492e45"
+checksum = "3d6354e975ea4ec28033ec3a36fa9baa1a02e3eb22ad740eeb4929370d4f5ba8"
 dependencies = [
  "cc",
  "cxxbridge-cmd",
@@ -78,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.137"
+version = "1.0.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d2cb64a95b4b5a381971482235c4db2e0208302a962acdbe314db03cbbe2fb"
+checksum = "31860c98f69fc14da5742c5deaf78983e846c7b27804ca8c8319e32eef421bde"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -91,15 +92,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.137"
+version = "1.0.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f797b0206463c9c2a68ed605ab28892cca784f1ef066050f4942e3de26ad885"
+checksum = "b0402a66013f3b8d3d9f2d7c9994656cc81e671054822b0728d7454d9231892f"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.137"
+version = "1.0.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79010a2093848e65a3e0f7062d3f02fb2ef27f866416dfe436fccfa73d3bb59"
+checksum = "64c0b38f32d68f3324a981645ee39b2d686af36d03c98a386df3716108c9feae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -210,6 +211,26 @@ name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "shlex"

--- a/rustutils/Cargo.toml
+++ b/rustutils/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 csscolorparser = "0.7.0"
-cxx = "1"
+cxx = "1.0.154"
 
 [profile.release]
 lto = true

--- a/rustutils/generate.sh
+++ b/rustutils/generate.sh
@@ -2,7 +2,7 @@
 
 # Run this script from the repository root
 # Install cxxbridge with:
-# $ cargo install cxxbridge-cmd
+# $ cargo install cxxbridge-cmd@1.0.154 --locked
 
 set -e
 

--- a/rustutils/rustutils.cmake
+++ b/rustutils/rustutils.cmake
@@ -8,7 +8,7 @@ include(FetchContent)
 FetchContent_Declare(
     Corrosion
     GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.5 # Optionally specify a commit hash, version tag or branch here
+    GIT_TAG v0.5.1 # Optionally specify a commit hash, version tag or branch here
 )
 FetchContent_MakeAvailable(Corrosion)
 


### PR DESCRIPTION
Turns out cxx bridge was installing latest, and everything after v1.0.154 had some issues, so reverting.

Upstream issue: https://github.com/dtolnay/cxx/issues/1506