### PR TITLE
Update PMTiles documentation with caching and offline limitations

### DIFF
--- a/platform/android/docs/data/PMTiles.md
+++ b/platform/android/docs/data/PMTiles.md
@@ -2,6 +2,8 @@
 
 Starting MapLibre Android 11.7.0, using [PMTiles](https://docs.protomaps.com/pmtiles/) as a data source is supported. You can prefix your vector tile source with `pmtiles://` to load a PMTiles file. The rest of the URL continue with be `https://` to load a remote PMTiles file, `asset://` to load an asset or `file://` to load a local PMTiles file.
 
+> Note: PMTiles sources currently do not support caching or offline pack downloads.
+
 Oliver Wipfli has made a style available that combines a [Protomaps]() basemap togehter with Foursquare's POI dataset. It is available in the [wipfli/foursquare-os-places-pmtiles](https://github.com/wipfli/foursquare-os-places-pmtiles) repository on GitHub. The style to use is
 
 ```

--- a/platform/ios/MapLibre.docc/PMTiles.md
+++ b/platform/ios/MapLibre.docc/PMTiles.md
@@ -4,6 +4,8 @@ Working with PMTiles
 
 Starting MapLibre iOS 6.10.0, using [PMTiles](https://docs.protomaps.com/pmtiles/) as a data source is supported. You can prefix your vector tile source with `pmtiles://` to load a PMTiles file. The rest of the URL continue with be `https://` to load a remote PMTiles file, `asset://` to load an asset or `file://` to load a local PMTiles file.
 
+> Note: PMTiles sources currently do not support caching or offline pack downloads.
+
 Oliver Wipfli has made a style available that combines a [Protomaps]() basemap togehter with Foursquare's POI dataset. It is available in the [wipfli/foursquare-os-places-pmtiles](https://github.com/wipfli/foursquare-os-places-pmtiles) repository on GitHub. The style to use is
 
 ```


### PR DESCRIPTION
As mentioned in #3690, this updates the PMTiles documentation to note the limitations with caching and offline pack downloads.