### PR TITLE
Expose MLNSource.attributionHtmlString

### DIFF
--- a/platform/darwin/src/MLNTileSource.h
+++ b/platform/darwin/src/MLNTileSource.h
@@ -204,6 +204,15 @@ MLN_EXPORT
  */
 @property (nonatomic, copy, readonly) NSArray<MLNAttributionInfo *> *attributionInfos;
 
+/**
+ The attribution HTML string associated with this source. 
+
+ By default, this is nil. If the source is initialized with a
+ configuration URL, this is nil until the configuration JSON file
+ is loaded.
+ */
+@property (nonatomic, copy, readonly) NSString *attributionHTMLString;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MLNTileSource.h
+++ b/platform/darwin/src/MLNTileSource.h
@@ -205,7 +205,7 @@ MLN_EXPORT
 @property (nonatomic, copy, readonly) NSArray<MLNAttributionInfo *> *attributionInfos;
 
 /**
- The attribution HTML string associated with this source. 
+ The attribution HTML string associated with this source.
 
  By default, this is nil. If the source is initialized with a
  configuration URL, this is nil until the configuration JSON file


### PR DESCRIPTION
Untested, and unsure if this is all that's needed to expose the property or if there's more.

Would resolve #3501 