### PR TITLE
make LongRunningMapView button more prominent in iOS test app

### DIFF
--- a/platform/ios/app-swift/Sources/MapLibreColors.swift
+++ b/platform/ios/app-swift/Sources/MapLibreColors.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+enum MapLibreColors {
+    static let primary = Color(red: 0x28 / 255.0, green: 0x5D / 255.0, blue: 0xAA / 255.0)
+    static let accent = Color(red: 0x95 / 255.0, green: 0xBE / 255.0, blue: 0xFA / 255.0)
+    static let white = Color.white
+}

--- a/platform/ios/app-swift/Sources/MapLibreNavigationView.swift
+++ b/platform/ios/app-swift/Sources/MapLibreNavigationView.swift
@@ -5,6 +5,15 @@ struct MapLibreNavigationView: View {
     var body: some View {
         NavigationStack {
             List {
+                Section {
+                    NavigationLink("Start Long Running Test") {
+                        LongRunningMapView()
+                    }
+                    .listRowBackground(MapLibreColors.primary)
+                    .foregroundColor(.white)
+                    .fontWeight(.bold)
+                }
+
                 NavigationLink("SimpleMap") {
                     SimpleMap().edgesIgnoringSafeArea(.all)
                 }
@@ -39,9 +48,6 @@ struct MapLibreNavigationView: View {
                 }
                 NavigationLink("ObserverExample") {
                     ObserverExampleViewUIViewControllerRepresentable()
-                }
-                NavigationLink("LongRunningMap") {
-                    LongRunningMapView().edgesIgnoringSafeArea(.all)
                 }
                 Group {
                     NavigationLink("AnimatedLineExample") {

--- a/platform/ios/app-swift/Sources/Stability/CountdownBadge.swift
+++ b/platform/ios/app-swift/Sources/Stability/CountdownBadge.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct CountdownBadge: View {
+    let remainingTime: TimeInterval
+
+    var body: some View {
+        Text(formatTime(remainingTime))
+            .font(.system(size: 16, weight: .bold, design: .monospaced))
+            .foregroundColor(.white)
+            .padding(12)
+            .background(MapLibreColors.primary)
+            .cornerRadius(12)
+    }
+
+    private func formatTime(_ timeInterval: TimeInterval) -> String {
+        let hours = Int(timeInterval) / 3600
+        let minutes = (Int(timeInterval) % 3600) / 60
+        let seconds = Int(timeInterval) % 60
+        return String(format: "%02dh %02dm %02ds", hours, minutes, seconds)
+    }
+}

--- a/platform/ios/app-swift/Sources/Stability/LongRunningMap.swift
+++ b/platform/ios/app-swift/Sources/Stability/LongRunningMap.swift
@@ -27,21 +27,32 @@ struct LongRunningMapView: View {
     let DURATION = 72.0 * 60.0 * 60.0
 
     @Environment(\.dismiss) var dismiss
+    @State private var remainingTime: TimeInterval = 72.0 * 60.0 * 60.0
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             UserMapView()
             NavigationMapView()
         }
+        .edgesIgnoringSafeArea(.bottom)
         .onAppear {
             UIApplication.shared.isIdleTimerDisabled = true
+            remainingTime = DURATION
         }
         .onDisappear {
             UIApplication.shared.isIdleTimerDisabled = false
         }
-        .onReceive(Timer.publish(every: DURATION, on: .current, in: .default).autoconnect()) { _ in
-            printMemoryUsage()
-            dismiss()
+        .onReceive(Timer.publish(every: 1.0, on: .current, in: .default).autoconnect()) { _ in
+            if remainingTime > 0 {
+                remainingTime -= 1.0
+            } else {
+                printMemoryUsage()
+                dismiss()
+            }
+        }
+        .overlay(alignment: .topLeading) {
+            CountdownBadge(remainingTime: remainingTime)
+                .padding(16)
         }
     }
 }


### PR DESCRIPTION
Add button on navigation view to open long running test. Also adds countdown.

**Button**

<img width="50%" alt="Simulator Screenshot - BAZEL_TEST_iPhone Xs_18 5 - 2026-01-13 at 14 14 10" src="https://github.com/user-attachments/assets/4ae6e484-0750-48de-ab79-272667adff45" />

**Countdown**

<img width="50%" alt="Simulator Screenshot - BAZEL_TEST_iPhone Xs_18 5 - 2026-01-13 at 14 14 20" src="https://github.com/user-attachments/assets/195051da-cced-49e3-8cc3-5d6bdd86e558" />
