### PR TITLE
Improve Core Builds for Linux

### DIFF
--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -78,8 +78,8 @@ jobs:
 
       - name: Build mbgl-core for Linux
         run: |
-          cmake --preset linux-${{ matrix.renderer }}-core -DCMAKE_CXX_COMPILER_LAUNCHER=""
-          cmake --build --preset linux-${{ matrix.renderer }}-core
+          cmake --preset linux-${{ matrix.renderer }} -DCMAKE_CXX_COMPILER_LAUNCHER=""
+          cmake --build build-linux-${{ matrix.renderer }} --target mbgl-core
 
       - name: Rename artifact
         run: |

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -103,7 +103,7 @@ jobs:
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
 
-      - name: Build MapLibre Native Core
+      - name: Build MapLibre Native
         env:
           CI: 1
         run: |
@@ -118,12 +118,12 @@ jobs:
             export SCCACHE_S3_NO_CREDENTIALS=1
           fi
 
-          cmake -B build -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMLN_WITH_CLANG_TIDY=ON \
+          cmake --preset linux-${{ matrix.renderer }} \
+            -DMLN_WITH_CLANG_TIDY=ON \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
-            -DMLN_WITH_COVERAGE=ON \
-            ${{ env.renderer_flag_cmake }}
-          cmake --build build --target mbgl-core mbgl-test-runner mbgl-render-test-runner mbgl-expression-test mbgl-render mbgl-benchmark-runner
+            -DMLN_WITH_COVERAGE=ON
+          cmake --build build-linux-${{ matrix.renderer }} --target mbgl-core mbgl-test-runner mbgl-render-test-runner mbgl-expression-test mbgl-render mbgl-benchmark-runner
 
       # mbgl-render (used for size test) & mbgl-benchmark-runner
 
@@ -136,7 +136,7 @@ jobs:
         with:
           name: mbgl-render
           path: |
-            build/bin/mbgl-render
+            build-linux-${{ matrix.renderer }}/bin/mbgl-render
 
       - name: Upload mbgl-benchmark-runner as artifact
         if: matrix.renderer == 'drawable' && github.event_name == 'pull_request'
@@ -144,13 +144,13 @@ jobs:
         with:
           name: mbgl-benchmark-runner
           path: |
-            build/mbgl-benchmark-runner
+            build-linux-${{ matrix.renderer }}/mbgl-benchmark-runner
 
       - name: Upload mbgl-render & mbgl-benchmark-runner to S3
         if: matrix.renderer == 'drawable' && github.ref == 'refs/heads/main' && vars.OIDC_AWS_ROLE_TO_ASSUME
         run: |
-          aws s3 cp build/bin/mbgl-render s3://maplibre-native/mbgl-render-main
-          aws s3 cp build/mbgl-benchmark-runner s3://maplibre-native/mbgl-benchmark-runner-main
+          aws s3 cp build-linux-${{ matrix.renderer }}/bin/mbgl-render s3://maplibre-native/mbgl-render-main
+          aws s3 cp build-linux-${{ matrix.renderer }}/mbgl-benchmark-runner s3://maplibre-native/mbgl-benchmark-runner-main
 
       # CodeQL
 
@@ -161,15 +161,15 @@ jobs:
 
       # unit tests
 
-      - run: chmod +x build/mbgl-test-runner
+      - run: chmod +x build-linux-${{ matrix.renderer }}/mbgl-test-runner
 
       - name: Run C++ tests
         continue-on-error: ${{ matrix.renderer == 'vulkan' }}
-        run: xvfb-run -a build/mbgl-test-runner
+        run: xvfb-run -a build-linux-${{ matrix.renderer }}/mbgl-test-runner
 
       # render tests
 
-      - run: chmod +x build/mbgl-render-test-runner
+      - run: chmod +x build-linux-${{ matrix.renderer }}/mbgl-render-test-runner
 
       - name: Run render test
         id: render_test
@@ -178,7 +178,7 @@ jobs:
           if [[ "$renderer" == *-rust ]]; then
             renderer=${renderer%-rust}
           fi
-          xvfb-run -a build/mbgl-render-test-runner --manifestPath=metrics/linux-"$renderer".json
+          xvfb-run -a build-linux-${{ matrix.renderer }}/mbgl-render-test-runner --manifestPath=metrics/linux-"$renderer".json
 
       - name: Upload render test result
         if: always() && steps.render_test.outcome == 'failure'
@@ -190,10 +190,10 @@ jobs:
 
       # expression tests
 
-      - run: chmod +x build/expression-test/mbgl-expression-test
+      - run: chmod +x build-linux-${{ matrix.renderer }}/expression-test/mbgl-expression-test
 
       - name: Run expression test
