### PR TITLE
core: fix narrowing conversion warnings in webgpu drawable

### DIFF
--- a/src/mbgl/webgpu/drawable.cpp
+++ b/src/mbgl/webgpu/drawable.cpp
@@ -814,7 +814,7 @@ void Drawable::draw(PaintParameters& parameters) const {
 
         impl->pipelineState = shaderWebGPU.getRenderPipeline(renderable,
                                                              vertexLayouts.empty() ? nullptr : vertexLayouts.data(),
-                                                             vertexLayouts.size(),
+                                                             static_cast<uint32_t>(vertexLayouts.size()),
                                                              colorMode,
                                                              depthMode,
                                                              stencilMode,
@@ -935,8 +935,9 @@ void Drawable::draw(PaintParameters& parameters) const {
         const auto& segment = static_cast<DrawSegment&>(*seg_);
         const auto& mlSegment = segment.getSegment();
         if (mlSegment.indexLength > 0) {
-            const uint32_t instanceCount = instanceAttributes ? instanceAttributes->getMaxCount() : 1;
-            const uint32_t indexOffset = mlSegment.indexOffset;
+            const uint32_t instanceCount = instanceAttributes ? static_cast<uint32_t>(instanceAttributes->getMaxCount())
+                                                              : 1;
+            const uint32_t indexOffset = static_cast<uint32_t>(mlSegment.indexOffset);
             const int32_t baseVertex = static_cast<int32_t>(mlSegment.vertexOffset);
             const uint32_t baseInstance = 0;
 
@@ -953,11 +954,11 @@ void Drawable::draw(PaintParameters& parameters) const {
             }
 
             wgpuRenderPassEncoderDrawIndexed(renderPassEncoder,
-                                             mlSegment.indexLength, // indexCount
-                                             instanceCount,         // instanceCount
-                                             indexOffset,           // firstIndex
-                                             baseVertex,            // baseVertex
-                                             baseInstance);         // firstInstance
+                                             static_cast<uint32_t>(mlSegment.indexLength), // indexCount
+                                             instanceCount,                                // instanceCount
+                                             indexOffset,                                  // firstIndex
+                                             baseVertex,                                   // baseVertex
+                                             baseInstance);                                // firstInstance
 
             context.renderingStats().numDrawCalls++;
         }


### PR DESCRIPTION
Add `static_cast<uint32_t>` for `size_t` → `uint32_t` conversions in drawable.cpp. These are flagged as errors on arm64 builds with `-Werror,-Wshorten-64-to-32`.