### PR TITLE
Fix render pipeline state bug

### DIFF
--- a/src/mbgl/mtl/context.cpp
+++ b/src/mbgl/mtl/context.cpp
@@ -382,7 +382,7 @@ bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,
         }
     }
     if (clipMaskPipelineState) {
-        encoder->setRenderPipelineState(clipMaskPipelineState.get());
+        mtlRenderPass.setRenderPipelineState(clipMaskPipelineState);
     } else {
         assert(!"Failed to create render pipeline state for clip masking");
         return false;


### PR DESCRIPTION
There are two places that the render pipeline state is set and one was using the new function on renderPass and one was not.  This fixes that problem.