### PR TITLE
Add rendering info reports to `ActionJournal`

### DIFF
--- a/include/mbgl/gfx/rendering_stats.hpp
+++ b/include/mbgl/gfx/rendering_stats.hpp
@@ -15,12 +15,11 @@ class SymbolLayer;
 namespace gfx {
 
 struct RenderingStats {
-    RenderingStats() = default;
     bool isZero() const;
 
-    /// Frame CPU encoding time (milliseconds)
+    /// Frame CPU encoding time (seconds)
     double encodingTime = 0.0;
-    /// Frame CPU rendering time (milliseconds)
+    /// Frame CPU rendering time (seconds)
     double renderingTime = 0.0;
 
     /// Number of frames rendered

--- a/include/mbgl/util/action_journal_options.hpp
+++ b/include/mbgl/util/action_journal_options.hpp
@@ -87,6 +87,23 @@ public:
      */
     uint32_t logFileCount() const { return logFileCount_; }
 
+    /**
+     * @brief Set the number of seconds to wait between rendering stats reports.
+     *
+     * @param interval time interval in seconds.
+     * @return ActionJournalOptions for chaining options together.
+     */
+    ActionJournalOptions& withRenderingReportInterval(const uint32_t interval) {
+        renderingStatsReportInterval_ = interval;
+        return *this;
+    }
+
+    /**
+     * @brief Gets the previously set (or default) time interval.
+     * @return Returns report time interval in seconds
+     */
+    uint32_t renderingStatsReportInterval() const { return renderingStatsReportInterval_; }
+
 protected:
     bool enable_ = false;
     // path of the log
@@ -95,6 +112,8 @@ protected:
     uint32_t logFileSize_ = 1024 * 1024;
     // number of log files (each of `logFileSize` size)
     uint32_t logFileCount_ = 5;
+    // the wait time (seconds) between rendering reports
+    uint32_t renderingStatsReportInterval_ = 60;
 };
 
 } // namespace util

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_options.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_options.cpp
@@ -18,13 +18,14 @@ util::ActionJournalOptions NativeMapOptions::getActionJournalOptions(jni::JNIEnv
     auto enabledField = javaClass.GetField<jni::jboolean>(env, "actionJournalEnabled");
     auto pathField = javaClass.GetField<jni::String>(env, "actionJournalPath");
     auto logFileSizeField = javaClass.GetField<jni::jlong>(env, "actionJournalLogFileSize");
-    auto logFileCountField = javaClass.GetField<jni::jlong>(env, "actionJournalLogFileCount");
+    auto renderingReportIntervalField = javaClass.GetField<jni::jlong>(env, "actionJournalRenderingReportInterval");
 
     return util::ActionJournalOptions()
         .enable(obj.Get(env, enabledField))
         .withPath(jni::Make<std::string>(env, obj.Get(env, pathField)))
         .withLogFileSize(obj.Get(env, logFileSizeField))
-        .withLogFileCount(obj.Get(env, logFileCountField));
+        .withLogFileCount(obj.Get(env, logFileCountField))
+        .withRenderingReportInterval(obj.Get(env, renderingReportIntervalField));
 }
 
 float NativeMapOptions::pixelRatio(jni::JNIEnv &env, const jni::Object<NativeMapOptions> &obj) {

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMapOptions.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/MapLibreMapOptions.java
@@ -811,6 +811,18 @@ public class MapLibreMapOptions implements Parcelable {
     return this;
   }
 
+   /**
+   * Set the number of seconds to wait between rendering stats reports.
+   *
+   * @param actionJournalRenderingReportInterval time interval in seconds
+   * @return This
+   */
+  @NonNull
+  public MapLibreMapOptions actionJournalRenderingReportInterval(int actionJournalRenderingReportInterval) {
+    this.actionJournalRenderingReportInterval = actionJournalRenderingReportInterval;
+    return this;
+  }
+
   /**
    * Enable local ideograph font family, defaults to true.
    *
@@ -938,6 +950,15 @@ public class MapLibreMapOptions implements Parcelable {
    */
   public long getActionJournalLogFileCount() {
     return actionJournalLogFileCount;
+  }
+
+    /**
+   * Get the current configured action journal rendering stats report time interval.
+   *
+   * @return time interval in seconds
+   */
+  public long getActionJournalRenderingReportInterval() {
+    return actionJournalRenderingReportInterval;
   }
 
   /**

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapOptions.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapOptions.java
@@ -9,6 +9,7 @@ public class NativeMapOptions {
   private final String actionJournalPath;
   private final long actionJournalLogFileSize;
   private final long actionJournalLogFileCount;
+  private final int actionJournalRenderingReportInterval;
 
   public NativeMapOptions(MapLibreMapOptions options) {
     pixelRatio = options.getPixelRatio();
@@ -18,6 +19,7 @@ public class NativeMapOptions {
     actionJournalPath = options.getActionJournalPath();
     actionJournalLogFileSize = options.getActionJournalLogFileSize();
     actionJournalLogFileCount = options.getActionJournalLogFileCount();
+    actionJournalRenderingReportInterval = options.getActionJournalRenderingReportInterval();
   }
 
   public NativeMapOptions(float pixelRatio, boolean crossSourceCollisions) {
@@ -28,6 +30,7 @@ public class NativeMapOptions {
     actionJournalPath = "";
     actionJournalLogFileSize = 0;
     actionJournalLogFileCount = 0;
+    actionJournalRenderingReportInterval = 0;
   }
 
   public float pixelRatio() {
@@ -52,5 +55,9 @@ public class NativeMapOptions {
 
   public long actionJournalLogFileCount() {
     return actionJournalLogFileCount;
+  }
+
+  public long actionJournalRenderingReportInterval() {
+    return actionJournalRenderingReportInterval;
   }
 }

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/RenderingStats.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/RenderingStats.java
@@ -1,9 +1,9 @@
 package org.maplibre.android.maps;
 
 public class RenderingStats {
-  /// Frame CPU encoding time (milliseconds)
+  /// Frame CPU encoding time (seconds)
   public double encodingTime = 0.0;
-  /// Frame CPU rendering time (milliseconds)
+  /// Frame CPU rendering time (seconds)
   public double renderingTime = 0.0;
 
   /// Number of frames rendered

--- a/platform/darwin/src/MLNActionJournalOptions.h
+++ b/platform/darwin/src/MLNActionJournalOptions.h
@@ -30,6 +30,11 @@ MLN_EXPORT
  */
 @property (nonatomic) NSInteger logFileCount;
 
+/**
+ * The wait time (seconds) between rendering reports
+ */
+@property (nonatomic) NSInteger renderingStatsReportInterval;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MLNActionJournalOptions.mm
+++ b/platform/darwin/src/MLNActionJournalOptions.mm
@@ -51,4 +51,8 @@
     return _actionJournalOptionsInternal->logFileCount();
 }
 