-        run: build/expression-test/mbgl-expression-test
+        run: build-linux-${{ matrix.renderer }}/expression-test/mbgl-expression-test
 
       - if: github.event_name == 'pull_request'
         uses: ./.github/actions/save-pr-number

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -107,14 +107,6 @@
       }
     },
     {
-      "name": "linux-opengl-core",
-      "inherits": "linux-opengl",
-      "cacheVariables": {
-        "MLN_CORE_INCLUDE_DEPS": "ON",
-        "MLN_USE_BUILTIN_ICU": "OFF"
-      }
-    },
-    {
       "name": "linux-vulkan",
       "binaryDir": "${sourceDir}/build-linux-vulkan",
       "inherits": "linux",
@@ -122,14 +114,6 @@
         "MLN_WITH_VULKAN": "ON",
         "MLN_WITH_WAYLAND": "OFF",
         "MLN_WITH_X11": "ON"
-      }
-    },
-    {
-      "name": "linux-vulkan-core",
-      "inherits": "linux-vulkan",
-      "cacheVariables": {
-        "MLN_CORE_INCLUDE_DEPS": "ON",
-        "MLN_USE_BUILTIN_ICU": "OFF"
       }
     },
     {

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -175,41 +175,40 @@ target_link_libraries(
         ${WEBP_LIBRARIES}
         $<$<NOT:$<BOOL:${MLN_USE_BUILTIN_ICU}>>:${ICUUC_LIBRARIES}>
         $<$<NOT:$<BOOL:${MLN_USE_BUILTIN_ICU}>>:${ICUI18N_LIBRARIES}>
-        $<$<BOOL:${MLN_USE_BUILTIN_ICU}>:$<IF:$<BOOL:${MLN_CORE_INCLUDE_DEPS}>,$<TARGET_OBJECTS:mbgl-vendor-icu>,mbgl-vendor-icu>>
+        $<$<BOOL:${MLN_USE_BUILTIN_ICU}>:mbgl-vendor-icu>
         PNG::PNG
         mbgl-vendor-nunicode
         mbgl-vendor-sqlite
 )
 
 # Bundle system provided libraries
-if(MLN_CORE_INCLUDE_DEPS AND NOT MLN_USE_BUILTIN_ICU AND NOT "${ARMERGE}" STREQUAL "ARMERGE-NOTFOUND")
+if(NOT MLN_USE_BUILTIN_ICU AND NOT "${ARMERGE}" STREQUAL "ARMERGE-NOTFOUND")
     message(STATUS "Found armerge: ${ARMERGE}")
     include(${CMAKE_CURRENT_LIST_DIR}/cmake/find_static_library.cmake)
-    find_static_library(PNG_STATIC_LIB NAMES png)
-    find_static_library(ZLIB_STATIC_LIB NAMES z)
-    find_static_library(JPEG_STATIC_LIB NAMES jpeg)
-    find_static_library(WEBP_STATIC_LIB NAMES webp)
-    find_static_library(CURL_STATIC_LIB NAMES curl)
-    find_static_library(UV_STATIC_LIB NAMES uv)
-    find_static_library(OPENSSL_STATIC_LIB NAMES ssl)
-    find_static_library(SQLITE_STATIC_LIB NAMES sqlite3)
+    set(STATIC_LIBS "")
+
+    find_static_library(STATIC_LIBS NAMES png)
+    find_static_library(STATIC_LIBS NAMES z)
+    find_static_library(STATIC_LIBS NAMES jpeg)
+    find_static_library(STATIC_LIBS NAMES webp)
+    find_static_library(STATIC_LIBS NAMES curl)
+    find_static_library(STATIC_LIBS NAMES uv)
+    find_static_library(STATIC_LIBS NAMES ssl)
+    find_static_library(STATIC_LIBS NAMES crypto)
+    find_static_library(STATIC_LIBS NAMES sqlite3)
 
     add_custom_command(
         TARGET mbgl-core
         POST_BUILD
         COMMAND armerge --keep-symbols '.*' --output libmbgl-core-amalgam.a
             $<TARGET_FILE:mbgl-core>
+            $<TARGET_FILE:freetype>
+            $<TARGET_FILE:mbgl-vendor-csscolorparser>
+            $<TARGET_FILE:harfbuzz>
             ${ICUUC_LIBRARY_DIRS}/libicuuc.a
             ${ICUUC_LIBRARY_DIRS}/libicudata.a
             ${ICUI18N_LIBRARY_DIRS}/libicui18n.a
-            ${PNG_STATIC_LIB}
-            ${ZLIB_STATIC_LIB}
-            ${JPEG_STATIC_LIB}
-            ${WEBP_STATIC_LIB}
-            ${CURL_STATIC_LIB}
-            ${UV_STATIC_LIB}
-            ${OPENSSL_STATIC_LIB}
-            ${SQLITE_STATIC_LIB}
+            ${STATIC_LIBS}
     )
 endif()
 


### PR DESCRIPTION
- Include freetype, harfbuzz, color parser and crypto in amalgamation.
- Change `find_static_library` function to extend a list to avoid repetition.
- Remove core CMake presets, always build amalgamation if armerge is installed.
