### PR TITLE
Bundle wgpu-native into Linux WebGPU amalgamation

### DIFF
--- a/.github/scripts/check-linux-webgpu-amalgam
+++ b/.github/scripts/check-linux-webgpu-amalgam
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <path-to-libmbgl-core-amalgam.a>" >&2
+  exit 2
+fi
+
+archive_path="$1"
+
+if [[ ! -f "$archive_path" ]]; then
+  echo "archive not found: $archive_path" >&2
+  exit 2
+fi
+
+unresolved_symbols="$(
+  nm -g --undefined-only "$archive_path" \
+    | grep -E '(^|[[:space:]])U[[:space:]]+wgpu([A-Z]|_)' \
+    || true
+)"
+
+if [[ -n "$unresolved_symbols" ]]; then
+  echo "found unresolved WebGPU symbols in $archive_path" >&2
+  echo "$unresolved_symbols" >&2
+  exit 1
+fi
+
+echo "no unresolved WebGPU symbols found in $archive_path"

--- a/.github/scripts/check-linux-webgpu-amalgam
+++ b/.github/scripts/check-linux-webgpu-amalgam
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
+# Linux-only helper: requires GNU nm long options.
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
   echo "usage: $0 <path-to-libmbgl-core-amalgam.a>" >&2
-  exit 2
+  exit 1
 fi
 
 archive_path="$1"
 
 if [[ ! -f "$archive_path" ]]; then
   echo "archive not found: $archive_path" >&2
-  exit 2
+  exit 1
 fi
 
 unresolved_symbols="$(

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -85,6 +85,8 @@ jobs:
   build-linux:
     needs: [create-release]
     runs-on: ${{ matrix.runner.os }}
+    env:
+      PRESET_RENDERER: ${{ matrix.preset_renderer || matrix.renderer }}
     strategy:
       matrix:
         include:
@@ -113,18 +115,18 @@ jobs:
 
       - name: Build mbgl-core for Linux
         run: |
-          cmake --preset linux-${{ matrix.preset_renderer || matrix.renderer }} -DCMAKE_CXX_COMPILER_LAUNCHER="" -DMLN_CREATE_AMALGAMATION=ON
-          cmake --build build-linux-${{ matrix.preset_renderer || matrix.renderer }} --target mbgl-core
+          cmake --preset linux-${PRESET_RENDERER} -DCMAKE_CXX_COMPILER_LAUNCHER="" -DMLN_CREATE_AMALGAMATION=ON
+          cmake --build build-linux-${PRESET_RENDERER} --target mbgl-core
 
       - name: Verify Linux WebGPU amalgamation
         if: matrix.renderer == 'wgpu'
         run: |
-          .github/scripts/check-linux-webgpu-amalgam build-linux-${{ matrix.preset_renderer || matrix.renderer }}/libmbgl-core-amalgam.a
+          .github/scripts/check-linux-webgpu-amalgam build-linux-${PRESET_RENDERER}/libmbgl-core-amalgam.a
 
       - name: Rename artifact
         run: |
-          cp build-linux-${{ matrix.preset_renderer || matrix.renderer }}/libmbgl-core.a libmaplibre-native-core-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
-          cp build-linux-${{ matrix.preset_renderer || matrix.renderer }}/libmbgl-core-amalgam.a libmaplibre-native-core-amalgam-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
+          cp build-linux-${PRESET_RENDERER}/libmbgl-core.a libmaplibre-native-core-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
+          cp build-linux-${PRESET_RENDERER}/libmbgl-core-amalgam.a libmaplibre-native-core-amalgam-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
 
       - name: Upload Linux artifacts
         if: github.event_name == 'pull_request'

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -89,19 +89,15 @@ jobs:
       matrix:
         include:
           - renderer: opengl
-            preset_renderer: opengl
             runner: { os: ubuntu-latest, arch: x64 }
           - renderer: vulkan
-            preset_renderer: vulkan
             runner: { os: ubuntu-latest, arch: x64 }
           - renderer: wgpu
             preset_renderer: webgpu-wgpu
             runner: { os: ubuntu-latest, arch: x64 }
           - renderer: opengl
-            preset_renderer: opengl
             runner: { os: ubuntu-24.04-arm, arch: arm64 }
           - renderer: vulkan
