### PR TITLE
also use MLN_WITH_GLFW in linux.cmake

### DIFF
--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -175,7 +175,9 @@ target_link_libraries(
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/bin)
 add_subdirectory(${PROJECT_SOURCE_DIR}/expression-test)
-add_subdirectory(${PROJECT_SOURCE_DIR}/platform/glfw)
+if(MLN_WITH_GLFW)
+	add_subdirectory(${PROJECT_SOURCE_DIR}/platform/glfw)
+endif()
 if(MLN_WITH_NODE)
     add_subdirectory(${PROJECT_SOURCE_DIR}/platform/node)
 endif()


### PR DESCRIPTION
As the flag exists it should also be used on linux machines. Also I'm not interested in the glfw app and am running into build problems with glfw.