### PR TITLE
Add runtime dimension guard to DEMData::backfillBorder

### DIFF
--- a/src/mbgl/geometry/dem_data.cpp
+++ b/src/mbgl/geometry/dem_data.cpp
@@ -52,8 +52,10 @@ DEMData::DEMData(const PremultipliedImage& _image, Tileset::RasterEncoding _enco
 void DEMData::backfillBorder(const DEMData& borderTileData, int8_t dx, int8_t dy) {
     auto& o = borderTileData;
 
-    // Tiles from the same source should always be of the same dimensions.
-    assert(dim == o.dim);
+    assert(dim == o.dim); // debug: catch mismatched tile dimensions early
+    if (dim != o.dim) {   // release: assert is gone, prevent out-of-bounds read
+        return;
+    }
 
     // We determine the pixel range to backfill based which corner/edge
     // `borderTileData` represents. For example, dx = -1, dy = -1 represents the


### PR DESCRIPTION
`backfillBorder()` assumes neighboring DEM tiles always have matching dimensions, but the only check is `assert(dim == o.dim)` which is stripped in release builds. When a tile server returns a small placeholder (e.g. 1×1 PNG) for a missing DEM tile, the function computes offsets that exceed the neighbor's buffer, causing an out-of-bounds read that can segfault.

This adds an early return when dimensions don't match, turning the debug-only invariant into a runtime guard. The assert is kept so developers still catch mismatches during development.

The early return means the caller in `RasterDEMTile::backfillBorder` still flips the `neighboringTiles` bitmask and calls `setPrepared(false)`. Both are intentional: the bitmask flip prevents the system from re-attempting backfill on every `onTileChanged` event, and `setPrepared(false)` only triggers a redundant texture re-upload for that tile — negligible cost.

I looked at more upstream fixes too (e.g. rejecting undersized tiles at parse time in `RasterDEMTileWorker::parse` so they follow the same 404/no-data path), but those approaches either require an arbitrary size threshold or knowledge of expected tile dimensions that the worker doesn't have. The dimension guard in `backfillBorder` handles any mismatch regardless of the actual sizes, so it felt like the right minimal starting point. Happy to expand the scope if you think a broader fix makes sense.

Fixes #4160