### PR TITLE
Assume CustomGeometrySource is cancelled when peer is null

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/style/sources/custom_geometry_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/sources/custom_geometry_source.cpp
@@ -126,7 +126,9 @@ bool CustomGeometrySource::isCancelled(jni::jint z, jni::jint x, jni::jint y) {
     static auto& javaClass = jni::Class<CustomGeometrySource>::Singleton(*_env);
     static auto isCancelled = javaClass.GetMethod<jboolean(jni::jint, jni::jint, jni::jint)>(*_env, "isCancelled");
 
-    assert(javaPeer);
+    if (!javaPeer) {
+        return true;
+    }
 
     auto peer = jni::Cast(*_env, javaClass, javaPeer);
     return peer.Call(*_env, isCancelled, z, x, y);


### PR DESCRIPTION
Fixes #3932: Crash when removing the source while tiles are being generated

I have verified this fix with the reproduction from the issue above