### PR TITLE
fix(metal) add missing DepthMode range

### DIFF
--- a/src/mbgl/mtl/context.cpp
+++ b/src/mbgl/mtl/context.cpp
@@ -294,7 +294,8 @@ const auto clipMaskStencilMode = gfx::StencilMode{
     /*.pass=*/gfx::StencilOpType::Replace,
 };
 const auto clipMaskDepthMode = gfx::DepthMode{/*.func=*/gfx::DepthFunctionType::Always,
-                                              /*.mask=*/gfx::DepthMaskType::ReadOnly};
+                                              /*.mask=*/gfx::DepthMaskType::ReadOnly,
+                                              /*.range=*/{0.0f, 1.0f}};
 } // namespace
 
 bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,


### PR DESCRIPTION
This PR fixes a compilation error I hit in the Metal backend:

```sh
  error: missing field 'range' initializer [-Werror,-Wmissing-field-initializers]
  error: no matching constructor for initialization of 'Range<float>'
```

It's caused by the DepthMode struct initialization, which was missing the required range field, causing build failures on macOS.