-            preset_renderer: vulkan
             runner: { os: ubuntu-24.04-arm, arch: arm64 }
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
@@ -117,18 +113,18 @@ jobs:
 
       - name: Build mbgl-core for Linux
         run: |
-          cmake --preset linux-${{ matrix.preset_renderer }} -DCMAKE_CXX_COMPILER_LAUNCHER="" -DMLN_CREATE_AMALGAMATION=ON
-          cmake --build build-linux-${{ matrix.preset_renderer }} --target mbgl-core
+          cmake --preset linux-${{ matrix.preset_renderer || matrix.renderer }} -DCMAKE_CXX_COMPILER_LAUNCHER="" -DMLN_CREATE_AMALGAMATION=ON
+          cmake --build build-linux-${{ matrix.preset_renderer || matrix.renderer }} --target mbgl-core
 
       - name: Verify Linux WebGPU amalgamation
         if: matrix.renderer == 'wgpu'
         run: |
-          .github/scripts/check-linux-webgpu-amalgam build-linux-${{ matrix.preset_renderer }}/libmbgl-core-amalgam.a
+          .github/scripts/check-linux-webgpu-amalgam build-linux-${{ matrix.preset_renderer || matrix.renderer }}/libmbgl-core-amalgam.a
 
       - name: Rename artifact
         run: |
-          cp build-linux-${{ matrix.preset_renderer }}/libmbgl-core.a libmaplibre-native-core-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
-          cp build-linux-${{ matrix.preset_renderer }}/libmbgl-core-amalgam.a libmaplibre-native-core-amalgam-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
+          cp build-linux-${{ matrix.preset_renderer || matrix.renderer }}/libmbgl-core.a libmaplibre-native-core-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
+          cp build-linux-${{ matrix.preset_renderer || matrix.renderer }}/libmbgl-core-amalgam.a libmaplibre-native-core-amalgam-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
 
       - name: Upload Linux artifacts
         if: github.event_name == 'pull_request'

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -115,18 +115,18 @@ jobs:
 
       - name: Build mbgl-core for Linux
         run: |
-          cmake --preset linux-${PRESET_RENDERER} -DCMAKE_CXX_COMPILER_LAUNCHER="" -DMLN_CREATE_AMALGAMATION=ON
-          cmake --build build-linux-${PRESET_RENDERER} --target mbgl-core
+          cmake --preset "linux-${PRESET_RENDERER}" -DCMAKE_CXX_COMPILER_LAUNCHER="" -DMLN_CREATE_AMALGAMATION=ON
+          cmake --build "build-linux-${PRESET_RENDERER}" --target mbgl-core
 
       - name: Verify Linux WebGPU amalgamation
         if: matrix.renderer == 'wgpu'
         run: |
-          .github/scripts/check-linux-webgpu-amalgam build-linux-${PRESET_RENDERER}/libmbgl-core-amalgam.a
+          .github/scripts/check-linux-webgpu-amalgam "build-linux-${PRESET_RENDERER}/libmbgl-core-amalgam.a"
 
       - name: Rename artifact
         run: |
-          cp build-linux-${PRESET_RENDERER}/libmbgl-core.a libmaplibre-native-core-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
-          cp build-linux-${PRESET_RENDERER}/libmbgl-core-amalgam.a libmaplibre-native-core-amalgam-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
+          cp "build-linux-${PRESET_RENDERER}/libmbgl-core.a" "libmaplibre-native-core-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a"
+          cp "build-linux-${PRESET_RENDERER}/libmbgl-core-amalgam.a" "libmaplibre-native-core-amalgam-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a"
 
       - name: Upload Linux artifacts
         if: github.event_name == 'pull_request'

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -89,12 +89,19 @@ jobs:
       matrix:
         include:
           - renderer: opengl
+            preset_renderer: opengl
             runner: { os: ubuntu-latest, arch: x64 }
           - renderer: vulkan
+            preset_renderer: vulkan
+            runner: { os: ubuntu-latest, arch: x64 }
+          - renderer: wgpu
+            preset_renderer: webgpu-wgpu
             runner: { os: ubuntu-latest, arch: x64 }
           - renderer: opengl
