### PR TITLE
iOS: Force `MLNMapView` layout after transitions

### DIFF
--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -1781,6 +1781,9 @@ public:
                        options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
                        context:windowScreenContext];
     }
+
+    // https://github.com/maplibre/maplibre-native/issues/4204
+    [self setNeedsLayout];
   }
 }
 


### PR DESCRIPTION
Following the sample provided in https://github.com/maplibre/maplibre-native/issues/4204, after returning to the map view the metal drawable will resize, but the internal size remains static. Forcing a layout after transitions resets and syncs the internal state.