### PR TITLE
Use sccache with S3 backend for Android CI

### DIFF
--- a/.github/actions/install-sccache/action.yml
+++ b/.github/actions/install-sccache/action.yml
@@ -9,5 +9,5 @@ runs:
       tar -xzf sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz
       sudo mv sccache-v0.10.0-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
       sudo chmod +x /usr/bin/sccache
-      rm -rf sccache-v0.10.0-x86_64-unknown-linux-musl
+      rm -rf sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz
     shell: bash

--- a/.github/actions/install-sccache/action.yml
+++ b/.github/actions/install-sccache/action.yml
@@ -1,0 +1,13 @@
+name: install-sccache
+description: "Install sccache"
+runs:
+  using: "composite"
+  steps:
+  - name: Install sccache
+    run: |
+      curl -LO https://github.com/mozilla/sccache/releases/download/v0.10.0/sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz
+      tar -xzf sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz
+      sudo mv sccache-v0.10.0-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
+      sudo chmod +x /usr/bin/sccache
+      rm -rf sccache-v0.10.0-x86_64-unknown-linux-musl
+    shell: bash

--- a/.github/actions/install-sccache/action.yml
+++ b/.github/actions/install-sccache/action.yml
@@ -9,5 +9,5 @@ runs:
       tar -xzf sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz
       sudo mv sccache-v0.10.0-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
       sudo chmod +x /usr/bin/sccache
-      rm -rf sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz
+      rm -rf sccache-v0.10.0-x86_64-unknown-linux-musl*
     shell: bash

--- a/.github/actions/setup-android-ci/action.yml
+++ b/.github/actions/setup-android-ci/action.yml
@@ -28,48 +28,6 @@ runs:
         distribution: "temurin"
         java-version: "17"
 
-    - uses: actions/setup-node@v4
-      with:
-        node-version-file: ".nvmrc"
-
-    - name: npm install
-      run: npm install --ignore-scripts
-      working-directory: .
-      shell: bash
-
-    - name: run platform/android/scripts/generate-style-code.mjs
-      run: node platform/android/scripts/generate-style-code.mjs
-      working-directory: .
-      shell: bash
-
-    - run: |
-        python3 -m venv venv
-        source venv/bin/activate
-        pip3 install pre-commit
-      shell: bash
-
-    - run: |
-        source venv/bin/activate
-        pre-commit run clang-format --all-files
-      continue-on-error: true # this can mean files are modified, which is not an error
-      shell: bash
-
-    - run: |
-        source venv/bin/activate
-        pre-commit run clang-format --all-files
-        rm -rf venv
-      shell: bash
-
-    - uses: infotroph/tree-is-clean@v1
-      with:
-        check_untracked: true
-
-    - uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: ${{ github.job }}
-        append-timestamp: false
-        max-size: 5G
-
     - name: restore-gradle-cache
       uses: actions/cache@v4
       env:
@@ -79,3 +37,5 @@ runs:
         key: ${{ env.cache-name }}-${{ hashFiles('platform/android/buildSrc/src/main/kotlin/maplibre.dependencies.gradle.kts') }}-${{ hashFiles('platform/android/build.gradle.kts') }}-${{ hashFiles('platform/android/local.properties') }}-${{ hashFiles('platform/android/gradle/wrapper/gradle-wrapper.properties') }}
         restore-keys: |
           - ${{ env.cache-name }}
+
+    - uses: ./.github/actions/install-sccache

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -61,6 +61,42 @@ jobs:
 
       - uses: ./.github/actions/setup-android-ci
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: npm install
+        run: npm install --ignore-scripts
+        working-directory: .
+        shell: bash
+
+      - name: run platform/android/scripts/generate-style-code.mjs
+        run: node platform/android/scripts/generate-style-code.mjs
+        working-directory: .
+        shell: bash
+
+      - run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip3 install pre-commit
+        shell: bash
+
+      - run: |
+          source venv/bin/activate
+          pre-commit run clang-format --all-files
+        continue-on-error: true # this can mean files are modified, which is not an error
+        shell: bash
+
+      - run: |
+          source venv/bin/activate
+          pre-commit run clang-format --all-files
+          rm -rf venv
+        shell: bash
+
+      - uses: infotroph/tree-is-clean@v1
+        with:
+          check_untracked: true
+
       - name: Configure AWS Credentials
         if: vars.OIDC_AWS_ROLE_TO_ASSUME
         uses: aws-actions/configure-aws-credentials@v4
