### PR TITLE
Release Node v6.1.0

### DIFF
--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## main
 
-## 6.1.0-pre.0
+## 6.1.0
 * Add `textFitWidth` and `textFitHeight` properties to sprites ([#2780](https://github.com/maplibre/maplibre-native/pull/2780)).
   More information can be found in the [MapLibre Style Spec](https://maplibre.org/maplibre-style-spec/sprite/#text-fit-properties).
 * Update NAN to 2.22.0 ([#2948](https://github.com/maplibre/maplibre-native/pull/2948))

--- a/platform/node/package-lock.json
+++ b/platform/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "6.1.0-pre.0",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "6.1.0-pre.0",
+      "version": "6.1.0",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/platform/node/package.json
+++ b/platform/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "6.1.0-pre.0",
+  "version": "6.1.0",
   "description": "Renders map tiles with MapLibre Native",
   "keywords": [
     "maplibre",


### PR DESCRIPTION
This PR releases Maplibre Node v6.1.0

I tested this windows and linux (x64/arm64) and it seem to work fine there. 

I also tested in macos, but like the existing release it works at first but the locks up the application after a certain number of renders, like mentioned in https://github.com/maplibre/maplibre-native/issues/2928 . I do wonder if there are any ideas to fix this (I have tried working with AI to look at the code and troubleshot but came up with nothing).  @louwers would vulkan be an alternative on macos? I am wondering if it would behave differently.