### PR TITLE
Fix: Missing data for single tiles when using GeoJsonSource

### DIFF
--- a/src/mbgl/tile/geojson_tile.cpp
+++ b/src/mbgl/tile/geojson_tile.cpp
@@ -23,14 +23,14 @@ void GeoJSONTile::updateData(std::shared_ptr<style::GeoJSONData> data_, bool nee
     MLN_TRACE_FUNC();
 
     assert(data_);
-    
+
     // Reset state if relayout is needed or if this is the first data update
     if (needsRelayout || !data) {
         reset();
     }
-    
+
     data = std::move(data_);
-    
+
     data->getTile(
         id.canonical,
         [this, self = weakFactory.makeWeakPtr(), capturedData = data.get()](TileFeatures features) {

--- a/src/mbgl/tile/geojson_tile.cpp
+++ b/src/mbgl/tile/geojson_tile.cpp
@@ -23,8 +23,14 @@ void GeoJSONTile::updateData(std::shared_ptr<style::GeoJSONData> data_, bool nee
     MLN_TRACE_FUNC();
 
     assert(data_);
+    
+    // Reset state if relayout is needed or if this is the first data update
+    if (needsRelayout || !data) {
+        reset();
+    }
+    
     data = std::move(data_);
-    if (needsRelayout) reset();
+    
     data->getTile(
         id.canonical,
         [this, self = weakFactory.makeWeakPtr(), capturedData = data.get()](TileFeatures features) {


### PR DESCRIPTION
## Changes
- Modified GeoJSONTile::updateData to properly reset tile state when data is updated
- Added condition to reset() when this is the first data update (data is null) or when needsRelayout is true
- This ensures that existing tiles are properly invalidated when new GeoJSON data is set

This fixes the issue where single tiles would not display updated data after switching overlays in GeoJsonSource, particularly noticeable when switching between different overlays like street lighting data.