### PR TITLE
Add funding manifest URL for MapLibre

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://www.maplibre.org/funding.json


### PR DESCRIPTION
Creating this file is required for applying to [FLOSS/fund](https://floss.fund/).

For example Python, https://www.python.org/funding.json

https://github.com/python/cpython/blob/main/.well-known/funding-manifest-urls

More info: https://fundingjson.org/