### PR TITLE
Apply more clang-tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -116,7 +116,10 @@ Checks: [
     -readability-avoid-nested-conditional-operator,
     -readability-math-missing-parentheses,
     -readability-enum-initial-value,
-    -boost-use-ranges
+    -boost-use-ranges,
+    # https://clang.llvm.org/extra/clang-tidy/checks/portability/template-virtual-member-function.html
+    # not caring about this check might cause issues with MSVC
+    -portability-template-virtual-member-function 
 ]
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/include/mbgl/style/expression/format_section_override.hpp
+++ b/include/mbgl/style/expression/format_section_override.hpp
@@ -21,7 +21,7 @@ public:
         using Object = std::unordered_map<std::string, expression::Value>;
         if (context.formattedSection && context.formattedSection->is<Object>()) {
             const auto& section = context.formattedSection->get<Object>();
-            if (section.find(propertyName) != section.end()) {
+            if (section.contains(propertyName)) {
                 return section.at(propertyName);
             }
         }

--- a/src/mbgl/actor/scheduler.cpp
+++ b/src/mbgl/actor/scheduler.cpp
@@ -25,7 +25,7 @@ void Scheduler::SetCurrent(Scheduler* scheduler) {
 
 Scheduler* Scheduler::GetCurrent(bool init) {
     if (!localScheduler && init) {
-        thread_local util::RunLoop runLoop;
+        thread_local static util::RunLoop runLoop;
         SetCurrent(&runLoop);
     }
     return localScheduler;

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -135,10 +135,10 @@ void AnnotationManager::update(const AnnotationID& id, const FillAnnotation& ann
 
 void AnnotationManager::remove(const AnnotationID& id) {
     CHECK_ANNOTATIONS_ENABLED_AND_RETURN_NOARG();
-    if (symbolAnnotations.find(id) != symbolAnnotations.end()) {
+    if (symbolAnnotations.contains(id)) {
         symbolTree.remove(symbolAnnotations.at(id));
         symbolAnnotations.erase(id);
-    } else if (shapeAnnotations.find(id) != shapeAnnotations.end()) {
+    } else if (shapeAnnotations.contains(id)) {
         auto it = shapeAnnotations.find(id);
         (void)*style.get().impl->removeLayer(it->second->layerID);
         shapeAnnotations.erase(it);

--- a/src/mbgl/geometry/debug_font_data.hpp
+++ b/src/mbgl/geometry/debug_font_data.hpp
@@ -1,7 +1,6 @@
 // This is an implementation file, so omit include guards.
 
 #include <cstdint>
-#include <map>
 
 const int8_t simplex_1[] = {5, 21, 5, 7, -1, -1, 5, 2, 4, 1, 5, 0, 6, 1, 5, 2};
 const int8_t simplex_2[] = {4, 21, 4, 14, -1, -1, 12, 21, 12, 14};
@@ -155,6 +154,8 @@ struct glyph {
 // Font data From Hershey Simplex Font
 // http://paulbourke.net/dataformats/hershey/
 
+
+// NOLINTBEGIN(modernize-use-designated-initializers)
 const glyph simplex[] = {
     /* 32	  */ {16, 0, nullptr},
     /* 33	! */
@@ -228,28 +229,6 @@ const glyph simplex[] = {
     /* 67	C */
     {21, sizeof(simplex_35), simplex_35},
     /* 68	D */
-    {21, sizeof(simplex_36), simplex_36},
-    /* 69	E */
-    {19, sizeof(simplex_37), simplex_37},
-    /* 70	F */
-    {18, sizeof(simplex_38), simplex_38},
-    /* 71	G */
-    {21, sizeof(simplex_39), simplex_39},
-    /* 72	H */
-    {22, sizeof(simplex_40), simplex_40},
-    /* 73	I */
-    {8, sizeof(simplex_41), simplex_41},
-    /* 74	J */
-    {16, sizeof(simplex_42), simplex_42},
-    /* 75	K */
-    {21, sizeof(simplex_43), simplex_43},
-    /* 76	L */
-    {17, sizeof(simplex_44), simplex_44},
-    /* 77	M */
-    {24, sizeof(simplex_45), simplex_45},
-    /* 78	N */
-    {22, sizeof(simplex_46), simplex_46},
-    /* 79	O */
     {22, sizeof(simplex_47), simplex_47},
     /* 80	P */
     {21, sizeof(simplex_48), simplex_48},
@@ -346,3 +325,4 @@ const glyph simplex[] = {
     /* 126	~ */
     {24, sizeof(simplex_94), simplex_94},
 };
+// NOLINTEND(modernize-use-designated-initializers)

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <mbgl/geometry/feature_index.hpp>
 #include <mbgl/math/minmax.hpp>
 #include <mbgl/renderer/layers/render_symbol_layer.hpp>
@@ -171,9 +172,10 @@ void FeatureIndex::query(std::unordered_map<std::string, std::vector<Feature>>& 
     std::vector<RefIndexedSubfeature> features = grid.query(
         {convertPoint<float>(box.min - additionalPadding), convertPoint<float>(box.max + additionalPadding)});
 
-    std::sort(features.begin(), features.end(), [](const RefIndexedSubfeature& a, const RefIndexedSubfeature& b) {
-        return a.getSortIndex() > b.getSortIndex();
-    });
+    std::ranges::sort(features,
+                      [](const RefIndexedSubfeature& a, const RefIndexedSubfeature& b) {
+                          return a.getSortIndex() > b.getSortIndex();
+                      });
     size_t previousSortIndex = std::numeric_limits<size_t>::max();
     for (const auto& indexedFeature : features) {
         // If this feature is the same as the previous feature, skip it.
@@ -206,9 +208,8 @@ std::unordered_map<std::string, std::vector<Feature>> FeatureIndex::lookupSymbol
     std::vector<std::reference_wrapper<const RefIndexedSubfeature>> sortedFeatures(symbolFeatures.begin(),
                                                                                    symbolFeatures.end());
 
-    std::sort(sortedFeatures.begin(),
-              sortedFeatures.end(),
-              [featureSortOrder](const RefIndexedSubfeature& a, const RefIndexedSubfeature& b) {
+    std::ranges::sort(sortedFeatures,
+             [featureSortOrder](const RefIndexedSubfeature& a, const RefIndexedSubfeature& b) {
                   // Same idea as the non-symbol sort order, but symbol features may
                   // have changed their sort order since their corresponding
                   // IndexedSubfeature was added to the CollisionIndex The

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -211,7 +211,7 @@ void DashPatternTexture::upload(gfx::UploadPass& uploadPass) {
         auto tempTexture = uploadPass.getContext().createTexture2D();
         tempTexture->upload(std::get<AlphaImage>(texture));
         tempTexture->setSamplerConfiguration(
-            {gfx::TextureFilterType::Linear, gfx::TextureWrapType::Repeat, gfx::TextureWrapType::Clamp});
+            {.filter=gfx::TextureFilterType::Linear, .wrapU=gfx::TextureWrapType::Repeat, .wrapV=gfx::TextureWrapType::Clamp});
         texture = std::move(tempTexture);
     }
 }

--- a/src/mbgl/gfx/depth_mode.hpp
+++ b/src/mbgl/gfx/depth_mode.hpp
@@ -15,7 +15,7 @@ public:
 #endif
 
 #if MLN_RENDER_BACKEND_OPENGL
-    static DepthMode disabled() { return DepthMode{DepthFunctionType::Always, DepthMaskType::ReadOnly, {0.0, 1.0}}; }
+    static DepthMode disabled() { return DepthMode{.func=DepthFunctionType::Always, .mask=DepthMaskType::ReadOnly, .range={0.0, 1.0}}; }
 #else
     static DepthMode disabled() {
         return DepthMode{.func = DepthFunctionType::Always, .mask = DepthMaskType::ReadOnly};

--- a/src/mbgl/gfx/gpu_expression.cpp
+++ b/src/mbgl/gfx/gpu_expression.cpp
@@ -108,9 +108,9 @@ UniqueGPUExpression GPUExpression::create(const Expression& expression, const Zo
 
 float GPUExpression::evaluateFloat(const float zoom) const {
     const auto index = std::distance(&inputs[0], std::upper_bound(&inputs[0], &inputs[stopCount], zoom));
-    if (index == 0) {
+    if (std::cmp_equal(index, 0)) {
         return stops.floats[0];
-    } else if (index == stopCount) {
+    } else if (std::cmp_equal(index, stopCount)) {
         return stops.floats[stopCount - 1];
     }
     switch (interpolation) {
@@ -154,9 +154,9 @@ Color GPUExpression::getColor(std::size_t index) const {
 
 Color GPUExpression::evaluateColor(const float zoom) const {
     const auto index = std::distance(&inputs[0], std::upper_bound(&inputs[0], &inputs[stopCount], zoom));
-    if (index == 0) {
+    if (std::cmp_equal(index, 0)) {
         return getColor(0);
-    } else if (index == stopCount) {
+    } else if (std::cmp_equal(index, stopCount)) {
         return getColor(stopCount - 1);
     }
     switch (interpolation) {

--- a/src/mbgl/gfx/polyline_generator.cpp
+++ b/src/mbgl/gfx/polyline_generator.cpp
@@ -100,7 +100,7 @@ void PolylineGenerator<PLV, PS>::generate(const GeometryCoordinates& coordinates
     }();
 
     // Ignore invalid geometry.
-    if (len < (options.type == FeatureType::Polygon ? 3 : 2)) {
+    if (std::cmp_less(len, (options.type == FeatureType::Polygon ? 3 : 2))) {
         return;
     }
 

--- a/src/mbgl/gfx/rendering_stats.cpp
+++ b/src/mbgl/gfx/rendering_stats.cpp
@@ -20,7 +20,7 @@ bool RenderingStats::isZero() const {
                                 memIndexBuffers,
                                 memVertexBuffers,
                                 memUniformBuffers};
-    return std::all_of(expectedZeros.begin(), expectedZeros.end(), [](auto x) { return x == 0; });
+    return std::ranges::all_of(expectedZeros, [](auto x) { return x == 0; });
 }
 
 RenderingStats& RenderingStats::operator+=(const RenderingStats& r) {
@@ -57,6 +57,7 @@ RenderingStats& RenderingStats::operator+=(const RenderingStats& r) {
 }
 
 #if !defined(NDEBUG)
+namespace {
 template <typename T>
 std::ostream& optionalStatLine(std::ostream& stream, T value, std::string_view label, std::string_view sep) {
     if (value) {
@@ -64,6 +65,8 @@ std::ostream& optionalStatLine(std::ostream& stream, T value, std::string_view l
     }
     return stream;
 }
+}
+
 std::string RenderingStats::toString(std::string_view sep) const {
     std::stringstream ss;
     optionalStatLine(ss, numFrames, "numFrames", sep);

--- a/src/mbgl/gfx/shader_group.cpp
+++ b/src/mbgl/gfx/shader_group.cpp
@@ -6,7 +6,7 @@ namespace gfx {
 
 bool ShaderGroup::isShader(const std::string& shaderName) const noexcept {
     std::shared_lock<std::shared_mutex> readerLock(programLock);
-    return programs.find(shaderName) != programs.end();
+    return programs.contains(shaderName);
 }
 
 const std::shared_ptr<gfx::Shader> ShaderGroup::getShader(const std::string& shaderName) const noexcept {
@@ -25,7 +25,7 @@ bool ShaderGroup::replaceShader(std::shared_ptr<gfx::Shader>&& shader) noexcept 
 
 bool ShaderGroup::replaceShader(std::shared_ptr<Shader>&& shader, const std::string& shaderName) noexcept {
     std::unique_lock<std::shared_mutex> writerLock(programLock);
-    if (programs.find(shaderName) == programs.end()) {
+    if (!programs.contains(shaderName)) {
         return false;
     }
 
@@ -39,7 +39,7 @@ bool ShaderGroup::registerShader(std::shared_ptr<gfx::Shader>&& shader) noexcept
 
 bool ShaderGroup::registerShader(std::shared_ptr<Shader>&& shader, const std::string& shaderName) noexcept {
     std::unique_lock<std::shared_mutex> writerLock(programLock);
-    if (programs.find(shaderName) != programs.end()) {
+    if (programs.contains(shaderName)) {
         return false;
     }
 

--- a/src/mbgl/gfx/shader_registry.cpp
+++ b/src/mbgl/gfx/shader_registry.cpp
@@ -13,7 +13,7 @@ ShaderGroup& ShaderRegistry::getLegacyGroup() noexcept {
 
 bool ShaderRegistry::isShaderGroup(const std::string& shaderGroupName) const noexcept {
     std::shared_lock<std::shared_mutex> readerLock(shaderGroupLock);
-    return shaderGroups.find(shaderGroupName) != shaderGroups.end();
+    return shaderGroups.contains(shaderGroupName);
 }
 
 const ShaderGroupPtr ShaderRegistry::getShaderGroup(const std::string& shaderGroupName) const noexcept {
@@ -28,7 +28,7 @@ const ShaderGroupPtr ShaderRegistry::getShaderGroup(const std::string& shaderGro
 
 bool ShaderRegistry::replaceShader(ShaderGroupPtr&& shader, const std::string& shaderGroupName) noexcept {
     std::unique_lock<std::shared_mutex> writerLock(shaderGroupLock);
-    if (shaderGroups.find(shaderGroupName) == shaderGroups.end()) {
+    if (!shaderGroups.contains(shaderGroupName)) {
         return false;
     }
 
@@ -38,7 +38,7 @@ bool ShaderRegistry::replaceShader(ShaderGroupPtr&& shader, const std::string& s
 
 bool ShaderRegistry::registerShaderGroup(ShaderGroupPtr&& shader, const std::string& shaderGroupName) noexcept {
     std::unique_lock<std::shared_mutex> writerLock(shaderGroupLock);
-    if (shaderGroups.find(shaderGroupName) != shaderGroups.end()) {
+    if (!shaderGroups.contains(shaderGroupName)) {
         return false;
     }
 

--- a/src/mbgl/gl/attribute.hpp
+++ b/src/mbgl/gl/attribute.hpp
@@ -41,9 +41,9 @@ public:
     static constexpr const char* getFirstAttribName() {
         // Static assert that attribute list starts with position: we bind it on location 0.
         using TypeOfFirst = typename std::tuple_element_t<0, std::tuple<As...>>;
-        static_assert(std::is_same<attributes::pos, TypeOfFirst>::value ||
-                          std::is_same<attributes::pos_offset, TypeOfFirst>::value ||
-                          std::is_same<attributes::pos_normal, TypeOfFirst>::value,
+        static_assert(std::is_same_v<attributes::pos, TypeOfFirst> ||
+                          std::is_same_v<attributes::pos_offset, TypeOfFirst> ||
+                          std::is_same_v<attributes::pos_normal, TypeOfFirst>,
                       "Program must start with position related attribute.");
         return concat_literals<&string_literal<'a', '_'>::value, TypeOfFirst::name>::value();
     }

--- a/src/mbgl/gl/resource_pool.hpp
+++ b/src/mbgl/gl/resource_pool.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <functional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -45,7 +44,7 @@ public:
     // Allocate a texture with the given size, pixel format, and channel type
     // If the texture is already allocated in the pool, the existing texture ID will be returned
     TextureID alloc(const Size& size, gfx::TexturePixelType pixelFormat, gfx::TextureChannelDataType channelType) {
-        return alloc({size, pixelFormat, channelType});
+        return alloc({.size=size, .pixelFormat=pixelFormat, .channelType=channelType});
     }
 
     TextureID alloc(const Texture2DDesc& desc);

--- a/src/mbgl/gl/value.hpp
+++ b/src/mbgl/gl/value.hpp
@@ -66,7 +66,7 @@ struct StencilFunc {
         int32_t ref;
         uint32_t mask;
     };
-    static const constexpr Type Default = {gfx::StencilMode::Always::func, 0, ~0u};
+    static const constexpr Type Default = {.func=gfx::StencilMode::Always::func, .ref=0, .mask=~0u};
     static void Set(const Type&);
     static Type Get();
 };
@@ -89,7 +89,7 @@ struct StencilOp {
         gfx::StencilOpType dppass;
     };
     static const constexpr Type Default = {
-        gfx::StencilOpType::Keep, gfx::StencilOpType::Keep, gfx::StencilOpType::Keep};
+        .sfail=gfx::StencilOpType::Keep, .dpfail=gfx::StencilOpType::Keep, .dppass=gfx::StencilOpType::Keep};
     static void Set(const Type&);
     static Type Get();
 };
@@ -140,7 +140,7 @@ struct BlendFunc {
         gfx::ColorBlendFactorType sfactor;
         gfx::ColorBlendFactorType dfactor;
     };
-    static const constexpr Type Default = {gfx::ColorBlendFactorType::One, gfx::ColorBlendFactorType::Zero};
+    static const constexpr Type Default = {.sfactor=gfx::ColorBlendFactorType::One, .dfactor=gfx::ColorBlendFactorType::Zero};
     static void Set(const Type&);
     static Type Get();
 };
@@ -183,7 +183,7 @@ struct Viewport {
         int32_t y;
         Size size;
     };
-    static const constexpr Type Default = {0, 0, {0, 0}};
+    static const constexpr Type Default = {.x=0, .y=0, .size={0, 0}};
     static void Set(const Type&);
     static Type Get();
 };

--- a/src/mbgl/layout/circle_layout.hpp
+++ b/src/mbgl/layout/circle_layout.hpp
@@ -45,7 +45,7 @@ public:
 
             const auto& sortKeyProperty = layout.template get<style::CircleSortKey>();
             float sortKey = sortKeyProperty.evaluate(*feature, zoom, style::CircleSortKey::defaultValue());
-            CircleFeature circleFeature{i, std::move(feature), sortKey};
+            CircleFeature circleFeature{.i=i, .feature=std::move(feature), .sortKey=sortKey};
             const auto sortPosition = std::lower_bound(features.cbegin(), features.cend(), circleFeature);
             features.insert(sortPosition, std::move(circleFeature));
         }
@@ -75,7 +75,7 @@ public:
         if (!bucket->hasData()) return;
 
         for (const auto& pair : layerPropertiesMap) {
-            renderData.emplace(pair.first, LayerRenderData{bucket, pair.second});
+            renderData.emplace(pair.first, LayerRenderData{.bucket=bucket, .layerProperties=pair.second});
         }
     }
 

--- a/src/mbgl/layout/merge_lines.cpp
+++ b/src/mbgl/layout/merge_lines.cpp
@@ -2,17 +2,16 @@
 #include <mbgl/layout/symbol_feature.hpp>
 #include <mbgl/util/hash.hpp>
 
-namespace mbgl {
-namespace util {
-
 // Map of key -> index into features
 using Index = std::unordered_map<size_t, size_t>;
 
-size_t mergeFromRight(std::vector<SymbolFeature>& features,
+namespace {
+
+size_t mergeFromRight(std::vector<mbgl::SymbolFeature>& features,
                       Index& rightIndex,
                       Index::iterator left,
                       size_t rightKey,
-                      GeometryCollection& geom) {
+                      mbgl::GeometryCollection& geom) {
     const size_t index = left->second;
     rightIndex.erase(left);
     rightIndex[rightKey] = index;
@@ -22,11 +21,11 @@ size_t mergeFromRight(std::vector<SymbolFeature>& features,
     return index;
 }
 
-size_t mergeFromLeft(std::vector<SymbolFeature>& features,
+size_t mergeFromLeft(std::vector<mbgl::SymbolFeature>& features,
                      Index& leftIndex,
                      Index::iterator right,
                      size_t leftKey,
-                     GeometryCollection& geom) {
+                     mbgl::GeometryCollection& geom) {
     const size_t index = right->second;
     leftIndex.erase(right);
     leftIndex[leftKey] = index;
@@ -37,9 +36,14 @@ size_t mergeFromLeft(std::vector<SymbolFeature>& features,
     return index;
 }
 
-size_t getKey(const std::u16string& text, const GeometryCoordinate& coord) {
-    return util::hash(text, coord.x, coord.y);
+size_t getKey(const std::u16string& text, const mbgl::GeometryCoordinate& coord) {
+    return mbgl::util::hash(text, coord.x, coord.y);
 }
+
+}
+
+namespace mbgl {
+    namespace util {
 
 void mergeLines(std::vector<SymbolFeature>& features) {
     Index leftIndex;

--- a/src/mbgl/layout/merge_lines.hpp
+++ b/src/mbgl/layout/merge_lines.hpp
@@ -12,18 +12,6 @@ class SymbolFeature;
 
 namespace util {
 
-unsigned int mergeFromRight(std::vector<SymbolFeature> &features,
-                            std::unordered_map<std::string, unsigned int> &rightIndex,
-                            std::unordered_map<std::string, unsigned int>::iterator left,
-                            std::string &rightKey,
-                            GeometryCollection &geom);
-
-unsigned int mergeFromLeft(std::vector<SymbolFeature> &features,
-                           std::unordered_map<std::string, unsigned int> &leftIndex,
-                           std::string &leftKey,
-                           std::unordered_map<std::string, unsigned int>::iterator right,
-                           GeometryCollection &geom);
-
 void mergeLines(std::vector<SymbolFeature> &features);
 
 } // end namespace util

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -27,13 +27,14 @@ namespace mbgl {
 
 using namespace style;
 
+namespace {
+
 template <class Property>
-static bool has(const style::SymbolLayoutProperties::PossiblyEvaluated& layout) {
+bool has(const style::SymbolLayoutProperties::PossiblyEvaluated& layout) {
     return layout.get<Property>().match([](const typename Property::Type& t) { return !t.empty(); },
                                         [](const auto&) { return true; });
 }
 
-namespace {
 expression::Value sectionOptionsToValue(const SectionOptions& options) {
     std::unordered_map<std::string, expression::Value> result;
     // TODO: Data driven properties that can be overridden on per section basis.
@@ -808,7 +809,7 @@ void SymbolLayout::addFeature(const std::size_t layoutFeatureIndex,
 }
 
 bool SymbolLayout::anchorIsTooClose(const std::u16string& text, const float repeatDistance, const Anchor& anchor) {
-    if (compareText.find(text) == compareText.end()) {
+    if (!compareText.contains(text)) {
         compareText.emplace(text, Anchors());
     } else {
         const auto& otherAnchors = compareText.find(text)->second;
@@ -997,7 +998,7 @@ void SymbolLayout::createBucket(const ImagePositions&,
             if (!firstLoad) {
                 bucket->justReloaded = true;
             }
-            renderData.emplace(pair.first, LayerRenderData{bucket, pair.second});
+            renderData.emplace(pair.first, LayerRenderData{.bucket=bucket, .layerProperties=pair.second});
         }
     }
 }

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -82,24 +82,24 @@ void Map::Impl::onUpdate() {
 
     transform.updateTransitions(timePoint);
 
-    UpdateParameters params = {style->impl->isLoaded(),
-                               mode,
-                               pixelRatio,
-                               debugOptions,
-                               timePoint,
-                               transform.getState(),
-                               style->impl->getGlyphURL(),
-                               style->impl->areSpritesLoaded(),
-                               style->impl->getTransitionOptions(),
-                               style->impl->getLight()->impl,
-                               style->impl->getImageImpls(),
-                               style->impl->getSourceImpls(),
-                               style->impl->getLayerImpls(),
-                               annotationManager.makeWeakPtr(),
-                               fileSource,
-                               prefetchZoomDelta,
-                               bool(stillImageRequest),
-                               crossSourceCollisions};
+    UpdateParameters params = {.styleLoaded=style->impl->isLoaded(),
+                               .mode=mode,
+                               .pixelRatio=pixelRatio,
+                               .debugOptions=debugOptions,
+                               .timePoint=timePoint,
+                               .transformState=transform.getState(),
+                               .glyphURL=style->impl->getGlyphURL(),
+                               .spriteLoaded=style->impl->areSpritesLoaded(),
+                               .transitionOptions=style->impl->getTransitionOptions(),
+                               .light=style->impl->getLight()->impl,
+                               .images=style->impl->getImageImpls(),
+                               .sources=style->impl->getSourceImpls(),
+                               .layers=style->impl->getLayerImpls(),
+                               .annotationManager=annotationManager.makeWeakPtr(),
+                               .fileSource=fileSource,
+                               .prefetchZoomDelta=prefetchZoomDelta,
+                               .stillImageRequest=bool(stillImageRequest),
+                               .crossSourceCollisions=crossSourceCollisions};
 
     rendererFrontend.update(std::make_shared<UpdateParameters>(std::move(params)));
 }
@@ -186,11 +186,11 @@ void Map::Impl::onDidFinishRenderingFrame(RenderMode renderMode,
     rendererFullyLoaded = renderMode == RenderMode::Full;
 
     if (mode == MapMode::Continuous) {
-        observer.onDidFinishRenderingFrame({MapObserver::RenderMode(renderMode),
-                                            needsRepaint,
-                                            placemenChanged,
-                                            frameEncodingTime,
-                                            frameRenderingTime});
+        observer.onDidFinishRenderingFrame({.mode=MapObserver::RenderMode(renderMode),
+                                            .needsRepaint=needsRepaint,
+                                            .placementChanged=placemenChanged,
+                                            .frameEncodingTime=frameEncodingTime,
+                                            .frameRenderingTime=frameRenderingTime});
 
         if (needsRepaint || transform.inTransition()) {
             onUpdate();

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -20,9 +20,10 @@ using namespace std::numbers;
 
 namespace mbgl {
 
+namespace {
 /** Converts the given angle (in radians) to be numerically close to the anchor
  * angle, allowing it to be interpolated properly without sudden jumps. */
-static double _normalizeAngle(double angle, double anchorAngle) {
+double _normalizeAngle(double angle, double anchorAngle) {
     if (std::isnan(angle) || std::isnan(anchorAngle)) {
         return 0;
     }
@@ -38,6 +39,7 @@ static double _normalizeAngle(double angle, double anchorAngle) {
     }
 
     return angle;
+}
 }
 
 Transform::Transform(MapObserver& observer_, ConstrainMode constrainMode, ViewportMode viewportMode)
@@ -109,7 +111,8 @@ void Transform::easeTo(const CameraOptions& inputCamera, const AnimationOptions&
     Duration duration = animation.duration.value_or(Duration::zero());
     if (state.getLatLngBounds() == LatLngBounds() && !isGestureInProgress() && duration != Duration::zero()) {
         // reuse flyTo, without exaggerated animation, to achieve constant ground speed.
-        return flyTo(camera, animation, true);
+        flyTo(camera, animation, true);
+        return;
     }
 
     double zoom = camera.zoom.value_or(getZoom());

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -689,7 +689,7 @@ ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng, 
 
 TileCoordinate TransformState::screenCoordinateToTileCoordinate(const ScreenCoordinate& point, uint8_t atZoom) const {
     if (size.isEmpty()) {
-        return {{}, 0};
+        return {.p={}, .z=0};
     }
 
     float targetZ = 0;
@@ -718,7 +718,7 @@ TileCoordinate TransformState::screenCoordinateToTileCoordinate(const ScreenCoor
     double t = z0 == z1 ? 0 : (targetZ - z0) / (z1 - z0);
 
     Point<double> p = util::interpolate(p0, p1, t) / scale * static_cast<double>(1 << atZoom);
-    return {{p.x, p.y}, static_cast<double>(atZoom)};
+    return {.p={p.x, p.y}, .z=static_cast<double>(atZoom)};
 }
 
 LatLng TransformState::screenCoordinateToLatLng(const ScreenCoordinate& point, LatLng::WrapMode wrapMode) const {

--- a/src/mbgl/programs/line_program.cpp
+++ b/src/mbgl/programs/line_program.cpp
@@ -12,6 +12,7 @@ using namespace style;
 
 static_assert(sizeof(LineLayoutVertex) == 8, "expected LineLayoutVertex size");
 
+namespace {
 template <class Values, class... Args>
 Values makeValues(const style::LinePaintProperties::PossiblyEvaluated& properties,
                   const RenderTile& tile,
@@ -25,6 +26,7 @@ Values makeValues(const style::LinePaintProperties::PossiblyEvaluated& propertie
                   uniforms::units_to_pixels::Value({{1.0f / pixelsToGLUnits[0], 1.0f / pixelsToGLUnits[1]}}),
                   uniforms::device_pixel_ratio::Value(pixelRatio),
                   std::forward<Args>(args)...};
+}
 }
 
 LineProgram::LayoutUniformValues LineProgram::layoutUniformValues(

--- a/src/mbgl/programs/program.hpp
+++ b/src/mbgl/programs/program.hpp
@@ -50,6 +50,7 @@ public:
 
     std::unique_ptr<gfx::Program<Name>> program;
 
+    // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
     Program([[maybe_unused]] const ProgramParameters& programParameters) {
         switch (gfx::Backend::GetType()) {
 #if MLN_RENDER_BACKEND_METAL

--- a/src/mbgl/programs/program.hpp
+++ b/src/mbgl/programs/program.hpp
@@ -11,8 +11,6 @@
 #include <mbgl/renderer/paint_property_binder.hpp>
 #include <mbgl/util/io.hpp>
 
-#include <unordered_map>
-
 #include <mbgl/shaders/shader_manifest.hpp>
 #if MLN_RENDER_BACKEND_OPENGL
 #include <mbgl/gl/program.hpp>

--- a/src/mbgl/programs/programs.cpp
+++ b/src/mbgl/programs/programs.cpp
@@ -18,6 +18,7 @@ Programs::Programs(const ProgramParameters& programParameters_)
 
 Programs::~Programs() = default;
 
+namespace {
 /// @brief Register a list of types with a shader registry instance
 /// @tparam ...T Type list parameter pack
 /// @param registry A shader registry instance
@@ -37,6 +38,7 @@ void registerTypes(gfx::ShaderRegistry& registry, const ProgramParameters& progr
             }
         }(registry.getLegacyGroup().registerShader(std::make_shared<T>(programParameters_))),
         ...);
+}
 }
 
 void Programs::registerWith(gfx::ShaderRegistry& registry) {

--- a/src/mbgl/programs/symbol_program.cpp
+++ b/src/mbgl/programs/symbol_program.cpp
@@ -34,6 +34,7 @@ std::unique_ptr<SymbolSizeBinder> SymbolSizeBinder::create(const float tileZoom,
         });
 }
 
+namespace {
 template <class Values, class... Args>
 Values makeValues(const bool isText,
                   const bool hasVariablePacement,
@@ -89,6 +90,7 @@ Values makeValues(const bool isText,
                   uniforms::rotate_symbol::Value(rotateInShader),
                   uniforms::aspect_ratio::Value(state.getSize().aspectRatio()),
                   std::forward<Args>(args)...};
+}
 }
 
 SymbolIconProgram::LayoutUniformValues SymbolIconProgram::layoutUniformValues(

--- a/src/mbgl/renderer/buckets/circle_bucket.cpp
+++ b/src/mbgl/renderer/buckets/circle_bucket.cpp
@@ -33,8 +33,9 @@ bool CircleBucket::hasData() const {
     return !segments.empty();
 }
 
+namespace {
 template <class Property>
-static float get(const CirclePaintProperties::PossiblyEvaluated& evaluated,
+float get(const CirclePaintProperties::PossiblyEvaluated& evaluated,
                  const std::string& id,
                  const std::map<std::string, CircleProgram::Binders>& paintPropertyBinders) {
     auto it = paintPropertyBinders.find(id);
@@ -43,6 +44,7 @@ static float get(const CirclePaintProperties::PossiblyEvaluated& evaluated,
     } else {
         return *it->second.statistics<Property>().max();
     }
+}
 }
 
 float CircleBucket::getQueryRadius(const RenderLayer& layer) const {

--- a/src/mbgl/renderer/buckets/debug_bucket.cpp
+++ b/src/mbgl/renderer/buckets/debug_bucket.cpp
@@ -26,7 +26,7 @@ DebugBucket::DebugBucket(const OverscaledTileID& id,
             std::optional<Point<int16_t>> prev;
 
             const glyph& glyph = simplex[c - 32];
-            for (int32_t j = 0; j < glyph.length; j += 2) {
+            for (int32_t j = 0; std::cmp_less(j, glyph.length); j += 2) {
                 if (glyph.data[j] == -1 && glyph.data[j + 1] == -1) {
                     prev = {};
                 } else {

--- a/src/mbgl/renderer/buckets/line_bucket.cpp
+++ b/src/mbgl/renderer/buckets/line_bucket.cpp
@@ -12,6 +12,20 @@ namespace mbgl {
 
 using namespace style;
 
+namespace {
+    template <class Property>
+    float get(const LinePaintProperties::PossiblyEvaluated& evaluated,
+                 const std::string& id,
+                 const std::map<std::string, LineProgram::Binders>& paintPropertyBinders) {
+    auto it = paintPropertyBinders.find(id);
+    if (it == paintPropertyBinders.end() || !it->second.statistics<Property>().max()) {
+        return evaluated.get<Property>().constantOr(Property::defaultValue());
+    } else {
+        return *it->second.statistics<Property>().max();
+    }
+}
+}
+
 LineBucket::LineBucket(LineBucket::PossiblyEvaluatedLayoutProperties layout_,
                        const std::map<std::string, Immutable<LayerProperties>>& layerPaintProperties,
                        const float zoom_,
@@ -132,18 +146,6 @@ void LineBucket::upload([[maybe_unused]] gfx::UploadPass& uploadPass) {
 
 bool LineBucket::hasData() const {
     return !segments.empty();
-}
-
-template <class Property>
-static float get(const LinePaintProperties::PossiblyEvaluated& evaluated,
-                 const std::string& id,
-                 const std::map<std::string, LineProgram::Binders>& paintPropertyBinders) {
-    auto it = paintPropertyBinders.find(id);
-    if (it == paintPropertyBinders.end() || !it->second.statistics<Property>().max()) {
-        return evaluated.get<Property>().constantOr(Property::defaultValue());
-    } else {
-        return *it->second.statistics<Property>().max();
-    }
 }
 
 float LineBucket::getQueryRadius(const RenderLayer& layer) const {

--- a/src/mbgl/renderer/layers/line_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.cpp
@@ -140,15 +140,16 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
             .expressionMask = expressionMask,
             .pad1 = 0};
 #else
-        const LineEvaluatedPropsUBO propsUBO{/*color =*/evaluate<LineColor>(parameters),
-                                             /*blur =*/evaluate<LineBlur>(parameters),
-                                             /*opacity =*/evaluate<LineOpacity>(parameters),
-                                             /*gapwidth =*/evaluate<LineGapWidth>(parameters),
-                                             /*offset =*/evaluate<LineOffset>(parameters),
-                                             /*width =*/evaluate<LineWidth>(parameters),
-                                             /*floorwidth =*/evaluate<LineFloorWidth>(parameters),
-                                             LineExpressionMask::None,
-                                             0};
+        const LineEvaluatedPropsUBO propsUBO{
+            .color = evaluate<LineColor>(parameters),
+            .blur = evaluate<LineBlur>(parameters),
+            .opacity = evaluate<LineOpacity>(parameters),
+            .gapwidth = evaluate<LineGapWidth>(parameters),
+            .offset = evaluate<LineOffset>(parameters),
+            .width = evaluate<LineWidth>(parameters),
+            .floorwidth = evaluate<LineFloorWidth>(parameters),
+            .expressionMask = LineExpressionMask::None,
+            .pad1 = 0};
 #endif // MLN_RENDER_BACKEND_METAL
 
         context.emplaceOrUpdateUniformBuffer(evaluatedPropsUniformBuffer, &propsUBO);

--- a/src/mbgl/renderer/layers/render_background_layer.cpp
+++ b/src/mbgl/renderer/layers/render_background_layer.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <mbgl/renderer/layers/render_background_layer.hpp>
 #include <mbgl/gfx/context.hpp>
 #include <mbgl/gfx/cull_face_mode.hpp>
@@ -188,7 +189,7 @@ void RenderBackgroundLayer::update(gfx::ShaderRegistry& shaders,
     // (Note that `RenderTiles` is empty, and this layer does not use it)
     tileLayerGroup->removeDrawablesIf([&](gfx::Drawable& drawable) -> bool {
         return drawable.getTileID() &&
-               (std::find(tileCover.begin(), tileCover.end(), *drawable.getTileID()) == tileCover.end());
+               (std::ranges::find(tileCover, *drawable.getTileID()) == tileCover.end());
     });
 
     // For each tile in the cover set, add a tile drawable if one doesn't already exist.

--- a/src/mbgl/renderer/layers/render_circle_layer.cpp
+++ b/src/mbgl/renderer/layers/render_circle_layer.cpp
@@ -77,6 +77,7 @@ bool RenderCircleLayer::hasCrossfade() const {
     return false;
 }
 
+namespace {
 GeometryCoordinate projectPoint(const GeometryCoordinate& p, const mat4& posMatrix, const Size& size) {
     vec4 pos = {{static_cast<double>(p.x), static_cast<double>(p.y), 0, 1}};
     matrix::transformMat4(pos, pos, posMatrix);
@@ -92,6 +93,7 @@ GeometryCoordinates projectQueryGeometry(const GeometryCoordinates& queryGeometr
         projectedGeometry.push_back(projectPoint(p, posMatrix, size));
     }
     return projectedGeometry;
+}
 }
 
 bool RenderCircleLayer::queryIntersectsFeature(const GeometryCoordinates& queryGeometry,

--- a/src/mbgl/renderer/layers/render_location_indicator_layer.cpp
+++ b/src/mbgl/renderer/layers/render_location_indicator_layer.cpp
@@ -823,7 +823,7 @@ protected:
                                std::shared_ptr<Texture>& texture,
                                const mbgl::LocationIndicatorRenderParameters& params) {
         bool updated = false;
-        if (textures.find(imagePath) == textures.end()) {
+        if (!textures.contains(imagePath)) {
             std::shared_ptr<Texture> tx = std::make_shared<Texture>();
             if (!imagePath.empty() && params.imageManager) {
                 tx->assign(params.imageManager->getSharedImage(imagePath));

--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -95,7 +95,7 @@ gfx::DepthMode PaintParameters::depthModeForSublayer([[maybe_unused]] uint8_t n,
 
 #if MLN_RENDER_BACKEND_OPENGL
     float depth = depthRangeSize + ((1 + currentLayer) * numSublayers + n) * depthEpsilon;
-    return gfx::DepthMode{gfx::DepthFunctionType::LessEqual, mask, {depth, depth}};
+    return gfx::DepthMode{.func=gfx::DepthFunctionType::LessEqual, .mask=mask, .range={depth, depth}};
 #else
     return gfx::DepthMode{gfx::DepthFunctionType::LessEqual, mask};
 #endif
@@ -103,7 +103,7 @@ gfx::DepthMode PaintParameters::depthModeForSublayer([[maybe_unused]] uint8_t n,
 
 gfx::DepthMode PaintParameters::depthModeFor3D() const {
 #if MLN_RENDER_BACKEND_OPENGL
-    return gfx::DepthMode{gfx::DepthFunctionType::LessEqual, gfx::DepthMaskType::ReadWrite, {0.0, depthRangeSize}};
+    return gfx::DepthMode{.func=gfx::DepthFunctionType::LessEqual, .mask=gfx::DepthMaskType::ReadWrite, .range={0.0, depthRangeSize}};
 #else
     return gfx::DepthMode{gfx::DepthFunctionType::LessEqual, gfx::DepthMaskType::ReadWrite};
 #endif
@@ -271,12 +271,12 @@ void PaintParameters::renderTileClippingMasks(const RenderTiles& renderTiles) {
                       *renderPass,
                       gfx::Triangles(),
                       gfx::DepthMode::disabled(),
-                      gfx::StencilMode{gfx::StencilMode::Always{},
-                                       stencilID,
-                                       0b11111111,
-                                       gfx::StencilOpType::Keep,
-                                       gfx::StencilOpType::Keep,
-                                       gfx::StencilOpType::Replace},
+                      gfx::StencilMode{.test=gfx::StencilMode::Always{},
+                                       .ref=stencilID,
+                                       .mask=0b11111111,
+                                       .fail=gfx::StencilOpType::Keep,
+                                       .depthFail=gfx::StencilOpType::Keep,
+                                       .pass=gfx::StencilOpType::Replace},
                       gfx::ColorMode::disabled(),
                       gfx::CullFaceMode::disabled(),
                       *staticData.quadTriangleIndexBuffer,
@@ -300,12 +300,12 @@ gfx::StencilMode PaintParameters::stencilModeForClipping(const UnwrappedTileID& 
     auto it = tileClippingMaskIDs.find(tileID);
     assert(it != tileClippingMaskIDs.end());
     const int32_t id = it != tileClippingMaskIDs.end() ? it->second : 0b00000000;
-    return gfx::StencilMode{gfx::StencilMode::Equal{0b11111111},
-                            id,
-                            0b00000000,
-                            gfx::StencilOpType::Keep,
-                            gfx::StencilOpType::Keep,
-                            gfx::StencilOpType::Replace};
+    return gfx::StencilMode{.test=gfx::StencilMode::Equal{0b11111111},
+                            .ref=id,
+                            .mask=0b00000000,
+                            .fail=gfx::StencilOpType::Keep,
+                            .depthFail=gfx::StencilOpType::Keep,
+                            .pass=gfx::StencilOpType::Replace};
 }
 
 gfx::StencilMode PaintParameters::stencilModeFor3D() {
@@ -318,21 +318,21 @@ gfx::StencilMode PaintParameters::stencilModeFor3D() {
     tileClippingMaskIDs.clear();
 
     const int32_t id = nextStencilID++;
-    return gfx::StencilMode{gfx::StencilMode::NotEqual{0b11111111},
-                            id,
-                            0b11111111,
-                            gfx::StencilOpType::Keep,
-                            gfx::StencilOpType::Keep,
-                            gfx::StencilOpType::Replace};
+    return gfx::StencilMode{.test=gfx::StencilMode::NotEqual{0b11111111},
+                            .ref=id,
+                            .mask=0b11111111,
+                            .fail=gfx::StencilOpType::Keep,
+                            .depthFail=gfx::StencilOpType::Keep,
+                            .pass=gfx::StencilOpType::Replace};
 }
 
 gfx::ColorMode PaintParameters::colorModeForRenderPass() const {
     if (debugOptions & MapDebugOptions::Overdraw) {
         constexpr float overdraw = 1.0f / 8.0f;
         return gfx::ColorMode{
-            gfx::ColorMode::Add{gfx::ColorBlendFactorType::ConstantColor, gfx::ColorBlendFactorType::One},
-            Color{overdraw, overdraw, overdraw, 0.0f},
-            gfx::ColorMode::Mask{true, true, true, true}};
+            .blendFunction=gfx::ColorMode::Add{gfx::ColorBlendFactorType::ConstantColor, gfx::ColorBlendFactorType::One},
+            .blendColor=Color{overdraw, overdraw, overdraw, 0.0f},
+            .mask=gfx::ColorMode::Mask{.r=true, .g=true, .b=true, .a=true}};
     } else if (pass == RenderPass::Translucent) {
         return gfx::ColorMode::alphaBlended();
     } else {

--- a/src/mbgl/renderer/pattern_atlas.cpp
+++ b/src/mbgl/renderer/pattern_atlas.cpp
@@ -35,7 +35,7 @@ std::optional<ImagePosition> PatternAtlas::getPattern(const std::string& id) con
 }
 
 std::optional<ImagePosition> PatternAtlas::addPattern(const style::Image::Impl& image) {
-    if (patterns.find(image.id) != patterns.end()) {
+    if (patterns.contains(image.id)) {
         return std::nullopt;
     }
     const uint16_t width = image.image.size.width + padding * 2;

--- a/src/mbgl/renderer/render_layer.cpp
+++ b/src/mbgl/renderer/render_layer.cpp
@@ -131,7 +131,7 @@ void RenderLayer::addRenderPassesFromTiles() {
 
 const LayerRenderData* RenderLayer::getRenderDataForPass(const RenderTile& tile, RenderPass pass) const {
     if (const LayerRenderData* renderData = tile.getLayerRenderData(*baseImpl)) {
-        return bool(RenderPass(renderData->layerProperties->renderPasses) & pass) ? renderData : nullptr;
+        return RenderPass(renderData->layerProperties->renderPasses) & pass ? renderData : nullptr;
     }
     return nullptr;
 }

--- a/src/mbgl/renderer/render_orchestrator.cpp
+++ b/src/mbgl/renderer/render_orchestrator.cpp
@@ -29,6 +29,8 @@
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/logging.hpp>
 
+#include <algorithm>
+
 namespace mbgl {
 
 using namespace style;
@@ -578,8 +580,7 @@ void RenderOrchestrator::queryRenderedSymbols(std::unordered_map<std::string, st
     };
 
     std::unordered_map<std::string, const RenderLayer*> crossTileSymbolIndexLayers;
-    std::copy_if(layers.begin(),
-                 layers.end(),
+    std::ranges::copy_if(layers,
                  std::inserter(crossTileSymbolIndexLayers, crossTileSymbolIndexLayers.begin()),
                  hasCrossTileIndex);
 
@@ -596,8 +597,8 @@ void RenderOrchestrator::queryRenderedSymbols(std::unordered_map<std::string, st
     // Although symbol query is global, symbol results are only sortable within
     // a bucket For a predictable global sort renderItems, we sort the buckets
     // based on their corresponding tile position
-    std::sort(
-        bucketQueryData.begin(), bucketQueryData.end(), [](const RetainedQueryData& a, const RetainedQueryData& b) {
+    std::ranges::sort(
+        bucketQueryData, [](const RetainedQueryData& a, const RetainedQueryData& b) {
             return std::tie(a.tileID.canonical.z, a.tileID.canonical.y, a.tileID.wrap, a.tileID.canonical.x) <
                    std::tie(b.tileID.canonical.z, b.tileID.canonical.y, b.tileID.wrap, b.tileID.canonical.x);
         });
@@ -612,7 +613,7 @@ void RenderOrchestrator::queryRenderedSymbols(std::unordered_map<std::string, st
 
         for (auto layer : bucketSymbols) {
             auto& resultFeatures = resultsByLayer[layer.first];
-            std::move(layer.second.begin(), layer.second.end(), std::inserter(resultFeatures, resultFeatures.end()));
+            std::ranges::move(layer.second, std::inserter(resultFeatures, resultFeatures.end()));
         }
     }
 }
@@ -641,8 +642,7 @@ std::vector<Feature> RenderOrchestrator::queryRenderedFeatures(
         if (RenderSource* renderSource = getRenderSource(sourceID)) {
             auto sourceResults = renderSource->queryRenderedFeatures(
                 geometry, transformState, filteredLayers, options, projMatrix);
-            std::move(
-                sourceResults.begin(), sourceResults.end(), std::inserter(resultsByLayer, resultsByLayer.begin()));
+            std::ranges::move(sourceResults, std::inserter(resultsByLayer, resultsByLayer.begin()));
         }
     }
 
@@ -984,7 +984,7 @@ void RenderOrchestrator::processChanges() {
 }
 
 bool RenderOrchestrator::addRenderTarget(RenderTargetPtr renderTarget) {
-    auto it = std::find(renderTargets.begin(), renderTargets.end(), renderTarget);
+    auto it = std::ranges::find(renderTargets, renderTarget);
     if (it == renderTargets.end()) {
         renderTargets.emplace_back(renderTarget);
         return true;
@@ -994,7 +994,7 @@ bool RenderOrchestrator::addRenderTarget(RenderTargetPtr renderTarget) {
 }
 
 bool RenderOrchestrator::removeRenderTarget(const RenderTargetPtr& renderTarget) {
-    auto it = std::find(renderTargets.begin(), renderTargets.end(), renderTarget);
+    auto it = std::ranges::find(renderTargets, renderTarget);
     if (it != renderTargets.end()) {
         renderTargets.erase(it);
         return true;

--- a/src/mbgl/renderer/render_source.cpp
+++ b/src/mbgl/renderer/render_source.cpp
@@ -58,7 +58,9 @@ std::unique_ptr<RenderSource> RenderSource::create(const Immutable<Source::Impl>
     return nullptr;
 }
 
-static RenderSourceObserver nullObserver;
+namespace {
+    RenderSourceObserver nullObserver;
+}
 
 RenderSource::RenderSource(Immutable<style::Source::Impl> impl)
     : baseImpl(std::move(impl)),

--- a/src/mbgl/renderer/renderer.cpp
+++ b/src/mbgl/renderer/renderer.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <mbgl/renderer/renderer.hpp>
 
 #include <mbgl/annotation/annotation_manager.hpp>
@@ -84,7 +85,7 @@ AnnotationIDs Renderer::getAnnotationIDs(const std::vector<Feature>& features) c
     }
     AnnotationIDs ids;
     ids.reserve(set.size());
-    std::move(set.begin(), set.end(), std::back_inserter(ids));
+    std::ranges::move(set, std::back_inserter(ids));
     return ids;
 }
 

--- a/src/mbgl/renderer/sources/render_tile_source.cpp
+++ b/src/mbgl/renderer/sources/render_tile_source.cpp
@@ -364,12 +364,12 @@ void TileSourceRenderItem::updateDebugDrawables(DebugLayerGroupMap& debugLayerGr
             const auto& debugBucket = tile.debugBucket;
             if (!debugBucket) continue;
 
-            const DebugUBO outlineUBO = {/* .matrix = */ util::cast<float>(tile.matrix),
-                                         /* .color = */ Color::white(),
-                                         /* .overlay_scale = */ 1.0f,
-                                         /* .pad1 = */ 0,
-                                         /* .pad2 = */ 0,
-                                         /* .pad3 = */ 0};
+            const DebugUBO outlineUBO = {.matrix=util::cast<float>(tile.matrix),
+                                         .color=Color::white(),
+                                         .overlay_scale=1.0f,
+                                         .pad1=0,
+                                         .pad2=0,
+                                         .pad3=0};
             if (0 == updateDrawables(outlineLayerGroup, tileID, outlineUBO)) {
                 addDrawable(outlineLayerGroup,
                             tileID,
@@ -380,12 +380,12 @@ void TileSourceRenderItem::updateDebugDrawables(DebugLayerGroupMap& debugLayerGr
                             debugBucket->segments);
             }
 
-            const DebugUBO textUBO = {/* .matrix = */ util::cast<float>(tile.matrix),
-                                      /* .color = */ Color::black(),
-                                      /* .overlay_scale = */ 1.0f,
-                                      /* .pad1 = */ 0,
-                                      /* .pad2 = */ 0,
-                                      /* .pad3 = */ 0};
+            const DebugUBO textUBO = {.matrix=util::cast<float>(tile.matrix),
+                                      .color=Color::black(),
+                                      .overlay_scale=1.0f,
+                                      .pad1=0,
+                                      .pad2=0,
+                                      .pad3=0};
             if (0 == updateDrawables(textLayerGroup, tileID, textUBO) && tile.getNeedsRendering()) {
                 addDrawable(textLayerGroup,
                             tileID,
@@ -427,12 +427,12 @@ void TileSourceRenderItem::updateDebugDrawables(DebugLayerGroupMap& debugLayerGr
                 addPolylineDrawable(tileLayerGroup, tile);
             }
 #else
-            const DebugUBO debugUBO = {/* .matrix = */ util::cast<float>(tile.matrix),
-                                       /* .color = */ Color::red(),
-                                       /* .overlay_scale = */ 1.0f,
-                                       /* .pad1 = */ 0,
-                                       /* .pad2 = */ 0,
-                                       /* .pad3 = */ 0};
+                const DebugUBO debugUBO = {.matrix=util::cast<float>(tile.matrix),
+                                        .color=Color::red(),
+                                        .overlay_scale=1.0f,
+                                        .pad1=0,
+                                        .pad2=0,
+                                        .pad3=0};
 
             if (0 == updateDrawables(tileLayerGroup, tileID, debugUBO) && tile.getNeedsRendering()) {
                 addDrawable(tileLayerGroup,

--- a/src/mbgl/sprite/sprite_loader.cpp
+++ b/src/mbgl/sprite/sprite_loader.cpp
@@ -17,7 +17,9 @@
 
 namespace mbgl {
 
-static SpriteLoaderObserver nullObserver;
+namespace {
+SpriteLoaderObserver nullObserver;
+}
 
 struct SpriteLoader::Data {
     std::shared_ptr<const std::string> image;
@@ -50,7 +52,7 @@ void SpriteLoader::load(const std::optional<style::Sprite> sprite, FileSource& f
         std::lock_guard<std::mutex> lock(dataMapMutex);
         Data* data = dataMap[sprite->id].get();
         if (res.error) {
-            observer->onSpriteError(*sprite, std::make_exception_ptr(std::runtime_error(res.error->message)));
+            observer->onSpriteError(sprite, std::make_exception_ptr(std::runtime_error(res.error->message)));
         } else if (res.notModified) {
             return;
         } else if (res.noContent) {
@@ -69,7 +71,7 @@ void SpriteLoader::load(const std::optional<style::Sprite> sprite, FileSource& f
             std::lock_guard<std::mutex> lock(dataMapMutex);
             Data* data = dataMap[sprite->id].get();
             if (res.error) {
-                observer->onSpriteError(*sprite, std::make_exception_ptr(std::runtime_error(res.error->message)));
+                observer->onSpriteError(sprite, std::make_exception_ptr(std::runtime_error(res.error->message)));
             } else if (res.notModified) {
                 return;
             } else if (res.noContent) {

--- a/src/mbgl/sprite/sprite_parser.cpp
+++ b/src/mbgl/sprite/sprite_parser.cpp
@@ -145,10 +145,10 @@ std::optional<style::ImageContent> getContent(const JSValue& value, const char* 
         if (content.IsArray() && content.Size() == 4 && content[rapidjson::SizeType(0)].IsNumber() &&
             content[rapidjson::SizeType(1)].IsNumber() && content[rapidjson::SizeType(2)].IsNumber() &&
             content[rapidjson::SizeType(3)].IsNumber()) {
-            return style::ImageContent{content[rapidjson::SizeType(0)].GetFloat(),
-                                       content[rapidjson::SizeType(1)].GetFloat(),
-                                       content[rapidjson::SizeType(2)].GetFloat(),
-                                       content[rapidjson::SizeType(3)].GetFloat()};
+            return style::ImageContent{.left=content[rapidjson::SizeType(0)].GetFloat(),
+                                       .top=content[rapidjson::SizeType(1)].GetFloat(),
+                                       .right=content[rapidjson::SizeType(2)].GetFloat(),
+                                       .bottom=content[rapidjson::SizeType(3)].GetFloat()};
         } else {
             Log::Warning(Event::Sprite,
                          "Invalid sprite image '" + std::string(name) + "': value of '" + property +

--- a/src/mbgl/tile/tile_loader.hpp
+++ b/src/mbgl/tile/tile_loader.hpp
@@ -51,7 +51,7 @@ private:
     Resource resource;
     std::shared_ptr<FileSource> fileSource;
     std::unique_ptr<AsyncRequest> request;
-    TileUpdateParameters updateParameters{Duration::zero(), false};
+    TileUpdateParameters updateParameters{.minimumUpdateInterval=Duration::zero(), .isVolatile=false};
 
     /// @brief It's possible for async requests in flight to mess with the request
     /// object at the same time as the loader's destructor. This construct is shared


### PR DESCRIPTION
Getting ready to update to the clang version that comes with Ubuntu 24.04 on CI, these are some additional fixes for things clang-tidy warns about.