+- (NSInteger)renderingStatsReportInterval {
+    return _actionJournalOptionsInternal->renderingStatsReportInterval();
+}
+
 @end

--- a/platform/darwin/src/MLNRenderingStats.h
+++ b/platform/darwin/src/MLNRenderingStats.h
@@ -6,9 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 MLN_EXPORT
 @interface MLNRenderingStats : NSObject
 
-/// Frame CPU encoding time (milliseconds)
+/// Frame CPU encoding time (seconds)
 @property (readonly) double encodingTime;
-/// Frame CPU rendering time (milliseconds)
+/// Frame CPU rendering time (seconds)
 @property (readonly) double renderingTime;
 
 /// Number of frames rendered

--- a/src/mbgl/util/action_journal_impl.cpp
+++ b/src/mbgl/util/action_journal_impl.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/util/action_journal_impl.hpp>
 #include <mbgl/util/logging.hpp>
+#include <mbgl/util/monotonic_timer.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/map/map.hpp>
 
@@ -137,10 +138,13 @@ public:
 ActionJournal::Impl::Impl(const Map& map_, const ActionJournalOptions& options_)
     : map(map_),
       options(options_),
-      scheduler(Scheduler::GetSequenced()) {
+      scheduler(Scheduler::GetSequenced()),
+      renderingInfoReportTime(options.renderingStatsReportInterval()) {
     assert(!options.path().empty());
     assert(options.logFileSize() > 0);
     assert(options.logFileCount() > 1);
+
+    previousFrameTime = util::MonotonicTimer::now().count();
 
     options.withPath((mbgl::filesystem::canonical(options.path()) / ACTION_JOURNAL_DIRECTORY_NAME).generic_string());
 
@@ -264,6 +268,59 @@ void ActionJournal::Impl::onDidFailLoadingMap(MapLoadError error, const std::str
                 .addEvent("error", errorStr)
                 .addEvent("code", static_cast<int>(error)));
     });
