### PR TITLE
Set cmake_minimum_required to 3.10 in maplibre-native-base

### DIFF
--- a/vendor/maplibre-native-base/CMakeLists.txt
+++ b/vendor/maplibre-native-base/CMakeLists.txt
@@ -2,7 +2,7 @@ if(TARGET maplibre-native-base)
     return()
 endif()
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(MAPBOX_BASE LANGUAGES CXX C)
 
 option(MAPBOX_BASE_BUILD_TESTING "Bypass project target check and enforce building tests" OFF)


### PR DESCRIPTION
Finally get rid of this warning.

> C/C++:   Compatibility with CMake < 3.10 will be removed from a future version of
> C/C++:   CMake.
> C/C++:   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
> C/C++:   to tell CMake that the project requires at least <min> but has been updated
> C/C++:   to work with policies introduced by <max> or earlier.