### PR TITLE
Tweak Android release

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -347,3 +347,5 @@ jobs:
       - name: Trigger release
         if: needs.android-build.outputs.make_release == 'true' && needs.android-build.result == 'success' && needs.android-build-cpp-test.result == 'success' && needs.android-build-render-test.result == 'success'
         run: gh workflow run android-release.yml --ref ${{ github.sha }}
+        env:
+         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -75,10 +75,25 @@ jobs:
             echo "prerelease=true" >> "$GITHUB_ENV"
           fi
 
-      - name: Create tag
+      - name: Create tag if it does not exist
         run: |
-          git tag -s -a android-v${{ env.version }} -m "Publish android-v${{ env.version }}" ${{ github.sha }}
-          git push origin android-v${{ env.version }}
+          git config user.name "MapLibre Team"
+          git config user.email "team@maplibre.org"
+          tag="android-v${{ env.version }}"
+
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            tag_sha=$(git rev-parse "$tag^{commit}")
+            if [ "$tag_sha" = "${{ github.sha }}" ]; then
+              echo "✅ Tag $tag exists and matches current commit SHA."
+              exit 0
+            else
+              echo "::error::❌ Tag $tag exists but points to a different commit. Aborting."
+              exit 1
+            fi
+          else
+            git tag -a "$tag" -m "Publish $tag" ${{ github.sha }}
+            git push origin "$tag"
+          fi
 
       - name: Create release
         id: create_release


### PR DESCRIPTION
In `android-ci.yml`: pass GH_TOKEN to trigger release.

In `android-release.yml`: set name and e-mail when creating tag with git. Also don't fail the workflow if a tag with the correct commit already exists.