### PR TITLE
[qt] Build on Windows with NOMINMAX

### DIFF
--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -128,8 +128,11 @@ target_sources(
 
 target_compile_definitions(
     mbgl-core
-    PRIVATE QT_IMAGE_DECODERS
-    PUBLIC __QT__
+    PRIVATE
+        QT_IMAGE_DECODERS
+        $<$<PLATFORM_ID:Windows>:NOMINMAX>
+    PUBLIC
+        __QT__
 )
 
 target_include_directories(


### PR DESCRIPTION
Build Qt-based MapLibre Native on Windows with `NOMINMAX` define to avoid issues with Vulkan.