### PR TITLE
add `maplibre-native-base` to `maplibre-native-headers.tar.gz` included in the core release

### DIFF
--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           tar czf maplibre-native-headers.tar.gz \
             include \
+            vendor/maplibre-native-base/include \
             vendor/maplibre-native-base/deps/variant/include \
             vendor/maplibre-native-base/deps/geometry.hpp/include
       - name: Create Release


### PR DESCRIPTION
I think this is one of the header-directories that I am still missing.
Not sure if this the last you are hearing from me about this (hope it is).

We will see ^^