### PR TITLE
fix check-job-skipped.ts

### DIFF
--- a/.github/scripts/check-job-skipped.ts
+++ b/.github/scripts/check-job-skipped.ts
@@ -16,7 +16,7 @@ async function run() {
   const jobName = process.env.JOB_NAME;
   if (!jobName) throw new Error("JOB_NAME not set");
 
-  const job = data.jobs.find(({name}) => name === jobName);
+  const job = data.jobs.find(({name}) => name.startsWith(jobName));
   if (!job) throw new Error(`job with name ${jobName} not found in workflow run with id ${run_id}`);
 
   core.setOutput('was_skipped', job.conclusion === 'skipped');

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -365,6 +365,7 @@ jobs:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Write release notifications
+        if: env.make_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/notify-release-on-prs.ts --tag ios-v${{ env.version }}


### PR DESCRIPTION
The job name is `android-build (opengl)` now so it did not find the right job.