### PR TITLE
Add support to range requests in AssetFileSource

### DIFF
--- a/platform/default/src/mbgl/storage/asset_file_source.cpp
+++ b/platform/default/src/mbgl/storage/asset_file_source.cpp
@@ -26,8 +26,8 @@ public:
           resourceOptions(resourceOptions_.clone()),
           clientOptions(clientOptions_.clone()) {}
 
-    void request(const std::string& url, const ActorRef<FileSourceRequest>& req) {
-        if (!acceptsURL(url)) {
+    void request(const Resource& resource, const ActorRef<FileSourceRequest>& req) {
+        if (!acceptsURL(resource.url)) {
             Response response;
             response.error = std::make_unique<Response::Error>(Response::Error::Reason::Other, "Invalid asset URL");
             req.invoke(&FileSourceRequest::setResponse, response);
@@ -37,7 +37,7 @@ public:
         // Cut off the protocol and prefix with path.
         const auto path = root + "/" +
                           mbgl::util::percentDecode(url.substr(std::char_traits<char>::length(util::ASSET_PROTOCOL)));
-        requestLocalFile(path, req);
+        requestLocalFile(path, req, resource.dataRange);
     }
 
     void setResourceOptions(ResourceOptions options) {
@@ -80,7 +80,7 @@ AssetFileSource::~AssetFileSource() = default;
 std::unique_ptr<AsyncRequest> AssetFileSource::request(const Resource& resource, Callback callback) {
     auto req = std::make_unique<FileSourceRequest>(std::move(callback));
 
-    impl->actor().invoke(&Impl::request, resource.url, req->actor());
+    impl->actor().invoke(&Impl::request, resource, req->actor());
 
     return req;
 }


### PR DESCRIPTION
As pointed out in #3304, PMTiles support was not extended to AssetFileSource, so this PR corrects this.