### PR TITLE
Add .git to .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,10 +1,4 @@
-# ignore .git, but make sure we can get commit hash
-!.git/HEAD
-!.git/refs
-!.git/refs/heads
-!.git/packed-refs
-.git/*
-
+.git
 node_modules
 bazel-out
 bazel-bin
@@ -13,3 +7,5 @@ bazel-testlogs
 .idea
 .vscode
 .cxx
+build-*
+build

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -148,16 +148,6 @@ cc_library(
     }),
 )
 
-genrule(
-    name = "git_hash",
-    outs = ["hash"],
-    cmd = """
-        git rev-parse HEAD > $@
-    """,
-    local = True,
-    visibility = ["//visibility:public"],
-)
-
 # Selects the rendering implementation to utilize in the core
 
 string_flag(

--- a/platform/ios/bazel/macros.bzl
+++ b/platform/ios/bazel/macros.bzl
@@ -5,14 +5,12 @@ def info_plist(name, base_info_plist, out, **kwargs):
         name = name,
         srcs = [
             base_info_plist,
-            "//:git_hash",
         ],
         outs = [
             out,
         ],
         cmd = ("""
         cp $(location {}) $@
-        plutil -replace MLNCommitHash -string $$(cat $(location //:git_hash)) $@
 
         token=\"""" + API_KEY + """\"
         plutil -replace MLNApiKey -string $$token $@

--- a/platform/ios/framework/Info-static.plist
+++ b/platform/ios/framework/Info-static.plist
@@ -14,8 +14,6 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>15256</string>
-	<key>MLNCommitHash</key>
-	<string>$(CURRENT_COMMIT_HASH)</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/platform/ios/framework/Info.plist
+++ b/platform/ios/framework/Info.plist
@@ -18,8 +18,6 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>15256</string>
-	<key>MLNCommitHash</key>
-	<string>$(CURRENT_COMMIT_HASH)</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/platform/macos/sdk/Info.plist
+++ b/platform/macos/sdk/Info.plist
@@ -20,8 +20,6 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>15256</string>
-	<key>MLNCommitHash</key>
-	<string>$(CURRENT_COMMIT_HASH)</string>
 	<key>MLNSemanticVersionString</key>
 	<string>$(CURRENT_SEMANTIC_VERSION)</string>
 </dict>


### PR DESCRIPTION
Add `.git` to `.bazelignore`. I tried to exclude only part of `.git` so that we could still embed the git has in the Info.plist. But that does not seem to be working well. So I get rid of that altogether in this PR.

Closes #3462