### PR TITLE
Use TARGET_OBJECTS generator expression in CMake for core builds

### DIFF
--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -142,7 +142,7 @@ target_include_directories(
 include(${PROJECT_SOURCE_DIR}/vendor/nunicode.cmake)
 include(${PROJECT_SOURCE_DIR}/vendor/sqlite.cmake)
 
-if(NOT ${ICU_FOUND} OR "${ICU_VERSION}" VERSION_LESS 62.0)
+if(NOT ${ICU_FOUND} OR "${ICU_VERSION}" VERSION_LESS 62.0 OR MLN_USE_BUILTIN_ICU)
     message(STATUS "ICU not found or too old, using builtin.")
 
     set(MLN_USE_BUILTIN_ICU TRUE)

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -143,7 +143,7 @@ include(${PROJECT_SOURCE_DIR}/vendor/nunicode.cmake)
 include(${PROJECT_SOURCE_DIR}/vendor/sqlite.cmake)
 
 if(NOT ${ICU_FOUND} OR "${ICU_VERSION}" VERSION_LESS 62.0 OR MLN_USE_BUILTIN_ICU)
-    message(STATUS "ICU not found or too old, using builtin.")
+    message(STATUS "ICU not found, too old or MLN_USE_BUILTIN_ICU requestd, using builtin.")
 
     set(MLN_USE_BUILTIN_ICU TRUE)
     include(${PROJECT_SOURCE_DIR}/vendor/icu.cmake)

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -167,7 +167,7 @@ target_link_libraries(
         ${WEBP_LIBRARIES}
         $<$<NOT:$<BOOL:${MLN_USE_BUILTIN_ICU}>>:ICU::i18n>
         $<$<NOT:$<BOOL:${MLN_USE_BUILTIN_ICU}>>:ICU::uc>
-        $<$<BOOL:${MLN_USE_BUILTIN_ICU}>:mbgl-vendor-icu>
+        $<$<BOOL:${MLN_USE_BUILTIN_ICU}>:$<IF:$<BOOL:${MLN_CORE_INCLUDE_DEPS}>,$<TARGET_OBJECTS:mbgl-vendor-icu>,mbgl-vendor-icu>>
         PNG::PNG
         mbgl-vendor-nunicode
         mbgl-vendor-sqlite


### PR DESCRIPTION
Should avoid [undefined symbols](https://github.com/maplibre/maplibre-native/issues/3483) for ICU.

cc @CommanderStorm