### PR TITLE
Use `ctcache` to cache `clang-tidy` results

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -128,6 +128,9 @@ jobs:
           if [ -n "${{ secrets.CTCACHE_AUTH_KEY }}" ]; then
             echo "setting CTCACHE_AUTH_KEY" 
             export CTCACHE_AUTH_KEY=${{ secrets.CTCACHE_AUTH_KEY }}
+          else
+            # do not write to cache if CTCACHE_AUTH_KEY not set
+            export CTCACHE_HOST_READ_ONLY=1
           fi
 
           cmake --preset linux-${{ matrix.variant.renderer }} \

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -91,9 +91,9 @@ jobs:
 
       - name: Install ctcache
         run: |
-          git clone https://github.com/matus-chochlik/ctcache.git
+          # pending open PR https://github.com/matus-chochlik/ctcache/pull/94
+          git clone https://github.com/louwers/ctcache.git
           cd ctcache
-          git checkout b54f74807fc02c8897247fda6229aabbac78a560
           cd ..
           mv ctcache /usr/local/bin
 
@@ -124,6 +124,11 @@ jobs:
           export CTCACHE_HOST=34.229.50.221
           export CTCACHE_PORT=5000
           export CTCACHE_PROTO=http
+
+          if [ -n "${{ secrets.CTCACHE_AUTH_KEY }}" ]; then
+            echo "setting CTCACHE_AUTH_KEY" 
+            export CTCACHE_AUTH_KEY=${{ secrets.CTCACHE_AUTH_KEY }}
+          fi
 
           cmake --preset linux-${{ matrix.variant.renderer }} \
             -DMLN_WITH_CLANG_TIDY=ON \

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -89,6 +89,14 @@ jobs:
           sudo chmod +x /usr/bin/sccache
           rm -rf sccache-v0.10.0-x86_64-unknown-linux-musl
 
+      - name: Install ctcache
+        run: |
+          git clone https://github.com/matus-chochlik/ctcache.git
+          cd ctcache
+          git checkout b54f74807fc02c8897247fda6229aabbac78a560
+          cd ..
+          mv ctcache /usr/local/bin
+
       - name: Configure AWS Credentials
         if: vars.OIDC_AWS_ROLE_TO_ASSUME
         uses: aws-actions/configure-aws-credentials@v4
@@ -112,8 +120,14 @@ jobs:
             export SCCACHE_S3_NO_CREDENTIALS=1
           fi
 
+          # ctcache configuration
+          export CTCACHE_HOST=34.229.50.221
+          export CTCACHE_PORT=5000
+          export CTCACHE_PROTO=http
+
           cmake --preset linux-${{ matrix.variant.renderer }} \
             -DMLN_WITH_CLANG_TIDY=ON \
+            -DCLANG_TIDY_COMMAND=/usr/local/bin/ctcache/clang-tidy \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
             -DMLN_WITH_COVERAGE=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,19 +30,6 @@ endif()
 
 include(cmake/clang-tidy.cmake)
 
-if (MLN_WITH_CLANG_TIDY)
-    find_program(CLANG_TIDY_COMMAND NAMES clang-tidy)
-    if(NOT CLANG_TIDY_COMMAND)
-        message(FATAL_ERROR "ENABLE_CLANG_TIDY is ON but clang-tidy is not found!")
-    else()
-        message(STATUS "Found clang-tidy at ${CLANG_TIDY_COMMAND}")
-    endif()
-    # TODO: there are options which are only available on GCC(e.g. -Werror=maybe-uninitialized),
-    # that's why we need to disable this `unknown-warning-option` here.
-    # We could check if current compiler supports particular flag before enabling it.
-    set(CLANG_TIDY_COMMAND "${CLANG_TIDY_COMMAND};--extra-arg=-Wno-unknown-warning-option;--extra-arg=-Wno-pragmas")
-endif()
-
 if (MLN_WITH_QT AND NOT CMAKE_OSX_DEPLOYMENT_TARGET)
     set(CMAKE_OSX_DEPLOYMENT_TARGET 13.0)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ if (MLN_DRAWABLE_RENDERER)
     message(FATAL "Do not pass MLN_DRAWABLE_RENDERER, the drawable renderer is now the default")
 endif()
 
+include(cmake/clang-tidy.cmake)
+
 if (MLN_WITH_CLANG_TIDY)
     find_program(CLANG_TIDY_COMMAND NAMES clang-tidy)
     if(NOT CLANG_TIDY_COMMAND)

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -1,0 +1,17 @@
+if (MLN_WITH_CLANG_TIDY OR MLN_CLANG_TIDY_COMMAND)
+    if(MLN_CLANG_TIDY_COMMAND)
+        set(CLANG_TIDY_COMMAND MLN_CLANG_TIDY_COMMAND)
+        message(STATUS "Using clang-tidy at ${CLANG_TIDY_COMMAND}")
+    else()
+        find_program(CLANG_TIDY_COMMAND NAMES clang-tidy)
+        if(NOT CLANG_TIDY_COMMAND)
+            message(FATAL_ERROR "ENABLE_CLANG_TIDY is ON but clang-tidy is not found!")
+        else()
+            message(STATUS "Found clang-tidy at ${CLANG_TIDY_COMMAND}")
+        endif()
+    endif()
+    # TODO: there are options which are only available on GCC(e.g. -Werror=maybe-uninitialized),
+    # that's why we need to disable this `unknown-warning-option` here.
+    # We could check if current compiler supports particular flag before enabling it.
+    set(CLANG_TIDY_COMMAND "${CLANG_TIDY_COMMAND};--extra-arg=-Wno-unknown-warning-option;--extra-arg=-Wno-pragmas")
+endif()


### PR DESCRIPTION
This PR integrates a cache for clang-tidy results. clang-tidy is a major slowdown for the linux-ci workflow, a compiler cache does not speed things up at all. From my testing:

> 42 minutes 18 seconds with sccache (compiler cache, 100% hit rate).
> 2 minutes 50 seconds with sccache + ctcache :sparkles:

For future reference here is how the server is set up:

```
python -m venv venv
source venv/bin/activate
git clone https://github.com/matus-chochlik/ctcache.git
cd ctcache
pip install -r requirements.txt
CTCACHE_WEBROOT=$PWD python src/ctcache/clang_tidy_cache_server.py --auth-key-writes=<secret key>
```

The secret key is set as `CTCACHE_AUTH_KEY` in the repo and is used when building from this repo where that secret is available. ctcache did not have any authentication so I contributed this as a [PR](https://github.com/matus-chochlik/ctcache/pull/94), I hope it is accepted in some form. I will update the workflow when this change has been upstreamed.