### PR TITLE
[vulkan] Prevent member variable shadowing in `mbgl::vulkan::ShaderProgram`

### DIFF
--- a/src/mbgl/shaders/vulkan/shader_program.cpp
+++ b/src/mbgl/shaders/vulkan/shader_program.cpp
@@ -124,7 +124,7 @@ ShaderProgram::~ShaderProgram() noexcept {
         return;
     }
 
-    context.enqueueDeletion([pipelines = std::move(pipelines)](auto&) mutable { pipelines.reset(); });
+    context.enqueueDeletion([ptr = std::move(pipelines)](auto&) mutable { ptr.reset(); });
 }
 
 const vk::UniquePipeline& ShaderProgram::getPipeline(const PipelineInfo& pipelineInfo) {


### PR DESCRIPTION
Prevent member variable shadowing in `mbgl::vulkan::ShaderProgram`. Makes Android Qt builds work.