### PR TITLE
Use weak pointer for core layer

### DIFF
--- a/platform/android/Makefile
+++ b/platform/android/Makefile
@@ -59,7 +59,7 @@ MLN_ANDROID_GRADLE_SINGLE_JOB = ./gradlew --parallel --max-workers=1 -Pmapbox.bu
 # Generate code based on the style specification
 .PHONY: android-style-code
 android-style-code:
-	node scripts/generate-style-code.js
+	node scripts/generate-style-code.mjs
 style-code: android-style-code
 
 define ANDROID_RULES

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/background_layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/background_layer.cpp
@@ -40,56 +40,94 @@ BackgroundLayer::~BackgroundLayer() = default;
 
 jni::Local<jni::Object<>> BackgroundLayer::getBackgroundColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toBackgroundLayer(layer).getBackgroundColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::BackgroundLayer::getDefaultBackgroundColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toBackgroundLayer(*layer).getBackgroundColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> BackgroundLayer::getBackgroundColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toBackgroundLayer(layer).getBackgroundColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toBackgroundLayer(*layer).getBackgroundColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void BackgroundLayer::setBackgroundColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toBackgroundLayer(layer).setBackgroundColorTransition(options);
+    toBackgroundLayer(*layer).setBackgroundColorTransition(options);
 }
 
 jni::Local<jni::Object<>> BackgroundLayer::getBackgroundPattern(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toBackgroundLayer(layer).getBackgroundPattern()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::BackgroundLayer::getDefaultBackgroundPattern()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toBackgroundLayer(*layer).getBackgroundPattern()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> BackgroundLayer::getBackgroundPatternTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toBackgroundLayer(layer).getBackgroundPatternTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toBackgroundLayer(*layer).getBackgroundPatternTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void BackgroundLayer::setBackgroundPatternTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toBackgroundLayer(layer).setBackgroundPatternTransition(options);
+    toBackgroundLayer(*layer).setBackgroundPatternTransition(options);
 }
 
 jni::Local<jni::Object<>> BackgroundLayer::getBackgroundOpacity(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toBackgroundLayer(layer).getBackgroundOpacity()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::BackgroundLayer::getDefaultBackgroundOpacity()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toBackgroundLayer(*layer).getBackgroundOpacity()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> BackgroundLayer::getBackgroundOpacityTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toBackgroundLayer(layer).getBackgroundOpacityTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toBackgroundLayer(*layer).getBackgroundOpacityTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void BackgroundLayer::setBackgroundOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toBackgroundLayer(layer).setBackgroundOpacityTransition(options);
+    toBackgroundLayer(*layer).setBackgroundOpacityTransition(options);
 }
 
 // BackgroundJavaLayerPeerFactory

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/circle_layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/circle_layer.cpp
@@ -41,166 +41,280 @@ CircleLayer::~CircleLayer() = default;
 
 jni::Local<jni::Object<>> CircleLayer::getCircleSortKey(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(layer).getCircleSortKey()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::CircleLayer::getDefaultCircleSortKey()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(*layer).getCircleSortKey()));
 }
 
 jni::Local<jni::Object<>> CircleLayer::getCircleRadius(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(layer).getCircleRadius()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::CircleLayer::getDefaultCircleRadius()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(*layer).getCircleRadius()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> CircleLayer::getCircleRadiusTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toCircleLayer(layer).getCircleRadiusTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toCircleLayer(*layer).getCircleRadiusTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void CircleLayer::setCircleRadiusTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toCircleLayer(layer).setCircleRadiusTransition(options);
+    toCircleLayer(*layer).setCircleRadiusTransition(options);
 }
 
 jni::Local<jni::Object<>> CircleLayer::getCircleColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(layer).getCircleColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::CircleLayer::getDefaultCircleColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(*layer).getCircleColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> CircleLayer::getCircleColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toCircleLayer(layer).getCircleColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toCircleLayer(*layer).getCircleColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void CircleLayer::setCircleColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toCircleLayer(layer).setCircleColorTransition(options);
+    toCircleLayer(*layer).setCircleColorTransition(options);
 }
 
 jni::Local<jni::Object<>> CircleLayer::getCircleBlur(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(layer).getCircleBlur()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::CircleLayer::getDefaultCircleBlur()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(*layer).getCircleBlur()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> CircleLayer::getCircleBlurTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toCircleLayer(layer).getCircleBlurTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toCircleLayer(*layer).getCircleBlurTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void CircleLayer::setCircleBlurTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toCircleLayer(layer).setCircleBlurTransition(options);
+    toCircleLayer(*layer).setCircleBlurTransition(options);
 }
 
 jni::Local<jni::Object<>> CircleLayer::getCircleOpacity(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(layer).getCircleOpacity()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::CircleLayer::getDefaultCircleOpacity()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(*layer).getCircleOpacity()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> CircleLayer::getCircleOpacityTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toCircleLayer(layer).getCircleOpacityTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toCircleLayer(*layer).getCircleOpacityTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void CircleLayer::setCircleOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toCircleLayer(layer).setCircleOpacityTransition(options);
+    toCircleLayer(*layer).setCircleOpacityTransition(options);
 }
 
 jni::Local<jni::Object<>> CircleLayer::getCircleTranslate(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(layer).getCircleTranslate()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::CircleLayer::getDefaultCircleTranslate()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(*layer).getCircleTranslate()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> CircleLayer::getCircleTranslateTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toCircleLayer(layer).getCircleTranslateTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toCircleLayer(*layer).getCircleTranslateTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void CircleLayer::setCircleTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toCircleLayer(layer).setCircleTranslateTransition(options);
+    toCircleLayer(*layer).setCircleTranslateTransition(options);
 }
 
 jni::Local<jni::Object<>> CircleLayer::getCircleTranslateAnchor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(layer).getCircleTranslateAnchor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::CircleLayer::getDefaultCircleTranslateAnchor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(*layer).getCircleTranslateAnchor()));
 }
 
 jni::Local<jni::Object<>> CircleLayer::getCirclePitchScale(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(layer).getCirclePitchScale()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::CircleLayer::getDefaultCirclePitchScale()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(*layer).getCirclePitchScale()));
 }
 
 jni::Local<jni::Object<>> CircleLayer::getCirclePitchAlignment(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(layer).getCirclePitchAlignment()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::CircleLayer::getDefaultCirclePitchAlignment()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(*layer).getCirclePitchAlignment()));
 }
 
 jni::Local<jni::Object<>> CircleLayer::getCircleStrokeWidth(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(layer).getCircleStrokeWidth()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::CircleLayer::getDefaultCircleStrokeWidth()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(*layer).getCircleStrokeWidth()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> CircleLayer::getCircleStrokeWidthTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toCircleLayer(layer).getCircleStrokeWidthTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toCircleLayer(*layer).getCircleStrokeWidthTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void CircleLayer::setCircleStrokeWidthTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toCircleLayer(layer).setCircleStrokeWidthTransition(options);
+    toCircleLayer(*layer).setCircleStrokeWidthTransition(options);
 }
 
 jni::Local<jni::Object<>> CircleLayer::getCircleStrokeColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(layer).getCircleStrokeColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::CircleLayer::getDefaultCircleStrokeColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(*layer).getCircleStrokeColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> CircleLayer::getCircleStrokeColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toCircleLayer(layer).getCircleStrokeColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toCircleLayer(*layer).getCircleStrokeColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void CircleLayer::setCircleStrokeColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toCircleLayer(layer).setCircleStrokeColorTransition(options);
