### PR TITLE
Fix `expected-lite` path in `core-release` workflow

### DIFF
--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -27,7 +27,7 @@ jobs:
             vendor/maplibre-native-base/deps/geometry.hpp/include \
             vendor/maplibre-native-base/deps/geojson.hpp/include \
             vendor/metal-cpp \
-            vendor/maplibre-native-base/extras/expected-lite/include
+            vendor/expected-lite/include
 
       - name: Create Release
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
The `expected-lite` dependency was moved from `vendor/maplibre-native-base/extras/expected-lite` to `vendor/expected-lite` in commit bb42ed111bb, but the workflow was not updated.