### PR TITLE
Revert "Fix the symbol blink issue by only placing the symbol in current level (#3534)"

### DIFF
--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -276,12 +276,6 @@ JointPlacement Placement::placeSymbol(const SymbolInstance& symbolInstance, cons
         // a parent tile that _should_ be placed.
         return kUnplaced;
     }
-
-    // Place the symbol only at the current level to prevent it from blinking during the transition.
-    if (ctx.getOverscaledID().overscaledZ != int(placementZoom)) {
-        return kUnplaced;
-    }
-
     const SymbolBucket& bucket = ctx.getBucket();
     const mat4& posMatrix = ctx.getRenderTile().matrix;
     const auto& collisionGroup = ctx.collisionGroup;


### PR DESCRIPTION
This reverts commit 55ff6a442809e60b990d4b24eddda43bdc577e93 or https://github.com/maplibre/maplibre-native/pull/3534

@qqz003 We need to find a different approach how to solve your problem, since this fix is causing various regressions...