### PR TITLE
Add an option to reverse the direction of the quick zoom gesture

### DIFF
--- a/platform/ios/src/MLNMapView.h
+++ b/platform/ios/src/MLNMapView.h
@@ -768,6 +768,15 @@ MLN_EXPORT
 @property (nonatomic, getter=isZoomEnabled) BOOL zoomEnabled;
 
 /**
+ A boolean value that reverses the direction of the quick zoom gesture.
+
+ When this property is set, the zoom-in and zoom-out behavior during the quick
+ zoom gesture (also called one-finger zoom) is reversed, aligning with the
+ behavior in Apple Maps. The default value is `NO`.
+ */
+@property (nonatomic, getter=isQuickZoomReversed) BOOL quickZoomReversed;
+
+/**
  A Boolean value that determines whether the user may scroll around the map,
  changing the center coordinate.
 

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -842,6 +842,7 @@ public:
     _pinch.delegate = self;
     [self addGestureRecognizer:_pinch];
     _zoomEnabled = YES;
+    _quickZoomReversed = NO;
 
 #if TARGET_IPHONE_SIMULATOR & (TARGET_CPU_X86 | TARGET_CPU_X86_64)
     if (isM1Simulator) {
@@ -2648,6 +2649,8 @@ public:
     {
         CGFloat distance = [quickZoom locationInView:quickZoom.view].y - self.quickZoomStart;
 
+        if (self.isQuickZoomReversed) distance = - distance;
+
         CGFloat newZoom = MAX(log2f(self.scale) + (distance / 75), *self.mbglMap.getBounds().minZoom);
 
         if ([self zoomLevel] == newZoom) return;
@@ -3162,6 +3165,12 @@ static void *windowScreenContext = &windowScreenContext;
     self.doubleTap.enabled = zoomEnabled;
     self.quickZoom.enabled = zoomEnabled;
     self.twoFingerTap.enabled = zoomEnabled;
+}
+
+- (void)setQuickZoomReversed:(BOOL)quickZoomReversed
+{
+    MLNLogDebug(@"Setting quickZoomReversed: %@", MLNStringFromBOOL(quickZoomReversed));
+    _quickZoomReversed = quickZoomReversed;
 }
 
 - (void)setScrollEnabled:(BOOL)scrollEnabled


### PR DESCRIPTION
An option called `quickZoomReversed` has been added for iOS. When this option is enabled, the functionality of the quick zoom gesture, also known as one-finger zoom, is reversed to match the behavior observed in Apple Maps.