### PR TITLE
core: Remove global uniform usage for render target shaders

### DIFF
--- a/include/mbgl/shaders/vulkan/heatmap.hpp
+++ b/include/mbgl/shaders/vulkan/heatmap.hpp
@@ -110,7 +110,7 @@ void main() {
     // multiply a_pos by 0.5, since we had it * 2 in order to sneak
     // in extrusion data
     gl_Position = drawable.matrix * vec4(floor(in_position * 0.5) + scaled_extrude, 0, 1);
-    applySurfaceTransform();
+    gl_Position.y *= -1.0;
 
     frag_weight = weight;
     frag_extrude = extrude;

--- a/include/mbgl/shaders/vulkan/heatmap_texture.hpp
+++ b/include/mbgl/shaders/vulkan/heatmap_texture.hpp
@@ -34,7 +34,7 @@ layout(location = 0) out vec2 frag_position;
 void main() {
 
     gl_Position = props.matrix * vec4(in_position * paintParams.world_size, 0, 1);
-    gl_Position.y *= -1.0;
+    applySurfaceTransform();
 
     frag_position = in_position;
 }

--- a/include/mbgl/shaders/vulkan/heatmap_texture.hpp
+++ b/include/mbgl/shaders/vulkan/heatmap_texture.hpp
@@ -34,7 +34,7 @@ layout(location = 0) out vec2 frag_position;
 void main() {
 
     gl_Position = props.matrix * vec4(in_position * paintParams.world_size, 0, 1);
-    applySurfaceTransform();
+    gl_Position.y *= -1.0;
 
     frag_position = in_position;
 }

--- a/include/mbgl/shaders/vulkan/hillshade_prepare.hpp
+++ b/include/mbgl/shaders/vulkan/hillshade_prepare.hpp
@@ -43,7 +43,7 @@ layout(location = 0) out vec2 frag_position;
 void main() {
 
     gl_Position = drawable.matrix * vec4(in_position, 0.0, 1.0);
-    applySurfaceTransform();
+    gl_Position.y *= -1.0;
 
     const vec2 epsilon = vec2(1.0) / tileProps.dimension;
     const float scale = (tileProps.dimension.x - 2.0) / tileProps.dimension.x;

--- a/src/mbgl/vulkan/render_pass.cpp
+++ b/src/mbgl/vulkan/render_pass.cpp
@@ -15,12 +15,20 @@ RenderPass::RenderPass(CommandEncoder& commandEncoder_, const char* name, const 
 
     resource.bind();
 
-    std::array<vk::ClearValue, 2> clearValues;
+    std::vector<vk::ClearValue> clearValues;
 
-    if (descriptor.clearColor.has_value())
-        clearValues[0].setColor(descriptor.clearColor.value().operator std::array<float, 4>());
-    clearValues[1].depthStencil.setDepth(descriptor.clearDepth.value_or(1.0f));
-    clearValues[1].depthStencil.setStencil(descriptor.clearStencil.value_or(0));
+    if (descriptor.clearColor.has_value()) {
+        vk::ClearValue value;
+        value.setColor(descriptor.clearColor.value().operator std::array<float, 4>());
+        clearValues.emplace_back(value);
+    }
+
+    if (descriptor.clearDepth.has_value() || descriptor.clearStencil.has_value()) {
+        vk::ClearValue value;
+        value.depthStencil.setDepth(descriptor.clearDepth.value_or(1.0f));
+        value.depthStencil.setStencil(descriptor.clearStencil.value_or(0));
+        clearValues.emplace_back(value);
+    }
 
     const auto renderPassBeginInfo = vk::RenderPassBeginInfo()
                                          .setRenderPass(resource.getRenderPass().get())


### PR DESCRIPTION
Currently the global uniforms aren't bound for render targets and lead to errors when accessed by `applySurfaceTransform`. It's usage can be safely replaced.