### PR TITLE
Add combined static linux targets

### DIFF
--- a/.github/scripts/install-linux-deps
+++ b/.github/scripts/install-linux-deps
@@ -10,3 +10,4 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
   libwebp-dev \
   libopengl0 \
   mesa-vulkan-drivers
+cargo install armerge@2.2.0

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -82,10 +82,14 @@ jobs:
           cmake --build --preset linux-${{ matrix.renderer }}-core
 
       - name: Rename artifact
-        run: cp build-linux-${{ matrix.renderer }}/libmbgl-core.a libmaplibre-native-core-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
+        run: |
+          cp build-linux-${{ matrix.renderer }}/libmbgl-core.a libmaplibre-native-core-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
+          cp build-linux-${{ matrix.renderer }}/libmbgl-core-amalgam.a libmaplibre-native-core-amalgam-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
 
       - name: Upload Linux artifact
-        run: gh release upload core-${{ github.sha }} libmaplibre-native-core-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
+        run: |
+          gh release upload core-${{ github.sha }} libmaplibre-native-core-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
+          gh release upload core-${{ github.sha }} libmaplibre-native-core-amalgam-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -138,6 +138,9 @@ cc_library(
         "@platforms//os:osx": [
             "//vendor:icu",
         ],
+        "@platforms//os:linux": [
+            "//vendor:sqlite",
+        ],
         "//conditions:default": [],
     }) + select({
         ":metal_renderer": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -109,7 +109,7 @@
       "inherits": "linux-opengl",
       "cacheVariables": {
         "MLN_CORE_INCLUDE_DEPS": "ON",
-        "MLN_USE_BUILTIN_ICU": "ON"
+        "MLN_USE_BUILTIN_ICU": "OFF"
       }
     },
     {
@@ -127,7 +127,7 @@
       "inherits": "linux-vulkan",
       "cacheVariables": {
         "MLN_CORE_INCLUDE_DEPS": "ON",
-        "MLN_USE_BUILTIN_ICU": "ON"
+        "MLN_USE_BUILTIN_ICU": "OFF"
       }
     },
     {

--- a/platform/default/BUILD.bazel
+++ b/platform/default/BUILD.bazel
@@ -145,6 +145,7 @@ cc_library(
         ],
         "@platforms//os:linux": [
             "default-collator",
+            "//vendor:sqlite",
         ],
         "@platforms//os:osx": [
             ":default-collator",

--- a/platform/linux/BUILD.bazel
+++ b/platform/linux/BUILD.bazel
@@ -16,9 +16,7 @@ cc_library(
     copts = CPP_FLAGS + MAPLIBRE_FLAGS,
     linkopts = [
         "-lGL",
-        "-lglfw",
         "-lX11",
-        "-lsqlite3",
         "-luv",
         "-lz",
         "-lcurl",
@@ -31,6 +29,26 @@ cc_library(
         "//:mbgl-core",
         "//platform/default:mbgl-default",
     ],
+)
+
+cc_static_library(
+    name = "maplibre-linux-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":impl",
+    ],
+)
+
+genrule(
+    name = "maplibre-linux-amalgam",
+    srcs = [":maplibre-linux-static"],
+    outs = ["libmaplibre-linux-amalgam.a"],
+    cmd_bash = """(
+        armerge --keep-symbols "^.+" --output $(OUTS) $(BINDIR)/platform/linux/libmaplibre-linux-static.a \
+            $$(pkg-config --variable=libdir icu-uc)/libicuuc.a \
+            $$(pkg-config --variable=libdir icu-uc)/libicudata.a \
+            $$(pkg-config --variable=libdir icu-i18n)/libicui18n.a
+    )"""
 )
 
 sh_binary(

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -175,7 +175,8 @@ target_link_libraries(
 )
 
 # Bundle system provided libraries
-if(MLN_CORE_INCLUDE_DEPS AND NOT MLN_USE_BUILTIN_ICU AND NOT "${ARMERGE}" STREQUAL "")
+if(MLN_CORE_INCLUDE_DEPS AND NOT MLN_USE_BUILTIN_ICU AND NOT "${ARMERGE}" STREQUAL "ARMERGE-NOTFOUND")
+    message(STATUS "Found armerge: ${ARMERGE}")
     add_custom_command(
         TARGET mbgl-core
         POST_BUILD

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -2,8 +2,6 @@ option(MLN_WITH_X11 "Build with X11 Support" ON)
 option(MLN_WITH_WAYLAND "Build with Wayland Support" OFF)
 
 find_package(CURL REQUIRED)
-find_package(ICU OPTIONAL_COMPONENTS i18n)
-find_package(ICU OPTIONAL_COMPONENTS uc)
 find_package(JPEG REQUIRED)
 find_package(PNG REQUIRED)
 find_package(PkgConfig REQUIRED)
@@ -14,6 +12,9 @@ find_package(Threads REQUIRED)
 
 pkg_search_module(WEBP libwebp REQUIRED)
 pkg_search_module(LIBUV libuv REQUIRED)
+pkg_search_module(ICUUC icu-uc)
+pkg_search_module(ICUI18N icu-i18n)
+find_program(ARMERGE NAMES armerge)
 
 if(MLN_WITH_WAYLAND)
     # See https://github.com/maplibre/maplibre-native/pull/2022
@@ -142,7 +143,7 @@ target_include_directories(
 include(${PROJECT_SOURCE_DIR}/vendor/nunicode.cmake)
 include(${PROJECT_SOURCE_DIR}/vendor/sqlite.cmake)
 
-if(NOT ${ICU_FOUND} OR "${ICU_VERSION}" VERSION_LESS 62.0 OR MLN_USE_BUILTIN_ICU)
+if(NOT ${ICUUC_FOUND} OR "${ICUUC_VERSION}" VERSION_LESS 62.0 OR MLN_USE_BUILTIN_ICU)
     message(STATUS "ICU not found, too old or MLN_USE_BUILTIN_ICU requestd, using builtin.")
 
     set(MLN_USE_BUILTIN_ICU TRUE)
@@ -165,13 +166,27 @@ target_link_libraries(
         ${X11_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT}
         ${WEBP_LIBRARIES}
-        $<$<NOT:$<BOOL:${MLN_USE_BUILTIN_ICU}>>:ICU::i18n>
-        $<$<NOT:$<BOOL:${MLN_USE_BUILTIN_ICU}>>:ICU::uc>
+        $<$<NOT:$<BOOL:${MLN_USE_BUILTIN_ICU}>>:${ICUUC_LIBRARIES}>
+        $<$<NOT:$<BOOL:${MLN_USE_BUILTIN_ICU}>>:${ICUI18N_LIBRARIES}>
         $<$<BOOL:${MLN_USE_BUILTIN_ICU}>:$<IF:$<BOOL:${MLN_CORE_INCLUDE_DEPS}>,$<TARGET_OBJECTS:mbgl-vendor-icu>,mbgl-vendor-icu>>
         PNG::PNG
         mbgl-vendor-nunicode
         mbgl-vendor-sqlite
+        mbgl-vendor-parsedate
 )
+
+# Bundle system provided libraries
+if(MLN_CORE_INCLUDE_DEPS AND NOT MLN_USE_BUILTIN_ICU AND NOT "${ARMERGE}" STREQUAL "")
+    add_custom_command(
+        TARGET mbgl-core
+        POST_BUILD
+        COMMAND armerge --keep-symbols '.*' --output libmbgl-core-amalgam.a
+            $<TARGET_FILE:mbgl-core>
+            ${ICUUC_LIBRARY_DIRS}/libicuuc.a
+            ${ICUUC_LIBRARY_DIRS}/libicudata.a
+            ${ICUI18N_LIBRARY_DIRS}/libicui18n.a
+    )
+endif()
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/bin)
 add_subdirectory(${PROJECT_SOURCE_DIR}/expression-test)

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -172,7 +172,6 @@ target_link_libraries(
         PNG::PNG
         mbgl-vendor-nunicode
         mbgl-vendor-sqlite
-        mbgl-vendor-parsedate
 )
 
 # Bundle system provided libraries

--- a/vendor/BUILD.bazel
+++ b/vendor/BUILD.bazel
@@ -235,3 +235,12 @@ cc_library(
     strip_include_prefix = "unordered_dense/include/ankerl",
     visibility = ["//visibility:public"],
 )
+
+cc_library(
+    name = "sqlite",
+    srcs = ["sqlite/src/sqlite3.c"],
+    hdrs = ["sqlite/include/sqlite3.h"],
+    include_prefix = "",
+    strip_include_prefix = "sqlite/include",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/sqlite.cmake
+++ b/vendor/sqlite.cmake
@@ -2,7 +2,7 @@ if(TARGET mbgl-vendor-sqlite)
     return()
 endif()
 
-if(MLN_WITH_QT)
+if(MLN_WITH_QT OR MLN_CORE_INCLUDE_DEPS)
     add_library(mbgl-vendor-sqlite OBJECT)
 else()
     add_library(mbgl-vendor-sqlite STATIC)


### PR DESCRIPTION
Adds new static library outputs to bazel and cmake, combining symbols from system vendor-provided dependencies (ICU) for easier use with pre-compiled static releases. This is done using `armerge` in a `genrule` (bazel) and custom command (cmake). These changes remove the requirement to link with the correct version of ICU by copying the symbols from ICU into MapLibre`s static library.

When built with cmake using `MLN_CORE_INCLUDE_DEPS`, the new library `libmbgl-core-amalgam.a` will be created if `armerge` is present and `MLN_USE_BUILTIN_ICU` isn't set.

Build the combined library with bazel via the target `//platform/linux:maplibre-linux-amalgam` to produce `libmaplibre-linux-amalgam.a`.

Both bazel and cmake also now link with the vendor copy of sqlite on Linux.