### PR TITLE
Fix validation error reported by VulkanSDK 1.4.313.0

### DIFF
--- a/include/mbgl/vulkan/context.hpp
+++ b/include/mbgl/vulkan/context.hpp
@@ -157,19 +157,16 @@ private:
     struct FrameResources {
         vk::UniqueCommandBuffer commandBuffer;
 
-        vk::UniqueSemaphore surfaceSemaphore;
-        vk::UniqueSemaphore frameSemaphore;
+        vk::UniqueSemaphore acquireSurfaceSemaphore;
         vk::UniqueFence flightFrameFence;
 
         std::vector<std::function<void(Context&)>> deletionQueue;
 
         FrameResources(vk::UniqueCommandBuffer& cb,
                        vk::UniqueSemaphore&& surf,
-                       vk::UniqueSemaphore&& frame,
                        vk::UniqueFence&& flight)
             : commandBuffer(std::move(cb)),
-              surfaceSemaphore(std::move(surf)),
-              frameSemaphore(std::move(frame)),
+              acquireSurfaceSemaphore(std::move(surf)),
               flightFrameFence(std::move(flight)) {}
 
         void runDeletionQueue(Context&);

--- a/include/mbgl/vulkan/renderable_resource.hpp
+++ b/include/mbgl/vulkan/renderable_resource.hpp
@@ -58,6 +58,7 @@ public:
     uint32_t getAcquiredImageIndex() const { return acquiredImageIndex; };
     void setAcquiredImageIndex(uint32_t index) { acquiredImageIndex = index; };
     const vk::Image getAcquiredImage() const;
+    const vk::Semaphore& getAcquiredSemaphore() const;
 
     bool hasSurfaceTransformSupport() const;
     bool didSurfaceTransformUpdate() const;
@@ -86,6 +87,7 @@ protected:
     std::vector<vk::Image> swapchainImages;
     std::vector<vk::UniqueImageView> swapchainImageViews;
     std::vector<vk::UniqueFramebuffer> swapchainFramebuffers;
+    std::vector<vk::UniqueSemaphore> swapchainSemaphores;
     vk::Format colorFormat{vk::Format::eUndefined};
 
     UniqueImageAllocation depthAllocation;

--- a/src/mbgl/vulkan/renderable_resource.cpp
+++ b/src/mbgl/vulkan/renderable_resource.cpp
@@ -159,6 +159,12 @@ void SurfaceRenderableResource::initSwapchain(uint32_t w, uint32_t h) {
 
     colorFormat = swapchainCreateInfo.imageFormat;
     extent = swapchainCreateInfo.imageExtent;
+
+    swapchainSemaphores.reserve(swapchainImageCount);
+    for (uint32_t index = 0; index < swapchainImageCount; ++index) {
+        swapchainSemaphores.emplace_back(device->createSemaphoreUnique({}));
+        backend.setDebugName(swapchainSemaphores.back().get(), "SurfaceSemaphore_" + std::to_string(index));
+    }
 }
 
 void SurfaceRenderableResource::initDepthStencil() {
@@ -239,6 +245,10 @@ const vk::Image SurfaceRenderableResource::getAcquiredImage() const {
     }
 
     return colorAllocations[acquiredImageIndex]->image;
+}
+
+const vk::Semaphore& SurfaceRenderableResource::getAcquiredSemaphore() const {
+    return swapchainSemaphores[acquiredImageIndex].get();
 }
 
 bool SurfaceRenderableResource::hasSurfaceTransformSupport() const {
@@ -391,6 +401,7 @@ void SurfaceRenderableResource::recreateSwapchain() {
     renderPass.reset();
     swapchainImageViews.clear();
     swapchainImages.clear();
+    swapchainSemaphores.clear();
 
     init(extent.width, extent.height);
 }


### PR DESCRIPTION
Fix semaphore signaling during surface present.

`vkQueueSubmit(): pSubmits[0].pSignalSemaphores[0] (VkSemaphore 0x160000000016[FrameSemaphore_1]) is being signaled by VkQueue 0x1b5f70b96b0, but it may still be in use by VkSwapchainKHR 0x30000000003.`
`Swapchain image 0 was presented but was not re-acquired, so VkSemaphore 0x160000000016[FrameSemaphore_1] may still be in use and cannot be safely reused with image index 2.
`