+            preset_renderer: opengl
             runner: { os: ubuntu-24.04-arm, arch: arm64 }
           - renderer: vulkan
+            preset_renderer: vulkan
             runner: { os: ubuntu-24.04-arm, arch: arm64 }
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
@@ -110,13 +117,18 @@ jobs:
 
       - name: Build mbgl-core for Linux
         run: |
-          cmake --preset linux-${{ matrix.renderer }} -DCMAKE_CXX_COMPILER_LAUNCHER="" -DMLN_CREATE_AMALGAMATION=ON
-          cmake --build build-linux-${{ matrix.renderer }} --target mbgl-core
+          cmake --preset linux-${{ matrix.preset_renderer }} -DCMAKE_CXX_COMPILER_LAUNCHER="" -DMLN_CREATE_AMALGAMATION=ON
+          cmake --build build-linux-${{ matrix.preset_renderer }} --target mbgl-core
+
+      - name: Verify Linux WebGPU amalgamation
+        if: matrix.renderer == 'wgpu'
+        run: |
+          .github/scripts/check-linux-webgpu-amalgam build-linux-${{ matrix.preset_renderer }}/libmbgl-core-amalgam.a
 
       - name: Rename artifact
         run: |
-          cp build-linux-${{ matrix.renderer }}/libmbgl-core.a libmaplibre-native-core-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
-          cp build-linux-${{ matrix.renderer }}/libmbgl-core-amalgam.a libmaplibre-native-core-amalgam-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
+          cp build-linux-${{ matrix.preset_renderer }}/libmbgl-core.a libmaplibre-native-core-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
+          cp build-linux-${{ matrix.preset_renderer }}/libmbgl-core-amalgam.a libmaplibre-native-core-amalgam-linux-${{ matrix.runner.arch }}-${{ matrix.renderer }}.a
 
       - name: Upload Linux artifacts
         if: github.event_name == 'pull_request'

--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -208,6 +208,13 @@ if(MLN_CREATE_AMALGAMATION)
         find_static_library(STATIC_LIBS NAMES GenericCodeGen)
     endif()
 