+}
+
+void ActionJournal::Impl::onDidFinishRenderingFrame(const RenderFrameStatus& frame) {
+
+    // update report time
+    double currentFrameTime = util::MonotonicTimer::now().count();
+    double elapsedTime = currentFrameTime - previousFrameTime;
+    previousFrameTime = currentFrameTime;
+
+    // update rendering stats
+    if (renderingStats.encodingMin > frame.renderingStats.encodingTime) {
+        renderingStats.encodingMin = frame.renderingStats.encodingTime;
+    }
+
+    if (renderingStats.encodingMax < frame.renderingStats.encodingTime) {
+        renderingStats.encodingMax = frame.renderingStats.encodingTime;
+    }
+
+    if (renderingStats.renderingMin > frame.renderingStats.renderingTime) {
+        renderingStats.renderingMin = frame.renderingStats.renderingTime;
+    }
+
+    if (renderingStats.renderingMax < frame.renderingStats.renderingTime) {
+        renderingStats.renderingMax = frame.renderingStats.renderingTime;
+    }
+
+    renderingStats.encodingTotal += frame.renderingStats.encodingTime;
+    renderingStats.renderingTotal += frame.renderingStats.renderingTime;
+    ++renderingStats.frameCount;
+
+    renderingInfoReportTime -= elapsedTime;
+    if (renderingInfoReportTime > 1e-9) {
+        return;
+    }
+
+    renderingInfoReportTime = options.renderingStatsReportInterval();
+
+    // skip if the full interval had an idle map
+    if (renderingStats.frameCount == 0) {
+        return;
+    }
+
+    scheduler->schedule([=, this, env = MapEnvironmentSnapshot(*this), stats = std::move(renderingStats)]() {
+        log(ActionJournalEvent("renderingStats", env)
+                .addEvent("encodingMin", stats.encodingMin)
+                .addEvent("encodingMax", stats.encodingMax)
+                .addEvent("encodingAvg", stats.encodingTotal / stats.frameCount)
+                .addEvent("renderingMin", stats.renderingMin)
+                .addEvent("renderingMax", stats.renderingMax)
+                .addEvent("renderingAvg", stats.renderingTotal / stats.frameCount));
+    });
+
+    renderingStats = {};
 }
 
 void ActionJournal::Impl::onWillStartRenderingMap() {

--- a/src/mbgl/util/action_journal_impl.hpp
+++ b/src/mbgl/util/action_journal_impl.hpp
@@ -37,6 +37,7 @@ public:
     void onWillStartLoadingMap() override;
     void onDidFinishLoadingMap() override;
     void onDidFailLoadingMap(MapLoadError, const std::string&) override;
+    void onDidFinishRenderingFrame(const RenderFrameStatus&) override;
     void onWillStartRenderingMap() override;
     void onDidFinishRenderingMap(RenderMode) override;
     void onDidFinishLoadingStyle() override;
@@ -95,10 +96,27 @@ protected:
 
     const std::shared_ptr<Scheduler> scheduler;
 
+    // log file
     std::mutex fileMutex;
     std::fstream currentFile;
     uint32_t currentFileIndex{0};
     size_t currentFileSize{0};
+
+    // rendering info reporting
+    double previousFrameTime;
+    double renderingInfoReportTime;
+
+    struct {
+        double encodingMin{std::numeric_limits<double>::max()};
+        double encodingMax{-std::numeric_limits<double>::max()};
+        double encodingTotal{0.0};
+
+        double renderingMin{std::numeric_limits<double>::max()};
+        double renderingMax{-std::numeric_limits<double>::max()};
+        double renderingTotal{0.0};
+
+        uint32_t frameCount{0};
+    } renderingStats;
 };
 
 } // namespace util

--- a/test/util/action_journal.test.cpp
+++ b/test/util/action_journal.test.cpp
@@ -428,3 +428,87 @@ TEST(ActionJournal, ValidateEvents) {
                   false,
                   gfx::RenderingStats());
 }
