### PR TITLE
core: Disable VMA leak check

### DIFF
--- a/include/mbgl/vulkan/renderer_backend.hpp
+++ b/include/mbgl/vulkan/renderer_backend.hpp
@@ -22,7 +22,7 @@
 #if !defined(NDEBUG) && !defined(__ANDROID__)
 #define ENABLE_VULKAN_VALIDATION
 // #define ENABLE_VULKAN_GPU_ASSISTED_VALIDATION
-//  #define ENABLE_VMA_DEBUG
+// #define ENABLE_VMA_DEBUG
 #endif
 
 namespace mbgl {

--- a/src/mbgl/vulkan/renderer_backend.cpp
+++ b/src/mbgl/vulkan/renderer_backend.cpp
@@ -36,7 +36,7 @@
 
 #ifdef ENABLE_VMA_DEBUG
 
-#define VMA_DEBUG_MARGIN 16
+#define VMA_DEBUG_MARGIN 4
 #define VMA_DEBUG_DETECT_CORRUPTION 1
 #define VMA_DEBUG_INITIALIZE_ALLOCATIONS 1
 
@@ -51,6 +51,14 @@
 
 #define VMA_DEBUG_LOG(str) VMA_DEBUG_LOG_FORMAT("%s", (str))
 #define VMA_LEAK_LOG_FORMAT(...) VMA_DEBUG_LOG_FORMAT(__VA_ARGS__)
+
+#else
+
+// - triggering VMA_ASSERT_LEAK in `VmaDeviceMemoryBlock::Destroy` without any log printed by
+// `VmaBlockMetadata_TLSF::DebugLogAllAllocations` (since all blocks are free).
+// - VMA_LEAK_LOG_FORMAT logs generate an equal number of alloc/free events.
+// - https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/issues/276
+#undef VMA_ASSERT_LEAK
 
 #endif
 


### PR DESCRIPTION
Disabling the memory allocator leak assert in default debug builds (can be enabled with `ENABLE_VMA_DEBUG`) since it sporadically triggers during CI runs. `VmaBlockMetadata_TLSF::DebugLogAllAllocations` logs and manually counting the alloc/free calls suggest that all memory blocks are freed, but the memory zones are not correctly merged.