### PR TITLE
Release allocated compass Bitmap as soon as possible

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/utils/BitmapUtils.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/utils/BitmapUtils.java
@@ -150,6 +150,7 @@ public class BitmapUtils {
       }
     }
   }
+
   /**
    * Decode byte array to drawable object
    *


### PR DESCRIPTION
We are allocating a Bitmap for custom compass images. It should get GC'ed eventually, but since we don't need it anymore, clean it up ASAP as recommended by the Android [docs](https://developer.android.com/reference/android/graphics/Bitmap#recycle()).

Hopefully fixes #3864