### PR TITLE
Add padding support to MapSnapshotter Android

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/snapshotter/map_snapshotter.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/snapshotter/map_snapshotter.cpp
@@ -26,10 +26,10 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
                                jni::jboolean _showLogo,
                                jni::jboolean _showAttribution,
                                const jni::String& _localIdeographFontFamily,
-                               jni::jfloat regionPaddingLeft,
-                               jni::jfloat regionPaddingTop,
-                               jni::jfloat regionPaddingRight,
-                               jni::jfloat regionPaddingBottom)
+                               jni::jfloat paddingLeft,
+                               jni::jfloat paddingTop,
+                               jni::jfloat paddingRight,
+                               jni::jfloat paddingBottom)
     : javaPeer(_env, _obj),
       pixelRatio(_pixelRatio) {
     // Get a reference to the JavaVM for callbacks
@@ -61,10 +61,10 @@ MapSnapshotter::MapSnapshotter(jni::JNIEnv& _env,
     }
 
     if (region) {
-        snapshotter->setRegionPadding({static_cast<double>(regionPaddingTop),
-                                       static_cast<double>(regionPaddingLeft),
-                                       static_cast<double>(regionPaddingBottom),
-                                       static_cast<double>(regionPaddingRight)});
+        snapshotter->setPadding({static_cast<double>(paddingTop),
+                                 static_cast<double>(paddingLeft),
+                                 static_cast<double>(paddingBottom),
+                                 static_cast<double>(paddingRight)});
         snapshotter->setRegion(LatLngBounds::getLatLngBounds(_env, region));
     }
 
@@ -146,15 +146,9 @@ void MapSnapshotter::setRegion(JNIEnv& env, const jni::Object<LatLngBounds>& reg
     snapshotter->setRegion(LatLngBounds::getLatLngBounds(env, region));
 }
 
-void MapSnapshotter::setRegionPadding(JNIEnv&,
-                                      jni::jint regionPaddingLeft,
-                                      jni::jint regionPaddingTop,
-                                      jni::jint regionPaddingRight,
-                                      jni::jint regionPaddingBottom) {
-    snapshotter->setRegionPadding({static_cast<double>(regionPaddingTop),
-                                   static_cast<double>(regionPaddingLeft),
-                                   static_cast<double>(regionPaddingBottom),
-                                   static_cast<double>(regionPaddingRight)});
+void MapSnapshotter::setPadding(JNIEnv&, jni::jint left, jni::jint top, jni::jint right, jni::jint bottom) {
+    snapshotter->setPadding(
+        {static_cast<double>(top), static_cast<double>(left), static_cast<double>(bottom), static_cast<double>(right)});
 }
 
 // Private methods //
@@ -368,7 +362,7 @@ void MapSnapshotter::registerNative(jni::JNIEnv& env) {
                                             METHOD(&MapSnapshotter::setSize, "setSize"),
                                             METHOD(&MapSnapshotter::setCameraPosition, "setCameraPosition"),
                                             METHOD(&MapSnapshotter::setRegion, "setRegion"),
-                                            METHOD(&MapSnapshotter::setRegionPadding, "setRegionPadding"),
+                                            METHOD(&MapSnapshotter::setPadding, "setPadding"),
                                             METHOD(&MapSnapshotter::start, "nativeStart"),
                                             METHOD(&MapSnapshotter::cancel, "nativeCancel"));
 }

--- a/platform/android/MapLibreAndroid/src/cpp/snapshotter/map_snapshotter.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/snapshotter/map_snapshotter.hpp
@@ -36,10 +36,10 @@ public:
                    jni::jboolean showLogo,
                    jni::jboolean _showAttribution,
                    const jni::String& localIdeographFontFamily,
-                   jni::jfloat regionPaddingLeft,
-                   jni::jfloat regionPaddingTop,
-                   jni::jfloat regionPaddingRight,
-                   jni::jfloat regionPaddingBottom);
+                   jni::jfloat paddingLeft,
+                   jni::jfloat paddingTop,
+                   jni::jfloat paddingRight,
+                   jni::jfloat paddingBottom);
 
     virtual ~MapSnapshotter() override;
 
@@ -53,7 +53,7 @@ public:
 
     void setRegion(JNIEnv&, const jni::Object<LatLngBounds>& region);
 
-    void setRegionPadding(JNIEnv&, jni::jint, jni::jint, jni::jint, jni::jint);
+    void setPadding(JNIEnv&, jni::jint left, jni::jint top, jni::jint right, jni::jint bottom);
 
     void start(JNIEnv&);
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/snapshotter/MapSnapshotter.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/snapshotter/MapSnapshotter.kt
@@ -209,11 +209,11 @@ open class MapSnapshotter(context: Context, options: Options) {
         }
 
         /**
-         * @param regionPadding of the padding of the region.
+         * @param padding of the padding of the region.
          * This is applied before the region, if region is null, it will not work
          * @return the mutated [Options]
          */
