### PR TITLE
Release Node v6.2.0-pre.0

### DIFF
--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## main
 
-## 6.1.1-pre.0
-* Fix freezing in macos/metal after ~32 renders ([#2948](https://github.com/maplibre/maplibre-native/pull/2948))
+## 6.2.0-pre.0
+* Fix freezing in macos/metal after ~32 renders ([Issue](https://github.com/maplibre/maplibre-native/issues/2928), [PR](https://github.com/maplibre/maplibre-native/pull/3673)).
+* Add HarfBuzz Text Shaping and Font Fallback Support ([#3611](https://github.com/maplibre/maplibre-native/pull/3611)).
+  This implements the [`font-faces` property of the MapLibre Style Spec](https://maplibre.org/maplibre-style-spec/font-faces/).
 
 ## 6.1.0
 * Add `textFitWidth` and `textFitHeight` properties to sprites ([#2780](https://github.com/maplibre/maplibre-native/pull/2780)).

--- a/platform/node/package-lock.json
+++ b/platform/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "6.1.1-pre.0",
+  "version": "6.2.0-pre.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "6.1.1-pre.0",
+      "version": "6.2.0-pre.0",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/platform/node/package.json
+++ b/platform/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "6.1.1-pre.0",
+  "version": "6.2.0-pre.0",
   "description": "Renders map tiles with MapLibre Native",
   "keywords": [
     "maplibre",


### PR DESCRIPTION
Add a pre-release that includes https://github.com/maplibre/maplibre-native/pull/3611 so it can be tested in the node version before a regular release can be made.