+    toCircleLayer(*layer).setCircleStrokeColorTransition(options);
 }
 
 jni::Local<jni::Object<>> CircleLayer::getCircleStrokeOpacity(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(layer).getCircleStrokeOpacity()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::CircleLayer::getDefaultCircleStrokeOpacity()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toCircleLayer(*layer).getCircleStrokeOpacity()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> CircleLayer::getCircleStrokeOpacityTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toCircleLayer(layer).getCircleStrokeOpacityTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toCircleLayer(*layer).getCircleStrokeOpacityTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void CircleLayer::setCircleStrokeOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toCircleLayer(layer).setCircleStrokeOpacityTransition(options);
+    toCircleLayer(*layer).setCircleStrokeOpacityTransition(options);
 }
 
 // CircleJavaLayerPeerFactory

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/fill_extrusion_layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/fill_extrusion_layer.cpp
@@ -41,122 +41,211 @@ FillExtrusionLayer::~FillExtrusionLayer() = default;
 
 jni::Local<jni::Object<>> FillExtrusionLayer::getFillExtrusionOpacity(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(layer).getFillExtrusionOpacity()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::FillExtrusionLayer::getDefaultFillExtrusionOpacity()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(*layer).getFillExtrusionOpacity()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> FillExtrusionLayer::getFillExtrusionOpacityTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toFillExtrusionLayer(layer).getFillExtrusionOpacityTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toFillExtrusionLayer(*layer).getFillExtrusionOpacityTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void FillExtrusionLayer::setFillExtrusionOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toFillExtrusionLayer(layer).setFillExtrusionOpacityTransition(options);
+    toFillExtrusionLayer(*layer).setFillExtrusionOpacityTransition(options);
 }
 
 jni::Local<jni::Object<>> FillExtrusionLayer::getFillExtrusionColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(layer).getFillExtrusionColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::FillExtrusionLayer::getDefaultFillExtrusionColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(*layer).getFillExtrusionColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> FillExtrusionLayer::getFillExtrusionColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toFillExtrusionLayer(layer).getFillExtrusionColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toFillExtrusionLayer(*layer).getFillExtrusionColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void FillExtrusionLayer::setFillExtrusionColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toFillExtrusionLayer(layer).setFillExtrusionColorTransition(options);
+    toFillExtrusionLayer(*layer).setFillExtrusionColorTransition(options);
 }
 
 jni::Local<jni::Object<>> FillExtrusionLayer::getFillExtrusionTranslate(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(layer).getFillExtrusionTranslate()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::FillExtrusionLayer::getDefaultFillExtrusionTranslate()));
+    }
+    return std::move(
+        *convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(*layer).getFillExtrusionTranslate()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> FillExtrusionLayer::getFillExtrusionTranslateTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toFillExtrusionLayer(layer).getFillExtrusionTranslateTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toFillExtrusionLayer(*layer).getFillExtrusionTranslateTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void FillExtrusionLayer::setFillExtrusionTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toFillExtrusionLayer(layer).setFillExtrusionTranslateTransition(options);
+    toFillExtrusionLayer(*layer).setFillExtrusionTranslateTransition(options);
 }
 
 jni::Local<jni::Object<>> FillExtrusionLayer::getFillExtrusionTranslateAnchor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(
+            env, style::FillExtrusionLayer::getDefaultFillExtrusionTranslateAnchor()));
+    }
     return std::move(
-        *convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(layer).getFillExtrusionTranslateAnchor()));
+        *convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(*layer).getFillExtrusionTranslateAnchor()));
 }
 
 jni::Local<jni::Object<>> FillExtrusionLayer::getFillExtrusionPattern(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(layer).getFillExtrusionPattern()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::FillExtrusionLayer::getDefaultFillExtrusionPattern()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(*layer).getFillExtrusionPattern()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> FillExtrusionLayer::getFillExtrusionPatternTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toFillExtrusionLayer(layer).getFillExtrusionPatternTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toFillExtrusionLayer(*layer).getFillExtrusionPatternTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void FillExtrusionLayer::setFillExtrusionPatternTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toFillExtrusionLayer(layer).setFillExtrusionPatternTransition(options);
+    toFillExtrusionLayer(*layer).setFillExtrusionPatternTransition(options);
 }
 
 jni::Local<jni::Object<>> FillExtrusionLayer::getFillExtrusionHeight(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(layer).getFillExtrusionHeight()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::FillExtrusionLayer::getDefaultFillExtrusionHeight()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(*layer).getFillExtrusionHeight()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> FillExtrusionLayer::getFillExtrusionHeightTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toFillExtrusionLayer(layer).getFillExtrusionHeightTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toFillExtrusionLayer(*layer).getFillExtrusionHeightTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void FillExtrusionLayer::setFillExtrusionHeightTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toFillExtrusionLayer(layer).setFillExtrusionHeightTransition(options);
+    toFillExtrusionLayer(*layer).setFillExtrusionHeightTransition(options);
 }
 
 jni::Local<jni::Object<>> FillExtrusionLayer::getFillExtrusionBase(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(layer).getFillExtrusionBase()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::FillExtrusionLayer::getDefaultFillExtrusionBase()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(*layer).getFillExtrusionBase()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> FillExtrusionLayer::getFillExtrusionBaseTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toFillExtrusionLayer(layer).getFillExtrusionBaseTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toFillExtrusionLayer(*layer).getFillExtrusionBaseTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void FillExtrusionLayer::setFillExtrusionBaseTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toFillExtrusionLayer(layer).setFillExtrusionBaseTransition(options);
+    toFillExtrusionLayer(*layer).setFillExtrusionBaseTransition(options);
 }
 
 jni::Local<jni::Object<>> FillExtrusionLayer::getFillExtrusionVerticalGradient(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(
+            env, style::FillExtrusionLayer::getDefaultFillExtrusionVerticalGradient()));
+    }
     return std::move(
-        *convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(layer).getFillExtrusionVerticalGradient()));
+        *convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(*layer).getFillExtrusionVerticalGradient()));
 }
 
 // FillExtrusionJavaLayerPeerFactory

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/fill_layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/fill_layer.cpp
@@ -41,107 +41,179 @@ FillLayer::~FillLayer() = default;
 
 jni::Local<jni::Object<>> FillLayer::getFillSortKey(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(layer).getFillSortKey()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::FillLayer::getDefaultFillSortKey()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(*layer).getFillSortKey()));
 }
 
 jni::Local<jni::Object<>> FillLayer::getFillAntialias(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(layer).getFillAntialias()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::FillLayer::getDefaultFillAntialias()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(*layer).getFillAntialias()));
 }
 
 jni::Local<jni::Object<>> FillLayer::getFillOpacity(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(layer).getFillOpacity()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::FillLayer::getDefaultFillOpacity()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(*layer).getFillOpacity()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> FillLayer::getFillOpacityTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toFillLayer(layer).getFillOpacityTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toFillLayer(*layer).getFillOpacityTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void FillLayer::setFillOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toFillLayer(layer).setFillOpacityTransition(options);
+    toFillLayer(*layer).setFillOpacityTransition(options);
 }
 
 jni::Local<jni::Object<>> FillLayer::getFillColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(layer).getFillColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::FillLayer::getDefaultFillColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(*layer).getFillColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> FillLayer::getFillColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toFillLayer(layer).getFillColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toFillLayer(*layer).getFillColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void FillLayer::setFillColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toFillLayer(layer).setFillColorTransition(options);
