### PR TITLE
Add null check to Projection.getContentPadding()

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/Projection.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/Projection.java
@@ -41,7 +41,10 @@ public class Projection {
   }
 
   int[] getContentPadding() {
-    double[] padding = nativeMapView.getCameraPosition().padding;
+    double[] padding = nativeMapView.getContentPadding();
+    if (padding == null) {
+      return new int[] {0, 0, 0, 0};
+    }
     return new int[] {(int) padding[0], (int) padding[1], (int) padding[2], (int) padding[3]};
   }
 


### PR DESCRIPTION
Grab is reporting a crash related to `padding` being `null` here.

Would be good to get a fix out. I don't know what combination of factors is causing `null` to be returned here, but let's add a defensive check here to make sure it doesn't crash. #3935