### PR TITLE
Fix calling completion callback for setContentInset in specific situation

### DIFF
--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -6339,7 +6339,8 @@ static void *windowScreenContext = &windowScreenContext;
     CLLocation *location = self.userLocation.location;
     if ( ! _showsUserLocation || ! location
         || ! CLLocationCoordinate2DIsValid(location.coordinate)
-        || self.userTrackingMode == MLNUserTrackingModeNone)
+        || self.userTrackingMode == MLNUserTrackingModeNone
+        || self.userTrackingState == MLNUserTrackingStateBegan)
     {
         if (completion)
         {


### PR DESCRIPTION
If for any reason you end up calling `setContentInset` while `self.userTrackingState == MLNUserTrackingStateBegan` the passed in `completion` callback is never called. This change makes it so that even though we don't track the user's location after calling `setContentInset` we still call the passed in `completion` callback.

You can reproduce this by calling `setUserTrackingMode` right before calling `setContentInset` and you can check if whatever in the `completion` callback for `setContentInset` is ever called back and it's usually not.