### PR TITLE
Use draft releases so we can use immutable releases

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -57,7 +57,7 @@ jobs:
           tag_name: ${{ steps.prepare_release.outputs.version_tag }}
           release_name: ${{steps.prepare_release.outputs.version_tag }}
           body_path: ${{ steps.prepare_release.outputs.release_notes }}
-          draft: false
+          draft: true
           prerelease: ${{ env.prerelease }}
 
   android-build-and-upload-release:
@@ -159,3 +159,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/notify-release-on-prs.ts --tag ${{ needs.android-create-release.outputs.version_tag }}
         working-directory: .
+
+  finilize-release:
+    runs-on: ubuntu-latest
+    needs:
+      - android-create-release
+      - android-build-and-upload-release
+    steps:
+      - name: Remove draft status of release
+        id: create_release
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_name: ${{ needs.android-create-release.outputs.version_tag }}
+          tag_name: ${{ needs.android-create-release.outputs.version_tag }}
+          draft: false

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -33,7 +33,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           gh release create core-${{ github.sha }} \
-            --draft=false \
+            --draft=true \
             --prerelease=false \
             --latest=false \
             --title "core-${{ github.sha }}" \

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -295,7 +295,7 @@ jobs:
           name: node-v${{ steps.package-version.outputs.current-version }}
           bodyFile: platform/node/changelog_for_version.md
           allowUpdates: true
-          draft: false
+          draft: true
           prerelease: ${{ steps.prepare_release.outputs.prerelease }}
 
       - name: Publish to NPM (release)


### PR DESCRIPTION
Node.js and core releases need to have their status updated manually for now.

I will check if it works with an Android release first.