### PR TITLE
macos: fix Xcode 26 build compatibility

### DIFF
--- a/platform/darwin/src/NSValue+MLNStyleAttributeAdditions.mm
+++ b/platform/darwin/src/NSValue+MLNStyleAttributeAdditions.mm
@@ -23,9 +23,9 @@
   // Foundation defines padding in counterclockwise order: top, left, bottom, right.
   MLNEdgeInsets insets = {
       .top = paddingArray[0],
-      .right = paddingArray[1],
-      .bottom = paddingArray[2],
       .left = paddingArray[3],
+      .bottom = paddingArray[2],
+      .right = paddingArray[1],
   };
   return [NSValue value:&insets withObjCType:@encode(MLNEdgeInsets)];
 }

--- a/platform/macos/src/MLNMapView.mm
+++ b/platform/macos/src/MLNMapView.mm
@@ -24,6 +24,8 @@
 #import "MLNPolyline.h"
 #import "MLNSettings.h"
 
+#include <optional>
+
 #import <mbgl/annotation/annotation.hpp>
 #import <mbgl/map/camera.hpp>
 #import <mbgl/map/map.hpp>
@@ -317,8 +319,9 @@ public:
 
   MLNRendererConfiguration *config = [MLNRendererConfiguration currentConfiguration];
 
-  auto localFontFamilyName =
-      config.localFontFamilyName ? std::string(config.localFontFamilyName.UTF8String) : nullptr;
+  std::optional<std::string> localFontFamilyName =
+      config.localFontFamilyName ? std::optional(std::string(config.localFontFamilyName.UTF8String))
+                                 : std::nullopt;
   auto renderer = std::make_unique<mbgl::Renderer>(_mbglView->getRendererBackend(),
                                                    config.scaleFactor, localFontFamilyName);
   BOOL enableCrossSourceCollisions = !config.perSourceCollisions;


### PR DESCRIPTION
Extends the iOS fixes from #4216 to macOS code.

## nullptr passed to non-null parameter

`MLNMapView.mm` uses `nullptr` as fallback for a `std::string`, which Xcode 26 now rejects with `-Wnonnull` promoted to error via `-Werror`. Same issue that was fixed for iOS in `MLNMapSnapshotter.mm` by #4216.

Fix: replace with `std::optional<std::string>` / `std::nullopt`.

## Designated initializer order

`NSValue+MLNStyleAttributeAdditions.mm` initializes `NSEdgeInsets` fields in style-spec order (top, right, bottom, left) instead of struct declaration order (top, left, bottom, right). Xcode 26 ships a newer Clang that flags this with `-Wreorder-init-list`, promoted to error via `-Werror`.

Fix: reorder designated initializers to match the struct layout.
