### PR TITLE
Add Vulkan device sharing example

### DIFF
--- a/include/mbgl/vulkan/renderer_backend.hpp
+++ b/include/mbgl/vulkan/renderer_backend.hpp
@@ -84,16 +84,16 @@ protected:
     virtual std::vector<const char*> getDeviceExtensions();
     std::vector<const char*> getDebugExtensions();
 
-    void initInstance();
-    void initDebug();
-    void initSurface();
-    void initDevice();
-    void initAllocator();
-    void initSwapchain();
-    void initCommandPool();
-    void initFrameCapture();
+    virtual void initInstance();
+    virtual void initDebug();
+    virtual void initSurface();
+    virtual void initDevice();
+    virtual void initAllocator();
+    virtual void initSwapchain();
+    virtual void initCommandPool();
+    virtual void initFrameCapture();
 
-    void destroyResources();
+    virtual void destroyResources();
 
 protected:
     vk::DynamicLoader dynamicLoader;
@@ -120,6 +120,7 @@ protected:
     VmaAllocator allocator;
 
     bool debugUtilsEnabled{false};
+    bool usingSharedContext{false};
 };
 
 } // namespace vulkan

--- a/platform/glfw/glfw_vulkan_backend.hpp
+++ b/platform/glfw/glfw_vulkan_backend.hpp
@@ -5,6 +5,10 @@
 #include <mbgl/vulkan/renderable_resource.hpp>
 #include <mbgl/vulkan/renderer_backend.hpp>
 
+// Example of using an application side VkInstance/VkDevice
+// that's shared with MapLibre's renderer backend
+// #define USE_SHARED_VK_CONTEXT
+
 struct GLFWwindow;
 
 class GLFWVulkanBackend final : public GLFWBackend,
@@ -28,6 +32,11 @@ public:
 
 protected:
     std::vector<const char*> getInstanceExtensions() override;
+
+#ifdef USE_SHARED_VK_CONTEXT
+    void initInstance() override;
+    void initDevice() override;
+#endif
 
     void activate() override {}
     void deactivate() override {}

--- a/src/mbgl/vulkan/offscreen_texture.cpp
+++ b/src/mbgl/vulkan/offscreen_texture.cpp
@@ -46,8 +46,12 @@ public:
     const vk::UniqueFramebuffer& getFramebuffer() const override { return framebuffer; };
 
     PremultipliedImage readStillImage() {
-        assert(false);
-        return {};
+        if (!colorTexture) {
+            return {};
+        }
+
+        const auto& image = static_cast<Texture2D&>(*colorTexture).readImage();
+        return image ? image->clone() : PremultipliedImage();
     }
 
     gfx::Texture2DPtr& getTexture() {


### PR DESCRIPTION
This PR adds the possibility to pass an external instance/device pair to the core backend, enabling resource sharing between the owner and MapLibre.