### PR TITLE
Release Node v6.2.0

### DIFF
--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## main
 
-## 6.2.0-pre.0
+## 6.2.0
 * Fix freezing in macos/metal after ~32 renders ([Issue](https://github.com/maplibre/maplibre-native/issues/2928), [PR](https://github.com/maplibre/maplibre-native/pull/3673)).
 * Add HarfBuzz Text Shaping and Font Fallback Support ([#3611](https://github.com/maplibre/maplibre-native/pull/3611)).
   This implements the [`font-faces` property of the MapLibre Style Spec](https://maplibre.org/maplibre-style-spec/font-faces/).

--- a/platform/node/package-lock.json
+++ b/platform/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "6.2.0-pre.0",
+  "version": "6.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-native",
-      "version": "6.2.0-pre.0",
+      "version": "6.2.0",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/platform/node/package.json
+++ b/platform/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-native",
-  "version": "6.2.0-pre.0",
+  "version": "6.2.0",
   "description": "Renders map tiles with MapLibre Native",
   "keywords": [
     "maplibre",


### PR DESCRIPTION
This PR Releases Node v6.2.0. I have tested the pre-release in Windows, Linux, and MacOS and it seems to work properly in all of them.

The only thing I have to note is when using the package on macos I did have to install harfbuzz with brew. I didn't seem to need to add anything extra in linux or windows.