### PR TITLE
Use sccache in linux-ci

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -66,10 +66,6 @@ jobs:
         with:
           languages: cpp
 
-      - uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ github.job }}
-
       - name: Get latest CMake and Ninja
         uses: lukka/get-cmake@latest
         with:
@@ -130,6 +126,9 @@ jobs:
           cmake --build build --target mbgl-core mbgl-test-runner mbgl-render-test-runner mbgl-expression-test mbgl-render mbgl-benchmark-runner
 
       # mbgl-render (used for size test) & mbgl-benchmark-runner
+
+      - name: Show sccache stats
+        run: sccache --show-stats
 
       - name: Upload mbgl-render as artifact
         if: matrix.renderer == 'drawable' && github.event_name == 'pull_request'


### PR DESCRIPTION
Since GitHub cache is tiny, and they have been promising to increase the cache size forever, it is time to explore other caching strategies because CI times are getting out of hand.

This PR tries to use [sccache](https://github.com/mozilla/sccache) (written in Rust btw) which has the ability to upload the cache to S3 if credentials are defined. So we will push & pull the cache on branches where the secret for AWS is set up, and pull the cache for other branches (mostly PRs from forks).

---

### Results

From about 1h 14m 51s (when no ccache is available) to 42m 16s (for the build step), which is comparable to ccache. So I think this is worth it. I will look into using it for other workflows in a follow-up PR.