### PR TITLE
Use a subset of activities for the sequential test

### DIFF
--- a/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/testapp/activity/SequentialActivityTest.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/testapp/activity/SequentialActivityTest.kt
@@ -13,7 +13,7 @@ class SequentialActivityTest(private val activity: Class<out Activity>) {
 
     companion object {
         // app currently has 100+ activities
-        private const val USE_ALL_ACTIVITIES = true
+        private const val USE_ALL_ACTIVITIES = false
         private const val ACTIVITY_DURATION = 5000L
 
         // ignores for both activity lists


### PR DESCRIPTION
Currently the `SequentialActivityTest` uses all the activities available in the test application. This has caused some flaky results and an increased runtime duration for instrumentation tests. Restricting the activity list from 100+ activities to ~18.