### PR TITLE
[cmake] Declare renderer backend as public

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -991,8 +991,8 @@ if(MLN_WITH_OPENGL)
     message(STATUS "Configuring GL-Native with OpenGL renderer backend")
     target_compile_definitions(
         mbgl-core
-        PRIVATE MLN_RENDER_BACKEND_OPENGL=1
         PUBLIC
+            MLN_RENDER_BACKEND_OPENGL=1
             "MLN_USE_UNORDERED_DENSE=$<BOOL:${MLN_USE_UNORDERED_DENSE}>"
     )
     list(APPEND
@@ -1136,8 +1136,8 @@ if(MLN_WITH_METAL)
     message(STATUS "Configuring Metal renderer backend")
     target_compile_definitions(
         mbgl-core
-        PRIVATE MLN_RENDER_BACKEND_METAL=1
         PUBLIC
+            MLN_RENDER_BACKEND_METAL=1
             "MLN_USE_UNORDERED_DENSE=$<BOOL:${MLN_USE_UNORDERED_DENSE}>"
     )
     list(APPEND
@@ -1235,7 +1235,7 @@ if(MLN_WITH_VULKAN)
 
     target_compile_definitions(
         mbgl-core
-        PRIVATE
+        PUBLIC
             MLN_RENDER_BACKEND_VULKAN=1
     )
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -61,7 +61,3 @@ target_link_libraries(
 )
 
 set_property(TARGET mbgl-benchmark PROPERTY FOLDER MapLibre)
-
-if(MLN_WITH_OPENGL)
-    target_compile_definitions(mbgl-benchmark PRIVATE "MLN_RENDER_BACKEND_OPENGL=1")
-endif()

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -56,7 +56,3 @@ install(TARGETS mbgl-offline mbgl-render RUNTIME DESTINATION bin)
 # ${PROJECT_SOURCE_DIR} )
 #
 # add_test(NAME mbgl-render-tool-test COMMAND mbgl-render WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} )
-
-if(MLN_WITH_OPENGL)
-    target_compile_definitions(mbgl-render PRIVATE "MLN_RENDER_BACKEND_OPENGL=1")
-endif()

--- a/platform/android/MapLibreAndroid/src/cpp/CMakeLists.txt
+++ b/platform/android/MapLibreAndroid/src/cpp/CMakeLists.txt
@@ -205,10 +205,6 @@ if(MLN_WITH_OPENGL)
             ${PROJECT_SOURCE_DIR}/android_gl_renderer_backend.cpp
             ${PROJECT_SOURCE_DIR}/android_gl_renderer_backend.hpp
     )
-    target_compile_definitions(
-        maplibre
-            PRIVATE MLN_RENDER_BACKEND_OPENGL=1
-    )
 endif()
 
 if(MLN_WITH_VULKAN)
@@ -216,10 +212,6 @@ if(MLN_WITH_VULKAN)
         maplibre PRIVATE
             ${PROJECT_SOURCE_DIR}/android_vulkan_renderer_backend.cpp
             ${PROJECT_SOURCE_DIR}/android_vulkan_renderer_backend.hpp
-    )
-    target_compile_definitions(
-        maplibre
-            PRIVATE MLN_RENDER_BACKEND_VULKAN=1
     )
 endif()
 

--- a/platform/darwin/darwin.cmake
+++ b/platform/darwin/darwin.cmake
@@ -172,13 +172,6 @@ target_link_libraries(
     PRIVATE mbgl-compiler-options mbgl-core
 )
 
-if(MLN_WITH_METAL)
-    target_compile_definitions(
-        custom-layer-examples
-        PRIVATE MLN_RENDER_BACKEND_METAL=1
-    )
-endif()
-
 target_include_directories(
     custom-layer-examples
     PUBLIC

--- a/platform/glfw/CMakeLists.txt
+++ b/platform/glfw/CMakeLists.txt
@@ -37,10 +37,6 @@ if(MLN_WITH_OPENGL)
         mbgl-glfw
         PRIVATE ${PROJECT_SOURCE_DIR}/platform/glfw/glfw_gl_backend.cpp
     )
-    target_compile_definitions(
-        mbgl-glfw
-        PRIVATE MLN_RENDER_BACKEND_OPENGL=1
-    )
 endif()
 
 if(MLN_WITH_EGL)
@@ -55,11 +51,6 @@ if(MLN_WITH_VULKAN)
         mbgl-glfw
         PRIVATE ${PROJECT_SOURCE_DIR}/platform/glfw/glfw_vulkan_backend.cpp
     )
-
-    target_compile_definitions(
-        mbgl-glfw
-        PRIVATE MLN_RENDER_BACKEND_VULKAN=1
-    )
 endif()
 
 if(MLN_WITH_METAL)
@@ -70,10 +61,6 @@ if(MLN_WITH_METAL)
         ${PROJECT_SOURCE_DIR}/platform/glfw/metal_backend.mm
         ${PROJECT_SOURCE_DIR}/platform/glfw/glfw_metal_backend.h
         ${PROJECT_SOURCE_DIR}/platform/glfw/metal_backend.h
-    )
-    target_compile_definitions(
-        mbgl-glfw
-        PRIVATE MLN_RENDER_BACKEND_METAL=1
     )
     target_link_libraries(
         mbgl-glfw

--- a/platform/ios/ios.cmake
+++ b/platform/ios/ios.cmake
@@ -90,10 +90,6 @@ set_target_properties(ios-sdk-static PROPERTIES
 
 if(MLN_WITH_METAL)
     message(STATUS "Configuring Metal renderer backend")
-    target_compile_definitions(
-        ios-sdk-static
-        PRIVATE MLN_RENDER_BACKEND_METAL=1
-    )
 endif()
 
 target_include_directories(

--- a/render-test/CMakeLists.txt
+++ b/render-test/CMakeLists.txt
@@ -65,7 +65,3 @@ target_link_libraries(
 )
 
 set_property(TARGET mbgl-render-test PROPERTY FOLDER MapLibre)
-
-if(MLN_WITH_OPENGL)
-    target_compile_definitions(mbgl-render-test PRIVATE "MLN_RENDER_BACKEND_OPENGL=1")
-endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -148,10 +148,6 @@ if(MLN_WITH_OPENGL)
             ${PROJECT_SOURCE_DIR}/test/renderer/backend_scope.test.cpp
             ${PROJECT_SOURCE_DIR}/test/util/offscreen_texture.test.cpp
     )
-    target_compile_definitions(
-        mbgl-test
-        PRIVATE MLN_RENDER_BACKEND_OPENGL=1
-    )
 endif()
 
 
@@ -163,17 +159,6 @@ if(MLN_WITH_VULKAN)
             ${PROJECT_SOURCE_DIR}/test/api/custom_drawable_layer.test.cpp
             ${PROJECT_SOURCE_DIR}/test/renderer/backend_scope.test.cpp
             ${PROJECT_SOURCE_DIR}/test/util/offscreen_texture.test.cpp
-    )
-    target_compile_definitions(
-        mbgl-test
-        PRIVATE MLN_RENDER_BACKEND_VULKAN=1
-    )
-endif()
-
-if(MLN_WITH_METAL)
-    target_compile_definitions(
-        mbgl-test
-        PRIVATE MLN_RENDER_BACKEND_METAL=1
     )
 endif()
 


### PR DESCRIPTION
Declare renderer backend as public so clients don't have to do it again. Probably some includes/link libraries can also be added as public, but maybe this will come later.