### PR TITLE
Test case for tile lifetime issue

### DIFF
--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -50,6 +50,11 @@ using RenderTiles = std::shared_ptr<const std::vector<std::reference_wrapper<con
 class RenderSource : protected TileObserver {
 public:
     static std::unique_ptr<RenderSource> create(const Immutable<style::Source::Impl>&, const TaggedScheduler&);
+
+    static bool registerRenderSourceType(const style::SourceType& type,
+                                         std::function<std::unique_ptr<RenderSource>(Immutable<style::Source::Impl>)>);
+    static bool unregisterRenderSourceType(const style::SourceType& type);
+
     ~RenderSource() override;
 
     bool isEnabled() const;

--- a/src/mbgl/util/std.hpp
+++ b/src/mbgl/util/std.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <type_traits>
 #include <utility>
 
@@ -25,3 +24,12 @@ void erase_if(Container& container, Predicate pred) {
 
 } // namespace util
 } // namespace mbgl
+
+namespace std {
+#if !__has_cpp_attribute(__cpp_lib_to_underlying)
+template <typename E>
+constexpr auto to_underlying(E e) noexcept {
+    return static_cast<std::underlying_type_t<E>>(e);
+}
+#endif
+} // namespace std

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -1945,7 +1945,6 @@ struct TestTile : public GeometryTile {
                 if (info_.safeWeakCheck) {
                     guard.emplace(self.lock());
                 }
-                // auto guard = self.lock();
                 if (self) {
                     setData(std::make_unique<GeoJSONTileData>(mapbox::feature::feature_collection<int16_t>{}));
                 } else {

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -45,6 +45,7 @@
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/scoped.hpp>
 #include <mbgl/util/std.hpp>
 
 #include <mapbox/std/weak.hpp>
@@ -2038,10 +2039,9 @@ TEST(Map, RemovedSource) {
     RenderSource::registerRenderSourceType(customSourceType, [&](Immutable<Source::Impl> impl) {
         return std::make_unique<TestRenderSource>(staticImmutableCast<TestSource::Impl>(impl), scheduler, info);
     });
-    // Automatic cleanup.  Use `std::scope_exit` when available.
-    std::unique_ptr<void, void (*)(void*)> unregister{&info, [](auto) {
-                                                          RenderSource::unregisterRenderSourceType(customSourceType);
-                                                      }};
+    Scoped unregister{[&]() {
+        RenderSource::unregisterRenderSourceType(customSourceType);
+    }};
 
     // Cause the test tile to block when asked to load
     std::unique_lock<std::mutex> waitLock(info.waitLock);


### PR DESCRIPTION
Adds a test case which forces a tile data request to finish after the tile is deleted because the source/layer that created it is removed.

Unfortunately, running this 1000x hasn't  reproduced the target crash, even when using the unsafe weak reference check.  I think that issue has been so elusive because it requires both of these rare cases to occur together.

