### PR TITLE
vulkan - Allow opting out of surface based rendering

### DIFF
--- a/include/mbgl/vulkan/renderer_backend.hpp
+++ b/include/mbgl/vulkan/renderer_backend.hpp
@@ -38,7 +38,7 @@ public:
 
     /// One-time shader initialization
     void initShaders(gfx::ShaderRegistry&, const ProgramParameters& programParameters) override;
-    void init();
+    virtual void init();
 
     const vk::DispatchLoaderDynamic& getDispatcher() const { return dispatcher; }
     const vk::UniqueInstance& getInstance() const { return instance; }

--- a/src/mbgl/vulkan/context.cpp
+++ b/src/mbgl/vulkan/context.cpp
@@ -228,12 +228,12 @@ void Context::beginFrame() {
 
     const auto& device = backend.getDevice();
     const auto& dispatcher = backend.getDispatcher();
-    
+
     // Check if this is surface-based or offscreen rendering
     // For offscreen rendering, we use RenderableResource directly, not SurfaceRenderableResource
     bool isSurfaceRendering = false;
     SurfaceRenderableResource* surfaceResource = nullptr;
-    
+
     try {
         // Try to get as SurfaceRenderableResource - will throw if it's not one
         surfaceResource = &backend.getDefaultRenderable().getResource<SurfaceRenderableResource>();
@@ -262,7 +262,8 @@ void Context::beginFrame() {
         }
     }
 
-    if (isSurfaceRendering && surfaceResource && surfaceResource->getPlatformSurface() && surfaceUpdateRequested && --surfaceUpdateLatency <= 0) {
+    if (isSurfaceRendering && surfaceResource && surfaceResource->getPlatformSurface() && surfaceUpdateRequested &&
+        --surfaceUpdateLatency <= 0) {
         surfaceResource->recreateSwapchain();
 
         // we wait for an idle device to recreate the swapchain
@@ -338,10 +339,10 @@ void Context::submitFrame() {
 
     const auto& device = backend.getDevice();
     const auto& graphicsQueue = backend.getGraphicsQueue();
-    
+
     bool isSurfaceRendering = false;
     SurfaceRenderableResource* surfaceResource = nullptr;
-    
+
     try {
         surfaceResource = &backend.getDefaultRenderable().getResource<SurfaceRenderableResource>();
         if (surfaceResource && surfaceResource->getPlatformSurface()) {
@@ -607,7 +608,7 @@ bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,
         // Not a surface resource, no rotation needed
         rad = 0.0f;
     }
-    
+
     const mat4 rotationMat = {cos(rad), -sin(rad), 0, 0, sin(rad), cos(rad), 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
 
     for (const auto& tileInfo : tileUBOs) {


### PR DESCRIPTION
Follow up to
- #3649 

I realized that init() calls initSurface(), which looks like this:

```cpp
void RendererBackend::initSurface() {
    getDefaultRenderable().getResource<SurfaceRenderableResource>().createPlatformSurface();
}
```

For offscreen rendering, we can't have references to the SurfaceRenderableResource, so the init() also has to be virtual, so that it can be overwritten for offscreen use.

Also the context.cpp, this PR puts all the surface rendering logic inside conditions.

The result of this is that finally, the Vulkan backend for Qt can [render correctly](https://github.com/maplibre/maplibre-native-qt/pull/216#issuecomment-3120775668), by injecting the Vulkan device from Qt into the MapLibre Native core