### PR TITLE
Make sure iOS pre-releases contain 'pre' and update changelog

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -271,6 +271,10 @@ jobs:
           if [[ -z "$version" ]]; then
             version="$(head VERSION)"-pre${{ github.sha }}
           fi
+          if [[ "$version" != *"pre"* ]]; then
+            echo "::error::Pre-release version must include 'pre' (Current version: $version)"
+            exit 1
+          fi
           echo version="$version" >> "$GITHUB_ENV"
           echo changelog_version_heading="## main" >> "$GITHUB_ENV"
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,15 @@ MapLibre welcomes participation and contributions from everyone. Please read [`M
 
 ## main
 
+## 6.14.0
+
+> [!IMPORTANT]
+> Please verify glyphs are loading correctly for your styles with this release. Despite careful testing, we also rely on our users to help test the new dynamic texture atlas and to [report any issues](https://github.com/maplibre/maplibre-native/issues/new?template=ios-bug-report.yml).
+
+- Force PMTiles metadata to always have XYZ tile scheme ([#3403](https://github.com/maplibre/maplibre-native/pull/3403)).
+- Add support to range requests in AssetFileSource ([#3404](https://github.com/maplibre/maplibre-native/pull/3404)).
+- Implement dynamic texture atlas ([#3198](https://github.com/maplibre/maplibre-native/pull/3198)).
+
 ## 6.13.0
 
 - Allow initializing MLNMapView with style JSON ([#3240](https://github.com/maplibre/maplibre-native/pull/3240)).


### PR DESCRIPTION
I accidentally pushed out 6.14.0 which was intended to be a pre-release.

Doesn't matter that much, but I added a note to the changelog that users should test this release themselves too without blindly updating. Everyone reads changelogs right?

Add a few lines to `ios-ci.yml` to make sure pre-release versions contain `pre`.