### PR TITLE
Exclude node 21 23 25

### DIFF
--- a/platform/node/CMakeLists.txt
+++ b/platform/node/CMakeLists.txt
@@ -7,6 +7,8 @@ endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/module.cmake)
 
+
+# For node versions, see: https://raw.githubusercontent.com/nodejs/node/main/doc/abi_version_registry.json
 add_node_module(
     mbgl-node
     INSTALL_PATH ${PROJECT_SOURCE_DIR}/platform/node/lib/{node_abi}/mbgl.node
@@ -16,6 +18,9 @@ add_node_module(
         47
         48
         51
+        120  # Node 21
+        131  # Node 23
+        141  # Node 25
 )
 
 if(WIN32)


### PR DESCRIPTION
The node-ci is breaking, because of node 25 with ubuntu 24. Example of PR where that is the case is e.g.:

- #3838 

There's a yearly LTS release of Node, with Node 26 coming out April 2026, and little reason to use the intermediate "uneven" releases.

Release Schedule:
https://nodejs.org/en/about/previous-releases

This PR excludes the 21, 23, 25 releases