### PR TITLE
[WIP] Add encoding parameter to RasterDEMSource (simple).

### DIFF
--- a/include/mbgl/style/sources/raster_dem_source.hpp
+++ b/include/mbgl/style/sources/raster_dem_source.hpp
@@ -12,8 +12,17 @@ namespace style {
 
 class RasterDEMSource : public RasterSource {
 public:
-    RasterDEMSource(std::string id, variant<std::string, Tileset> urlOrTileset, uint16_t tileSize);
+    RasterDEMSource(std::string id,
+                    variant<std::string, Tileset> urlOrTileset,
+                    uint16_t tileSize,
+                    std::optional<Tileset::DEMEncoding> encoding = std::nullopt);
+    
+    void loadDescription(FileSource& fileSource) override;
+    
     bool supportsLayerType(const mbgl::style::LayerTypeInfo*) const override;
+    
+private:
+    std::optional<Tileset::DEMEncoding> encoding;
 };
 
 template <>

--- a/include/mbgl/style/sources/raster_dem_source.hpp
+++ b/include/mbgl/style/sources/raster_dem_source.hpp
@@ -16,11 +16,11 @@ public:
                     variant<std::string, Tileset> urlOrTileset,
                     uint16_t tileSize,
                     std::optional<Tileset::DEMEncoding> encoding = std::nullopt);
-    
+
     void loadDescription(FileSource& fileSource) override;
-    
+
     bool supportsLayerType(const mbgl::style::LayerTypeInfo*) const override;
-    
+
 private:
     std::optional<Tileset::DEMEncoding> encoding;
 };

--- a/include/mbgl/style/sources/raster_source.hpp
+++ b/include/mbgl/style/sources/raster_source.hpp
@@ -26,7 +26,7 @@ public:
     class Impl;
     const Impl& impl() const;
 
-    void loadDescription(FileSource&) final;
+    void loadDescription(FileSource&) override;
 
     bool supportsLayerType(const mbgl::style::LayerTypeInfo*) const override;
 
@@ -34,10 +34,10 @@ public:
 
 protected:
     Mutable<Source::Impl> createMutable() const noexcept final;
-
-private:
     const variant<std::string, Tileset> urlOrTileset;
     std::unique_ptr<AsyncRequest> req;
+
+private:
     mapbox::base::WeakPtrFactory<Source> weakFactory{this};
     // Do not add members here, see `WeakPtrFactory`
 };

--- a/src/mbgl/style/conversion/source.cpp
+++ b/src/mbgl/style/conversion/source.cpp
@@ -75,7 +75,7 @@ static std::optional<std::unique_ptr<Source>> convertRasterDEMSource(const std::
         }
         tileSize = static_cast<uint16_t>(*size);
     }
-    
+
     std::optional<Tileset::DEMEncoding> encoding = Tileset::DEMEncoding::Mapbox;
     auto encodingValue = objectMember(value, "encoding");
     if (encodingValue) {
@@ -87,12 +87,12 @@ static std::optional<std::unique_ptr<Source>> convertRasterDEMSource(const std::
                 encoding = {Tileset::DEMEncoding::Mapbox};
             } else {
                 error.message =
-                "invalid raster-dem encoding type - valid types are 'mapbox' "
-                "and 'terrarium' ";
+                    "invalid raster-dem encoding type - valid types are 'mapbox' "
+                    "and 'terrarium' ";
             }
         }
     }
-    
+
     return {std::make_unique<RasterDEMSource>(id, std::move(*urlOrTileset), tileSize, encoding)};
 }
 

--- a/src/mbgl/style/conversion/source.cpp
+++ b/src/mbgl/style/conversion/source.cpp
@@ -75,8 +75,25 @@ static std::optional<std::unique_ptr<Source>> convertRasterDEMSource(const std::
         }
         tileSize = static_cast<uint16_t>(*size);
     }
