### PR TITLE
Make sure AndroidRendererFrontend exists when accessing it

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.hpp
@@ -27,9 +27,13 @@ class AsyncTask;
 
 namespace android {
 
-class AndroidRendererFrontend : public RendererFrontend {
+class AndroidRendererFrontend : public RendererFrontend, public std::enable_shared_from_this<AndroidRendererFrontend> {
 public:
-    AndroidRendererFrontend(MapRenderer&);
+    AndroidRendererFrontend(Private, MapRenderer&);
+
+    static std::shared_ptr<AndroidRendererFrontend> create(MapRenderer&);
+    void init();
+
     ~AndroidRendererFrontend() override;
 
     void reset() override;
@@ -63,6 +67,10 @@ private:
     util::RunLoop* mapRunLoop;
     std::unique_ptr<util::AsyncTask> updateAsyncTask;
     std::shared_ptr<UpdateParameters> updateParams;
+
+    struct Private {
+        explicit Private() = default;
+    };
 };
 
 } // namespace android

--- a/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.hpp
@@ -28,6 +28,10 @@ class AsyncTask;
 namespace android {
 
 class AndroidRendererFrontend : public RendererFrontend, public std::enable_shared_from_this<AndroidRendererFrontend> {
+    struct Private {
+        explicit Private() = default;
+    };
+
 public:
     AndroidRendererFrontend(Private, MapRenderer&);
 
@@ -67,10 +71,6 @@ private:
     util::RunLoop* mapRunLoop;
     std::unique_ptr<util::AsyncTask> updateAsyncTask;
     std::shared_ptr<UpdateParameters> updateParams;
-
-    struct Private {
-        explicit Private() = default;
-    };
 };
 
 } // namespace android

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -75,7 +75,7 @@ NativeMapView::NativeMapView(jni::JNIEnv& _env,
     }
 
     // Create a renderer frontend
-    rendererFrontend = std::make_unique<AndroidRendererFrontend>(mapRenderer);
+    rendererFrontend = AndroidRendererFrontend::create(mapRenderer);
 
     // Create Map options
     MapOptions options;

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -329,7 +329,7 @@ public:
     void onSpriteRequested(const std::optional<mbgl::style::Sprite>&) override;
 
 private:
-    std::unique_ptr<AndroidRendererFrontend> rendererFrontend;
+    std::shared_ptr<AndroidRendererFrontend> rendererFrontend;
 
     JavaVM* vm = nullptr;
     jni::WeakReference<jni::Object<NativeMapView>> javaPeer;


### PR DESCRIPTION
This should improve things somewhat since at least `AndroidRendererFrontend` still exists when the async task is run.

I think the `mapRenderer` reference could still dangle.