### PR TITLE
Rename Symbol SDF shader

### DIFF
--- a/include/mbgl/shaders/gl/shader_info.hpp
+++ b/include/mbgl/shaders/gl/shader_info.hpp
@@ -220,7 +220,7 @@ struct ShaderInfo<BuiltIn::SymbolIconShader, gfx::Backend::Type::OpenGL> {
 };
 
 template <>
-struct ShaderInfo<BuiltIn::SymbolSDFIconShader, gfx::Backend::Type::OpenGL> {
+struct ShaderInfo<BuiltIn::SymbolSDFShader, gfx::Backend::Type::OpenGL> {
     static const std::vector<AttributeInfo> attributes;
     static const std::vector<UniformBlockInfo> uniformBlocks;
     static const std::vector<TextureInfo> textures;

--- a/include/mbgl/shaders/gl/symbol_sdf.hpp
+++ b/include/mbgl/shaders/gl/symbol_sdf.hpp
@@ -6,8 +6,8 @@ namespace mbgl {
 namespace shaders {
 
 template <>
-struct ShaderSource<BuiltIn::SymbolSDFIconShader, gfx::Backend::Type::OpenGL> {
-    static constexpr const char* name = "SymbolSDFIconShader";
+struct ShaderSource<BuiltIn::SymbolSDFShader, gfx::Backend::Type::OpenGL> {
+    static constexpr const char* name = "SymbolSDFShader";
     static constexpr const char* vertex = R"(layout (location = 0) in vec4 a_pos_offset;
 layout (location = 1) in vec4 a_data;
 layout (location = 2) in vec4 a_pixeloffset;

--- a/include/mbgl/shaders/mtl/symbol.hpp
+++ b/include/mbgl/shaders/mtl/symbol.hpp
@@ -211,8 +211,8 @@ half4 fragment fragmentMain(FragmentStage in [[stage_in]],
 };
 
 template <>
-struct ShaderSource<BuiltIn::SymbolSDFIconShader, gfx::Backend::Type::Metal> {
-    static constexpr auto name = "SymbolSDFIconShader";
+struct ShaderSource<BuiltIn::SymbolSDFShader, gfx::Backend::Type::Metal> {
+    static constexpr auto name = "SymbolSDFShader";
     static constexpr auto vertexMainFunction = "vertexMain";
     static constexpr auto fragmentMainFunction = "fragmentMain";
 

--- a/include/mbgl/shaders/shader_source.hpp
+++ b/include/mbgl/shaders/shader_source.hpp
@@ -38,7 +38,7 @@ enum class BuiltIn {
     LineSDFShader,
     RasterShader,
     SymbolIconShader,
-    SymbolSDFIconShader,
+    SymbolSDFShader,
     SymbolTextAndIconShader,
     WideVectorShader
 };

--- a/include/mbgl/shaders/vulkan/symbol.hpp
+++ b/include/mbgl/shaders/vulkan/symbol.hpp
@@ -203,8 +203,8 @@ void main() {
 };
 
 template <>
-struct ShaderSource<BuiltIn::SymbolSDFIconShader, gfx::Backend::Type::Vulkan> {
-    static constexpr const char* name = "SymbolSDFIconShader";
+struct ShaderSource<BuiltIn::SymbolSDFShader, gfx::Backend::Type::Vulkan> {
+    static constexpr const char* name = "SymbolSDFShader";
 
     static const std::array<AttributeInfo, 10> attributes;
     static constexpr std::array<AttributeInfo, 0> instanceAttributes{};

--- a/shaders/manifest.json
+++ b/shaders/manifest.json
@@ -201,7 +201,7 @@
         "uses_ubos": true
     },
     {
-        "name": "SymbolSDFIconShader",
+        "name": "SymbolSDFShader",
         "header": "symbol_sdf",
         "glsl_vert": "symbol_sdf.vertex.glsl",
         "glsl_frag": "symbol_sdf.fragment.glsl",

--- a/src/mbgl/gl/renderer_backend.cpp
+++ b/src/mbgl/gl/renderer_backend.cpp
@@ -144,7 +144,7 @@ void RendererBackend::initShaders(gfx::ShaderRegistry& shaders, const ProgramPar
                   shaders::BuiltIn::LocationIndicatorTexturedShader,
                   shaders::BuiltIn::RasterShader,
                   shaders::BuiltIn::SymbolIconShader,
-                  shaders::BuiltIn::SymbolSDFIconShader,
+                  shaders::BuiltIn::SymbolSDFShader,
                   shaders::BuiltIn::SymbolTextAndIconShader>(shaders, programParameters);
 }
 

--- a/src/mbgl/mtl/renderer_backend.cpp
+++ b/src/mbgl/mtl/renderer_backend.cpp
@@ -129,7 +129,7 @@ void RendererBackend::initShaders(gfx::ShaderRegistry& shaders, const ProgramPar
                   shaders::BuiltIn::LocationIndicatorTexturedShader,
                   shaders::BuiltIn::RasterShader,
                   shaders::BuiltIn::SymbolIconShader,
-                  shaders::BuiltIn::SymbolSDFIconShader,
+                  shaders::BuiltIn::SymbolSDFShader,
                   shaders::BuiltIn::SymbolTextAndIconShader,
                   shaders::BuiltIn::WideVectorShader>(shaders, programParameters);
 }

--- a/src/mbgl/renderer/layers/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/layers/render_symbol_layer.cpp
@@ -40,7 +40,7 @@ using namespace shaders;
 namespace {
 
 constexpr std::string_view SymbolIconShaderName = "SymbolIconShader";
-constexpr std::string_view SymbolSDFIconShaderName = "SymbolSDFIconShader";
+constexpr std::string_view SymbolSDFShaderName = "SymbolSDFShader";
 constexpr std::string_view SymbolTextAndIconShaderName = "SymbolTextAndIconShader";
 constexpr std::string_view CollisionBoxShaderName = "CollisionBoxShader";
 constexpr std::string_view CollisionCircleShaderName = "CollisionCircleShader";
@@ -475,7 +475,7 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
         symbolIconGroup = shaders.getShaderGroup(std::string(SymbolIconShaderName));
     }
     if (!symbolSDFGroup) {
-        symbolSDFGroup = shaders.getShaderGroup(std::string(SymbolSDFIconShaderName));
+        symbolSDFGroup = shaders.getShaderGroup(std::string(SymbolSDFShaderName));
     }
     if (!symbolTextAndIconGroup) {
         symbolTextAndIconGroup = shaders.getShaderGroup(std::string(SymbolTextAndIconShaderName));

--- a/src/mbgl/shaders/gl/shader_info.cpp
+++ b/src/mbgl/shaders/gl/shader_info.cpp
@@ -467,15 +467,15 @@ const std::vector<TextureInfo> SymbolIconShaderInfo::textures = {
 };
 
 // Symbol SDF
-using SymbolSDFIconShaderInfo = ShaderInfo<BuiltIn::SymbolSDFIconShader, gfx::Backend::Type::OpenGL>;
+using SymbolSDFShaderInfo = ShaderInfo<BuiltIn::SymbolSDFShader, gfx::Backend::Type::OpenGL>;
 
-const std::vector<UniformBlockInfo> SymbolSDFIconShaderInfo::uniformBlocks = {
+const std::vector<UniformBlockInfo> SymbolSDFShaderInfo::uniformBlocks = {
     UniformBlockInfo{"GlobalPaintParamsUBO", idGlobalPaintParamsUBO},
     UniformBlockInfo{"SymbolDrawableUBO", idSymbolDrawableUBO},
     UniformBlockInfo{"SymbolTilePropsUBO", idSymbolTilePropsUBO},
     UniformBlockInfo{"SymbolEvaluatedPropsUBO", idSymbolEvaluatedPropsUBO},
 };
-const std::vector<AttributeInfo> SymbolSDFIconShaderInfo::attributes = {
+const std::vector<AttributeInfo> SymbolSDFShaderInfo::attributes = {
     AttributeInfo{"a_pos_offset", idSymbolPosOffsetVertexAttribute},
     AttributeInfo{"a_data", idSymbolDataVertexAttribute},
     AttributeInfo{"a_pixeloffset", idSymbolPixelOffsetVertexAttribute},
@@ -487,7 +487,7 @@ const std::vector<AttributeInfo> SymbolSDFIconShaderInfo::attributes = {
     AttributeInfo{"a_halo_width", idSymbolHaloWidthVertexAttribute},
     AttributeInfo{"a_halo_blur", idSymbolHaloBlurVertexAttribute},
 };
-const std::vector<TextureInfo> SymbolSDFIconShaderInfo::textures = {
+const std::vector<TextureInfo> SymbolSDFShaderInfo::textures = {
     TextureInfo{"u_texture", idSymbolImageTexture},
 };
 

--- a/src/mbgl/shaders/mtl/symbol.cpp
+++ b/src/mbgl/shaders/mtl/symbol.cpp
@@ -27,9 +27,9 @@ const std::array<TextureInfo, 1> SymbolIconShaderSource::textures = {
 //
 // Symbol sdf
 
-using SymbolSDFIconShaderSource = ShaderSource<BuiltIn::SymbolSDFIconShader, gfx::Backend::Type::Metal>;
+using SymbolSDFShaderSource = ShaderSource<BuiltIn::SymbolSDFShader, gfx::Backend::Type::Metal>;
 
-const std::array<AttributeInfo, 10> SymbolSDFIconShaderSource::attributes = {
+const std::array<AttributeInfo, 10> SymbolSDFShaderSource::attributes = {
     // always attributes
     AttributeInfo{symbolUBOCount + 0, gfx::AttributeDataType::Short4, idSymbolPosOffsetVertexAttribute},
     AttributeInfo{symbolUBOCount + 1, gfx::AttributeDataType::UShort4, idSymbolDataVertexAttribute},
@@ -44,7 +44,7 @@ const std::array<AttributeInfo, 10> SymbolSDFIconShaderSource::attributes = {
     AttributeInfo{symbolUBOCount + 8, gfx::AttributeDataType::Float, idSymbolHaloWidthVertexAttribute},
     AttributeInfo{symbolUBOCount + 9, gfx::AttributeDataType::Float, idSymbolHaloBlurVertexAttribute},
 };
-const std::array<TextureInfo, 1> SymbolSDFIconShaderSource::textures = {
+const std::array<TextureInfo, 1> SymbolSDFShaderSource::textures = {
     TextureInfo{0, idSymbolImageTexture},
 };
 

--- a/src/mbgl/shaders/vulkan/symbol.cpp
+++ b/src/mbgl/shaders/vulkan/symbol.cpp
@@ -28,9 +28,9 @@ const std::array<TextureInfo, 1> SymbolIconShaderSource::textures = {
 //
 // Symbol sdf
 
-using SymbolSDFIconShaderSource = ShaderSource<BuiltIn::SymbolSDFIconShader, gfx::Backend::Type::Vulkan>;
+using SymbolSDFShaderSource = ShaderSource<BuiltIn::SymbolSDFShader, gfx::Backend::Type::Vulkan>;
 
-const std::array<AttributeInfo, 10> SymbolSDFIconShaderSource::attributes = {
+const std::array<AttributeInfo, 10> SymbolSDFShaderSource::attributes = {
     // always attributes
     AttributeInfo{0, gfx::AttributeDataType::Short4, idSymbolPosOffsetVertexAttribute},
     AttributeInfo{1, gfx::AttributeDataType::UShort4, idSymbolDataVertexAttribute},
@@ -45,7 +45,7 @@ const std::array<AttributeInfo, 10> SymbolSDFIconShaderSource::attributes = {
     AttributeInfo{8, gfx::AttributeDataType::Float, idSymbolHaloWidthVertexAttribute},
     AttributeInfo{9, gfx::AttributeDataType::Float, idSymbolHaloBlurVertexAttribute},
 };
-const std::array<TextureInfo, 1> SymbolSDFIconShaderSource::textures = {
+const std::array<TextureInfo, 1> SymbolSDFShaderSource::textures = {
     TextureInfo{0, idSymbolImageTexture},
 };
 

--- a/src/mbgl/vulkan/renderer_backend.cpp
+++ b/src/mbgl/vulkan/renderer_backend.cpp
@@ -692,7 +692,7 @@ void RendererBackend::initShaders(gfx::ShaderRegistry& shaders, const ProgramPar
                   shaders::BuiltIn::LocationIndicatorTexturedShader,
                   shaders::BuiltIn::RasterShader,
                   shaders::BuiltIn::SymbolIconShader,
-                  shaders::BuiltIn::SymbolSDFIconShader,
+                  shaders::BuiltIn::SymbolSDFShader,
                   shaders::BuiltIn::SymbolTextAndIconShader,
                   shaders::BuiltIn::WideVectorShader>(shaders, programParameters);
 }

--- a/test/util/hash.test.cpp
+++ b/test/util/hash.test.cpp
@@ -153,7 +153,7 @@ TEST(OrderIndependentHash, Shaders) {
                       BuiltIn::LocationIndicatorTexturedShader,
                       BuiltIn::RasterShader,
                       BuiltIn::SymbolIconShader,
-                      BuiltIn::SymbolSDFIconShader,
+                      BuiltIn::SymbolSDFShader,
                       BuiltIn::SymbolTextAndIconShader>();
 }
 


### PR DESCRIPTION
Legacy Symbol SDF shader had 2 versions: Symbol SDF Text and Symbol SDF Icon. 
In drawable version they were merged in a single shader: `Symbol SDF Icon Shader`.
In this PR I renamed it to `Symbol SDF Shader` - it renders text or icon.