### PR TITLE
Force PMTiles metadata to always have XYZ tile scheme

### DIFF
--- a/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
@@ -291,8 +291,10 @@ private:
                 doc.AddMember("tilejson", "3.0.0", allocator);
 
                 if (!doc.HasMember("scheme")) {
-                    doc.AddMember("scheme", rapidjson::Value().SetString("xyz"), allocator);
+                    doc.AddMember("scheme", rapidjson::Value(), allocator);
                 }
+
+                doc["scheme"] = rapidjson::Value().SetString("xyz");
 
                 if (!doc.HasMember("tiles")) {
                     doc.AddMember("tiles", rapidjson::Value(), allocator);


### PR DESCRIPTION
This PR reflects the discussion #3366, where it was demonstrated that other PMTiles libraries always assume XYZ tile addressing, so it will be done in here as well.