### PR TITLE
Make debug releases for Android

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: platform/android/MapLibreAndroid/build/outputs/aar/MapLibreAndroid-drawable-debug.aar
-          asset_name: MapLibreAndroid-release.aar
+          asset_name: MapLibreAndroid-debug.aar
           asset_content_type: application/zip
 
       - name: Upload aar (Vulkan)
@@ -131,8 +131,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: platform/android/MapLibreAndroid/build/outputs/aar/MapLibreAndroid-vulkan-release.aar
-          asset_name: MapLibreAndroid-release-vulkan.aar
+          asset_path: platform/android/MapLibreAndroid/build/outputs/aar/MapLibreAndroid-vulkan-debug.aar
+          asset_name: MapLibreAndroid-debug-vulkan.aar
           asset_content_type: application/zip
 
       - name: Upload debug symbols (OpenGL)

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -57,7 +57,9 @@ jobs:
       - name: Build package
         run: |
           RENDERER=vulkan make apackage
+          BUILDTYPE=Debug RENDERER=vulkan make apackage
           RENDERER=drawable make apackage
+          BUILDTYPE=Debug RENDERER=drawable make apackage
 
       # create github release
       - name: Prepare release
@@ -103,7 +105,27 @@ jobs:
           asset_name: MapLibreAndroid-release.aar
           asset_content_type: application/zip
 
+      - name: Upload aar (OpenGL, Debug)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: platform/android/MapLibreAndroid/build/outputs/aar/MapLibreAndroid-drawable-debug.aar
+          asset_name: MapLibreAndroid-release.aar
+          asset_content_type: application/zip
+
       - name: Upload aar (Vulkan)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: platform/android/MapLibreAndroid/build/outputs/aar/MapLibreAndroid-vulkan-release.aar
+          asset_name: MapLibreAndroid-release-vulkan.aar
+          asset_content_type: application/zip
+
+      - name: Upload aar (Vulkan, Debug)
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main
 
+## 11.8.7
+
+We now make releases with debug builds to make it easier to report issues with relevant logs.
+
+They are available with a `-debug` postfix on Maven Central, for example `org.maplibre.gl:android-sdk-vulkan-debug`.
+
 ## 11.8.6
 
 ### ✨ Features and improvements

--- a/platform/android/Makefile
+++ b/platform/android/Makefile
@@ -231,7 +231,7 @@ apackage:
 	make android-lib-arm-v7 && make android-lib-arm-v8 && make android-lib-x86 && make android-lib-x86-64
 	$(MLN_ANDROID_GRADLE) -Pmaplibre.abis=all assemble$(RENDERER)$(BUILDTYPE)
 	mkdir -p build
-	tar -czvf build/$(DEBUG_TAR_FILE_NAME) -C MapLibreAndroid/build/intermediates/library_jni/$(RENDERER)Release/*JniLibsProjectOnly/jni .
+	tar -czvf build/$(DEBUG_TAR_FILE_NAME) -C MapLibreAndroid/build/intermediates/library_jni/$(RENDERER)$(BUILDTYPE)/*JniLibsProjectOnly/jni .
 
 # Build test app instrumentation tests apk and test app apk for all abi's
 .PHONY: android-ui-test

--- a/platform/android/MapLibreAndroid/gradle.properties
+++ b/platform/android/MapLibreAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=11.8.6
+VERSION_NAME=11.8.7
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20

--- a/platform/android/buildSrc/src/main/kotlin/maplibre.gradle-publish.gradle.kts
+++ b/platform/android/buildSrc/src/main/kotlin/maplibre.gradle-publish.gradle.kts
@@ -49,6 +49,7 @@ fun configureMavenPublication(
     publicationName: String,
     artifactIdPostfix: String,
     descriptionPostfix: String,
+    buildType: String = "Release"
 ) {
     publishing {
         publications {
@@ -57,7 +58,7 @@ fun configureMavenPublication(
                 artifactId = "${project.extra["mapLibreArtifactId"]}$artifactIdPostfix"
                 version = project.version.toString()
 
-                from(components["${renderer}Release"])
+                from(components["${renderer}${buildType}"])
 
                 pom {
                     name.set("${project.extra["mapLibreArtifactTitle"]}$descriptionPostfix")
@@ -98,11 +99,14 @@ tasks {
 
 afterEvaluate {
     configureMavenPublication("drawable", "opengl", "", "")
+    configureMavenPublication("drawable", "opengldebug", "-debug", " (Debug)", "Debug")
     configureMavenPublication("vulkan", "vulkan", "-vulkan", "(Vulkan)")
+    configureMavenPublication("vulkan", "vulkandebug", "-vulkan-debug", "(Vulkan, Debug)", "Debug")
     // Right now this is the same as the first, but in the future we might release a major version
     // which defaults to Vulkan (or has support for multiple backends). We will keep using only
     // OpenGL ES with this artifact ID if that happens.
     configureMavenPublication("drawable", "opengl2", "-opengl", " (OpenGL ES)")
+    configureMavenPublication("drawable", "opengl2debug", "-opengl-debug", " (OpenGL ES, Debug)", "Debug")
 }
 
 


### PR DESCRIPTION
To produce a more useful log it is sometimes useful to run a debug build. This PR makes it so that we release debug builds for Android alongside the normal release builds.