### PR TITLE
chore(security): remove unnessesarily persisted permissions

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Get all Android files that have changed
         if: github.event_name != 'workflow_dispatch'
@@ -62,7 +61,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: ./.github/actions/setup-android-ci
 
@@ -229,7 +227,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: ./.github/actions/setup-android-ci
 
@@ -288,7 +285,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: ./.github/actions/setup-android-ci
 

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Get all Android files that have changed
         if: github.event_name != 'workflow_dispatch'
@@ -59,6 +61,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-android-ci
 
@@ -224,6 +228,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-android-ci
 
@@ -281,6 +287,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-android-ci
 

--- a/.github/workflows/android-device-test.yml
+++ b/.github/workflows/android-device-test.yml
@@ -79,6 +79,9 @@ jobs:
     if: github.repository_owner == 'maplibre' && github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4
         with:

--- a/.github/workflows/android-device-test.yml
+++ b/.github/workflows/android-device-test.yml
@@ -81,7 +81,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4
         with:

--- a/.github/workflows/android-testapp-release.yml
+++ b/.github/workflows/android-testapp-release.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Create Release
         run: |
@@ -48,7 +47,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: ./.github/actions/setup-android-ci
 

--- a/.github/workflows/android-testapp-release.yml
+++ b/.github/workflows/android-testapp-release.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Create Release
         run: |
@@ -44,6 +47,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-android-ci
 

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Cleanup
         run: |

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Cleanup
         run: |

--- a/.github/workflows/gh-pages-android-api.yml
+++ b/.github/workflows/gh-pages-android-api.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v4
         with:

--- a/.github/workflows/gh-pages-android-api.yml
+++ b/.github/workflows/gh-pages-android-api.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v4
         with:

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Get all iOS files that have changed
         if: github.event_name != 'workflow_dispatch'
@@ -78,7 +77,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Cache Bazel
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -41,6 +41,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Get all iOS files that have changed
         if: github.event_name != 'workflow_dispatch'
@@ -75,6 +77,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Cache Bazel
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/.github/workflows/ios-device-test.yml
+++ b/.github/workflows/ios-device-test.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Generate token
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4

--- a/.github/workflows/ios-device-test.yml
+++ b/.github/workflows/ios-device-test.yml
@@ -22,6 +22,9 @@ jobs:
     if: github.repository_owner == 'maplibre' && github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Generate token
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4

--- a/.github/workflows/ios-release-cocoapods.yml
+++ b/.github/workflows/ios-release-cocoapods.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Release (CocoaPods)
         shell: bash -leo pipefail {0}  # so pod is found

--- a/.github/workflows/ios-release-cocoapods.yml
+++ b/.github/workflows/ios-release-cocoapods.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Release (CocoaPods)
         shell: bash -leo pipefail {0}  # so pod is found

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -36,6 +36,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Get all Linux files that have changed
         if: github.event_name != 'workflow_dispatch'
@@ -68,6 +70,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
@@ -222,6 +226,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Install dependencies
         run: .github/scripts/install-linux-deps

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Get all Linux files that have changed
         if: github.event_name != 'workflow_dispatch'
@@ -71,7 +70,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
@@ -227,7 +225,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Install dependencies
         run: .github/scripts/install-linux-deps

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -61,7 +61,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Cache Bazel
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -60,6 +60,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Cache Bazel
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -101,6 +101,8 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Get OS Architecture
         if: runner.os == 'MacOS' || runner.os == 'Linux'

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -102,7 +102,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Get OS Architecture
         if: runner.os == 'MacOS' || runner.os == 'Linux'

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Use Node.js from nvmrc
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4
@@ -70,7 +69,6 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Get OS Architecture
         if: runner.os == 'MacOS' || runner.os == 'Linux'
@@ -254,7 +252,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Use Node.js from nvmrc
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -14,6 +14,9 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Use Node.js from nvmrc
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4
@@ -66,6 +69,8 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: true
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Get OS Architecture
         if: runner.os == 'MacOS' || runner.os == 'Linux'
@@ -247,6 +252,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Use Node.js from nvmrc
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4

--- a/.github/workflows/pr-bloaty-ios.yml
+++ b/.github/workflows/pr-bloaty-ios.yml
@@ -25,7 +25,6 @@ jobs:
             .github
             .nvmrc
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4
         with:
@@ -49,7 +48,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Cache Bloaty
         id: cache-bloaty