-        fun withRegionPadding(left:Int, top:Int, right:Int, bottom:Int): Options {
+        fun withPadding(left:Int, top:Int, right:Int, bottom:Int): Options {
             this.regionPadding = intArrayOf(left, top, right, bottom)
             return this
         }
@@ -418,7 +418,7 @@ open class MapSnapshotter(context: Context, options: Options) {
      * @param left, top, right, bottom
      */
     @Keep
-    external fun setRegionPadding(left:Int, top:Int, right:Int, bottom:Int)
+    external fun setPadding(left:Int, top:Int, right:Int, bottom:Int)
 
     /**
      * Updates the snapshotter with a new style url
@@ -773,10 +773,10 @@ open class MapSnapshotter(context: Context, options: Options) {
         showLogo: Boolean,
         showAttribution: Boolean,
         localIdeographFontFamily: String?,
-        regionPaddingLeft: Float,
-        regionPaddingTop: Float,
-        regionPaddingRight: Float,
-        regionPaddingBottom: Float
+        paddingLeft: Float,
+        paddingTop: Float,
+        paddingRight: Float,
+        paddingBottom: Float
     )
 
     @Keep

--- a/platform/default/include/mbgl/map/map_snapshotter.hpp
+++ b/platform/default/include/mbgl/map/map_snapshotter.hpp
@@ -60,8 +60,8 @@ public:
     void setRegion(const LatLngBounds&);
     LatLngBounds getRegion() const;
 
-    void setRegionPadding(const mbgl::EdgeInsets&);
-    mbgl::EdgeInsets getRegionPadding() const;
+    void setPadding(const mbgl::EdgeInsets&);
+    mbgl::EdgeInsets getPadding() const;
 
     style::Style& getStyle();
     const style::Style& getStyle() const;

--- a/platform/default/src/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/src/mbgl/map/map_snapshotter.cpp
@@ -200,7 +200,7 @@ public:
         map.jumpTo(map.cameraForLatLngs(latLngs, regionInsets));
     }
 
-    void setRegionPadding(const mbgl::EdgeInsets& insets) {
+    void setPadding(const mbgl::EdgeInsets& insets) {
         regionInsets = insets;
         if (!region.isEmpty()) {
             std::vector<LatLng> latLngs = {region.southwest(), region.northeast()};
@@ -208,7 +208,7 @@ public:
         }
     }
 
-    mbgl::EdgeInsets getRegionPadding() const { return regionInsets; }
+    mbgl::EdgeInsets getPadding() const { return regionInsets; }
 
     void snapshot(MapSnapshotter::Callback callback) {
         if (!callback) {
@@ -338,7 +338,12 @@ Size MapSnapshotter::getSize() const {
 }
 
 void MapSnapshotter::setCameraOptions(const CameraOptions& options) {
-    impl->getMap().jumpTo(options);
+    CameraOptions optionsWithPadding = options;
+    if (!options.padding) {
+        // Apply region padding if no padding is explicitly set in camera options
+        optionsWithPadding.withPadding(impl->getPadding());
+    }
+    impl->getMap().jumpTo(optionsWithPadding);
 }
 
 CameraOptions MapSnapshotter::getCameraOptions() const {
@@ -350,15 +355,15 @@ void MapSnapshotter::setRegion(const LatLngBounds& region) {
 }
 
 LatLngBounds MapSnapshotter::getRegion() const {
-    return impl->getMap().latLngBoundsForCamera(impl->getMap().getCameraOptions(getRegionPadding()));
+    return impl->getMap().latLngBoundsForCamera(impl->getMap().getCameraOptions(getPadding()));
 }
 
-void MapSnapshotter::setRegionPadding(const mbgl::EdgeInsets& insets) {
-    impl->setRegionPadding(insets);
+void MapSnapshotter::setPadding(const mbgl::EdgeInsets& insets) {
+    impl->setPadding(insets);
 }
 
-mbgl::EdgeInsets MapSnapshotter::getRegionPadding() const {
-    return impl->getRegionPadding();
+mbgl::EdgeInsets MapSnapshotter::getPadding() const {
+    return impl->getPadding();
 }
 
 style::Style& MapSnapshotter::getStyle() {


### PR DESCRIPTION
Here the different between no padding and padding(left:20, top:60, right:20, bottom:60)
<img width="200" alt="maplibre_snapshot2" src="https://github.com/user-attachments/assets/9f6673ed-a362-44a5-b348-963f7d2dc736" />
<img width="200" alt="maplibre_snapshot2_padding" src="https://github.com/user-attachments/assets/ba09c271-ab66-452b-886f-e345d1051840" />
