### PR TITLE
Fix nullability of attributionHtmlString

### DIFF
--- a/platform/darwin/src/MLNTileSource.h
+++ b/platform/darwin/src/MLNTileSource.h
@@ -211,7 +211,7 @@ MLN_EXPORT
  configuration URL, this is nil until the configuration JSON file
  is loaded.
  */
-@property (nonatomic, copy, readonly) NSString *attributionHTMLString;
+@property (nonatomic, copy, nullable, readonly) NSString *attributionHTMLString;
 
 @end
 


### PR DESCRIPTION
My previous PR #3502 got the typing wrong here; this should've been `nullable`.

Workaround until this fix releases: explicitly cast it as nullable (`as String?` in Kotlin) and then use it.