### PR TITLE
Fix static XCFramework creation

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -83,6 +83,12 @@ git_override(
     tag = "1.0.157",
 )
 
+git_override(
+    module_name = "rules_apple",
+    commit = "5005493",
+    remote = "https://github.com/louwers/rules_apple.git",
+)
+
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2021",

--- a/platform/ios/BUILD.bazel
+++ b/platform/ios/BUILD.bazel
@@ -102,7 +102,9 @@ public_hdrs = [
 
 apple_static_xcframework(
     name = "MapLibre.static",
+    bundle_id = "com.maplibre.mapbox",
     bundle_name = "MapLibre",
+    infoplists = ["info_static_plist"],
     ios = {
         "simulator": [
             "x86_64",
@@ -112,6 +114,7 @@ apple_static_xcframework(
     },
     minimum_os_versions = {"ios": "12.0"},
     public_hdrs = public_hdrs,
+    version = ":maplibre_ios_version",
     visibility = ["//visibility:public"],
     deps = ["//platform:ios-sdk"],
 )


### PR DESCRIPTION
Create static XCFramework with:

```
bazel build //platform/ios:MapLibre.static --//:renderer=metal --compilation_mode="opt" --copt -g --copt="-Oz" --strip never --output_groups=+dsyms --apple_generate_dsym
```

Add to Xcode, in General, make sure "Embed & Sign" is set to **Do Not Embed**.

<img width="797" height="181" alt="image" src="https://github.com/user-attachments/assets/3b2670e7-c940-4703-ac0b-80402cc9d764" />

In Build Settings set Other Linker Flags to `-ObjC`.

<img width="715" height="54" alt="image" src="https://github.com/user-attachments/assets/fd96594a-77bf-4ca5-8d1c-77bef57f08b4" />

In Build Phases, add Mapbox.bundle to Copy Bundle Resources (still needs to be renamed).

<img width="883" height="157" alt="image" src="https://github.com/user-attachments/assets/39925773-74ac-4406-a87c-23103ea23cb6" />

Draft PR until https://github.com/bazelbuild/rules_apple/pull/2791 is upstreamed and released.