### PR TITLE
set font for local glyph rasterizer GLFW app Apple platforms

### DIFF
--- a/platform/glfw/CMakeLists.txt
+++ b/platform/glfw/CMakeLists.txt
@@ -31,6 +31,13 @@ set_property(
     PROPERTY COMPILE_DEFINITIONS MLN_ASSETS_PATH=\"${PROJECT_SOURCE_DIR}/platform/glfw/assets/\"
 )
 
+if(APPLE)
+    target_sources(
+        mbgl-glfw
+        PRIVATE ${PROJECT_SOURCE_DIR}/platform/glfw/glfw_apple_init.mm
+    )
+endif()
+
 if(MLN_WITH_OPENGL)
     find_package(OpenGL REQUIRED)
     target_sources(

--- a/platform/glfw/glfw_apple_init.mm
+++ b/platform/glfw/glfw_apple_init.mm
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+// Called early in GLFW initialization so that the local glyph rasterizer
+// can find a suitable CJK font via NSUserDefaults.
+__attribute__((constructor))
+static void setDefaultIdeographicFont() {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if (![defaults objectForKey:@"MLNIdeographicFontFamilyName"]) {
+        [defaults setObject:@[@"PingFang TC"] forKey:@"MLNIdeographicFontFamilyName"];
+    }
+}


### PR DESCRIPTION
@bdon noticed that CJK fonts are not loading with the GLFW app when they rely on the local glyph rasterizer.

The issue is that `MLNIdeographicFontFamilyName` was not set to any font. This PR fixes that.