### PR TITLE
simplify backend selection on android

### DIFF
--- a/platform/android/MapLibreAndroid/build.gradle.kts
+++ b/platform/android/MapLibreAndroid/build.gradle.kts
@@ -78,7 +78,7 @@ android {
             dimension = "renderer"
             externalNativeBuild {
                 cmake {
-                    arguments("-DMLN_WITH_OPENGL=ON", "-DMLN_WITH_VULKAN=OFF")
+                    arguments("-DMLN_WITH_OPENGL=ON")
                 }
             }
         }
@@ -86,7 +86,7 @@ android {
             dimension = "renderer"
             externalNativeBuild {
                 cmake {
-                    arguments("-DMLN_WITH_OPENGL=OFF", "-DMLN_WITH_VULKAN=ON")
+                    arguments("-DMLN_WITH_VULKAN=ON")
                 }
             }
         }

--- a/platform/android/MapLibreAndroidTestApp/build.gradle.kts
+++ b/platform/android/MapLibreAndroidTestApp/build.gradle.kts
@@ -81,7 +81,7 @@ android {
             dimension = "renderer"
             externalNativeBuild {
                 cmake {
-                    arguments("-DMLN_WITH_OPENGL=ON", "-DMLN_WITH_VULKAN=OFF")
+                    arguments("-DMLN_WITH_OPENGL=ON")
                 }
             }
         }
@@ -89,7 +89,7 @@ android {
             dimension = "renderer"
             externalNativeBuild {
                 cmake {
-                    arguments("-DMLN_WITH_OPENGL=OFF", "-DMLN_WITH_VULKAN=ON")
+                    arguments("-DMLN_WITH_VULKAN=ON")
                 }
             }
         }


### PR DESCRIPTION
MLN_WITH_OPENGL and MLN_WITH_VULKAN are both OFF by default, so it's sufficient to turn on what's needed.

https://github.com/maplibre/maplibre-native/blob/dd489469879a38f404051bc97ff2b8ba075f91be/CMakeLists.txt#L11-L15