### PR TITLE
Fix compile error when building with MLN_USE_TRACY

### DIFF
--- a/src/mbgl/tile/tile_cache.cpp
+++ b/src/mbgl/tile/tile_cache.cpp
@@ -88,7 +88,7 @@ void TileCache::deferPendingReleases() {
     // last one and the destruction actually occurs here on this thread.
     std::function<void()> func{[tile_{CaptureWrapper{std::move(wrap)}}, this]() mutable {
         MLN_TRACE_ZONE(deferPendingReleases lambda);
-        MLN_ZONE_VALUE(wrap_.releases.size());
+        MLN_ZONE_VALUE(tile_.items.size());
         tile_.items.clear();
 
         std::lock_guard<std::mutex> counterLock(deferredSignalLock);


### PR DESCRIPTION
Was: `wrap_` is not found. I assume this was meant to be `tile_.items`, not `wrap_.releases`.

(I'm not actually sure what tracy is; I just saw some related macros in the code and was experimenting with them)