-
-    return {std::make_unique<RasterDEMSource>(id, std::move(*urlOrTileset), tileSize)};
+    
+    std::optional<Tileset::DEMEncoding> encoding = Tileset::DEMEncoding::Mapbox;
+    auto encodingValue = objectMember(value, "encoding");
+    if (encodingValue) {
+        std::optional<std::string> encodingFormat = toString(*encodingValue);
+        if (encodingFormat) {
+            if (*encodingFormat == "terrarium") {
+                encoding = {Tileset::DEMEncoding::Terrarium};
+            } else if (*encodingFormat == "mapbox") {
+                encoding = {Tileset::DEMEncoding::Mapbox};
+            } else {
+                error.message =
+                "invalid raster-dem encoding type - valid types are 'mapbox' "
+                "and 'terrarium' ";
+            }
+        }
+    }
+    
+    return {std::make_unique<RasterDEMSource>(id, std::move(*urlOrTileset), tileSize, encoding)};
 }
 
 static std::optional<std::unique_ptr<Source>> convertVectorSource(const std::string& id,

--- a/src/mbgl/style/sources/raster_dem_source.cpp
+++ b/src/mbgl/style/sources/raster_dem_source.cpp
@@ -1,3 +1,4 @@
+#include <mbgl/storage/file_source.hpp>
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion/tileset.hpp>
 #include <mbgl/style/layer.hpp>
@@ -5,14 +6,71 @@
 #include <mbgl/style/sources/raster_dem_source.hpp>
 #include <mbgl/style/sources/raster_source_impl.hpp>
 #include <mbgl/tile/tile.hpp>
+#include <mbgl/util/async_request.hpp>
+#include <mbgl/util/exception.hpp>
 #include <mbgl/util/mapbox.hpp>
 #include <utility>
 
 namespace mbgl {
 namespace style {
 
-RasterDEMSource::RasterDEMSource(std::string id, variant<std::string, Tileset> urlOrTileset_, uint16_t tileSize)
-    : RasterSource(std::move(id), std::move(urlOrTileset_), tileSize, SourceType::RasterDEM) {}
+RasterDEMSource::RasterDEMSource(std::string id,
+                                 variant<std::string, Tileset> urlOrTileset_,
+                                 uint16_t tileSize,
+                                 std::optional<Tileset::DEMEncoding> encoding)
+    : RasterSource(std::move(id), std::move(urlOrTileset_), tileSize, SourceType::RasterDEM), encoding(encoding) {}
+
+void RasterDEMSource::loadDescription(FileSource& fileSource) {
+    if (urlOrTileset.is<Tileset>()) {
+        baseImpl = makeMutable<Impl>(impl(), urlOrTileset.get<Tileset>());
+        loaded = true;
+        observer->onSourceLoaded(*this);
+        return;
+    }
+
+    if (req) {
+        return;
+    }
+
+    const auto& rawURL = urlOrTileset.get<std::string>();
+    const auto& url = util::mapbox::canonicalizeSourceURL(fileSource.getResourceOptions().tileServerOptions(), rawURL);
+
+    req = fileSource.request(Resource::source(url), [this, url, &fileSource](const Response& res) {
+        if (res.error) {
+            observer->onSourceError(*this, std::make_exception_ptr(std::runtime_error(res.error->message)));
+        } else if (res.notModified) {
+            return;
+        } else if (res.noContent) {
+            observer->onSourceError(*this, std::make_exception_ptr(std::runtime_error("unexpectedly empty TileJSON")));
+        } else {
+            conversion::Error error;
+            std::optional<Tileset> tileset = conversion::convertJSON<Tileset>(*res.data, error);
+            if (!tileset) {
+                observer->onSourceError(*this, std::make_exception_ptr(util::StyleParseException(error.message)));
+                return;
+            }
+            const auto& tileServerOptions = fileSource.getResourceOptions().tileServerOptions();
+            if (tileServerOptions.uriSchemeAlias() == "mapbox") {
+                util::mapbox::canonicalizeTileset(tileServerOptions, *tileset, url, getType(), getTileSize());
+            }
+            
+            if (encoding) {
+                tileset->encoding = encoding.value();
+            }
+                        
+            bool changed = impl().tileset != *tileset;
+
+            baseImpl = makeMutable<Impl>(impl(), *tileset);
+            loaded = true;
+
+            observer->onSourceLoaded(*this);
+
+            if (changed) {
+                observer->onSourceChanged(*this);
+            }
+        }
+    });
+}
 
 bool RasterDEMSource::supportsLayerType(const mbgl::style::LayerTypeInfo* info) const {
     return mbgl::underlying_type(Tile::Kind::RasterDEM) == mbgl::underlying_type(info->tileKind);

--- a/src/mbgl/style/sources/raster_dem_source.cpp
+++ b/src/mbgl/style/sources/raster_dem_source.cpp
@@ -18,7 +18,8 @@ RasterDEMSource::RasterDEMSource(std::string id,
                                  variant<std::string, Tileset> urlOrTileset_,
                                  uint16_t tileSize,
                                  std::optional<Tileset::DEMEncoding> encoding)
-    : RasterSource(std::move(id), std::move(urlOrTileset_), tileSize, SourceType::RasterDEM), encoding(encoding) {}
+    : RasterSource(std::move(id), std::move(urlOrTileset_), tileSize, SourceType::RasterDEM),
+      encoding(encoding) {}
 
 void RasterDEMSource::loadDescription(FileSource& fileSource) {
     if (urlOrTileset.is<Tileset>()) {
@@ -53,11 +54,11 @@ void RasterDEMSource::loadDescription(FileSource& fileSource) {
             if (tileServerOptions.uriSchemeAlias() == "mapbox") {
                 util::mapbox::canonicalizeTileset(tileServerOptions, *tileset, url, getType(), getTileSize());
             }
-            
+
             if (encoding) {
                 tileset->encoding = encoding.value();
             }
-                        
+
             bool changed = impl().tileset != *tileset;
 
             baseImpl = makeMutable<Impl>(impl(), *tileset);


### PR DESCRIPTION
Fixes #3564 

This is a minimal changeset to be compared to #3570.

Instead of refactoring out a `TileSource` and adding `RasterDEMOptions`, this just adds an `encoding` param to `RasterDEMSource` and copies over the implementation of `loadDescription` from `RasterSource` to insert the encoding param.