### PR TITLE
core: Fix scissor rectangle size

### DIFF
--- a/src/mbgl/renderer/renderer_impl.cpp
+++ b/src/mbgl/renderer/renderer_impl.cpp
@@ -186,7 +186,7 @@ void Renderer::Impl::render(const RenderTree& renderTree, const std::shared_ptr<
     observer->onWillStartRenderingFrame();
 
     const TransformState& state = renderTreeParameters.transformParams.state;
-    const Size& size = state.getSize();
+    const Size& size = staticData->backendSize;
     const EdgeInsets& frustumOffset = state.getFrustumOffset();
     const gfx::ScissorRect scissorRect = {
         .x = static_cast<int32_t>(frustumOffset.left() * pixelRatio),
@@ -195,8 +195,8 @@ void Renderer::Impl::render(const RenderTree& renderTree, const std::shared_ptr<
 #else
         .y = static_cast<int32_t>(frustumOffset.top() * pixelRatio),
 #endif
-        .width = static_cast<uint32_t>((size.width - (frustumOffset.left() + frustumOffset.right())) * pixelRatio),
-        .height = static_cast<uint32_t>((size.height - (frustumOffset.top() + frustumOffset.bottom())) * pixelRatio),
+        .width = size.width - static_cast<uint32_t>((frustumOffset.left() + frustumOffset.right()) * pixelRatio),
+        .height = size.height - static_cast<uint32_t>((frustumOffset.top() + frustumOffset.bottom()) * pixelRatio),
     };
 
     PaintParameters parameters{


### PR DESCRIPTION
`TransformState` stores the size adjusted to the custom `pixelRatio` provided by the user, while the renderer uses the device value leading to a mismatch between the computed scissor rect and fullscreen texture.
Fixes https://github.com/maplibre/maplibre-native/issues/4143 and possibly https://github.com/maplibre/maplibre-native/issues/4109 (untested).