### PR TITLE
Pass draft parameter in android-release for immutable release

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -53,6 +53,8 @@ jobs:
       BUILDTYPE: Debug
       IS_LOCAL_DEVELOPMENT: false
       MLN_ANDROID_STL: c++_static
+      SENTRY_ORG: maplibre
+      SENTRY_PROJECT: maplibre-android
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN_ANDROID }}
     steps:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -53,8 +53,6 @@ jobs:
       BUILDTYPE: Debug
       IS_LOCAL_DEVELOPMENT: false
       MLN_ANDROID_STL: c++_static
-      SENTRY_ORG: maplibre
-      SENTRY_PROJECT: maplibre-android
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN_ANDROID }}
     steps:
@@ -95,6 +93,11 @@ jobs:
           pre-commit run clang-format --all-files
           rm -rf venv
         shell: bash
+
+      - if: env.SENTRY_DSN != ''
+        run: |
+          echo "SENTRY_ORG=maplibre" >> "$GITHUB_ENV"
+          echo "SENTRY_PROJECT=maplibre-android" >> "$GITHUB_ENV"
 
       - uses: infotroph/tree-is-clean@69d598a958e8cb8f3d0e3d52b5ebcd8684f2adc2 # v1.0.6
         with:

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -122,6 +122,7 @@ jobs:
         with:
           tag_name: ${{ needs.android-create-release.outputs.version_tag }}
           fail_on_unmatched_files: true
+          draft: true
           files: |
             platform/android/MapLibreAndroid/build/outputs/aar/MapLibreAndroid-${{ matrix.RENDERER }}-${{ env.buildtype }}-${{ needs.android-create-release.outputs.version_tag }}.aar
             platform/android/build/debug-symbols-maplibre-android-${{ matrix.RENDERER }}-${{ env.buildtype }}-${{ needs.android-create-release.outputs.version_tag }}.tar.gz


### PR DESCRIPTION
Fixing this error:

👩‍🏭 Creating new GitHub release for tag android-v11.13.4...
⬆️ Uploading MapLibreAndroid-opengl-debug-android-v11.13.4.aar...
⬆️ Uploading debug-symbols-maplibre-android-opengl-debug-android-v11.13.4.tar.gz...
Error: Cannot upload assets to an immutable release. - https://docs.github.com/rest

And also this one:

Run sentry-cli debug-files upload MapLibreAndroidTestApp
error: A project ID or slug is required (provide with --project)