### PR TITLE
Adds Style Preprocessor Plugin Capability

### DIFF
--- a/bazel/core.bzl
+++ b/bazel/core.bzl
@@ -4,6 +4,7 @@ MLN_LAYER_PLUGIN_HEADERS = [
     "src/mbgl/plugin/plugin_layer_impl.hpp",
     "src/mbgl/plugin/plugin_layer_render.hpp",
     "src/mbgl/plugin/plugin_layer_properties.hpp",
+    "src/mbgl/plugin/plugin_style_filter.hpp",
 ]
 
 MLN_LAYER_PLUGIN_SOURCE = [
@@ -12,6 +13,7 @@ MLN_LAYER_PLUGIN_SOURCE = [
     "src/mbgl/plugin/plugin_layer_impl.cpp",
     "src/mbgl/plugin/plugin_layer_render.cpp",
     "src/mbgl/plugin/plugin_layer_properties.cpp",
+    "src/mbgl/plugin/plugin_style_filter.cpp",
 ]
 
 MLN_PUBLIC_GENERATED_STYLE_HEADERS = [

--- a/include/mbgl/style/style.hpp
+++ b/include/mbgl/style/style.hpp
@@ -20,6 +20,7 @@ namespace style {
 class Light;
 class Source;
 class Layer;
+class PluginStyleFilter;
 
 class Style {
 public:
@@ -71,6 +72,9 @@ public:
     void addLayer(std::unique_ptr<Layer>, const std::optional<std::string>& beforeLayerID = std::nullopt);
     std::unique_ptr<Layer> removeLayer(const std::string& layerID);
 
+    // Add style parsing filter
+    void addStyleFilter(std::shared_ptr<mbgl::style::PluginStyleFilter>);
+    
     // Private implementation
     class Impl;
     const std::unique_ptr<Impl> impl;

--- a/platform/BUILD.bazel
+++ b/platform/BUILD.bazel
@@ -271,6 +271,8 @@ objc_library(
         "//platform/darwin:app/CustomStyleLayerExample.m",
         "//platform/darwin:app/PluginLayerExample.h",
         "//platform/darwin:app/PluginLayerExample.mm",
+        "//platform/darwin:app/StyleFilterExample.h",
+        "//platform/darwin:app/StyleFilterExample.mm",
         "//platform/darwin:app/PluginLayerExampleMetalRendering.h",
         "//platform/darwin:app/PluginLayerExampleMetalRendering.mm",
         "//platform/ios:ios_app_srcs",

--- a/platform/darwin/BUILD.bazel
+++ b/platform/darwin/BUILD.bazel
@@ -308,6 +308,8 @@ exports_files(
         "app/PluginLayerTestStyle.json",
         "app/PluginLayerExample.h",
         "app/PluginLayerExample.mm",
+        "app/StyleFilterExample.h",
+        "app/StyleFilterExample.mm",
         "app/PluginLayerExampleMetalRendering.h",
         "app/PluginLayerExampleMetalRendering.mm",
         "test/amsterdam.geojson",

--- a/platform/darwin/app/StyleFilterExample.h
+++ b/platform/darwin/app/StyleFilterExample.h
@@ -1,0 +1,16 @@
+//
+//  StyleFilterExample.h
+//  MapLibre
+//
+//  Created by Malcolm Toon on 7/25/25.
+//
+
+#import "MLNStyleFilter.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface StyleFilterExample : MLNStyleFilter
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/app/StyleFilterExample.mm
+++ b/platform/darwin/app/StyleFilterExample.mm
@@ -1,0 +1,60 @@
+#import "StyleFilterExample.h"
+
+@implementation StyleFilterExample
+
+// This will filter the data passed in
+-(NSData *)filterData:(NSData *)data {
+    // Don't call super
+    
+    // This example will remove any layer that has "metal-rendering-layer" in the id
+    
+    // Parse the JSON: Make the containers mutable
+    NSError *error = nil;
+    NSMutableDictionary *styleDictionary = [NSJSONSerialization JSONObjectWithData:data
+                                                                          options:NSJSONReadingMutableContainers
+                                                                            error:&error];
+    
+    NSData *tempResult = data;
+    if (styleDictionary) {
+        
+        // Get the layer array
+        NSMutableArray *layerArray = [styleDictionary objectForKey:@"layers"];
+        
+        // Create an array to hold which objects to remove since we can't remove them in the loop
+        NSMutableArray *removedLayers = [NSMutableArray array];
+        
+        // Loop the layers and look for any layers that have the search string in them
+        for (NSMutableDictionary *layer in layerArray) {
+            NSString *layerID = [layer objectForKey:@"id"];
+            
+            // If we find the layers we're looking for, add them to the list of layers to remove
+            if ([layerID containsString:@"metal-rendering-layer"]) {
+                [removedLayers addObject:layer];
+            }
+        }
+        
+        // Go through and remove any layers that were found
+        for (NSMutableDictionary *l in removedLayers) {
+            [layerArray removeObject:l];
+        }
+        
+        // Re-create the JSON, this time the layers we filtered out won't be there
+        NSData *filteredStyleJSON = [NSJSONSerialization dataWithJSONObject:styleDictionary
+                                                                    options:0
+                                                                      error:&error];
+        
+        // If the JSON write is successful, then set the output to the new json style
+        if (filteredStyleJSON) {
+            tempResult = filteredStyleJSON;
+        }
+        
+    }
+    
+    // Return the data
+    return tempResult;
+    
+}
+
+
+
+@end

--- a/platform/darwin/bazel/files.bzl
+++ b/platform/darwin/bazel/files.bzl
@@ -109,7 +109,8 @@ MLN_DARWIN_OBJC_HEADERS = [
     "src/NSValue+MLNAdditions.h",
     "src/MLNPluginLayer.h",
     "src/MLNPluginStyleLayer.h",
-    "src/MLNNetworkResponse.h",
+    "src/MLNStyleFilter.h",
+    "src/MLNStyleFilter_Private.h",
 ]
 
 MLN_DARWIN_OBJCPP_HEADERS = [
@@ -226,6 +227,7 @@ MLN_DARWIN_PUBLIC_OBJCPP_SOURCE = [
     "src/MLNPluginLayer.mm",
     "src/MLNPluginStyleLayer.mm",
     "src/MLNNetworkResponse.mm",
+    "src/MLNStyleFilter.mm",
 ]
 MLN_DARWIN_PUBLIC_OBJCPP_CUSTOM_DRAWABLE_SOURCE = [
     "src/MLNCustomDrawableStyleLayer_Private.h",

--- a/platform/darwin/src/MLNStyleFilter.h
+++ b/platform/darwin/src/MLNStyleFilter.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MLNStyleFilter : NSObject
+
+// This will filter the data passed in
+-(NSData *)filterData:(NSData *)data;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MLNStyleFilter.mm
+++ b/platform/darwin/src/MLNStyleFilter.mm
@@ -1,0 +1,23 @@
+#import "MLNStyleFilter.h"
+#include <mbgl/plugin/plugin_style_filter.hpp>
+
+@interface MLNStyleFilter () {
+    std::shared_ptr<mbgl::style::PluginStyleFilter> _coreFilter;
+}
+
+@end
+
+@implementation MLNStyleFilter
+
+-(NSData *)filterData:(NSData *)data {
+    // Base class does nothing but return the same data passed in
+    return data;
+}
+
+// Private
+-(void)setFilter:(std::shared_ptr<mbgl::style::PluginStyleFilter>)filter {
+    _coreFilter = filter;
+}
+
+
+@end

--- a/platform/darwin/src/MLNStyleFilter_Private.h
+++ b/platform/darwin/src/MLNStyleFilter_Private.h
@@ -1,0 +1,14 @@
+
+#ifndef MLNStyleFilter_Private_h
+#define MLNStyleFilter_Private_h
+
+#import "MLNStyleFilter.h"
+#include <mbgl/plugin/plugin_style_filter.hpp>
+
+@interface MLNStyleFilter(Private)
+
+-(void)setFilter:(std::shared_ptr<mbgl::style::PluginStyleFilter>)filter;
+
+@end
+
+#endif /* MLNStyleFilter_Private_h */

--- a/platform/ios/app/MBXViewController.mm
+++ b/platform/ios/app/MBXViewController.mm
@@ -27,6 +27,7 @@
 #import "PluginLayerExample.h"
 #import "PluginLayerExampleMetalRendering.h"
 #import "MLNPluginStyleLayer.h"
+#import "StyleFilterExample.h"
 
 static const CLLocationCoordinate2D WorldTourDestinations[] = {
     { .latitude = 38.8999418, .longitude = -77.033996 },
@@ -281,6 +282,7 @@ CLLocationCoordinate2D randomWorldCoordinate(void) {
 
     [self.mapView addPluginLayerType:[PluginLayerExample class]];
     [self.mapView addPluginLayerType:[PluginLayerExampleMetalRendering class]];
+    [self.mapView addStyleFilter:[[StyleFilterExample alloc] init]];
 
 }
 

--- a/platform/ios/src/MLNMapView.h
+++ b/platform/ios/src/MLNMapView.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class MLNScaleBar;
 @class MLNShape;
 @class MLNPluginLayer;
+@class MLNStyleFilter;
 
 @protocol MLNMapViewDelegate;
 @protocol MLNAnnotation;
@@ -2321,6 +2322,11 @@ of north, the map will automatically snap to exact north.
  Adds a plug-in layer that is external to this library
  */
 - (void)addPluginLayerType:(Class)pluginLayerClass;
+
+/**
+ Adds a style filter to the map view
+ */
+-(void)addStyleFilter:(MLNStyleFilter *)styleFilter;
 
 @end
 

--- a/src/mbgl/plugin/plugin_style_filter.cpp
+++ b/src/mbgl/plugin/plugin_style_filter.cpp
@@ -1,0 +1,14 @@
+#include <mbgl/plugin/plugin_style_filter.hpp>
+
+using namespace mbgl::style;
+
+// This method
+const std::string PluginStyleFilter::filterResponse(const std::string& res) {
+    
+    if (_filterStyleFunction) {
+        auto tempResult = _filterStyleFunction(res);
+        return tempResult;
+    }
+    return res;
+    
+}

--- a/src/mbgl/plugin/plugin_style_filter.hpp
+++ b/src/mbgl/plugin/plugin_style_filter.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <functional>
+
+
+namespace mbgl {
+
+namespace style {
+
+class PluginStyleFilter {
+public:
+    
+    using OnFilterStyle = std::function<const std::string(const std::string&)>;
+
+    OnFilterStyle _filterStyleFunction;
+    
+    // This method
+    const std::string filterResponse(const std::string&);
+};
+
+
+}
+}

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -177,5 +177,13 @@ std::unique_ptr<Layer> Style::removeLayer(const std::string& id) {
     return impl->removeLayer(id);
 }
 
+// Add style parsing filter
+void Style::addStyleFilter(std::shared_ptr<mbgl::style::PluginStyleFilter> filter) {
+    impl->mutated = true;
+    return impl->addStyleFilter(filter);
+
+}
+
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/style_impl.hpp
+++ b/src/mbgl/style/style_impl.hpp
@@ -30,6 +30,7 @@ namespace mbgl {
 class FileSource;
 class AsyncRequest;
 class SpriteLoader;
+class Response;
 
 namespace style {
 
@@ -68,6 +69,9 @@ public:
     Layer* addLayer(std::unique_ptr<Layer>, const std::optional<std::string>& beforeLayerID = std::nullopt);
     std::unique_ptr<Layer> removeLayer(const std::string& layerID);
 
+    // Add style parsing filter
+    void addStyleFilter(std::shared_ptr<mbgl::style::PluginStyleFilter>);
+
     std::string getName() const;
     CameraOptions getDefaultCamera() const;
 
@@ -98,6 +102,9 @@ public:
 private:
     void parse(const std::string&);
 
+    void filterThenParse(const std::string&);
+    std::vector<std::shared_ptr<PluginStyleFilter>> _styleFilters;
+                        
     std::shared_ptr<FileSource> fileSource;
 
     std::string url;


### PR DESCRIPTION

### Style Preprocessor
This will add the ability to latch into the style loading and modify the style before it gets to the actual style parsing. There are two parts to this functionality. The first is a C++ based latch into the actual style that will allow a lambda to be assigned to each filter that will receive (in order of add) the data after it's loaded from the source (e.g. http/file/etc). Each filter is passed the output of the previous filter.

The second part is a platform implementation of this for iOS that creates a base filter class that the user can descend from, override a single method and then get the input data and return the data to pass along the filter chain. Since the filters are added at runtime, this will allow run-time filter plugins to be registered and utilized.

Potential uses for this are libraries of different filter types (e.g. uncompressing a compressed/encrypted format, filtering or translating layer properties before they are parsed, injecting specific layer types for all styles, etc).

An example implementation is included in the PR.  This filter gets the style passed to it before it's parsed and it adjusts the style to remove some layer types.  Since the plug-in receives the style before it goes to the parser, any transformation of the style could happen in the filter.

```
@implementation StyleFilterExample

// This will filter the data passed in
-(NSData *)filterData:(NSData *)data {
    // Don't call super

    // This example will remove any layer that has "metal-rendering-layer" in the id

    // Parse the JSON: Make the containers mutable
    NSError *error = nil;
    NSMutableDictionary *styleDictionary = [NSJSONSerialization JSONObjectWithData:data
                                                                          options:NSJSONReadingMutableContainers
                                                                            error:&error];

    NSData *tempResult = data;
    if (styleDictionary) {

        // Get the layer array
        NSMutableArray *layerArray = [styleDictionary objectForKey:@"layers"];

        // Create an array to hold which objects to remove since we can't remove them in the loop
        NSMutableArray *removedLayers = [NSMutableArray array];

        // Loop the layers and look for any layers that have the search string in them
        for (NSMutableDictionary *layer in layerArray) {
            NSString *layerID = [layer objectForKey:@"id"];

            // If we find the layers we're looking for, add them to the list of layers to remove
            if ([layerID containsString:@"metal-rendering-layer"]) {
                [removedLayers addObject:layer];
            }
        }

        // Go through and remove any layers that were found
        for (NSMutableDictionary *l in removedLayers) {
            [layerArray removeObject:l];
        }

        // Re-create the JSON, this time the layers we filtered out won't be there
        NSData *filteredStyleJSON = [NSJSONSerialization dataWithJSONObject:styleDictionary
                                                                    options:0
                                                                      error:&error];

        // If the JSON write is successful, then set the output to the new json style
        if (filteredStyleJSON) {
            tempResult = filteredStyleJSON;
        }

    }

    // Return the data
    return tempResult;

}
```

The style preprocessors are coupled to the engine at runtime using the addStyleFilter method on the map view.
```
    [self.mapView addStyleFilter:[[StyleFilterExample alloc] init]];
```
