### PR TITLE
Fix Android backend cleanup

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/android_gl_renderer_backend.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/android_gl_renderer_backend.cpp
@@ -37,7 +37,13 @@ AndroidGLRendererBackend::AndroidGLRendererBackend()
     : gl::RendererBackend(gfx::ContextMode::Unique),
       mbgl::gfx::Renderable({64, 64}, std::make_unique<AndroidGLRenderableResource>(*this)) {}
 
-AndroidGLRendererBackend::~AndroidGLRendererBackend() = default;
+AndroidGLRendererBackend::~AndroidGLRendererBackend() {
+#ifndef NDEBUG
+    if (context && static_cast<gl::Context&>(*context).getCleanupOnDestruction()) {
+        assert(eglGetCurrentContext() != EGL_NO_CONTEXT);
+    }
+#endif
+}
 
 gl::ProcAddress AndroidGLRendererBackend::getExtensionFunctionPointer(const char* name) {
     assert(gfx::BackendScope::exists());

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -196,7 +196,11 @@ void MapRenderer::requestSnapshot(SnapshotCallback callback) {
 
 void MapRenderer::resetRenderer() {
     renderer.reset();
+#if MLN_RENDER_BACKEND_OPENGL
+    // GL requires the context managed by the java surface for cleanup
+    // Vulkan resources can be released on any thread (finalizer in this case)
     backend.reset();
+#endif
     swapBehaviorFlush = false;
 }
 

--- a/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/map_renderer.cpp
@@ -196,6 +196,7 @@ void MapRenderer::requestSnapshot(SnapshotCallback callback) {
 
 void MapRenderer::resetRenderer() {
     renderer.reset();
+    backend.reset();
     swapBehaviorFlush = false;
 }
 

--- a/platform/android/MapLibreAndroid/src/opengl/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreGLSurfaceView.java
+++ b/platform/android/MapLibreAndroid/src/opengl/java/org/maplibre/android/maps/renderer/surfaceview/MapLibreGLSurfaceView.java
@@ -272,9 +272,7 @@ public class MapLibreGLSurfaceView extends MapLibreSurfaceView {
 
     private void destroySurfaceImp() {
       if (mEglSurface != null && mEglSurface != EGL10.EGL_NO_SURFACE) {
-        mEgl.eglMakeCurrent(mEglDisplay, EGL10.EGL_NO_SURFACE,
-          EGL10.EGL_NO_SURFACE,
-          EGL10.EGL_NO_CONTEXT);
+        mEgl.eglMakeCurrent(mEglDisplay, EGL10.EGL_NO_SURFACE, EGL10.EGL_NO_SURFACE, mEglContext);
         MapLibreGLSurfaceView view = mGLSurfaceViewWeakRef.get();
         if (view != null) {
           view.eglWindowSurfaceFactory.destroySurface(mEgl, mEglDisplay, mEglSurface);
@@ -284,6 +282,13 @@ public class MapLibreGLSurfaceView extends MapLibreSurfaceView {
     }
 
     public void finish() {
+      if (mEglDisplay != null) {
+        mEgl.eglMakeCurrent(mEglDisplay,
+                EGL10.EGL_NO_SURFACE,
+                EGL10.EGL_NO_SURFACE,
+                EGL10.EGL_NO_CONTEXT);
+      }
+
       if (mEglContext != null) {
         MapLibreGLSurfaceView view = mGLSurfaceViewWeakRef.get();
         if (view != null) {


### PR DESCRIPTION
Currently the `AndroidGLRendererBackend` is deleted when the `MapRenderer` object is garbage collected. This forces OpenGL resource cleanup on the finalizer thread after the render thread and it's context are deleted. 
Fixed by explicitly deleting the backend before the rendering surface is destroyed.