### PR TITLE
Handle `BufferResource::version` overflow

### DIFF
--- a/src/mbgl/vulkan/buffer_resource.cpp
+++ b/src/mbgl/vulkan/buffer_resource.cpp
@@ -78,7 +78,7 @@ BufferResource::BufferResource(
         const auto frameCount = backend.getMaxFrames();
         totalSize = bufferWindowSize * frameCount;
 
-        bufferWindowVersions = std::vector<VersionType>(frameCount, 0);
+        bufferWindowVersions = std::vector<VersionType>(frameCount, VersionType{});
     }
 
     const auto bufferInfo = vk::BufferCreateInfo()


### PR DESCRIPTION
`BufferResource::version` uses a `std::uint16_t` counter that overflows after ~18 minutes of frame updates (at 60 fps). 

1. Vulkan uses a less than comparison leading to skipped updates (see https://github.com/maplibre/maplibre-native/issues/3387).
2. Metal/WebGPU check for equality which is unaffected by the wraparound