### PR TITLE
Handle style builder exceptions

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/Style.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/Style.java
@@ -741,8 +741,8 @@ public class Style {
       for (Source source : builder.sources) {
         try {
           addSource(source);
-        } catch (CannotAddSourceException e) {
-          Logger.e(TAG, "Failed to add source", e);
+        } catch (CannotAddSourceException exception) {
+          Logger.e(TAG, "Failed to add source", exception);
         }
       }
 
@@ -759,8 +759,8 @@ public class Style {
             addLayerBelow(layerWrapper.layer, MapLibreConstants.LAYER_ID_ANNOTATIONS);
           }
         }
-      } catch (CannotAddLayerException e) {
-        Logger.e(TAG, "Failed to add layer", e);
+      } catch (CannotAddLayerException exception) {
+        Logger.e(TAG, "Failed to add layer", exception);
       }
 
       for (Builder.ImageWrapper image : builder.images) {


### PR DESCRIPTION
Added try/catch blocks for `CannotAddSourceException` and `CannotAddLayerException` around style builder calls.
Possible fix for https://github.com/maplibre/maplibre-native/issues/3854 (the crash is triggered by a java exception in `onDidFinishLoadingStyle`)