+    toFillLayer(*layer).setFillColorTransition(options);
 }
 
 jni::Local<jni::Object<>> FillLayer::getFillOutlineColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(layer).getFillOutlineColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::FillLayer::getDefaultFillOutlineColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(*layer).getFillOutlineColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> FillLayer::getFillOutlineColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toFillLayer(layer).getFillOutlineColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toFillLayer(*layer).getFillOutlineColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void FillLayer::setFillOutlineColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toFillLayer(layer).setFillOutlineColorTransition(options);
+    toFillLayer(*layer).setFillOutlineColorTransition(options);
 }
 
 jni::Local<jni::Object<>> FillLayer::getFillTranslate(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(layer).getFillTranslate()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::FillLayer::getDefaultFillTranslate()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(*layer).getFillTranslate()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> FillLayer::getFillTranslateTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toFillLayer(layer).getFillTranslateTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toFillLayer(*layer).getFillTranslateTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void FillLayer::setFillTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toFillLayer(layer).setFillTranslateTransition(options);
+    toFillLayer(*layer).setFillTranslateTransition(options);
 }
 
 jni::Local<jni::Object<>> FillLayer::getFillTranslateAnchor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(layer).getFillTranslateAnchor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::FillLayer::getDefaultFillTranslateAnchor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(*layer).getFillTranslateAnchor()));
 }
 
 jni::Local<jni::Object<>> FillLayer::getFillPattern(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(layer).getFillPattern()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::FillLayer::getDefaultFillPattern()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toFillLayer(*layer).getFillPattern()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> FillLayer::getFillPatternTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toFillLayer(layer).getFillPatternTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toFillLayer(*layer).getFillPatternTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void FillLayer::setFillPatternTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toFillLayer(layer).setFillPatternTransition(options);
+    toFillLayer(*layer).setFillPatternTransition(options);
 }
 
 // FillJavaLayerPeerFactory

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/heatmap_layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/heatmap_layer.cpp
@@ -41,70 +41,115 @@ HeatmapLayer::~HeatmapLayer() = default;
 
 jni::Local<jni::Object<>> HeatmapLayer::getHeatmapRadius(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHeatmapLayer(layer).getHeatmapRadius()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::HeatmapLayer::getDefaultHeatmapRadius()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHeatmapLayer(*layer).getHeatmapRadius()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> HeatmapLayer::getHeatmapRadiusTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toHeatmapLayer(layer).getHeatmapRadiusTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toHeatmapLayer(*layer).getHeatmapRadiusTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void HeatmapLayer::setHeatmapRadiusTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toHeatmapLayer(layer).setHeatmapRadiusTransition(options);
+    toHeatmapLayer(*layer).setHeatmapRadiusTransition(options);
 }
 
 jni::Local<jni::Object<>> HeatmapLayer::getHeatmapWeight(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHeatmapLayer(layer).getHeatmapWeight()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::HeatmapLayer::getDefaultHeatmapWeight()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHeatmapLayer(*layer).getHeatmapWeight()));
 }
 
 jni::Local<jni::Object<>> HeatmapLayer::getHeatmapIntensity(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHeatmapLayer(layer).getHeatmapIntensity()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::HeatmapLayer::getDefaultHeatmapIntensity()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHeatmapLayer(*layer).getHeatmapIntensity()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> HeatmapLayer::getHeatmapIntensityTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toHeatmapLayer(layer).getHeatmapIntensityTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toHeatmapLayer(*layer).getHeatmapIntensityTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void HeatmapLayer::setHeatmapIntensityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toHeatmapLayer(layer).setHeatmapIntensityTransition(options);
+    toHeatmapLayer(*layer).setHeatmapIntensityTransition(options);
 }
 
 jni::Local<jni::Object<>> HeatmapLayer::getHeatmapColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    auto propertyValue = toHeatmapLayer(layer).getHeatmapColor();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::HeatmapLayer::getDefaultHeatmapColor()));
