### PR TITLE
fix misplaced LineOffset and LineGapWidth

### DIFF
--- a/src/mbgl/renderer/layers/line_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/line_layer_tweaker.cpp
@@ -259,8 +259,8 @@ void LineLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters
 
                     .blur_t = std::get<0>(binders->get<LineBlur>()->interpolationFactor(zoom)),
                     .opacity_t = std::get<0>(binders->get<LineOpacity>()->interpolationFactor(zoom)),
-                    .gapwidth_t = std::get<0>(binders->get<LineOffset>()->interpolationFactor(zoom)),
-                    .offset_t = std::get<0>(binders->get<LineGapWidth>()->interpolationFactor(zoom)),
+                    .gapwidth_t = std::get<0>(binders->get<LineGapWidth>()->interpolationFactor(zoom)),
+                    .offset_t = std::get<0>(binders->get<LineOffset>()->interpolationFactor(zoom)),
                     .width_t = std::get<0>(binders->get<LineWidth>()->interpolationFactor(zoom)),
                     .pattern_from_t = std::get<0>(binders->get<LinePattern>()->interpolationFactor(zoom)),
                     .pattern_to_t = std::get<1>(binders->get<LinePattern>()->interpolationFactor(zoom))


### PR DESCRIPTION
Just a small bug, where the LineOffset/LineGapWidth should be swapped