### PR TITLE
fix number-format/currency expression test for darwin

### DIFF
--- a/platform/darwin/core/number_format.mm
+++ b/platform/darwin/core/number_format.mm
@@ -8,23 +8,17 @@ namespace platform {
 std::string formatNumber(double number, const std::string& localeId, const std::string& currency,
                          uint8_t minFractionDigits, uint8_t maxFractionDigits) {
 
-    static NSNumberFormatter *numberFormatter;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        numberFormatter = [[NSNumberFormatter alloc] init];
-    });
+    // Create a new formatter each time to avoid state pollution between calls
+    NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
 
     numberFormatter.locale = !localeId.empty() ? [NSLocale localeWithLocaleIdentifier:@(localeId.c_str())] : nil;
     numberFormatter.currencyCode = !currency.empty() ? @(currency.c_str()) : nil;
+
     if (currency.empty()) {
         numberFormatter.minimumFractionDigits = minFractionDigits;
         numberFormatter.maximumFractionDigits = maxFractionDigits;
         numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
     } else {
-        // Reset fraction digits to NSNumberFormatter's default values, so that the
-        // system will choose formatting based on number formatter locale.
-        numberFormatter.minimumFractionDigits = 0;
-        numberFormatter.maximumFractionDigits = 0;
         numberFormatter.numberStyle = NSNumberFormatterCurrencyStyle;
     }
     NSString *formatted = [numberFormatter stringFromNumber:@(number)];


### PR DESCRIPTION
I find that when running the expression test suite for `macos` preset ( Metal ) or the new `macos-webgpu-dawn` preset, the number-format/currency expression test fails.

Expected: ["¥123,457", "€123,457"]
Actual: ["¥123,457", "€123,456.79"]

It seems to be caused by the numberFormatter being static, and values set in previous function invocations disturb later invocations. The test is passing, by using a new instance of numberFormatter instead of reusing it.