+    }
+
+    auto propertyValue = toHeatmapLayer(*layer).getHeatmapColor();
     if (propertyValue.isUndefined()) {
-        propertyValue = toHeatmapLayer(layer).getDefaultHeatmapColor();
+        propertyValue = toHeatmapLayer(*layer).getDefaultHeatmapColor();
     }
     return std::move(*convert<jni::Local<jni::Object<>>>(env, propertyValue));
 }
 
 jni::Local<jni::Object<>> HeatmapLayer::getHeatmapOpacity(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHeatmapLayer(layer).getHeatmapOpacity()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::HeatmapLayer::getDefaultHeatmapOpacity()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHeatmapLayer(*layer).getHeatmapOpacity()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> HeatmapLayer::getHeatmapOpacityTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toHeatmapLayer(layer).getHeatmapOpacityTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toHeatmapLayer(*layer).getHeatmapOpacityTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void HeatmapLayer::setHeatmapOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toHeatmapLayer(layer).setHeatmapOpacityTransition(options);
+    toHeatmapLayer(*layer).setHeatmapOpacityTransition(options);
 }
 
 // HeatmapJavaLayerPeerFactory

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/hillshade_layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/hillshade_layer.cpp
@@ -41,86 +41,148 @@ HillshadeLayer::~HillshadeLayer() = default;
 
 jni::Local<jni::Object<>> HillshadeLayer::getHillshadeIlluminationDirection(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(
+            env, style::HillshadeLayer::getDefaultHillshadeIlluminationDirection()));
+    }
     return std::move(
-        *convert<jni::Local<jni::Object<>>>(env, toHillshadeLayer(layer).getHillshadeIlluminationDirection()));
+        *convert<jni::Local<jni::Object<>>>(env, toHillshadeLayer(*layer).getHillshadeIlluminationDirection()));
 }
 
 jni::Local<jni::Object<>> HillshadeLayer::getHillshadeIlluminationAnchor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::HillshadeLayer::getDefaultHillshadeIlluminationAnchor()));
+    }
     return std::move(
-        *convert<jni::Local<jni::Object<>>>(env, toHillshadeLayer(layer).getHillshadeIlluminationAnchor()));
+        *convert<jni::Local<jni::Object<>>>(env, toHillshadeLayer(*layer).getHillshadeIlluminationAnchor()));
 }
 
 jni::Local<jni::Object<>> HillshadeLayer::getHillshadeExaggeration(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHillshadeLayer(layer).getHillshadeExaggeration()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::HillshadeLayer::getDefaultHillshadeExaggeration()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHillshadeLayer(*layer).getHillshadeExaggeration()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> HillshadeLayer::getHillshadeExaggerationTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toHillshadeLayer(layer).getHillshadeExaggerationTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toHillshadeLayer(*layer).getHillshadeExaggerationTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void HillshadeLayer::setHillshadeExaggerationTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toHillshadeLayer(layer).setHillshadeExaggerationTransition(options);
+    toHillshadeLayer(*layer).setHillshadeExaggerationTransition(options);
 }
 
 jni::Local<jni::Object<>> HillshadeLayer::getHillshadeShadowColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHillshadeLayer(layer).getHillshadeShadowColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::HillshadeLayer::getDefaultHillshadeShadowColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHillshadeLayer(*layer).getHillshadeShadowColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> HillshadeLayer::getHillshadeShadowColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toHillshadeLayer(layer).getHillshadeShadowColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toHillshadeLayer(*layer).getHillshadeShadowColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void HillshadeLayer::setHillshadeShadowColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toHillshadeLayer(layer).setHillshadeShadowColorTransition(options);
+    toHillshadeLayer(*layer).setHillshadeShadowColorTransition(options);
 }
 
 jni::Local<jni::Object<>> HillshadeLayer::getHillshadeHighlightColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHillshadeLayer(layer).getHillshadeHighlightColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::HillshadeLayer::getDefaultHillshadeHighlightColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHillshadeLayer(*layer).getHillshadeHighlightColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> HillshadeLayer::getHillshadeHighlightColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toHillshadeLayer(layer).getHillshadeHighlightColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toHillshadeLayer(*layer).getHillshadeHighlightColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void HillshadeLayer::setHillshadeHighlightColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toHillshadeLayer(layer).setHillshadeHighlightColorTransition(options);
+    toHillshadeLayer(*layer).setHillshadeHighlightColorTransition(options);
 }
 
 jni::Local<jni::Object<>> HillshadeLayer::getHillshadeAccentColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHillshadeLayer(layer).getHillshadeAccentColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::HillshadeLayer::getDefaultHillshadeAccentColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toHillshadeLayer(*layer).getHillshadeAccentColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> HillshadeLayer::getHillshadeAccentColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toHillshadeLayer(layer).getHillshadeAccentColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toHillshadeLayer(*layer).getHillshadeAccentColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void HillshadeLayer::setHillshadeAccentColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toHillshadeLayer(layer).setHillshadeAccentColorTransition(options);
