### PR TITLE
Improve core static build release

### DIFF
--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -13,8 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Create maplibre-native-headers.tar.gz
-        run: tar czf maplibre-native-headers.tar.gz include
-
+        run: tar czf maplibre-native-headers.tar.gz \
+          include \
+          vendor/maplibre-native-base/deps/variant/include \
+          vendor/maplibre-native-base/deps/geometry.hpp/include
       - name: Create Release
         run: |
           gh release create core-${{ github.sha }} \
@@ -22,7 +24,7 @@ jobs:
             --prerelease=false \
             --latest=false \
             --title "core-${{ github.sha }}" \
-            maplibre-native-headers.tar.gz
+            maplibre-native-headers.tar.gz LICENSE.core.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Create maplibre-native-headers.tar.gz
         run: tar czf maplibre-native-headers.tar.gz \
           include \

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -107,7 +107,8 @@
       "name": "linux-opengl-core",
       "inherits": "linux-opengl",
       "cacheVariables": {
-        "MLN_CORE_INCLUDE_DEPS": "ON"
+        "MLN_CORE_INCLUDE_DEPS": "ON",
+        "MLN_USE_BUILTIN_ICU": "ON"
       }
     },
     {
@@ -124,7 +125,8 @@
       "name": "linux-vulkan-core",
       "inherits": "linux-vulkan",
       "cacheVariables": {
-        "MLN_CORE_INCLUDE_DEPS": "ON"
+        "MLN_CORE_INCLUDE_DEPS": "ON",
+        "MLN_USE_BUILTIN_ICU": "ON"
       }
     }
   ],

--- a/vendor/nunicode.cmake
+++ b/vendor/nunicode.cmake
@@ -2,7 +2,7 @@ if(TARGET mbgl-vendor-nunicode)
     return()
 endif()
 
-if(MLN_WITH_QT)
+if(MLN_WITH_QT OR MLN_CORE_INCLUDE_DEPS)
     add_library(mbgl-vendor-nunicode OBJECT)
 else()
     add_library(mbgl-vendor-nunicode STATIC)


### PR DESCRIPTION
Makes sure ICU and nunicode are included in static library.

Adds some additional headers to the distributed archive with headers.