+
+TEST(ActionJournal, RenderingStats) {
+    ActionJournalTest test(ActionJournalOptions()
+                               .enable()
+                               .withPath(".")
+                               .withLogFileCount(2)
+                               .withLogFileSize(1024 * 1024 * 5)
+                               .withRenderingInfoReportInterval(2),
+        MapMode::Continuous);
+
+    test.map->getStyle().loadJSON(util::read_file("test/fixtures/api/empty.json"));
+    test.map->getActionJournal()->impl->flush();
+    test.map->getActionJournal()->impl->clearLog();
+
+    const auto onDidFinishRenderingFrame =
+        static_cast<void (RendererObserver::*)(RendererObserver::RenderMode, bool, bool, const gfx::RenderingStats&)>(
+            &RendererObserver::onDidFinishRenderingFrame);
+
+    const std::vector<gfx::RenderingStats> testStats = {
+        {.encodingTime = 0.00273499998729676, .renderingTime = 0.0000957687443587929},
+        {.encodingTime = 0.010939366680880388, .renderingTime = 0.0001340633297028641},
+        {.encodingTime = 0.023845999967306852, .renderingTime = 0.00011808499693870545},
+        {.encodingTime = 0.018161798150416603, .renderingTime = 0.00011148519331106433},
+    };
+
+    const auto encodingMin = std::ranges::min_element(
+        testStats, [](const auto& a, const auto& b) { return a.encodingTime < b.encodingTime; });
+    const auto encodingMax = std::ranges::min_element(
+        testStats, [](const auto& a, const auto& b) { return a.encodingTime > b.encodingTime; });
+    const auto renderingMin = std::ranges::min_element(
+        testStats, [](const auto& a, const auto& b) { return a.renderingTime < b.renderingTime; });
+    const auto renderingMax = std::ranges::min_element(
+        testStats, [](const auto& a, const auto& b) { return a.renderingTime > b.renderingTime; });
+    
+    const auto encodingAvg = std::accumulate(testStats.begin(),
+                                             testStats.end(),
+                                             0.0,
+                                             [](const auto& a, const auto& b) { return a + b.encodingTime; }) /
+                             testStats.size();
+
+    const auto renderingAvg = std::accumulate(testStats.begin(),
+                                              testStats.end(),
+                                              0.0,
+                                              [](const auto& a, const auto& b) { return a + b.renderingTime; }) /
+                              testStats.size();
+
+    const auto validateDouble = [](const mbgl::JSValue& json, const auto name, const double value) {
+        EXPECT_TRUE(json.HasMember(name));
+        EXPECT_TRUE(json[name].IsDouble());
+        EXPECT_DOUBLE_EQ(json[name].GetDouble(), value);
+    };
+
+    const auto validateStats = [&](const mbgl::JSValue& json) {;
+        validateDouble(json, "encodingMin", encodingMin->encodingTime);
+        validateDouble(json, "encodingMax", encodingMax->encodingTime);
+        validateDouble(json, "encodingAvg", encodingAvg);
+        validateDouble(json, "renderingMin", renderingMin->renderingTime);
+        validateDouble(json, "renderingMax", renderingMax->renderingTime);
+        validateDouble(json, "renderingAvg", renderingAvg);
+    };
+
+    // accumulate frames in the journal
+    for (const auto& frameStats : testStats) {
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(test.options.renderingStatsReportInterval() * 1000 / 2 / testStats.size()));
+        test.map->getImpl().onDidFinishRenderingFrame(RendererObserver::RenderMode::Partial, false, false, frameStats);
+
+        test.map->getActionJournal()->impl->flush();
+        const auto& log = test.map->getActionJournal()->getLog();
+        EXPECT_EQ(log.size(), 0);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(test.options.renderingStatsReportInterval() * 1000 / 2));
+
+    // trigger the journal event using a frame with average times to keep the state unchanged
+    validateEvent(test,
+                  "renderingStats",
+                  validateStats,
+                  onDidFinishRenderingFrame,
+                  RendererObserver::RenderMode::Partial,
+                  false,
+                  false,
+                  gfx::RenderingStats{.encodingTime = encodingAvg, .renderingTime = renderingAvg});
+}


### PR DESCRIPTION
This PR adds a rendering stats event to the action journal logging. 
The event contains min/max/average encoding and rendering frame times over a configurable time interval.