+    toHillshadeLayer(*layer).setHillshadeAccentColorTransition(options);
 }
 
 // HillshadeJavaLayerPeerFactory

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/layer.cpp.ejs
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/layer.cpp.ejs
@@ -57,15 +57,24 @@ namespace android {
 <% if (property.name != 'heatmap-color') { -%>
     jni::Local<jni::Object<>> <%- camelize(type) %>Layer::get<%- camelize(property.name) %>(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
-        return std::move(*convert<jni::Local<jni::Object<>>>(env, to<%- camelize(type) %>Layer(layer).get<%- camelize(property.name) %>()));
+        auto layer = layerPtr.get();
+        if (!layer) {
+            return std::move(*convert<jni::Local<jni::Object<>>>(env, style::<%- camelize(type) %>Layer::getDefault<%- camelize(property.name) %>()));
+        }
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, to<%- camelize(type) %>Layer(*layer).get<%- camelize(property.name) %>()));
     }
 
 <% } else { -%>
     jni::Local<jni::Object<>> HeatmapLayer::getHeatmapColor(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
-        auto propertyValue =  to<%- camelize(type) %>Layer(layer).getHeatmapColor();
+        auto layer = layerPtr.get();
+        if (!layer) {
+            return std::move(*convert<jni::Local<jni::Object<>>>(env, style::<%- camelize(type) %>Layer::getDefaultHeatmapColor()));
+        }
+
+        auto propertyValue =  to<%- camelize(type) %>Layer(*layer).getHeatmapColor();
         if (propertyValue.isUndefined()) {
-            propertyValue =  to<%- camelize(type) %>Layer(layer).getDefaultHeatmapColor();
+            propertyValue =  to<%- camelize(type) %>Layer(*layer).getDefaultHeatmapColor();
         }
         return std::move(*convert<jni::Local<jni::Object<>>>(env, propertyValue));
     }
@@ -74,15 +83,23 @@ namespace android {
 <% if (property.transition) { -%>
     jni::Local<jni::Object<TransitionOptions>> <%- camelize(type) %>Layer::get<%- camelize(property.name) %>Transition(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
-        mbgl::style::TransitionOptions options = to<%- camelize(type) %>Layer(layer).get<%- camelize(property.name) %>Transition();
+        auto layer = layerPtr.get();
+        if (!layer) {
+            return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+        }
+        mbgl::style::TransitionOptions options = to<%- camelize(type) %>Layer(*layer).get<%- camelize(property.name) %>Transition();
         return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
     }
 
     void <%- camelize(type) %>Layer::set<%- camelize(property.name) %>Transition(jni::JNIEnv&, jlong duration, jlong delay) {
+        auto layer = layerPtr.get();
+        if (!layer) {
+            return;
+        }
         mbgl::style::TransitionOptions options;
         options.duration.emplace(mbgl::Milliseconds(duration));
         options.delay.emplace(mbgl::Milliseconds(delay));
-        to<%- camelize(type) %>Layer(layer).set<%- camelize(property.name) %>Transition(options);
+        to<%- camelize(type) %>Layer(*layer).set<%- camelize(property.name) %>Transition(options);
     }
 
 <% } -%>

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/layer.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/layer.hpp
@@ -78,7 +78,7 @@ protected:
     std::unique_ptr<mbgl::style::Layer> ownedLayer;
 
     // Raw reference to the layer
-    mbgl::style::Layer& layer;
+    mapbox::base::WeakPtr<mbgl::style::Layer> layerPtr;
 };
 
 /**

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/line_layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/line_layer.cpp
@@ -41,199 +41,335 @@ LineLayer::~LineLayer() = default;
 
 jni::Local<jni::Object<>> LineLayer::getLineCap(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineCap()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineCap()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineCap()));
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineJoin(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineJoin()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineJoin()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineJoin()));
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineMiterLimit(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineMiterLimit()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineMiterLimit()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineMiterLimit()));
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineRoundLimit(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineRoundLimit()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineRoundLimit()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineRoundLimit()));
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineSortKey(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineSortKey()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineSortKey()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineSortKey()));
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineOpacity(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineOpacity()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineOpacity()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineOpacity()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LineLayer::getLineOpacityTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLineLayer(layer).getLineOpacityTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLineLayer(*layer).getLineOpacityTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LineLayer::setLineOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLineLayer(layer).setLineOpacityTransition(options);
+    toLineLayer(*layer).setLineOpacityTransition(options);
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LineLayer::getLineColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLineLayer(layer).getLineColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLineLayer(*layer).getLineColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LineLayer::setLineColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLineLayer(layer).setLineColorTransition(options);
+    toLineLayer(*layer).setLineColorTransition(options);
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineTranslate(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineTranslate()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineTranslate()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineTranslate()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LineLayer::getLineTranslateTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLineLayer(layer).getLineTranslateTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLineLayer(*layer).getLineTranslateTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LineLayer::setLineTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLineLayer(layer).setLineTranslateTransition(options);
+    toLineLayer(*layer).setLineTranslateTransition(options);
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineTranslateAnchor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineTranslateAnchor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineTranslateAnchor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineTranslateAnchor()));
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineWidth(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineWidth()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineWidth()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineWidth()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LineLayer::getLineWidthTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLineLayer(layer).getLineWidthTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLineLayer(*layer).getLineWidthTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LineLayer::setLineWidthTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLineLayer(layer).setLineWidthTransition(options);
+    toLineLayer(*layer).setLineWidthTransition(options);
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineGapWidth(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineGapWidth()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineGapWidth()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineGapWidth()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LineLayer::getLineGapWidthTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLineLayer(layer).getLineGapWidthTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLineLayer(*layer).getLineGapWidthTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LineLayer::setLineGapWidthTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLineLayer(layer).setLineGapWidthTransition(options);
+    toLineLayer(*layer).setLineGapWidthTransition(options);
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineOffset(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineOffset()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineOffset()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineOffset()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LineLayer::getLineOffsetTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLineLayer(layer).getLineOffsetTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLineLayer(*layer).getLineOffsetTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LineLayer::setLineOffsetTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLineLayer(layer).setLineOffsetTransition(options);
+    toLineLayer(*layer).setLineOffsetTransition(options);
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineBlur(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineBlur()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineBlur()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineBlur()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LineLayer::getLineBlurTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLineLayer(layer).getLineBlurTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLineLayer(*layer).getLineBlurTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LineLayer::setLineBlurTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLineLayer(layer).setLineBlurTransition(options);
+    toLineLayer(*layer).setLineBlurTransition(options);
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineDasharray(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineDasharray()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineDasharray()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineDasharray()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LineLayer::getLineDasharrayTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLineLayer(layer).getLineDasharrayTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLineLayer(*layer).getLineDasharrayTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LineLayer::setLineDasharrayTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLineLayer(layer).setLineDasharrayTransition(options);
+    toLineLayer(*layer).setLineDasharrayTransition(options);
 }
 
 jni::Local<jni::Object<>> LineLayer::getLinePattern(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLinePattern()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLinePattern()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLinePattern()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LineLayer::getLinePatternTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLineLayer(layer).getLinePatternTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLineLayer(*layer).getLinePatternTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LineLayer::setLinePatternTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLineLayer(layer).setLinePatternTransition(options);
+    toLineLayer(*layer).setLinePatternTransition(options);
 }
 
 jni::Local<jni::Object<>> LineLayer::getLineGradient(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(layer).getLineGradient()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LineLayer::getDefaultLineGradient()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLineLayer(*layer).getLineGradient()));
 }
 
 // LineJavaLayerPeerFactory

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/location_indicator_layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/location_indicator_layer.cpp
@@ -40,176 +40,302 @@ LocationIndicatorLayer::~LocationIndicatorLayer() = default;
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getTopImage(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getTopImage()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LocationIndicatorLayer::getDefaultTopImage()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getTopImage()));
 }
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getBearingImage(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getBearingImage()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::LocationIndicatorLayer::getDefaultBearingImage()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getBearingImage()));
 }
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getShadowImage(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getShadowImage()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::LocationIndicatorLayer::getDefaultShadowImage()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getShadowImage()));
 }
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getPerspectiveCompensation(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(
+            env, style::LocationIndicatorLayer::getDefaultPerspectiveCompensation()));
+    }
     return std::move(
-        *convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getPerspectiveCompensation()));
+        *convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getPerspectiveCompensation()));
 }
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getImageTiltDisplacement(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::LocationIndicatorLayer::getDefaultImageTiltDisplacement()));
+    }
     return std::move(
-        *convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getImageTiltDisplacement()));
+        *convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getImageTiltDisplacement()));
 }
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getBearing(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getBearing()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LocationIndicatorLayer::getDefaultBearing()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getBearing()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LocationIndicatorLayer::getBearingTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(layer).getBearingTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(*layer).getBearingTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LocationIndicatorLayer::setBearingTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLocationIndicatorLayer(layer).setBearingTransition(options);
+    toLocationIndicatorLayer(*layer).setBearingTransition(options);
 }
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getLocation(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getLocation()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::LocationIndicatorLayer::getDefaultLocation()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getLocation()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LocationIndicatorLayer::getLocationTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(layer).getLocationTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(*layer).getLocationTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LocationIndicatorLayer::setLocationTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLocationIndicatorLayer(layer).setLocationTransition(options);
+    toLocationIndicatorLayer(*layer).setLocationTransition(options);
 }
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getAccuracyRadius(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getAccuracyRadius()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::LocationIndicatorLayer::getDefaultAccuracyRadius()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getAccuracyRadius()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LocationIndicatorLayer::getAccuracyRadiusTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(layer).getAccuracyRadiusTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(*layer).getAccuracyRadiusTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LocationIndicatorLayer::setAccuracyRadiusTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLocationIndicatorLayer(layer).setAccuracyRadiusTransition(options);
+    toLocationIndicatorLayer(*layer).setAccuracyRadiusTransition(options);
 }
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getTopImageSize(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getTopImageSize()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::LocationIndicatorLayer::getDefaultTopImageSize()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getTopImageSize()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LocationIndicatorLayer::getTopImageSizeTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(layer).getTopImageSizeTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(*layer).getTopImageSizeTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LocationIndicatorLayer::setTopImageSizeTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLocationIndicatorLayer(layer).setTopImageSizeTransition(options);
+    toLocationIndicatorLayer(*layer).setTopImageSizeTransition(options);
 }
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getBearingImageSize(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getBearingImageSize()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::LocationIndicatorLayer::getDefaultBearingImageSize()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getBearingImageSize()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LocationIndicatorLayer::getBearingImageSizeTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(layer).getBearingImageSizeTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(*layer).getBearingImageSizeTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LocationIndicatorLayer::setBearingImageSizeTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLocationIndicatorLayer(layer).setBearingImageSizeTransition(options);
+    toLocationIndicatorLayer(*layer).setBearingImageSizeTransition(options);
 }
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getShadowImageSize(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getShadowImageSize()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::LocationIndicatorLayer::getDefaultShadowImageSize()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getShadowImageSize()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LocationIndicatorLayer::getShadowImageSizeTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(layer).getShadowImageSizeTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(*layer).getShadowImageSizeTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LocationIndicatorLayer::setShadowImageSizeTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLocationIndicatorLayer(layer).setShadowImageSizeTransition(options);
+    toLocationIndicatorLayer(*layer).setShadowImageSizeTransition(options);
 }
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getAccuracyRadiusColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::LocationIndicatorLayer::getDefaultAccuracyRadiusColor()));
+    }
     return std::move(
-        *convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getAccuracyRadiusColor()));
+        *convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getAccuracyRadiusColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LocationIndicatorLayer::getAccuracyRadiusColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(layer).getAccuracyRadiusColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(*layer).getAccuracyRadiusColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LocationIndicatorLayer::setAccuracyRadiusColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLocationIndicatorLayer(layer).setAccuracyRadiusColorTransition(options);
+    toLocationIndicatorLayer(*layer).setAccuracyRadiusColorTransition(options);
 }
 
 jni::Local<jni::Object<>> LocationIndicatorLayer::getAccuracyRadiusBorderColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(
+            env, style::LocationIndicatorLayer::getDefaultAccuracyRadiusBorderColor()));
+    }
     return std::move(
-        *convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(layer).getAccuracyRadiusBorderColor()));
+        *convert<jni::Local<jni::Object<>>>(env, toLocationIndicatorLayer(*layer).getAccuracyRadiusBorderColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> LocationIndicatorLayer::getAccuracyRadiusBorderColorTransition(
     jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(layer).getAccuracyRadiusBorderColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toLocationIndicatorLayer(*layer).getAccuracyRadiusBorderColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void LocationIndicatorLayer::setAccuracyRadiusBorderColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toLocationIndicatorLayer(layer).setAccuracyRadiusBorderColorTransition(options);
+    toLocationIndicatorLayer(*layer).setAccuracyRadiusBorderColorTransition(options);
 }
 
 // LocationIndicatorJavaLayerPeerFactory

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/raster_layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/raster_layer.cpp
@@ -41,120 +41,200 @@ RasterLayer::~RasterLayer() = default;
 
 jni::Local<jni::Object<>> RasterLayer::getRasterOpacity(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(layer).getRasterOpacity()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::RasterLayer::getDefaultRasterOpacity()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(*layer).getRasterOpacity()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> RasterLayer::getRasterOpacityTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toRasterLayer(layer).getRasterOpacityTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toRasterLayer(*layer).getRasterOpacityTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void RasterLayer::setRasterOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toRasterLayer(layer).setRasterOpacityTransition(options);
+    toRasterLayer(*layer).setRasterOpacityTransition(options);
 }
 
 jni::Local<jni::Object<>> RasterLayer::getRasterHueRotate(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(layer).getRasterHueRotate()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::RasterLayer::getDefaultRasterHueRotate()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(*layer).getRasterHueRotate()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> RasterLayer::getRasterHueRotateTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toRasterLayer(layer).getRasterHueRotateTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toRasterLayer(*layer).getRasterHueRotateTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void RasterLayer::setRasterHueRotateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toRasterLayer(layer).setRasterHueRotateTransition(options);
+    toRasterLayer(*layer).setRasterHueRotateTransition(options);
 }
 
 jni::Local<jni::Object<>> RasterLayer::getRasterBrightnessMin(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(layer).getRasterBrightnessMin()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::RasterLayer::getDefaultRasterBrightnessMin()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(*layer).getRasterBrightnessMin()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> RasterLayer::getRasterBrightnessMinTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toRasterLayer(layer).getRasterBrightnessMinTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toRasterLayer(*layer).getRasterBrightnessMinTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void RasterLayer::setRasterBrightnessMinTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toRasterLayer(layer).setRasterBrightnessMinTransition(options);
+    toRasterLayer(*layer).setRasterBrightnessMinTransition(options);
 }
 
 jni::Local<jni::Object<>> RasterLayer::getRasterBrightnessMax(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(layer).getRasterBrightnessMax()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::RasterLayer::getDefaultRasterBrightnessMax()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(*layer).getRasterBrightnessMax()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> RasterLayer::getRasterBrightnessMaxTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toRasterLayer(layer).getRasterBrightnessMaxTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toRasterLayer(*layer).getRasterBrightnessMaxTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void RasterLayer::setRasterBrightnessMaxTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toRasterLayer(layer).setRasterBrightnessMaxTransition(options);
+    toRasterLayer(*layer).setRasterBrightnessMaxTransition(options);
 }
 
 jni::Local<jni::Object<>> RasterLayer::getRasterSaturation(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(layer).getRasterSaturation()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::RasterLayer::getDefaultRasterSaturation()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(*layer).getRasterSaturation()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> RasterLayer::getRasterSaturationTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toRasterLayer(layer).getRasterSaturationTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toRasterLayer(*layer).getRasterSaturationTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void RasterLayer::setRasterSaturationTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toRasterLayer(layer).setRasterSaturationTransition(options);
+    toRasterLayer(*layer).setRasterSaturationTransition(options);
 }
 
 jni::Local<jni::Object<>> RasterLayer::getRasterContrast(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(layer).getRasterContrast()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::RasterLayer::getDefaultRasterContrast()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(*layer).getRasterContrast()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> RasterLayer::getRasterContrastTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toRasterLayer(layer).getRasterContrastTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toRasterLayer(*layer).getRasterContrastTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void RasterLayer::setRasterContrastTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toRasterLayer(layer).setRasterContrastTransition(options);
+    toRasterLayer(*layer).setRasterContrastTransition(options);
 }
 
 jni::Local<jni::Object<>> RasterLayer::getRasterResampling(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(layer).getRasterResampling()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::RasterLayer::getDefaultRasterResampling()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(*layer).getRasterResampling()));
 }
 
 jni::Local<jni::Object<>> RasterLayer::getRasterFadeDuration(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(layer).getRasterFadeDuration()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::RasterLayer::getDefaultRasterFadeDuration()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toRasterLayer(*layer).getRasterFadeDuration()));
 }
 
 // RasterJavaLayerPeerFactory

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/symbol_layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/symbol_layer.cpp
@@ -41,443 +41,770 @@ SymbolLayer::~SymbolLayer() = default;
 
 jni::Local<jni::Object<>> SymbolLayer::getSymbolPlacement(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getSymbolPlacement()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultSymbolPlacement()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getSymbolPlacement()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getSymbolSpacing(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getSymbolSpacing()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultSymbolSpacing()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getSymbolSpacing()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getSymbolAvoidEdges(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getSymbolAvoidEdges()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultSymbolAvoidEdges()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getSymbolAvoidEdges()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getSymbolSortKey(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getSymbolSortKey()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultSymbolSortKey()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getSymbolSortKey()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getSymbolZOrder(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getSymbolZOrder()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultSymbolZOrder()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getSymbolZOrder()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconAllowOverlap(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconAllowOverlap()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconAllowOverlap()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconAllowOverlap()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconIgnorePlacement(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconIgnorePlacement()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconIgnorePlacement()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconIgnorePlacement()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconOptional(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconOptional()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconOptional()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconOptional()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconRotationAlignment(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconRotationAlignment()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconRotationAlignment()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconRotationAlignment()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconSize(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconSize()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconSize()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconSize()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconTextFit(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconTextFit()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconTextFit()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconTextFit()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconTextFitPadding(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconTextFitPadding()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconTextFitPadding()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconTextFitPadding()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconImage(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconImage()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconImage()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconImage()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconRotate(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconRotate()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconRotate()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconRotate()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconPadding(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconPadding()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconPadding()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconPadding()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconKeepUpright(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconKeepUpright()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconKeepUpright()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconKeepUpright()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconOffset(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconOffset()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconOffset()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconOffset()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconAnchor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconAnchor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconAnchor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconAnchor()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconPitchAlignment(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconPitchAlignment()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconPitchAlignment()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconPitchAlignment()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextPitchAlignment(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextPitchAlignment()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextPitchAlignment()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextPitchAlignment()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextRotationAlignment(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextRotationAlignment()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextRotationAlignment()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextRotationAlignment()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextField(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextField()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextField()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextField()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextFont(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextFont()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextFont()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextFont()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextSize(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextSize()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextSize()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextSize()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextMaxWidth(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextMaxWidth()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextMaxWidth()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextMaxWidth()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextLineHeight(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextLineHeight()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextLineHeight()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextLineHeight()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextLetterSpacing(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextLetterSpacing()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextLetterSpacing()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextLetterSpacing()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextJustify(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextJustify()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextJustify()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextJustify()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextRadialOffset(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextRadialOffset()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextRadialOffset()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextRadialOffset()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextVariableAnchor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextVariableAnchor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextVariableAnchor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextVariableAnchor()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextVariableAnchorOffset(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextVariableAnchorOffset()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextVariableAnchorOffset()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextVariableAnchorOffset()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextAnchor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextAnchor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextAnchor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextAnchor()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextMaxAngle(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextMaxAngle()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextMaxAngle()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextMaxAngle()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextWritingMode(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextWritingMode()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextWritingMode()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextWritingMode()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextRotate(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextRotate()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextRotate()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextRotate()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextPadding(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextPadding()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextPadding()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextPadding()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextKeepUpright(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextKeepUpright()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextKeepUpright()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextKeepUpright()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextTransform(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextTransform()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextTransform()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextTransform()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextOffset(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextOffset()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextOffset()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextOffset()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextAllowOverlap(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextAllowOverlap()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextAllowOverlap()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextAllowOverlap()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextIgnorePlacement(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextIgnorePlacement()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextIgnorePlacement()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextIgnorePlacement()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextOptional(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextOptional()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextOptional()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextOptional()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getSymbolScreenSpace(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getSymbolScreenSpace()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultSymbolScreenSpace()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getSymbolScreenSpace()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconOpacity(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconOpacity()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconOpacity()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconOpacity()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> SymbolLayer::getIconOpacityTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toSymbolLayer(layer).getIconOpacityTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toSymbolLayer(*layer).getIconOpacityTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void SymbolLayer::setIconOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toSymbolLayer(layer).setIconOpacityTransition(options);
+    toSymbolLayer(*layer).setIconOpacityTransition(options);
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> SymbolLayer::getIconColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toSymbolLayer(layer).getIconColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toSymbolLayer(*layer).getIconColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void SymbolLayer::setIconColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toSymbolLayer(layer).setIconColorTransition(options);
+    toSymbolLayer(*layer).setIconColorTransition(options);
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconHaloColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconHaloColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconHaloColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconHaloColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> SymbolLayer::getIconHaloColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toSymbolLayer(layer).getIconHaloColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toSymbolLayer(*layer).getIconHaloColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void SymbolLayer::setIconHaloColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toSymbolLayer(layer).setIconHaloColorTransition(options);
+    toSymbolLayer(*layer).setIconHaloColorTransition(options);
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconHaloWidth(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconHaloWidth()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconHaloWidth()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconHaloWidth()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> SymbolLayer::getIconHaloWidthTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toSymbolLayer(layer).getIconHaloWidthTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toSymbolLayer(*layer).getIconHaloWidthTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void SymbolLayer::setIconHaloWidthTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toSymbolLayer(layer).setIconHaloWidthTransition(options);
+    toSymbolLayer(*layer).setIconHaloWidthTransition(options);
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconHaloBlur(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconHaloBlur()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconHaloBlur()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconHaloBlur()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> SymbolLayer::getIconHaloBlurTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toSymbolLayer(layer).getIconHaloBlurTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toSymbolLayer(*layer).getIconHaloBlurTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void SymbolLayer::setIconHaloBlurTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toSymbolLayer(layer).setIconHaloBlurTransition(options);
+    toSymbolLayer(*layer).setIconHaloBlurTransition(options);
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconTranslate(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconTranslate()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconTranslate()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconTranslate()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> SymbolLayer::getIconTranslateTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toSymbolLayer(layer).getIconTranslateTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toSymbolLayer(*layer).getIconTranslateTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void SymbolLayer::setIconTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toSymbolLayer(layer).setIconTranslateTransition(options);
+    toSymbolLayer(*layer).setIconTranslateTransition(options);
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getIconTranslateAnchor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getIconTranslateAnchor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultIconTranslateAnchor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getIconTranslateAnchor()));
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextOpacity(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextOpacity()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextOpacity()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextOpacity()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> SymbolLayer::getTextOpacityTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toSymbolLayer(layer).getTextOpacityTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toSymbolLayer(*layer).getTextOpacityTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void SymbolLayer::setTextOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toSymbolLayer(layer).setTextOpacityTransition(options);
+    toSymbolLayer(*layer).setTextOpacityTransition(options);
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> SymbolLayer::getTextColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toSymbolLayer(layer).getTextColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toSymbolLayer(*layer).getTextColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void SymbolLayer::setTextColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toSymbolLayer(layer).setTextColorTransition(options);
+    toSymbolLayer(*layer).setTextColorTransition(options);
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextHaloColor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextHaloColor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextHaloColor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextHaloColor()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> SymbolLayer::getTextHaloColorTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toSymbolLayer(layer).getTextHaloColorTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toSymbolLayer(*layer).getTextHaloColorTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void SymbolLayer::setTextHaloColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toSymbolLayer(layer).setTextHaloColorTransition(options);
+    toSymbolLayer(*layer).setTextHaloColorTransition(options);
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextHaloWidth(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextHaloWidth()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextHaloWidth()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextHaloWidth()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> SymbolLayer::getTextHaloWidthTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toSymbolLayer(layer).getTextHaloWidthTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toSymbolLayer(*layer).getTextHaloWidthTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void SymbolLayer::setTextHaloWidthTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toSymbolLayer(layer).setTextHaloWidthTransition(options);
+    toSymbolLayer(*layer).setTextHaloWidthTransition(options);
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextHaloBlur(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextHaloBlur()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextHaloBlur()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextHaloBlur()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> SymbolLayer::getTextHaloBlurTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toSymbolLayer(layer).getTextHaloBlurTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toSymbolLayer(*layer).getTextHaloBlurTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void SymbolLayer::setTextHaloBlurTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toSymbolLayer(layer).setTextHaloBlurTransition(options);
+    toSymbolLayer(*layer).setTextHaloBlurTransition(options);
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextTranslate(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextTranslate()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextTranslate()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextTranslate()));
 }
 
 jni::Local<jni::Object<TransitionOptions>> SymbolLayer::getTextTranslateTransition(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    mbgl::style::TransitionOptions options = toSymbolLayer(layer).getTextTranslateTransition();
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, mbgl::style::TransitionOptions()));
+    }
+    mbgl::style::TransitionOptions options = toSymbolLayer(*layer).getTextTranslateTransition();
     return std::move(*convert<jni::Local<jni::Object<TransitionOptions>>>(env, options));
 }
 
 void SymbolLayer::setTextTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return;
+    }
     mbgl::style::TransitionOptions options;
     options.duration.emplace(mbgl::Milliseconds(duration));
     options.delay.emplace(mbgl::Milliseconds(delay));
-    toSymbolLayer(layer).setTextTranslateTransition(options);
+    toSymbolLayer(*layer).setTextTranslateTransition(options);
 }
 
 jni::Local<jni::Object<>> SymbolLayer::getTextTranslateAnchor(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
-    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(layer).getTextTranslateAnchor()));
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(*convert<jni::Local<jni::Object<>>>(env, style::SymbolLayer::getDefaultTextTranslateAnchor()));
+    }
+    return std::move(*convert<jni::Local<jni::Object<>>>(env, toSymbolLayer(*layer).getTextTranslateAnchor()));
 }
 
 // SymbolJavaLayerPeerFactory


### PR DESCRIPTION
A Java layer object can outlive it's core peer layer while still holding a hard reference to it. This PR replaces the reference with a weak pointer and adds checks before accessing it. Fixes https://github.com/maplibre/maplibre-native/issues/3924.