### PR TITLE
Publish MapLibre Android to Maven Central

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -146,8 +146,8 @@ jobs:
             ./gradlew :MapLibreAndroid:publishVulkan${{ env.buildtype }}PublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
           fi
         env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}

--- a/platform/android/build.gradle.kts
+++ b/platform/android/build.gradle.kts
@@ -12,10 +12,10 @@ nexusPublishing {
     repositories {
         sonatype {
             stagingProfileId.set(extra["sonatypeStagingProfileId"] as String?)
-            username.set(extra["ossrhUsername"] as String?)
-            password.set(extra["ossrhPassword"] as String?)
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            username.set(extra["mavenCentralUsername"] as String?)
+            password.set(extra["mavenCentralPassword"] as String?)
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }

--- a/platform/android/buildSrc/src/main/kotlin/maplibre.publish-root.gradle.kts
+++ b/platform/android/buildSrc/src/main/kotlin/maplibre.publish-root.gradle.kts
@@ -1,6 +1,6 @@
 extra["signing.keyId"] = System.getenv("SIGNING_KEY_ID")
 extra["signing.password"] = System.getenv("SIGNING_PASSWORD")
 extra["signing.secretKeyRingFile"] = "${projectDir}/../signing-key.gpg"
-extra["ossrhUsername"] = System.getenv("OSSRH_USERNAME")
-extra["ossrhPassword"] = System.getenv("OSSRH_PASSWORD")
+extra["mavenCentralUsername"] = System.getenv("MAVEN_CENTRAL_USERNAME")
+extra["mavenCentralPassword"] = System.getenv("MAVEN_CENTRAL_PASSWORD")
 extra["sonatypeStagingProfileId"] = System.getenv("SONATYPE_STAGING_PROFILE_ID")


### PR DESCRIPTION
Follow [these steps](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/) to migrate from OSSRH (which has shut down) to Maven Central.