### PR TITLE
Use libuv run loop implementation on macOS

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,7 +29,8 @@
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
         "MLN_WITH_METAL": "ON",
         "MLN_WITH_OPENGL": "OFF",
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_BUILD_TYPE": "Debug",
+        "MLN_DARWIN_USE_LIBUV": "ON"
       }
     },
     {

--- a/docs/mdbook/src/platforms/macos/README.md
+++ b/docs/mdbook/src/platforms/macos/README.md
@@ -25,7 +25,7 @@ git clone --recurse-submodules git@github.com:maplibre/maplibre-native.git
 Make sure the following Homebrew packages are installed:
 
 ```sh
-brew install bazelisk webp libuv webp icu4c jpeg-turbo glfw
+brew install bazelisk webp libuv webp icu4c jpeg-turbo glfw libuv
 brew link icu4c --force
 ```
 

--- a/platform/darwin/darwin.cmake
+++ b/platform/darwin/darwin.cmake
@@ -12,10 +12,31 @@ target_link_libraries(
         z
 )
 
+if(MLN_DARWIN_USE_LIBUV)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(LIBUV REQUIRED IMPORTED_TARGET libuv)
+
+    target_link_libraries(mbgl-core
+        PRIVATE
+            PkgConfig::LIBUV
+    )
+endif()
+
 target_sources(
     mbgl-core
     PRIVATE
-        ${PROJECT_SOURCE_DIR}/platform/darwin/core/async_task.cpp
+        $<$<BOOL:${MLN_DARWIN_USE_LIBUV}>:
+            ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/async_task.cpp
+            ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/run_loop.cpp
+            ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/util/timer.cpp
+        >
+
+        $<$<NOT:$<BOOL:${MLN_DARWIN_USE_LIBUV}>>:
+            ${PROJECT_SOURCE_DIR}/platform/darwin/core/async_task.cpp
+            ${PROJECT_SOURCE_DIR}/platform/darwin/core/run_loop.cpp
+            ${PROJECT_SOURCE_DIR}/platform/darwin/core/timer.cpp
+        >
+
         ${PROJECT_SOURCE_DIR}/platform/darwin/core/collator.mm
         ${PROJECT_SOURCE_DIR}/platform/darwin/core/http_file_source.mm
         ${PROJECT_SOURCE_DIR}/platform/darwin/core/image.mm
@@ -24,9 +45,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/platform/darwin/core/native_apple_interface.m
         ${PROJECT_SOURCE_DIR}/platform/darwin/core/nsthread.mm
         ${PROJECT_SOURCE_DIR}/platform/darwin/core/number_format.mm
-        ${PROJECT_SOURCE_DIR}/platform/darwin/core/run_loop.cpp
         ${PROJECT_SOURCE_DIR}/platform/darwin/core/string_nsstring.mm
-        ${PROJECT_SOURCE_DIR}/platform/darwin/core/timer.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/gfx/headless_backend.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/gfx/headless_frontend.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/layermanager/layer_manager.cpp


### PR DESCRIPTION
The GLFW app crashes when using the CFRunLoop implementation.