### PR TITLE
Fix sccache error in Windows-CI

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -112,7 +112,7 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - uses: mozilla-actions/sccache-action@v0.0.8
+      - uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Initialize sccache
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Get all Windows files that have changed
         if: github.event_name != 'workflow_dispatch'
@@ -62,7 +63,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          fetch-depth: 0
 
       - uses: ilammy/msvc-dev-cmd@v1
 
@@ -75,7 +75,7 @@ jobs:
 
       - name: Acquire/Build Maplibre Native Core Dependencies
         env:
-          CI: 1
+          CI: 1,
           VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
         timeout-minutes: 120
         run: |
@@ -122,6 +122,7 @@ jobs:
       - name: Configure MapLibre Native Core
         env:
           CI: 1
+          VCPKG_INSTALL_OPTIONS: "--debug"
           VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 #          VCPKG_KEEP_ENV_VARS: "CMAKE_CXX_COMPILER_LAUNCHER;CMAKE_C_COMPILER_LAUNCHER"
           CMAKE_C_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -77,7 +77,7 @@ jobs:
         env:
           CI: 1
           VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-        timeout-minutes: 60
+        timeout-minutes: 120
         run: |
           & ${{ github.workspace }}\platform\windows\Get-VendorPackages.ps1 -Triplet ${{ env.VSCMD_ARG_TGT_ARCH }}-windows -Renderer All
 
@@ -127,7 +127,7 @@ jobs:
           CMAKE_C_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"
           CMAKE_CXX_COMPILER_LAUNCHER: "${{ env.SCCACHE_PATH }}"
           RENDERER: "${{ matrix.renderer }}"
-        timeout-minutes: 60
+        timeout-minutes: 120
         run: |
           cmake --version
           & ${{ github.workspace }}\.github\scripts\windows-ci_configure_wrapper.ps1

--- a/platform/windows/Get-VendorPackages.ps1
+++ b/platform/windows/Get-VendorPackages.ps1
@@ -35,6 +35,7 @@ if(-not (Test-Path ('{0}\vcpkg.exe' -f $vcpkg_temp_dir)))
 
 & ('{0}\vcpkg.exe' -f $vcpkg_temp_dir) $(
     @(
+        '--debug',
         '--disable-metrics',
         ('--overlay-triplets={0}' -f [System.IO.Path]::Combine($PWD.Path, 'vendor', 'vcpkg-custom-triplets')),
         ('--triplet={0}' -f $Triplet),


### PR DESCRIPTION
Windows-CI is failing with the following error:

```
This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset
```

Updating the `Mozilla-Actions/sccache-action` to [v0.0.9](https://github.com/Mozilla-Actions/sccache-action/releases/tag/v0.0.9) should fix this.