### PR TITLE
Create separate workflow for making Cocoapods release

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -329,8 +329,7 @@ jobs:
       - name: Release (CocoaPods)
         shell: bash -leo pipefail {0}  # so pod is found
         if: env.make_release
-        run: |
-          VERSION=${{ env.version }} COCOAPODS_TRUNK_TOKEN=${{ secrets.COCOAPODS_PASSWORD }} pod trunk push MapLibre.podspec
+        run: gh workflow run ios-release-cocoapods.yml --field version=${{ env.version }}
 
   ios-build-cmake:
     needs: pre_job

--- a/.github/workflows/ios-release-cocoapods.yml
+++ b/.github/workflows/ios-release-cocoapods.yml
@@ -1,0 +1,24 @@
+name: ios-release-cocoapods
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+
+jobs:
+  ios-release-cocoapods:
+    defaults:
+      run:
+        working-directory: platform/ios
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Release (CocoaPods)
+        shell: bash -leo pipefail {0}  # so pod is found
+        run: |
+          VERSION=${{ github.event.inputs.version }} COCOAPODS_TRUNK_TOKEN=${{ secrets.COCOAPODS_PASSWORD }} pod trunk push MapLibre.podspec


### PR DESCRIPTION
When the Cocoapods release fails (for example when Cocoapods is down) we need to be able to re-run the release.

This PR moves the release to a separate workflow to facilitate this.


Will fix https://github.com/maplibre/maplibre-native/issues/3457