### PR TITLE
Save a bit more space in Android CI by getting rid of swap storage

### DIFF
--- a/.github/actions/setup-android-ci/action.yml
+++ b/.github/actions/setup-android-ci/action.yml
@@ -13,7 +13,7 @@ runs:
         haskell: true
         large-packages: true
         docker-images: true
-        swap-storage: false
+        swap-storage: true
 
     - name: Validate VERSION
       run: .github/scripts/validate-version.sh platform/android/VERSION


### PR DESCRIPTION
Running out of [storage](https://github.com/maplibre/maplibre-native/actions/runs/17053548076/job/48346869345?pr=3246A) again.

