### PR TITLE
[node] Add options parameter to addImage method in Node.js type definitions

### DIFF
--- a/platform/node/index.d.ts
+++ b/platform/node/index.d.ts
@@ -156,7 +156,7 @@ declare module '@maplibre/maplibre-gl-native' {
     /**
      * Add image to map's style
      */
-    addImage: (imageId: string, image: any) => void;
+    addImage: (imageId: string, image: any, options: any) => void;
 
     /**
      * Remove image from map's style


### PR DESCRIPTION
The addImage method signature was missing the optional third parameter for image options.
This update aligns the TypeScript definitions with the actual implementation.

ref: https://github.com/maplibre/maplibre-native/blob/59aca67f394ebf52eeab997566bc0f4ab50fb362/platform/node/src/node_map.cpp#L804-L806