--- a/.github/workflows/pr-bloaty-ios.yml
+++ b/.github/workflows/pr-bloaty-ios.yml
@@ -24,6 +24,8 @@ jobs:
           sparse-checkout: |
             .github
             .nvmrc
+          persist-credentials: false
+          fetch-depth: 0
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4
         with:
@@ -45,6 +47,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Cache Bloaty
         id: cache-bloaty

--- a/.github/workflows/pr-linux-tests.yml
+++ b/.github/workflows/pr-linux-tests.yml
@@ -27,6 +27,8 @@ jobs:
           sparse-checkout: |
             .github
             .nvmrc
+          persist-credentials: false
+          fetch-depth: 0
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4
         with:
@@ -48,6 +50,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - uses: ./.github/actions/get-pr-number
         id: get-pr-number
@@ -139,6 +144,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: true
+          persist-credentials: false
+          fetch-depth: 0
 
       - uses: ./.github/actions/get-pr-number
         id: get-pr-number

--- a/.github/workflows/pr-linux-tests.yml
+++ b/.github/workflows/pr-linux-tests.yml
@@ -28,7 +28,6 @@ jobs:
             .github
             .nvmrc
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4
         with:
@@ -52,7 +51,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: ./.github/actions/get-pr-number
         id: get-pr-number
@@ -145,7 +143,6 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: ./.github/actions/get-pr-number
         id: get-pr-number

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -107,7 +107,6 @@ jobs:
           path: source
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Install test dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -106,6 +106,8 @@ jobs:
         with:
           path: source
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Install test dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -27,6 +27,9 @@ jobs:
       - uses: taiki-e/install-action@e5f8d33e7166e0491b2ab4ff0567cc6cd6772737 # v2.61.7
         with: { tool: just }
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
       - run: just -v ci-test
 
   msrv:
@@ -36,6 +39,9 @@ jobs:
       - uses: taiki-e/install-action@e5f8d33e7166e0491b2ab4ff0567cc6cd6772737 # v2.61.7
         with: { tool: just }
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
       - name: Read crate metadata
         id: metadata
         run: echo "rust-version=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -29,7 +29,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
       - run: just -v ci-test
 
   msrv:
@@ -41,7 +40,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
       - name: Read crate metadata
         id: metadata
         run: echo "rust-version=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/typecheck-scripts.yml
+++ b/.github/workflows/typecheck-scripts.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - run: |
           npm install

--- a/.github/workflows/typecheck-scripts.yml
+++ b/.github/workflows/typecheck-scripts.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - run: |
           npm install

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -18,7 +18,6 @@ jobs:
             .github
             .nvmrc
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4
         with:
@@ -42,7 +41,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: ./.github/actions/download-workflow-run-artifact
         with:

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -17,6 +17,8 @@ jobs:
           sparse-checkout: |
             .github
             .nvmrc
+          persist-credentials: false
+          fetch-depth: 0
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4
         with:
@@ -38,6 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - uses: ./.github/actions/download-workflow-run-artifact
         with:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -40,6 +40,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Get all Windows files that have changed
         if: github.event_name != 'workflow_dispatch'
@@ -66,6 +68,7 @@ jobs:
           sparse-checkout: |
             platform/windows/vendor
             platform/windows/Get-VendorPackages.ps1
+          persist-credentials: false
 
       - name: Get vcpkg commit id
         run: |
@@ -119,6 +122,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
@@ -255,6 +259,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           submodules: recursive
+          persist-credentials: false
 
       - uses: msys2/setup-msys2@fb197b72ce45fb24f17bf3f807a388985654d1f2 # v2.29.0
         with:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Get all Windows files that have changed
         if: github.event_name != 'workflow_dispatch'

--- a/vendor/maplibre-native-base/.github/workflows/ci.yml
+++ b/vendor/maplibre-native-base/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Build and run tests
         run: |

--- a/vendor/maplibre-native-base/.github/workflows/ci.yml
+++ b/vendor/maplibre-native-base/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Build and run tests
         run: |


### PR DESCRIPTION
I think we are currently not using these permissions.
Lets remove them.

Given how complex the CI is, this is really not as simple as it sounds.

THis also seems to be a [best practice](https://docs.zizmor.sh/audits/#artipacked), but that is secondary to this PR.

When removing them, I was conservative, there are other occurrences where we might be able to remove them. This is the larger part that we can just remove without deeply looking at.