+    if(MLN_WITH_WEBGPU AND MLN_WEBGPU_IMPL_WGPU)
+        if(NOT WGPU_STATIC_LIBRARY)
+            message(FATAL_ERROR "Linux WebGPU amalgamation requires WGPU_STATIC_LIBRARY")
+        endif()
+        list(APPEND STATIC_LIBS "${WGPU_STATIC_LIBRARY}")
+    endif()
+
     add_custom_command(
         TARGET mbgl-core
         POST_BUILD

--- a/vendor/wgpu.cmake
+++ b/vendor/wgpu.cmake
@@ -67,19 +67,20 @@ list(APPEND _wgpu_lib_search_paths
     "${_mln_wgpu_source_dir}/build/release"
 )
 
-# On Android/iOS, use manual path search since find_library may not work with cross-compilation toolchains
-macro(mln_wgpu_find_exact_library out_var)
+# Resolve the exact archive/import library filename emitted by wgpu-native.
+macro(mln_wgpu_find_exact_library out_var out_description)
     foreach(_search_path ${_wgpu_lib_search_paths})
         if(EXISTS "${_search_path}/${_wgpu_lib_name}")
-            set(${out_var} "${_search_path}/${_wgpu_lib_name}" CACHE FILEPATH "wgpu-native library")
+            set(${out_var} "${_search_path}/${_wgpu_lib_name}" CACHE FILEPATH "${out_description}")
             break()
         endif()
     endforeach()
 endmacro()
 
+# On Android/iOS, use manual path search since find_library may not work with cross-compilation toolchains
 macro(mln_wgpu_find_library)
     if(ANDROID OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
-        mln_wgpu_find_exact_library(WGPU_LIBRARY)
+        mln_wgpu_find_exact_library(WGPU_LIBRARY "wgpu-native library")
     else()
         find_library(WGPU_LIBRARY
             NAMES wgpu_native libwgpu_native
@@ -91,7 +92,7 @@ macro(mln_wgpu_find_library)
 endmacro()
 
 mln_wgpu_find_library()
-mln_wgpu_find_exact_library(WGPU_STATIC_LIBRARY)
+mln_wgpu_find_exact_library(WGPU_STATIC_LIBRARY "wgpu-native static library")
 
 if(NOT WGPU_LIBRARY)
     message(STATUS "Pre-built wgpu-native library not found, attempting to build from source...")
@@ -142,7 +143,7 @@ if(NOT WGPU_LIBRARY)
 
     # Try to find the library again
     mln_wgpu_find_library()
-    mln_wgpu_find_exact_library(WGPU_STATIC_LIBRARY)
+    mln_wgpu_find_exact_library(WGPU_STATIC_LIBRARY "wgpu-native static library")
 
     if(NOT WGPU_LIBRARY)
         message(FATAL_ERROR "Failed to locate wgpu-native library after building")

--- a/vendor/wgpu.cmake
+++ b/vendor/wgpu.cmake
@@ -68,14 +68,18 @@ list(APPEND _wgpu_lib_search_paths
 )
 
 # On Android/iOS, use manual path search since find_library may not work with cross-compilation toolchains
+macro(mln_wgpu_find_exact_library out_var)
+    foreach(_search_path ${_wgpu_lib_search_paths})
+        if(EXISTS "${_search_path}/${_wgpu_lib_name}")
+            set(${out_var} "${_search_path}/${_wgpu_lib_name}" CACHE FILEPATH "wgpu-native library")
+            break()
+        endif()
+    endforeach()
+endmacro()
+
 macro(mln_wgpu_find_library)
     if(ANDROID OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
-        foreach(_search_path ${_wgpu_lib_search_paths})
-            if(EXISTS "${_search_path}/${_wgpu_lib_name}")
-                set(WGPU_LIBRARY "${_search_path}/${_wgpu_lib_name}" CACHE FILEPATH "wgpu-native library")
-                break()
-            endif()
-        endforeach()
+        mln_wgpu_find_exact_library(WGPU_LIBRARY)
     else()
         find_library(WGPU_LIBRARY
             NAMES wgpu_native libwgpu_native
@@ -86,17 +90,8 @@ macro(mln_wgpu_find_library)
     endif()
 endmacro()
 
-macro(mln_wgpu_find_static_library)
-    foreach(_search_path ${_wgpu_lib_search_paths})
-        if(EXISTS "${_search_path}/${_wgpu_lib_name}")
-            set(WGPU_STATIC_LIBRARY "${_search_path}/${_wgpu_lib_name}" CACHE FILEPATH "wgpu-native static library")
-            break()
-        endif()
-    endforeach()
-endmacro()
-
 mln_wgpu_find_library()
-mln_wgpu_find_static_library()
+mln_wgpu_find_exact_library(WGPU_STATIC_LIBRARY)
 
 if(NOT WGPU_LIBRARY)
     message(STATUS "Pre-built wgpu-native library not found, attempting to build from source...")
@@ -147,7 +142,7 @@ if(NOT WGPU_LIBRARY)
 
     # Try to find the library again
     mln_wgpu_find_library()
-    mln_wgpu_find_static_library()
+    mln_wgpu_find_exact_library(WGPU_STATIC_LIBRARY)
 
     if(NOT WGPU_LIBRARY)
         message(FATAL_ERROR "Failed to locate wgpu-native library after building")
@@ -156,10 +151,6 @@ if(NOT WGPU_LIBRARY)
     message(STATUS "Successfully built wgpu-native: ${WGPU_LIBRARY}")
 else()
     message(STATUS "Found wgpu-native library: ${WGPU_LIBRARY}")
-endif()
-
-if(NOT WGPU_STATIC_LIBRARY AND WGPU_LIBRARY MATCHES "\\.(a|lib)$")
-    set(WGPU_STATIC_LIBRARY "${WGPU_LIBRARY}" CACHE FILEPATH "wgpu-native static library" FORCE)
 endif()
 
 if(WGPU_STATIC_LIBRARY)

--- a/vendor/wgpu.cmake
+++ b/vendor/wgpu.cmake
@@ -86,7 +86,17 @@ macro(mln_wgpu_find_library)
     endif()
 endmacro()
 
+macro(mln_wgpu_find_static_library)
+    foreach(_search_path ${_wgpu_lib_search_paths})
+        if(EXISTS "${_search_path}/${_wgpu_lib_name}")
+            set(WGPU_STATIC_LIBRARY "${_search_path}/${_wgpu_lib_name}" CACHE FILEPATH "wgpu-native static library")
+            break()
+        endif()
+    endforeach()
+endmacro()
+
 mln_wgpu_find_library()
+mln_wgpu_find_static_library()
 
 if(NOT WGPU_LIBRARY)
     message(STATUS "Pre-built wgpu-native library not found, attempting to build from source...")
@@ -137,6 +147,7 @@ if(NOT WGPU_LIBRARY)
 
     # Try to find the library again
     mln_wgpu_find_library()
+    mln_wgpu_find_static_library()
 
     if(NOT WGPU_LIBRARY)
         message(FATAL_ERROR "Failed to locate wgpu-native library after building")
@@ -145,6 +156,18 @@ if(NOT WGPU_LIBRARY)
     message(STATUS "Successfully built wgpu-native: ${WGPU_LIBRARY}")
 else()
     message(STATUS "Found wgpu-native library: ${WGPU_LIBRARY}")
+endif()
+
+if(NOT WGPU_STATIC_LIBRARY AND WGPU_LIBRARY MATCHES "\\.(a|lib)$")
+    set(WGPU_STATIC_LIBRARY "${WGPU_LIBRARY}" CACHE FILEPATH "wgpu-native static library" FORCE)
+endif()
+
+if(WGPU_STATIC_LIBRARY)
+    message(STATUS "Found wgpu-native static library: ${WGPU_STATIC_LIBRARY}")
+elseif(MLN_CREATE_AMALGAMATION)
+    message(FATAL_ERROR
+        "MLN_CREATE_AMALGAMATION=ON requires a static wgpu-native library, "
+        "but none was found in: ${_wgpu_lib_search_paths}")
 endif()
 
 # Generate WebGPU-Cpp wrapper if needed

--- a/vendor/wgpu.cmake
+++ b/vendor/wgpu.cmake
@@ -67,19 +67,20 @@ list(APPEND _wgpu_lib_search_paths
     "${_mln_wgpu_source_dir}/build/release"
 )
 
-# On Android/iOS, use manual path search since find_library may not work with cross-compilation toolchains
-macro(mln_wgpu_find_exact_library out_var)
+# Resolve the exact archive/import library filename emitted by wgpu-native.
+macro(mln_wgpu_find_exact_library out_var out_description)
     foreach(_search_path ${_wgpu_lib_search_paths})
         if(EXISTS "${_search_path}/${_wgpu_lib_name}")
-            set(${out_var} "${_search_path}/${_wgpu_lib_name}" CACHE FILEPATH "wgpu-native library")
+            set(${out_var} "${_search_path}/${_wgpu_lib_name}" CACHE FILEPATH "${out_description}")
             break()
         endif()
     endforeach()
 endmacro()
 
+# On Android/iOS, use manual path search since find_library may not work with cross-compilation toolchains
 macro(mln_wgpu_find_library)
     if(ANDROID OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
-        mln_wgpu_find_exact_library(WGPU_LIBRARY)
+        mln_wgpu_find_exact_library(WGPU_LIBRARY "wgpu-native library")
     else()
         find_library(WGPU_LIBRARY
             NAMES wgpu_native libwgpu_native
@@ -91,7 +92,7 @@ macro(mln_wgpu_find_library)
 endmacro()
 
 mln_wgpu_find_library()
-mln_wgpu_find_exact_library(WGPU_STATIC_LIBRARY)
+mln_wgpu_find_exact_library(WGPU_STATIC_LIBRARY "wgpu-native static library")
 
 if(NOT WGPU_LIBRARY OR MLN_WGPU_NATIVE_VERSION)
     # Use a specific version of WGPU. This is required when to a rust application
@@ -158,7 +159,7 @@ if(NOT WGPU_LIBRARY OR MLN_WGPU_NATIVE_VERSION)
 
     # Try to find the library again
     mln_wgpu_find_library()
-    mln_wgpu_find_exact_library(WGPU_STATIC_LIBRARY)
+    mln_wgpu_find_exact_library(WGPU_STATIC_LIBRARY "wgpu-native static library")
 
     if(NOT WGPU_LIBRARY)
         message(FATAL_ERROR "Failed to locate wgpu-native library after building")

--- a/vendor/wgpu.cmake
+++ b/vendor/wgpu.cmake
@@ -68,14 +68,18 @@ list(APPEND _wgpu_lib_search_paths
 )
 
 # On Android/iOS, use manual path search since find_library may not work with cross-compilation toolchains
+macro(mln_wgpu_find_exact_library out_var)
+    foreach(_search_path ${_wgpu_lib_search_paths})
+        if(EXISTS "${_search_path}/${_wgpu_lib_name}")
+            set(${out_var} "${_search_path}/${_wgpu_lib_name}" CACHE FILEPATH "wgpu-native library")
+            break()
+        endif()
+    endforeach()
+endmacro()
+
 macro(mln_wgpu_find_library)
     if(ANDROID OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
-        foreach(_search_path ${_wgpu_lib_search_paths})
-            if(EXISTS "${_search_path}/${_wgpu_lib_name}")
-                set(WGPU_LIBRARY "${_search_path}/${_wgpu_lib_name}" CACHE FILEPATH "wgpu-native library")
-                break()
-            endif()
-        endforeach()
+        mln_wgpu_find_exact_library(WGPU_LIBRARY)
     else()
         find_library(WGPU_LIBRARY
             NAMES wgpu_native libwgpu_native
@@ -86,17 +90,8 @@ macro(mln_wgpu_find_library)
     endif()
 endmacro()
 
-macro(mln_wgpu_find_static_library)
-    foreach(_search_path ${_wgpu_lib_search_paths})
-        if(EXISTS "${_search_path}/${_wgpu_lib_name}")
-            set(WGPU_STATIC_LIBRARY "${_search_path}/${_wgpu_lib_name}" CACHE FILEPATH "wgpu-native static library")
-            break()
-        endif()
-    endforeach()
-endmacro()
-
 mln_wgpu_find_library()
-mln_wgpu_find_static_library()
+mln_wgpu_find_exact_library(WGPU_STATIC_LIBRARY)
 
 if(NOT WGPU_LIBRARY OR MLN_WGPU_NATIVE_VERSION)
     # Use a specific version of WGPU. This is required when to a rust application
@@ -163,7 +158,7 @@ if(NOT WGPU_LIBRARY OR MLN_WGPU_NATIVE_VERSION)
 
     # Try to find the library again
     mln_wgpu_find_library()
-    mln_wgpu_find_static_library()
+    mln_wgpu_find_exact_library(WGPU_STATIC_LIBRARY)
 
     if(NOT WGPU_LIBRARY)
         message(FATAL_ERROR "Failed to locate wgpu-native library after building")
@@ -172,10 +167,6 @@ if(NOT WGPU_LIBRARY OR MLN_WGPU_NATIVE_VERSION)
     message(STATUS "Successfully built wgpu-native: ${WGPU_LIBRARY}")
 else()
     message(STATUS "Found wgpu-native library: ${WGPU_LIBRARY}")
-endif()
-
-if(NOT WGPU_STATIC_LIBRARY AND WGPU_LIBRARY MATCHES "\\.(a|lib)$")
-    set(WGPU_STATIC_LIBRARY "${WGPU_LIBRARY}" CACHE FILEPATH "wgpu-native static library" FORCE)
 endif()
 
 if(WGPU_STATIC_LIBRARY)

--- a/vendor/wgpu.cmake
+++ b/vendor/wgpu.cmake
@@ -86,7 +86,17 @@ macro(mln_wgpu_find_library)
     endif()
 endmacro()
 
+macro(mln_wgpu_find_static_library)
+    foreach(_search_path ${_wgpu_lib_search_paths})
+        if(EXISTS "${_search_path}/${_wgpu_lib_name}")
+            set(WGPU_STATIC_LIBRARY "${_search_path}/${_wgpu_lib_name}" CACHE FILEPATH "wgpu-native static library")
+            break()
+        endif()
+    endforeach()
+endmacro()
+
 mln_wgpu_find_library()
+mln_wgpu_find_static_library()
 
 if(NOT WGPU_LIBRARY OR MLN_WGPU_NATIVE_VERSION)
     # Use a specific version of WGPU. This is required when to a rust application
@@ -153,6 +163,7 @@ if(NOT WGPU_LIBRARY OR MLN_WGPU_NATIVE_VERSION)
 
     # Try to find the library again
     mln_wgpu_find_library()
+    mln_wgpu_find_static_library()
 
     if(NOT WGPU_LIBRARY)
         message(FATAL_ERROR "Failed to locate wgpu-native library after building")
@@ -161,6 +172,18 @@ if(NOT WGPU_LIBRARY OR MLN_WGPU_NATIVE_VERSION)
     message(STATUS "Successfully built wgpu-native: ${WGPU_LIBRARY}")
 else()
     message(STATUS "Found wgpu-native library: ${WGPU_LIBRARY}")
+endif()
+
+if(NOT WGPU_STATIC_LIBRARY AND WGPU_LIBRARY MATCHES "\\.(a|lib)$")
+    set(WGPU_STATIC_LIBRARY "${WGPU_LIBRARY}" CACHE FILEPATH "wgpu-native static library" FORCE)
+endif()
+
+if(WGPU_STATIC_LIBRARY)
+    message(STATUS "Found wgpu-native static library: ${WGPU_STATIC_LIBRARY}")
+elseif(MLN_CREATE_AMALGAMATION)
+    message(FATAL_ERROR
+        "MLN_CREATE_AMALGAMATION=ON requires a static wgpu-native library, "
+        "but none was found in: ${_wgpu_lib_search_paths}")
 endif()
 
 # Create compatibility shims for Dawn header paths if they don't exist


### PR DESCRIPTION
## Summary

Fix Linux WebGPU amalgamation builds so `libmbgl-core-amalgam.a` also includes `libwgpu_native.a` when building with:

- `MLN_CREATE_AMALGAMATION=ON`
- `MLN_WITH_WEBGPU=ON`
- `MLN_WEBGPU_IMPL_WGPU=ON`

## Motivation

This was needed for downstream consumers such as `maplibre-native-rs`.

Before this change, the Linux WebGPU amalgam archive could be produced, but it still contained unresolved `wgpu*` symbols. As a result, `maplibre-native-rs` could not use it through `MLN_CORE_LIBRARY_PATH` alone and still needed an extra `wgpu_native` linker dependency.

## Changes

- resolve a dedicated `WGPU_STATIC_LIBRARY` for Linux `wgpu-native`
- include that static archive in the Linux amalgamation step
- add a Linux-only check script to fail if unresolved `wgpu*` symbols remain
- add a Linux `wgpu` lane to `core-release.yml`

## Validation

Validated locally on Linux by:

- building `maplibre-native` with Linux `wgpu + amalgamation`
- confirming `libmbgl-core-amalgam.a` has no unresolved `wgpu*` symbols
- linking it into `maplibre-native-rs` via `MLN_CORE_LIBRARY_PATH`
- running a successful headless render smoke test downstream

## Size impact

This increases the Linux x64 WebGPU amalgam size, which is expected because `libwgpu_native.a` is now bundled into the archive.

For reference:

- bundled `libwgpu_native.a`: ~51.6 MiB
- resulting Linux x64 WebGPU amalgam: ~385.5 MiB

Compared with existing Linux x64 amalgam artifacts from `core-release`:

- OpenGL amalgam: ~326.7 MiB
- Vulkan amalgam: ~352.6 MiB
- WebGPU (`wgpu`) amalgam after this change: ~385.5 MiB

So the artifact does get larger, but the increase is in line with the size of the bundled `wgpu-native` static archive and does not appear abnormal.

  | Artifact | Before | After |
  |---|---:|---:|
  | Linux x64 OpenGL amalgam | 326.7 MiB | 326.7 MiB |
  | Linux x64 Vulkan amalgam | 352.6 MiB | 352.6 MiB |
  | Linux x64 WebGPU amalgam |  | 385.5 MiB |

- Reference: bundled libwgpu_native.a in the local build is about 51.6 MiB

## Note

This change bundles `wgpu-native` into the amalgam archive, but does not try to bundle all Linux system libraries.
