### PR TITLE
Debug android-device-farm-run.sh

### DIFF
--- a/scripts/aws-device-farm/aws-device-farm-run.sh
+++ b/scripts/aws-device-farm/aws-device-farm-run.sh
@@ -87,6 +87,14 @@ arn="$(aws devicefarm schedule-run \
   --execution-configuration videoCapture=false \
   --output text --query run.arn)"
 
+echo ARN: $arn  >&2
+
+if [ -z "$arn" ]; then
+  echo "Error: Failed to schedule Device Farm run or got empty ARN" >&2
+  exit 1
+fi
+
+
 echo "$arn"
 
 if [[ "$wait_for_completion" != "true" ]]; then

--- a/scripts/aws-device-farm/aws-device-farm-run.sh
+++ b/scripts/aws-device-farm/aws-device-farm-run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o xtrace
 
 # List of required environment variables
 required_vars=(


### PR DESCRIPTION
The render test run is failing in #3198 

Need to understand what is happening.

Enabling xtrace so I can run `aws devicefarm` locally with the same arguments.