### PR TITLE
Demo #4039

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -120,6 +120,7 @@ public:
     LatLng latLngForPixel(const ScreenCoordinate&) const;
     std::vector<ScreenCoordinate> pixelsForLatLngs(const std::vector<LatLng>&) const;
     std::vector<LatLng> latLngsForPixels(const std::vector<ScreenCoordinate>&) const;
+    bool isLatLngOnScreen(const LatLng&) const;
 
     // Transform
     TransformState getTransfromState() const;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -454,6 +454,15 @@ std::vector<LatLng> Map::latLngsForPixels(const std::vector<ScreenCoordinate>& s
     return ret;
 }
 
+bool Map::isLatLngOnScreen(const LatLng& latLng) const {
+    const double epsilon = 0.5;
+    ScreenCoordinate pixel = pixelForLatLng(latLng);
+    Size size = getTransfromState().getSize();
+    double w = size.width;
+    double h = size.height;
+    return pixel.x >= -epsilon && pixel.y >= -epsilon && pixel.x <= w + epsilon && pixel.y <= h + epsilon;
+}
+
 // MARK: - Transform
 
 TransformState Map::getTransfromState() const {

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -195,6 +195,12 @@ TEST(Map, LatLngBoundsToCamera) {
     CameraOptions virtualCamera = test.map.cameraForLatLngBounds(bounds, {});
     ASSERT_TRUE(bounds.contains(*virtualCamera.center));
     EXPECT_NEAR(*virtualCamera.zoom, 1.55467, 1e-5);
+
+    test.map.jumpTo(virtualCamera);
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.northwest()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.northeast()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.southeast()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.southwest()));
 }
 
 TEST(Map, LatLngBoundsToCameraWithExcessivePadding) {
@@ -207,6 +213,12 @@ TEST(Map, LatLngBoundsToCameraWithExcessivePadding) {
     CameraOptions virtualCamera = test.map.cameraForLatLngBounds(bounds, {500, 0, 1200, 0});
     ASSERT_TRUE(bounds.contains(*virtualCamera.center));
     EXPECT_NEAR(*virtualCamera.zoom, 16.0, 1e-5);
+
+    test.map.jumpTo(virtualCamera);
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.northwest()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.northeast()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.southeast()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.southwest()));
 }
 
 TEST(Map, LatLngBoundsToCameraWithBearing) {
@@ -220,6 +232,12 @@ TEST(Map, LatLngBoundsToCameraWithBearing) {
     ASSERT_TRUE(bounds.contains(*virtualCamera.center));
     EXPECT_NEAR(*virtualCamera.zoom, 1.21385, 1e-5);
     EXPECT_NEAR(virtualCamera.bearing.value_or(0), 35.0, 1e-5);
+
+    test.map.jumpTo(virtualCamera);
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.northwest()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.northeast()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.southeast()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.southwest()));
 }
 
 TEST(Map, LatLngBoundsToCameraWithBearingPitchAndPadding) {
@@ -231,7 +249,7 @@ TEST(Map, LatLngBoundsToCameraWithBearingPitchAndPadding) {
 
     CameraOptions virtualCamera = test.map.cameraForLatLngBounds(bounds, {}, 35, 20);
     ASSERT_TRUE(bounds.contains(*virtualCamera.center));
-    EXPECT_NEAR(*virtualCamera.zoom, 13.66272, 1e-5);
+    EXPECT_NEAR(*virtualCamera.zoom, 13.66272, 1e-5); // The zoom should be close to the 0-pitch case, z = 1.2
     ASSERT_DOUBLE_EQ(*virtualCamera.pitch, 20.0);
     EXPECT_NEAR(virtualCamera.bearing.value_or(0), 35.0, 1e-5);
 
@@ -247,6 +265,18 @@ TEST(Map, LatLngBoundsToCameraWithBearingPitchAndPadding) {
     ASSERT_DOUBLE_EQ(*virtualCameraPadded.zoom, *virtualCamera.zoom + util::log2(scaleChange));
     ASSERT_DOUBLE_EQ(*virtualCameraPadded.pitch, *virtualCamera.pitch);
     ASSERT_DOUBLE_EQ(*virtualCameraPadded.bearing, *virtualCamera.bearing);
+
+    test.map.jumpTo(virtualCamera);
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.northwest()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.northeast()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.southeast()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.southwest()));
+
+    test.map.jumpTo(virtualCameraPadded);
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.northwest()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.northeast()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.southeast()));
+    EXPECT_TRUE(test.map.isLatLngOnScreen(bounds.southwest()));
 }
 
 TEST(Map, LatLngsToCamera) {


### PR DESCRIPTION
This PR changes unit tests to fail, demonstrating #4039.

Unit test results:

```
Note: Google Test filter = Map.LatLngBounds*
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from Map
[ RUN      ] Map.LatLngBoundsToCamera
[       OK ] Map.LatLngBoundsToCamera (149 ms)
[ RUN      ] Map.LatLngBoundsToCameraWithExcessivePadding
[ERROR] {mbgl-test-runne}[General]: Unable to calculate appropriate zoom level for bounds. Vertical or horizontal padding is greater than map's height or width.
/home/nathan/maplibre-native/test/map/map.test.cpp:218: Failure
Value of: test.map.isLatLngOnScreen(bounds.northwest())
  Actual: false
Expected: true

/home/nathan/maplibre-native/test/map/map.test.cpp:219: Failure
Value of: test.map.isLatLngOnScreen(bounds.northeast())
  Actual: false
Expected: true

/home/nathan/maplibre-native/test/map/map.test.cpp:220: Failure
Value of: test.map.isLatLngOnScreen(bounds.southeast())
  Actual: false
Expected: true

/home/nathan/maplibre-native/test/map/map.test.cpp:221: Failure
Value of: test.map.isLatLngOnScreen(bounds.southwest())
  Actual: false
Expected: true

[  FAILED  ] Map.LatLngBoundsToCameraWithExcessivePadding (76 ms)
[ RUN      ] Map.LatLngBoundsToCameraWithBearing
[       OK ] Map.LatLngBoundsToCameraWithBearing (69 ms)
[ RUN      ] Map.LatLngBoundsToCameraWithBearingPitchAndPadding
/home/nathan/maplibre-native/test/map/map.test.cpp:270: Failure
Value of: test.map.isLatLngOnScreen(bounds.northwest())
  Actual: false
Expected: true

/home/nathan/maplibre-native/test/map/map.test.cpp:271: Failure
Value of: test.map.isLatLngOnScreen(bounds.northeast())
  Actual: false
Expected: true

/home/nathan/maplibre-native/test/map/map.test.cpp:272: Failure
Value of: test.map.isLatLngOnScreen(bounds.southeast())
  Actual: false
Expected: true

/home/nathan/maplibre-native/test/map/map.test.cpp:273: Failure
Value of: test.map.isLatLngOnScreen(bounds.southwest())
  Actual: false
Expected: true

/home/nathan/maplibre-native/test/map/map.test.cpp:276: Failure
Value of: test.map.isLatLngOnScreen(bounds.northwest())
  Actual: false
Expected: true

/home/nathan/maplibre-native/test/map/map.test.cpp:277: Failure
Value of: test.map.isLatLngOnScreen(bounds.northeast())
  Actual: false
Expected: true

/home/nathan/maplibre-native/test/map/map.test.cpp:278: Failure
Value of: test.map.isLatLngOnScreen(bounds.southeast())
  Actual: false
Expected: true

/home/nathan/maplibre-native/test/map/map.test.cpp:279: Failure
Value of: test.map.isLatLngOnScreen(bounds.southwest())
  Actual: false
Expected: true

[  FAILED  ] Map.LatLngBoundsToCameraWithBearingPitchAndPadding (87 ms)
[----------] 4 tests from Map (382 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (382 ms total)
[  PASSED  ] 2 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] Map.LatLngBoundsToCameraWithExcessivePadding
[  FAILED  ] Map.LatLngBoundsToCameraWithBearingPitchAndPadding

 2 FAILED TESTS
```