### PR TITLE
Backport to android-10.x.x: Compile for Android with support for 16 KB page sizes

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/cpp/CMakeLists.txt
+++ b/platform/android/MapboxGLAndroidSDK/src/cpp/CMakeLists.txt
@@ -216,4 +216,7 @@ target_link_libraries(mapbox-gl
                               mbgl-core
                               mbgl-vendor-unique_resource)
 
+target_link_options(mapbox-gl
+                    PRIVATE "-Wl,-z,max-page-size=16384")
+
 install(TARGETS mapbox-gl LIBRARY DESTINATION lib)


### PR DESCRIPTION
Equivalent to #2852, but for NDK 25 (see https://developer.android.com/guide/practices/page-sizes#cmake).