### PR TITLE
Mark AWS Device Farm run as failed if it was SKIPPED

### DIFF
--- a/scripts/aws-device-farm/aws-device-farm-run.sh
+++ b/scripts/aws-device-farm/aws-device-farm-run.sh
@@ -53,6 +53,7 @@ test_package_url="$(jq -r '.upload.url' <<< "$response")"
 curl -T "$appFile" "$app_url"
 curl -T "$testFile" "$test_package_url"
 
+# Wait for uploads to succeed
 max_checks=10
 sleep_time=5
 
@@ -63,9 +64,6 @@ check_status() {
 while ((max_checks--)); do
   status_app="$(check_status "$app_arn")"
   status_test_package="$(check_status "$test_package_arn")"
-
-  status_app="$status_app"
-  status_test_package="$status_test_package"
 
   if [[ "$status_app" == "SUCCEEDED" && "$status_test_package" == "SUCCEEDED" ]]; then
     echo "Uploads succeeded" >&2
@@ -78,40 +76,69 @@ while ((max_checks--)); do
   sleep $sleep_time
 done
 
-# Schedule test run
-arn="$(aws devicefarm schedule-run \
-  --project-arn "$AWS_DEVICE_FARM_PROJECT_ARN" \
-  --name "MapLibre Native $name" \
-  --app-arn "$app_arn" \
-  --device-pool-arn "$AWS_DEVICE_FARM_DEVICE_POOL_ARN" \
-  --test type=$testType,testPackageArn=$test_package_arn${testFilter:+,filter=$testFilter}${testSpecArn:+,testSpecArn=$testSpecArn} \
-  --execution-configuration videoCapture=false \
-  --output text --query run.arn)"
+# Retry logic: reschedule when result is SKIPPED up to 3 times
+max_retries=3
+for attempt in $(seq 1 $max_retries); do
+  echo "Scheduling Device Farm run (attempt $attempt)" >&2
+  arn=$(aws devicefarm schedule-run \
+    --project-arn "$AWS_DEVICE_FARM_PROJECT_ARN" \
+    --name "MapLibre Native $name" \
+    --app-arn "$app_arn" \
+    --device-pool-arn "$AWS_DEVICE_FARM_DEVICE_POOL_ARN" \
+    --test type=$testType,testPackageArn=$test_package_arn${testFilter:+,filter=$testFilter}${testSpecArn:+,testSpecArn=$testSpecArn} \
+    --execution-configuration videoCapture=false \
+    --output text --query run.arn)
 
-echo ARN: $arn  >&2
+  echo "ARN: $arn" >&2
 
-if [ -z "$arn" ]; then
-  echo "Error: Failed to schedule Device Farm run or got empty ARN" >&2
-  exit 1
-fi
+  if [[ -z "$arn" ]]; then
+    echo "Error: Failed to schedule Device Farm run or got empty ARN" >&2
+    exit 1
+  fi
 
+  if [[ "$wait_for_completion" != "true" ]]; then
+    echo "Not waiting for run to complete" >&2
+    exit 0
+  fi
 
-echo "$arn"
+  # Wait for run result
+  while true; do
+    sleep 30
+    result=$(aws devicefarm get-run --arn "$arn" --output text --query "run.result")
+    case $result in
+      FAILED|ERRORED|STOPPED)
+        echo "$arn"
+        echo "Run $result" >&2
+        exit 1
+        ;;
+      SKIPPED)
+        echo "Run skipped on attempt $attempt" >&2
+        if [[ $attempt -lt $max_retries ]]; then
+          echo "Retrying..." >&2
+          break  # break wait loop and retry
+        else
+          echo "$arn"
+          echo "Max retries ($max_retries) reached. Exiting." >&2
+          exit 1
+        fi
+        ;;
+      PASSED)
+        echo "$arn"
+        echo "Run $result" >&2
+        exit 0
+        ;;
+      PENDING)
+        continue
+        ;;
+      *)
+        echo "Unexpected run result $result" >&2
+        exit 1
+        ;;
+    esac
+  done
 
-if [[ "$wait_for_completion" != "true" ]]; then
-  echo "Not waiting for run to complete" >&2
-  exit 0
-fi
-
-# wait until result is not PENDING
-# https://awscli.amazonaws.com/v2/documentation/api/latest/reference/devicefarm/get-run.html#output
-while true; do
-  sleep 30
-  result="$(aws devicefarm get-run --arn "$arn" --output text --query "run.result")"
-  case $result in
-    FAILED|ERRORED|STOPPED) echo "Run $result" >&2 && exit 1 ;;
-    SKIPPED|PASSED) echo "Run $result" >&2 && exit 0 ;;
-    PENDING) continue ;;
-    *) echo "Unexpected run result $result" >&2 && exit 1 ;;
-  esac
 done
+
+# If for-loop exits without passing or failing, exit with error
+echo "Retries exhausted without a definitive result." >&2
+exit 1


### PR DESCRIPTION
Workaround until we figure out why tests are skipped...