@@ -68,8 +104,6 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
-
-      - uses: ./.github/actions/install-sccache
 
       - name: Configure sccache
         run: |
@@ -80,11 +114,6 @@ jobs:
             echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
             echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
           fi
-
-      - name: Sanity check
-        run: |
-          echo "$SCCACHE_BUCKET"
-          echo "$SCCACHE_REGION"
 
       - name: Check code style
         if: matrix.renderer == 'opengl'
@@ -116,7 +145,7 @@ jobs:
 
       - name: Build Benchmark, copy to platform/android
         run: |
-          ./gradlew assemble${{ matrix.renderer }}Release assemble${{ matrix.renderer }}ReleaseAndroidTest -PtestBuildType=release
+          ./gradlew assemble${{ matrix.renderer }}Release assemble${{ matrix.renderer }}ReleaseAndroidTest -PtestBuildType=release -Pmaplibre.abis=arm64-v8a
           cp MapLibreAndroidTestApp/build/outputs/apk/${{ matrix.renderer }}/release/MapLibreAndroidTestApp-${{ matrix.renderer }}-release.apk .
           cp MapLibreAndroidTestApp/build/outputs/apk/androidTest/${{ matrix.renderer }}/release/MapLibreAndroidTestApp-${{ matrix.renderer }}-release-androidTest.apk .
 
@@ -150,7 +179,7 @@ jobs:
 
       - name: Build Instrumentation Tests (${{ matrix.renderer }}), copy to platform/android
         run: |
-          ./gradlew assemble${{ matrix.renderer }}Debug assemble${{ matrix.renderer }}DebugAndroidTest -PtestBuildType=debug
+          ./gradlew assemble${{ matrix.renderer }}Debug assemble${{ matrix.renderer }}DebugAndroidTest -PtestBuildType=debug -Pmaplibre.abis=arm64-v8a
           cp MapLibreAndroidTestApp/build/outputs/apk/${{ matrix.renderer }}/debug/MapLibreAndroidTestApp-${{ matrix.renderer }}-debug.apk InstrumentationTestApp${{ env.renderer }}.apk
           cp MapLibreAndroidTestApp/build/outputs/apk/androidTest/${{ matrix.renderer }}/debug/MapLibreAndroidTestApp-${{ matrix.renderer }}-debug-androidTest.apk InstrumentationTests${{ env.renderer }}.apk
 
@@ -178,41 +207,38 @@ jobs:
         working-directory: test/android
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        if: startsWith(runner.name, 'GitHub Actions')
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: false
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: false
-
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "17"
-
-      - uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ github.job }}
-          append-timestamp: false
-          max-size: 5G
+      - uses: ./.github/actions/setup-android-ci
 
       - name: Create data.zip in assets directory
         run: zip -r test/android/app/src/main/assets/data.zip -@ < test/android/app/src/main/assets/to_zip.txt
         working-directory: .
 
+      - name: Configure AWS Credentials
+        if: vars.OIDC_AWS_ROLE_TO_ASSUME
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
+      - name: Configure sccache
+        run: |
+          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
+          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
+
+          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
+            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
+          fi
+
       - name: Build C++ Unit Tests App
         run: |
-          ./gradlew assembleDebug assembleAndroidTest
+          ./gradlew assembleDebug assembleAndroidTest -Pmaplibre.abis=arm64-v8a
           cp app/build/outputs/apk/debug/app-debug.apk .
           cp app/build/outputs/apk/androidTest/release/app-release-androidTest.apk .
 
@@ -239,33 +265,30 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        if: startsWith(runner.name, 'GitHub Actions')
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: false
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: false
-
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ github.job }}
-          append-timestamp: false
-          max-size: 5G
+      - uses: ./.github/actions/setup-android-ci
 
-      - uses: actions/setup-java@v4
+      - name: Configure AWS Credentials
+        if: vars.OIDC_AWS_ROLE_TO_ASSUME
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          distribution: "temurin"
-          java-version: "17"
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
+      - name: Configure sccache
+        run: |
+          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
+          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
+
+          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
+            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
+          fi
 
       - name: Build and Upload Render Test APKs (${{ matrix.flavor }})
         uses: ./.github/actions/android-build-and-upload-render-test

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -73,16 +73,18 @@ jobs:
 
       - name: Configure sccache
         run: |
-          echo SCCACHE_BUCKET=maplibre-native-sccache > "$GITHUB_ENV"
-          echo SCCACHE_REGION=eu-central-1 > "$GITHUB_ENV"
+          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
+          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
 
           if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
             echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
