### PR TITLE
Remove bazel-out from xcframework

### DIFF
--- a/platform/darwin/BUILD.bazel
+++ b/platform/darwin/BUILD.bazel
@@ -112,6 +112,13 @@ js_run_binary(
     visibility = ["//visibility:public"],
 )
 
+# Production-only generated code without test files
+filegroup(
+    name = "generated_code_production",
+    srcs = MLN_GENERATED_DARWIN_STYLE_SOURCE + MLN_GENERATED_DARWIN_STYLE_HEADERS,
+    visibility = ["//visibility:public"],
+)
+
 objc_library(
     name = "test_utility",
     srcs = [
@@ -190,7 +197,7 @@ cc_library(
         ":darwin_objc_hdrs",
         ":darwin_objcpp_hdrs",
         ":darwin_private_hdrs",
-        ":generated_code",
+        ":generated_code_production",
     ],
     hdrs = [
         ":generated_style_hdrs",
@@ -340,7 +347,7 @@ js_library(
         ":darwin_objcpp_hdrs",
         ":darwin_objcpp_srcs",
         ":darwin_private_hdrs",
-        ":generated_code",
+        ":generated_code_production",
         ":generated_style_hdrs",
         ":generated_style_srcs",
     ] + select({


### PR DESCRIPTION
This PR removes bazel-out dir from xcframework for iOS release. 

**BEFORE:**
<img width="1463" height="687" alt="image" src="https://github.com/user-attachments/assets/6ea726e6-164d-42bb-8780-ecaa85517329" />

**AFTER:**
<img width="1535" height="726" alt="image" src="https://github.com/user-attachments/assets/d84120d6-26c2-4e65-af15-ddd51cb4083c" />


Diff size:
<img width="792" height="523" alt="image" src="https://github.com/user-attachments/assets/e94a765c-370f-4959-8aa3-ac26d6e9bba2" />
