### PR TITLE
Use `check-job-skipped.ts` in other workflows

### DIFF
--- a/.github/scripts/check-job-skipped.ts
+++ b/.github/scripts/check-job-skipped.ts
@@ -20,6 +20,7 @@ async function run() {
   if (!job) throw new Error(`job with name ${jobName} not found in workflow run with id ${run_id}`);
 
   core.setOutput('was_skipped', job.conclusion === 'skipped');
+  core.setOutput('was_skipped_or_cancelled', job.conclusion === 'skipped' || job.conclusion === 'cancelled');
 }
 
 try {

--- a/.github/workflows/pr-bloaty-ios.yml
+++ b/.github/workflows/pr-bloaty-ios.yml
@@ -17,13 +17,19 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.check_skip.outputs.should_skip }}
+      should_skip: ${{ steps.parent_workflow.outputs.was_skipped_or_cancelled }}
     steps:
-      - id: check_skip
-        run: |
-          conclusion=$(curl --retry 12 --retry-all-errors ${{ github.event.workflow_run.jobs_url }} | jq -r '.jobs[] | select(.name == "ios-build").conclusion')
-          should_skip=$([[ "$conclusion" = "skipped" || "$conclusion" = "cancelled" ]] && echo "true" || echo "false")
-          echo "should_skip=$should_skip" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - name: Get parent workflow result
+        id: parent_workflow
+        run: node .github/scripts/check-job-skipped.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_RUN_ID: ${{ github.event.workflow_run.id }}
+          JOB_NAME: ios-build
 
   pr-bloaty-ios:
     needs: pre_job

--- a/.github/workflows/pr-linux-tests.yml
+++ b/.github/workflows/pr-linux-tests.yml
@@ -20,13 +20,19 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.check_skip.outputs.should_skip }}
+      should_skip: ${{ steps.parent_workflow.outputs.was_skipped_or_cancelled }}
     steps:
-      - id: check_skip
-        run: |
-          conclusion=$(curl --retry 12 --retry-all-errors ${{ github.event.workflow_run.jobs_url }} | jq -r '.jobs[] | select(.name == "linux-build-and-test").conclusion')
-          should_skip=$([[ "$conclusion" = "skipped" || "$conclusion" = "cancelled" ]] && echo "true" || echo "false")
-          echo "should_skip=$should_skip" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - name: Get parent workflow result
+        id: parent_workflow
+        run: node .github/scripts/check-job-skipped.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_RUN_ID: ${{ github.event.workflow_run.id }}
+          JOB_NAME: linux-build-and-test
 
   pr-bloaty:
     needs: pre_job

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -10,13 +10,19 @@ jobs:
   pre_job:
     runs-on: ubuntu-latest
     outputs:
-      should_run: ${{ steps.check_skip.outputs.should_run }}
+      should_run: ${{ !steps.parent_workflow.outputs.was_skipped_or_cancelled }}
     steps:
-      - id: check_skip
-        run: |
-          conclusion=$(curl --retry 12 --retry-all-errors ${{ github.event.workflow_run.jobs_url }} | jq -r '.jobs[] | select(.name == "linux-coverage").conclusion')
-          should_run=$([[ "$conclusion" = "success" ]] && echo "true" || echo "false")
-          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - name: Get parent workflow result
+        id: parent_workflow
+        run: node .github/scripts/check-job-skipped.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_RUN_ID: ${{ github.event.workflow_run.id }}
+          JOB_NAME: linux-coverage
 
   upload-coverage:
     needs: pre_job


### PR DESCRIPTION
This is a more reliable way to check if a job in a parent workflow was skipped or cancelled.