### PR TITLE
Pass proper argument to delegate method on macos platfrom

### DIFF
--- a/platform/macos/src/MLNMapView+Impl.mm
+++ b/platform/macos/src/MLNMapView+Impl.mm
@@ -162,7 +162,7 @@ void MLNMapViewImpl::onGlyphsRequested(const mbgl::FontStack& fontStack, const m
 void MLNMapViewImpl::onTileAction(mbgl::TileOperation operation, const mbgl::OverscaledTileID& tile, const std::string& sourceID) {
     [mapView tileDidTriggerAction:MLNTileOperation(static_cast<int>(operation))
                                 x:tile.canonical.x
-                                y:tile.canonical.x
+                                y:tile.canonical.y
                                 z:tile.canonical.z
                              wrap:tile.wrap
                       overscaledZ:tile.overscaledZ


### PR DESCRIPTION
This is a draft for two reasons:

1. I haven't tested this. I'm a downstream user of maplibre native, but I don't have my build environment wired up to build and consume home cooked maplibre-native. That said, it looks like a trivial typo, introduced when this code was first written in ce4dcb7a9b76

2. There's a bit of a mystery here: I noticed the errant behavior on iOS, but the iOS platform code looks good: https://github.com/maplibre/maplibre-native/blob/a13472a410a246dca5529f4d3a80ea8fb14ef1f5/platform/ios/src/MLNMapView%2BImpl.mm#L167-L170

 Only the macos platform code looks problematic. Is iOS using the macos platform code?