### PR TITLE
Update Taywee/args in .gitmodules, use https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,7 +57,7 @@
 	url = https://github.com/protomaps/PMTiles.git
 [submodule "vendor/maplibre-native-base/extras/args"]
 	path = vendor/maplibre-native-base/extras/args
-	url = git@github.com:Taywee/args.git
+	url = https://github.com/Taywee/args
 [submodule "vendor/maplibre-native-base/extras/expected-lite"]
 	path = vendor/maplibre-native-base/extras/expected-lite
 	url = https://github.com/martinmoene/expected-lite.git


### PR DESCRIPTION
fix error during submodule update, use https instead of ssh in url of `Taywee/args`

```
fatal: clone of 'git@github.com:Taywee/args.git' into submodule path '/home/jin/lab/maplibre-native/vendor/maplibre-native-base/extras/args' failed
Failed to clone 'vendor/maplibre-native-base/extras/args' a second time, aborting
```