### PR TITLE
Compatibility fixes for WebAssembly and WebGL 2

### DIFF
--- a/src/mbgl/gl/buffer_allocator.cpp
+++ b/src/mbgl/gl/buffer_allocator.cpp
@@ -262,13 +262,24 @@ public:
         }
         MBGL_CHECK_ERROR(glBindBuffer(type, buffer->id));
 
-        // Map the next available slice of memory
+        // Map the next available slice of memory. On WASM/emscripten we don't have
+        // glMapBufferRange available, so use glBufferSubData as a fallback (upload
+        // directly from client memory).
+        const auto writtenIndex = buffer->pointer;
+#ifdef __EMSCRIPTEN__
+        // glBufferSubData accepts the real size to upload; no need to provide
+        // alignedSize as the upload size — upload only `size` bytes.
+        MBGL_CHECK_ERROR(glBufferSubData(type, buffer->pointer, static_cast<GLsizeiptr>(size), data));
+
+        residentBuffer = buffer->addRef(nullptr, writtenIndex, size);
+        buffer->pointer += alignedSize;
+#else
+        // Map and memcpy path for platforms that support mapping.
         auto* buf = MBGL_CHECK_ERROR(
             glMapBufferRange(type,
                              buffer->pointer,
                              alignedSize,
                              GL_MAP_INVALIDATE_RANGE_BIT | GL_MAP_UNSYNCHRONIZED_BIT | GL_MAP_WRITE_BIT));
-        const auto writtenIndex = buffer->pointer;
 
         if (buf) {
             std::memcpy(buf, data, size);
@@ -280,6 +291,7 @@ public:
             assert(0);
             return false;
         }
+#endif
 
 #ifndef NDEBUG
         MBGL_CHECK_ERROR(glBindBuffer(type, 0));
@@ -436,6 +448,15 @@ private:
         auto& destBuffer = buffers[toIndex];
         const auto recycledWriteIndex = destBuffer.pointer;
 
+        // On WASM/emscripten, glMapBufferRange is unavailable; use glBufferSubData
+        // to upload the contents instead.
+#ifdef __EMSCRIPTEN__
+        MBGL_CHECK_ERROR(glBufferSubData(type,
+                                         recycledWriteIndex,
+                                         static_cast<GLsizeiptr>(ref.getOwner()->getSize()),
+                                         ref.getOwner()->getManagedBuffer().getContents().data()));
+        destBuffer.pointer += alignedSize;
+#else
         auto* buf = MBGL_CHECK_ERROR(
             glMapBufferRange(type,
                              recycledWriteIndex,
@@ -450,6 +471,7 @@ private:
             assert(0);
             return false;
         }
+#endif
 
         // 2.c: Now the ref must be made aware of the relocation of its contents.
         // Note that this means defragmentation can never run on refs that are

--- a/src/mbgl/gl/fence.cpp
+++ b/src/mbgl/gl/fence.cpp
@@ -37,14 +37,33 @@ void Fence::insert() noexcept {
     MLN_TRACE_FUNC();
 
     assert(!fence);
+#ifdef __EMSCRIPTEN__
+    // WebGL / Emscripten environments may not expose GL sync objects
+    // (glFenceSync / glClientWaitSync). As a fallback, flush commands to
+    // the driver so work is submitted; we cannot create a GPU fence, so
+    // leave `fence` null and emulate completion in `isSignaled()`.
+    MBGL_CHECK_ERROR(glFlush());
+    fence = nullptr;
+#else
     fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+#endif
 }
 
 bool Fence::isSignaled() const {
     MLN_TRACE_FUNC();
 
     if (!fence) {
+        // If we don't have a real GL sync object (e.g. on WASM/WebGL),
+        // fall back to a blocking wait to ensure GPU work is complete.
+        // This is heavy ( stalls until completion ) but correct. If you
+        // need a non-blocking approach, consider emulating fences with
+        // timer queries or a different strategy.
+#ifdef __EMSCRIPTEN__
+        MBGL_CHECK_ERROR(glFinish());
+        return true;
+#else
         return false;
+#endif
     }
 
     GLenum fenceStatus = glClientWaitSync(fence, GL_SYNC_FLUSH_COMMANDS_BIT, 0);


### PR DESCRIPTION
Compatibility fixes for WebAssembly and WebGL 2.

Note that I used GPT-5 mini/copilot to actually deal with the fixes so I'm happy for better suggestions.

FYI @birkskyum 