### PR TITLE
Bump minimum Android SDK version from 21 to 23

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog MapLibre Native for Android
 
+## main
+
+- 💥 Breaking: bump minimum SDK version from 21 to 23.
+
 ## 11.13.5
 
 ### ✨ Features and improvements

--- a/platform/android/MapLibreAndroid/build.gradle.kts
+++ b/platform/android/MapLibreAndroid/build.gradle.kts
@@ -60,7 +60,7 @@ android {
 
     defaultConfig {
         compileSdk = 34
-        minSdk = 21
+        minSdk = 23
         targetSdk = 33
         buildConfigField("String", "GIT_REVISION_SHORT", "\"${getGitRevision()}\"")
         buildConfigField("String", "GIT_REVISION", "\"${getGitRevision(false)}\"")

--- a/platform/android/MapLibreAndroidTestApp/build.gradle.kts
+++ b/platform/android/MapLibreAndroidTestApp/build.gradle.kts
@@ -24,7 +24,7 @@ android {
 
     defaultConfig {
         applicationId = "org.maplibre.android.testapp"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 33
         versionCode = 14
         testInstrumentationRunner = "org.maplibre.android.InstrumentationRunner"

--- a/render-test/android/app/build.gradle.kts
+++ b/render-test/android/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
     defaultConfig {
         applicationId = "org.maplibre.render_test_runner"
         compileSdk = 34
-        minSdk = 21
+        minSdk = 23
         targetSdk = 33
 
         val abi = if (project.hasProperty("maplibre.abis")) {


### PR DESCRIPTION
Due to some issues @adrian-cojocaru uncovered around how libraries are loaded prior to SDK version 23, this PR bumps the minimum version to 23. Asking on [Slack](https://osmus.slack.com/archives/C04G140P9U6/p1759168720399089), and it seems this does not have a significant impact on anyone.

Still, we will make a major (breaking) release for this.

Hopefully fixes #3833