### PR TITLE
Split iOS CMake preset into ios (base) + ios-metal

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -230,7 +230,7 @@ jobs:
           submodules: recursive
 
       - name: Configure build with CMake
-        run: cmake --preset ios
+        run: cmake --preset ios-metal
 
       - name: Build mbgl-core
         run: cmake --build build-ios --target mbgl-core ios-sdk-static app

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,22 +8,28 @@
   "configurePresets": [
     {
       "name": "ios",
-      "displayName": "iOS",
+      "hidden": true,
       "generator": "Xcode",
-      "description": "Create Xcode project for iOS",
-      "binaryDir": "${sourceDir}/build-ios",
+      "description": "Base iOS preset",
       "toolchainFile": "${sourceDir}/platform/ios/ios.toolchain.cmake",
       "cacheVariables": {
         "CMAKE_SYSTEM_NAME": "iOS",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "14.0",
-        "MLN_WITH_METAL": "ON",
-        "MLN_WITH_OPENGL": "OFF"
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "14.0"
       },
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-metal",
+      "displayName": "iOS Metal",
+      "inherits": "ios",
+      "binaryDir": "${sourceDir}/build-ios",
+      "cacheVariables": {
+        "MLN_WITH_METAL": "ON"
       }
     },
     {

--- a/docs/mdbook/src/platforms/ios/README.md
+++ b/docs/mdbook/src/platforms/ios/README.md
@@ -78,7 +78,7 @@ You can also build targets from the command line. For example, if you want to bu
 It is also possible to generate an Xcode project using CMake. As of February 2025, targets `mbgl-core`, `ios-sdk-static` and `app` (Objective-C development app) are supported.
 
 ```
-cmake --preset ios -DDEVELOPMENT_TEAM_ID=YOUR_TEAM_ID
+cmake --preset ios-metal -DDEVELOPMENT_TEAM_ID=YOUR_TEAM_ID
 xed build-ios/MapLibre\ Native.xcodeproj
 ```
 


### PR DESCRIPTION
Split the ios CMake preset to match the pattern used by macos, linux, and windows:

- ios is now a hidden base preset (renderer-neutral)
- ios-metal inherits from it with MLN_WITH_METAL=ON

This makes it easy to add other iOS renderer presets (e.g. ios-webgpu-dawn) that share the same base configuration.

Updated references in CI and docs