### PR TITLE
Update NDK to 28.1.13356709

### DIFF
--- a/platform/android/buildSrc/src/main/kotlin/Versions.kt
+++ b/platform/android/buildSrc/src/main/kotlin/Versions.kt
@@ -1,4 +1,4 @@
 object Versions {
-    const val ndkVersion = "27.0.12077973"
+    const val ndkVersion = "28.1.13356709"
     const val cmakeVersion = "3.24.0+"
 }

--- a/render-test/android/app/build.gradle.kts
+++ b/render-test/android/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    ndkVersion = "27.0.12077973"
+    ndkVersion = "28.1.13356709"
 
     sourceSets {
         getByName("test") {


### PR DESCRIPTION
Fixes an issue where using CMake 4 results in an error.

https://github.com/android/ndk/releases/tag/r28b