### PR TITLE
improve automated MapLibre Android release

### DIFF
--- a/.github/scripts/ensure-tag.sh
+++ b/.github/scripts/ensure-tag.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <tag> [<commit-sha>]"
+  echo "  <tag>        Git tag name to create or verify"
+  echo "  <commit-sha> Optional commit SHA to use (defaults to HEAD)"
+  echo ""
+  echo "This script will:"
+  echo "  - Check if the tag exists and matches the specified commit"
+  echo "  - Create and push the tag if it doesn't exist"
+  echo "  - Exit with error if tag exists but points to different commit"
+  exit 1
+fi
+
+tag=$1
+commit_sha=${2:-$(git rev-parse HEAD)}
+
+if [ -z "$(git config user.name)" ]; then
+  git config user.name "MapLibre Team"
+fi
+
+if [ -z "$(git config user.email)" ]; then
+  git config user.email "team@maplibre.org"
+fi
+
+if git rev-parse "$tag" >/dev/null 2>&1; then
+  tag_sha=$(git rev-parse "$tag^{commit}")
+  if [ "$tag_sha" = "$commit_sha" ]; then
+    echo "✅ Tag $tag exists and matches specified commit SHA."
+    exit 0
+  else
+    echo "::error::❌ Tag $tag exists but points to a different commit."
+    echo "  Expected: $commit_sha"
+    echo "  Actual:   $tag_sha"
+    exit 1
+  fi
+else
+  git tag -a "$tag" -m "Publish $tag" "$commit_sha"
+  # git push origin "$tag"
+  echo "✅ Created tag $tag for commit $commit_sha."
+fi

--- a/.github/scripts/validate-version.sh
+++ b/.github/scripts/validate-version.sh
@@ -3,21 +3,40 @@
 validate_version() {
   local version="$1"
   if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-pre.*)?$ ]]; then
-    echo "::error::Invalid version '$version' in $(realpath VERSION). Expected: X.Y.Z or X.Y.Z-pre*"
+    echo "::error::Invalid version '$version' in $(realpath "$version_file"). Expected: X.Y.Z or X.Y.Z-pre*"
     return 1
   fi
   return 0
 }
 
-version=$(cat VERSION 2>/dev/null)
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version-file>"
+  echo ""
+  echo "This script will:"
+  echo "  - Validate version format in specified file"
+  echo "  - Export version to GITHUB_ENV if in GitHub Actions"
+  exit 1
+fi
+
+version_file="$1"
+
+if [ ! -f "$version_file" ]; then
+  echo "::error::Version file not found: $(realpath "$version_file")"
+  exit 1
+fi
+
+version=$(cat "$version_file" 2>/dev/null)
 if [ -z "$version" ]; then
-  echo "::error::No VERSION file found or empty in $PWD"
+  echo "::error::Version file is empty: $(realpath "$version_file")"
   exit 1
 fi
 
 if validate_version "$version"; then
-  echo "Version validation successful: $version"
+  echo "✅ Version validation successful: $version"
   if [[ -n "${GITHUB_ENV:-}" ]]; then
     echo "version=$version" >> "$GITHUB_ENV"
   fi
+  exit 0
+else
+  exit 1
 fi

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -65,8 +65,8 @@ jobs:
           fetch-depth: 0
 
       - name: Validate VERSION
-        run: ../../.github/scripts/validate-version.sh
-        working-directory: platform/android
+        run: .github/scripts/validate-version.sh platform/android/VERSION
+        working-directory: .
 
       - run: echo "cmake.dir=$(dirname "$(dirname "$(command -v cmake)")")" >> local.properties
 

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -46,8 +46,6 @@ jobs:
       BUILDTYPE: Debug
       IS_LOCAL_DEVELOPMENT: false
       MLN_ANDROID_STL: c++_static
-    outputs:
-      make_release: ${{ steps.make_release.outputs.make_release }}
     steps:
       - name: Free Disk Space (Ubuntu)
         if: startsWith(runner.name, 'GitHub Actions')
@@ -206,17 +204,6 @@ jobs:
             platform/android/InstrumentationTestApp.apk
             platform/android/InstrumentationTests.apk
 
-      - name: VERSION file changed
-        id: version-file-android-changed
-        uses: tj-actions/changed-files@v46
-        with:
-          files: platform/android/VERSION
-
-      - name: Should make release?
-        id: make_release
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push' && steps.version-file-android-changed.outputs.any_changed == 'true'
-        run: echo make_release=true >> "$GITHUB_OUTPUT"
-
   android-build-cpp-test:
     runs-on: ubuntu-24.04
 
@@ -352,11 +339,33 @@ jobs:
         if: env.success != 'true'
         run: exit 1
 
+      # automatically trigger android-release when code is pushed to main
+      # and the platform/android/VERSION file has changed
       - uses: actions/checkout@v4
-        if: needs.android-build.outputs.make_release == 'true' && env.success
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+      - name: VERSION file changed
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        id: version-file-android-changed
+        uses: tj-actions/changed-files@v46
+        with:
+          files: platform/android/VERSION
+
+      - name: Should make release?
+        if: env.success && github.ref == 'refs/heads/main' && github.event_name == 'push' && steps.version-file-android-changed.outputs.any_changed == 'true'
+        run: echo make_release=true >> "$GITHUB_ENV"
+
+      - name: Validate and set version
+        if: env.make_release == 'true'
+        working-directory: .
+        run: .github/scripts/validate-version.sh platform/android/VERSION
+
+      - name: Create tag if it does not exist
+        if: env.make_release == 'true'
+        run: .github/scripts/ensure-tag.sh android-v${{ env.version }} ${{ github.sha }}
 
       - name: Trigger release
-        if: needs.android-build.outputs.make_release == 'true' && env.success
-        run: gh workflow run android-release.yml --ref ${{ github.sha }}
+        if: env.make_release == 'true'
+        run: gh workflow run android-release.yml --ref android-v${{ env.version }}
         env:
          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -37,7 +37,8 @@ jobs:
         run: make run-android-nitpick
 
       - name: Validate and set version
-        run: ../../.github/scripts/validate-version.sh
+        working-directory: .
+        run: .github/scripts/validate-version.sh platform/android/VERSION
 
       - name: Build package
         run: |
@@ -69,24 +70,8 @@ jobs:
           fi
 
       - name: Create tag if it does not exist
-        run: |
-          git config user.name "MapLibre Team"
-          git config user.email "team@maplibre.org"
-          tag="android-v${{ env.version }}"
-
-          if git rev-parse "$tag" >/dev/null 2>&1; then
-            tag_sha=$(git rev-parse "$tag^{commit}")
-            if [ "$tag_sha" = "${{ github.sha }}" ]; then
-              echo "✅ Tag $tag exists and matches current commit SHA."
-              exit 0
-            else
-              echo "::error::❌ Tag $tag exists but points to a different commit. Aborting."
-              exit 1
-            fi
-          else
-            git tag -a "$tag" -m "Publish $tag" ${{ github.sha }}
-            git push origin "$tag"
-          fi
+        working-directory: .
+        run: .github/scripts/ensure-tag.sh android-v${{ env.version }} ${{ github.sha }}
 
       - name: Create release
         id: create_release


### PR DESCRIPTION
The `android-release` workflow is triggered from `android-ci`.

But the `gh workflow run android-release.yml --ref {ref}` command requires a tag, not a commit. So create the tag before triggering the workflow. I extracted the `ensure-tag.sh` script and made some improvements to the `validate-version.sh` script.