### PR TITLE
docs: remove `@param` for property

### DIFF
--- a/platform/ios/src/MLNMapView.h
+++ b/platform/ios/src/MLNMapView.h
@@ -1046,8 +1046,6 @@ vertically on the map.
 
 /**
  * The maximum bounds of the map that can be shown on screen.
- *
- * @param MLNCoordinateBounds the bounds to constrain the screen to.
  */
 @property (nonatomic) MLNCoordinateBounds maximumScreenBounds;
 


### PR DESCRIPTION
This line of the comment is redundant and gives a warning due to using `@param` when only a property is declared and not a function.

<img width="1078" height="104" alt="Bildschirmfoto 2025-09-29 um 07 56 29" src="https://github.com/user-attachments/assets/ff31284d-73b6-4b98-9741-fc4b797de62a" />
