### PR TITLE
Fix CMake deprecation warning

### DIFF
--- a/vendor/maplibre-native-base/CMakeLists.txt
+++ b/vendor/maplibre-native-base/CMakeLists.txt
@@ -2,7 +2,7 @@ if(TARGET maplibre-native-base)
     return()
 endif()
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10...3.24 FATAL_ERROR)
 project(MAPBOX_BASE LANGUAGES CXX C)
 
 option(MAPBOX_BASE_BUILD_TESTING "Bypass project target check and enforce building tests" OFF)


### PR DESCRIPTION
## Summary
- limit `cmake_minimum_required` range in `maplibre-native-base`

## Testing
- `cmake --preset linux-opengl`

------
https://chatgpt.com/codex/tasks/task_e_6840782c09448331844c0e6daed61f45