### PR TITLE
Add macos-metal cmake preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -48,7 +48,7 @@
       "name": "macos-metal-xcode",
       "displayName": "macOS (Xcode)",
       "generator": "Xcode",
-      "binaryDir": "${sourceDir}/build-macos-xcode",
+      "binaryDir": "${sourceDir}/build-macos-metal-xcode",
       "inherits": "macos-metal"
     },
     {

--- a/docs/mdbook/src/platforms/macos/README.md
+++ b/docs/mdbook/src/platforms/macos/README.md
@@ -79,8 +79,8 @@ build-macos/mbgl-test-runner
 Create and open an Xcode project with CMake:
 
 ```sh
-cmake --preset macos-xcode
-xed build-macos-xcode/MapLibre\ Native.xcodeproj
+cmake --preset macos-metal-xcode
+xed build-macos-metal-xcode/MapLibre\ Native.xcodeproj
 ```
 
 Configure project for Vulkan (make sure [MoltenVK](https://github.com/KhronosGroup/MoltenVK) is installed):


### PR DESCRIPTION
Until now there was a `macos` preset, which acted both as a base preset, but also as a Metal preset. This assumption that all macos presets should have `MLN_WITH_METAL=ON` doesn't hold, which means that several other presets (macos-vulkan, macos-webgpu-x)  wrongly inherit it and has to set it off again `MLN_WITH_METAL=OFF`

This preset adds a `macos-metal` preset (similar to `macos-vulkan`), which will be used for `macos-metal-xcode` and `macos-metal-node`.

I also renamed `macos-xcode` -> `macos-metal-xcode`, so that it's similar to `macos-vulkan-xcode`