### PR TITLE
Prevent `Style.validateState()` exception on location state updates

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/SymbolLocationLayerRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/SymbolLocationLayerRenderer.java
@@ -245,6 +245,10 @@ final class SymbolLocationLayerRenderer implements LocationLayerRenderer {
   }
 
   private void setLayerVisibility(@NonNull String layerId, boolean visible) {
+    if (!style.isFullyLoaded()) {
+      return;
+    }
+
     Layer layer = style.getLayer(layerId);
     if (layer != null) {
       String targetVisibility = visible ? VISIBLE : NONE;

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/location/ManualLocationUpdatesActivity.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/location/ManualLocationUpdatesActivity.kt
@@ -30,6 +30,7 @@ class ManualLocationUpdatesActivity : AppCompatActivity(), OnMapReadyCallback {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_location_manual_update)
+        mapView = findViewById(R.id.mapView)
         locationEngine = LocationEngineDefault.getDefaultLocationEngine(mapView.context)
         val fabManualUpdate = findViewById<FloatingActionButton>(R.id.fabManualLocationChange)
         fabManualUpdate.setOnClickListener { v: View? ->
@@ -66,7 +67,6 @@ class ManualLocationUpdatesActivity : AppCompatActivity(), OnMapReadyCallback {
                 }
             }
         }
-        mapView = findViewById(R.id.mapView)
         mapView.onCreate(savedInstanceState)
         if (PermissionsManager.areLocationPermissionsGranted(this)) {
             mapView.getMapAsync(this)


### PR DESCRIPTION
Add check to prevent style exception. https://github.com/maplibre/maplibre-native/issues/3506#issuecomment-2991783147
Still not clear how `StaleMessageHandler.handleMessage` is active without a valid style as their lifetime seems controlled by the same location component methods (`onLocationLayerStart`/`onLocationLayerStop`).