### PR TITLE
Make sure renderThread is alive before calling requestExitAndWait()

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog MapLibre Native for Android
 
-## main
+## 11.8.8
+
+### ✨ Features and improvements
+
+- Update NDK to 28.1.13356709 ([#3450](https://github.com/maplibre/maplibre-native/pull/3450)).
+
+### 🐞 Bug fixes
+
+- Make sure renderThread is alive before calling requestExitAndWait().
 
 ## 11.8.7
 

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐞 Bug fixes
 
-- Make sure renderThread is alive before calling requestExitAndWait().
+- Make sure renderThread is alive before calling requestExitAndWait() ([#3461](https://github.com/maplibre/maplibre-native/pull/3461)).
 
 ## 11.8.7
 

--- a/platform/android/MapLibreAndroid/gradle.properties
+++ b/platform/android/MapLibreAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=11.8.7
+VERSION_NAME=11.8.8
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreSurfaceView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreSurfaceView.java
@@ -435,9 +435,9 @@ public abstract class MapLibreSurfaceView extends SurfaceView implements Surface
       synchronized (renderThreadManager) {
         shouldExit = true;
         renderThreadManager.notifyAll();
-        while (!exited) {
+        while (!exited && this.isAlive()) {
           try {
-            renderThreadManager.wait();
+            renderThreadManager.wait(100);
           } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
           }

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreSurfaceView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreSurfaceView.java
@@ -51,7 +51,7 @@ public abstract class MapLibreSurfaceView extends SurfaceView implements Surface
   @Override
   protected void finalize() throws Throwable {
     try {
-      if (renderThread != null) {
+      if (renderThread != null && renderThread.isAlive()) {
         // thread may still be running if this view was never
         // attached to a window.
         renderThread.requestExitAndWait();
@@ -249,7 +249,7 @@ public abstract class MapLibreSurfaceView extends SurfaceView implements Surface
     if (detachedListener != null) {
       detachedListener.onSurfaceViewDetached();
     }
-    if (renderThread != null) {
+    if (renderThread != null && renderThread.isAlive()) {
       renderThread.requestExitAndWait();
     }
     detached = true;


### PR DESCRIPTION
I think this will fix a crash @sjg-wdw reported.

OsmAnd applied this exact fix. https://github.com/osmandapp/OsmAnd/issues/16161
