### PR TITLE
Validate version android-ci and android-release workflow

### DIFF
--- a/.github/scripts/validate-version.sh
+++ b/.github/scripts/validate-version.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+validate_version() {
+  local version="$1"
+  if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-pre.*)?$ ]]; then
+    echo "::error::Invalid version format in VERSION file. Expected: X.Y.Z or X.Y.Z-pre*"
+    return 1
+  fi
+  return 0
+}
+
+version=$(cat VERSION 2>/dev/null)
+if [ -z "$version" ]; then
+  echo "::error::VERSION file not found or empty"
+  exit 1
+fi
+
+if validate_version "$version"; then
+  echo "Version validation successful: $version"
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    echo "version=$version" >> "$GITHUB_ENV"
+  fi
+fi

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -66,6 +66,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Validate VERSION
+        run: ../../.github/scripts/validate-version.sh
+        working-directory: platform/android
+
       - run: echo "cmake.dir=$(dirname "$(dirname "$(command -v cmake)")")" >> local.properties
 
       - uses: actions/setup-java@v4

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -42,9 +42,10 @@ jobs:
       - name: Android nitpick
         run: make run-android-nitpick
 
-      - name: Set version name
+      - name: Validate and set version
+        working-directory: platform/android
         run: |
-          echo version="$(cat VERSION)" > "$GITHUB_ENV"
+          ../../.github/scripts/validate-version.sh
 
       - name: Build package
         run: |


### PR DESCRIPTION
For some reason the android-release workflow is complaining that it cannot find the `VERSION` file even though the working directory is set to `platform/android`.