-            echo SCCACHE_S3_NO_CREDENTIALS=1 > "$GITHUB_ENV"
+            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
           fi
 
       - name: Sanity check
-        run: echo "$SCCACHE_REGION"
+        run: |
+          echo "$SCCACHE_BUCKET"
+          echo "$SCCACHE_REGION"
 
       - name: Check code style
         if: matrix.renderer == 'opengl'

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,5 +1,8 @@
 name: android-ci
 
+permissions:
+  id-token: write         # needed for AWS
+
 on:
   push:
     branches:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -161,6 +161,9 @@ jobs:
             platform/android/InstrumentationTestApp${{ env.renderer }}.apk
             platform/android/InstrumentationTests${{ env.renderer }}.apk
 
+      - name: Show sccache stats
+        run: sccache --show-stats
+
   android-build-cpp-test:
     runs-on: ubuntu-24.04
 
@@ -219,9 +222,6 @@ jobs:
           path: |
             ./test/android/app-debug.apk
             ./test/android/app-release-androidTest.apk
-
-      - name: Show sccache stats
-        run: sccache --show-stats
 
   android-build-render-test:
     strategy:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -58,6 +58,29 @@ jobs:
 
       - uses: ./.github/actions/setup-android-ci
 
+      - name: Configure AWS Credentials
+        if: vars.OIDC_AWS_ROLE_TO_ASSUME
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
+      - uses: ./.github/actions/install-sccache
+
+      - name: Configure sccache
+        run: |
+          echo SCCACHE_BUCKET=maplibre-native-sccache > "$GITHUB_ENV"
+          echo SCCACHE_REGION=eu-central-1 > "$GITHUB_ENV"
+
+          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
+            echo SCCACHE_S3_NO_CREDENTIALS=1 > "$GITHUB_ENV"
+          fi
+
+      - name: Sanity check
+        run: echo "$SCCACHE_REGION"
+
       - name: Check code style
         if: matrix.renderer == 'opengl'
         run: make android-check
@@ -193,6 +216,9 @@ jobs:
           path: |
             ./test/android/app-debug.apk
             ./test/android/app-release-androidTest.apk
+
+      - name: Show sccache stats
+        run: sccache --show-stats
 
   android-build-render-test:
     strategy:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -81,13 +81,7 @@ jobs:
       - if: matrix.variant.rust
         run: cargo install cxxbridge-cmd --version 1.0.157 --locked
 
-      - name: Install sccache
-        run: |
-          curl -LO https://github.com/mozilla/sccache/releases/download/v0.10.0/sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz
-          tar -xzf sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz
-          sudo mv sccache-v0.10.0-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
-          sudo chmod +x /usr/bin/sccache
-          rm -rf sccache-v0.10.0-x86_64-unknown-linux-musl
+      - uses: ./.github/actions/install-sccache
 
       - name: Configure AWS Credentials
         if: vars.OIDC_AWS_ROLE_TO_ASSUME

--- a/platform/android/MapLibrePlugin/src/main/kotlin/org/maplibre/CcachePlugin.kt
+++ b/platform/android/MapLibrePlugin/src/main/kotlin/org/maplibre/CcachePlugin.kt
@@ -43,8 +43,8 @@ fun findCacheToolPath(): String? {
         }
     }
 
-    // Try to find ccache first, then fallback to sccache
-    return findCommandPath(ccacheCommand) ?: findCommandPath(sccacheCommand)
+    // Try to find sccache first, then fallback to ccache
+    return findCommandPath(sccacheCommand) ?: findCommandPath(ccacheCommand)
 }
 
 class CcachePlugin : Plugin<Project> {

--- a/platform/android/settings.gradle.kts
+++ b/platform/android/settings.gradle.kts
@@ -39,3 +39,9 @@ includeBuild(cppTestProjectDir) {
 }
 
 includeBuild("./MapLibrePlugin")
+
+buildCache {
+    local {
+        isEnabled = true
+    }
+}


### PR DESCRIPTION
Some optimizations to speed up Android CI.

Use sccache with S3 for all builds. Unfortunately the config needs to be copy pasted in all jobs/workflows, since reusable actions cannot modify environment variables.

Brings the total time of android-ci down from **1h 51m 42s** to **33m 41s** (with 100% cache hit rate).

Cache is updated when workflows run in the context of this repository (needs to authenticate with AWS, for that secrets are required).