### PR TITLE
Add Pixel 4a to Android render test run

### DIFF
--- a/.github/workflows/android-device-test.yml
+++ b/.github/workflows/android-device-test.yml
@@ -20,16 +20,17 @@ jobs:
             testFile: RenderTests-opengl.apk,
             appFile: RenderTestsApp-opengl.apk,
             name: "Android Render Tests (OpenGL)",
-            # Google Pixel 7 Pro
-            devicePool: "arn:aws:devicefarm:us-west-2:373521797162:devicepool:20687d72-0e46-403e-8f03-0941850665bc/9692fe7f-86a9-4ecc-908f-175600968564"
+            # Pixel 4a Android 12, Pixel 7 Pro Android 13
+            devicePool: "arn:aws:devicefarm:us-west-2:373521797162:devicepool:20687d72-0e46-403e-8f03-0941850665bc/55db2b56-930a-4485-bdc0-03409a5a6060",
+            testSpecArn: "arn:aws:devicefarm:us-west-2:373521797162:upload:20687d72-0e46-403e-8f03-0941850665bc/c1fc7d3e-dfe3-4a31-9ee0-7b0f71b08872"
           },
           {
             artifactName: android-render-tests-vulkan,
             testFile: RenderTests-vulkan.apk,
             appFile: RenderTestsApp-vulkan.apk,
             name: "Android Render Tests (Vulkan)",
-            # Google Pixel 7 Pro
-            devicePool: "arn:aws:devicefarm:us-west-2:373521797162:devicepool:20687d72-0e46-403e-8f03-0941850665bc/9692fe7f-86a9-4ecc-908f-175600968564",
+            # Pixel 4a Android 12, Pixel 7 Pro Android 13
+            devicePool: "arn:aws:devicefarm:us-west-2:373521797162:devicepool:20687d72-0e46-403e-8f03-0941850665bc/55db2b56-930a-4485-bdc0-03409a5a6060",
             # android-render-test.yml
             # see https://github.com/maplibre/ci-runners/tree/main/aws-device-farm/custom-test-envs
             testSpecArn: "arn:aws:devicefarm:us-west-2:373521797162:upload:20687d72-0e46-403e-8f03-0941850665bc/c1fc7d3e-dfe3-4a31-9ee0-7b0f71b08872"
@@ -169,6 +170,8 @@ jobs:
           results_dir="$(mktemp -d)"
           echo results_dir="$results_dir" >> "$GITHUB_ENV"
           node scripts/aws-device-farm/store-test-artifacts.mjs --runArn ${{ env.run_arn }} --outputDir "$results_dir"
+          # unzip and delete .zip files so we don't have nested .zip
+          find "$results_dir" -type f -name '*.zip' -exec sh -c 'unzip -o -d "$(dirname "$1")" "$1" && rm "$1"' _ {} \;
           zip -r test_artifacts.zip "$results_dir"
 
       - name: Store Benchmark Results

--- a/scripts/aws-device-farm/store-test-artifacts.mjs
+++ b/scripts/aws-device-farm/store-test-artifacts.mjs
@@ -2,7 +2,6 @@ import * as fs from "node:fs";
 import { Readable } from "node:stream";
 import { finished } from "node:stream/promises";
 import * as path from "node:path";
-import * as crypto from "node:crypto";
 import { parseArgs } from "node:util";
 
 import { ArtifactType, ListArtifactsCommand, ListJobsCommand, ListSuitesCommand } from "@aws-sdk/client-device-farm";
@@ -104,7 +103,8 @@ async function storeRunArtifacts(arnArr, outputDir) {
           if (!artifact.name || !artifact.url || !artifact.type) return;
           if (artifactsToDownload.includes(artifact.type)) {
             if (!artifact.arn) return;
-            const destination = path.join(outputDir, `${Buffer.from(artifact.arn).toString('base64')}.${artifact.extension}`);
+            const destination = path.join(outputDir, ...[job.device?.name || ""].filter(x => x), `${Buffer.from(artifact.arn).toString('base64')}.${artifact.extension}`);
+            await fs.promises.mkdir(path.dirname(destination), { recursive: true });
             try {
               await fs.promises.access(destination);
               return; // already exists


### PR DESCRIPTION
Also fixes an issue where a missing test spec was causing files for OpenGL ES not to be pulled.