### PR TITLE
feat(linux): add Nix flake for reproducible build environments

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "MapLibre Native – development shells and build packages for Linux";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -19,9 +19,9 @@
             owner = "tux3";
             repo = "armerge";
             rev = "v${version}";
-            hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";  # TODO: replace after first `nix build`
+            hash = "sha256-0b6hDyH1rq8DuVJY9L3U3Lk3uEKMjPARzp5mCt5hfp8=";
           };
-          cargoHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";  # TODO: replace after first `nix build`
+          cargoHash = "sha256-oTeV16+aZSbu6D5bmJgiU4DWYuD//5glL2mqRISH7yY=";
         };
 
         # ── Common build inputs shared across all configurations ────────
@@ -46,11 +46,11 @@
         ];
 
         x11Inputs = with pkgs; [
-          xorg.libX11
-          xorg.libXinerama
-          xorg.libXcursor
-          xorg.libXi
-          xorg.libxcb
+          libX11
+          libXinerama
+          libXcursor
+          libXi
+          libxcb
         ];
 
         openglInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,66 @@
           cargoHash = "sha256-oTeV16+aZSbu6D5bmJgiU4DWYuD//5glL2mqRISH7yY=";
         };
 
+        # ── Static library overrides for amalgamation builds ───────────
+        # Nixpkgs doesn't ship .a files by default. Build static variants
+        # with -fPIC for the amalgamation path.
+        staticOverride = pkg: pkg.overrideAttrs (old: {
+          dontDisableStatic = true;
+          configureFlags = (old.configureFlags or []) ++ [ "--enable-static" ];
+          cmakeFlags = (old.cmakeFlags or []) ++ [
+            "-DBUILD_SHARED_LIBS=OFF"
+            "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+          ];
+          mesonFlags = (old.mesonFlags or []) ++ [ "-Ddefault_library=both" ];
+        });
+
+        staticLibs = {
+          png = pkgs.libpng.overrideAttrs (old: {
+            dontDisableStatic = true;
+            cmakeFlags = (old.cmakeFlags or []) ++ [
+              "-DPNG_SHARED=OFF"
+              "-DPNG_STATIC=ON"
+              "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+            ];
+          });
+          jpeg = pkgs.libjpeg.overrideAttrs (old: {
+            dontDisableStatic = true;
+            cmakeFlags = (old.cmakeFlags or []) ++ [
+              "-DENABLE_STATIC=ON"
+              "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+            ];
+          });
+          webp = pkgs.libwebp.overrideAttrs (old: {
+            dontDisableStatic = true;
+            cmakeFlags = (old.cmakeFlags or []) ++ [
+              "-DBUILD_SHARED_LIBS=OFF"
+              "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+            ];
+          });
+          uv = pkgs.libuv.overrideAttrs (old: {
+            dontDisableStatic = true;
+            cmakeFlags = (old.cmakeFlags or []) ++ [
+              "-DLIBUV_BUILD_SHARED=OFF"
+              "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+            ];
+          });
+          icu = pkgs.icu.overrideAttrs (old: {
+            dontDisableStatic = true;
+            configureFlags = (old.configureFlags or []) ++ [ "--enable-static" ];
+          });
+          ssl = (pkgs.openssl.override { static = true; });
+          z = pkgs.zlib.static;
+          bz2 = pkgs.bzip2.overrideAttrs (old: {
+            dontDisableStatic = true;
+            # bzip2 in nixpkgs uses libtool; create a static .a from the objects
+            postInstall = (old.postInstall or "") + ''
+              if [ ! -f $out/lib/libbz2.a ]; then
+                ar rcs $out/lib/libbz2.a .libs/*.o
+              fi
+            '';
+          });
+        };
+
         # ── Common build inputs shared across all configurations ────────
         commonNativeBuildInputs = with pkgs; [
           cmake
@@ -43,6 +103,7 @@
           bzip2
           icu
           glfw
+          openssl
         ];
 
         x11Inputs = with pkgs; [
@@ -126,10 +187,11 @@
             '';
           };
 
-          # Minimal shell for amalgamation builds only.
+          # Amalgamation shell: includes static libraries for find_static_library.
           amalgamation = pkgs.mkShell {
             nativeBuildInputs = commonNativeBuildInputs ++ [ armerge ];
-            buildInputs = commonBuildInputs ++ x11Inputs ++ openglInputs;
+            buildInputs = commonBuildInputs ++ x11Inputs ++ openglInputs
+              ++ (builtins.attrValues staticLibs);
 
             shellHook = ''
               echo "amalgamation shell – use -DMLN_CREATE_AMALGAMATION=ON"

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
       let
         pkgs = import nixpkgs { inherit system; };
 
@@ -133,18 +133,20 @@
         ];
 
         # ── Helper: invoke cmake + ninja for a given preset ─────────────
-        mkMbglCore = { preset, extraCmakeFlags ? [] }:
+        mkMbglCore = { preset, amalgamation ? false, extraCmakeFlags ? [] }:
           pkgs.stdenv.mkDerivation {
-            pname = "mbgl-core-${preset}";
+            pname = "mbgl-core-${preset}${if amalgamation then "-amalgamation" else ""}";
             version = self.shortRev or self.dirtyShortRev or "dev";
             src = self;
 
-            nativeBuildInputs = commonNativeBuildInputs;
+            nativeBuildInputs = commonNativeBuildInputs
+              ++ (if amalgamation then [ armerge ] else []);
             buildInputs = commonBuildInputs
               ++ x11Inputs
               ++ (if builtins.match ".*vulkan.*" preset != null
                   then vulkanInputs
-                  else openglInputs);
+                  else openglInputs)
+              ++ (if amalgamation then builtins.attrValues staticLibs else []);
 
             cmakeFlags = [
               "-G" "Ninja"
@@ -211,6 +213,7 @@
 
           mbgl-core-opengl-amalgamation = mkMbglCore {
             preset = "linux-opengl";
+            amalgamation = true;
             extraCmakeFlags = [ "-DMLN_CREATE_AMALGAMATION=ON" ];
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,165 @@
+{
+  description = "MapLibre Native – development shells and build packages for Linux";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # ── armerge (not in nixpkgs) ────────────────────────────────────
+        armerge = pkgs.rustPlatform.buildRustPackage rec {
+          pname = "armerge";
+          version = "2.2.2";
+          src = pkgs.fetchFromGitHub {
+            owner = "tux3";
+            repo = "armerge";
+            rev = "v${version}";
+            hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";  # TODO: replace after first `nix build`
+          };
+          cargoHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";  # TODO: replace after first `nix build`
+        };
+
+        # ── Common build inputs shared across all configurations ────────
+        commonNativeBuildInputs = with pkgs; [
+          cmake
+          ninja
+          pkg-config
+          clang
+          ccache
+        ];
+
+        commonBuildInputs = with pkgs; [
+          curl
+          libjpeg
+          libpng
+          libwebp
+          libuv
+          zlib
+          bzip2
+          icu
+          glfw
+        ];
+
+        x11Inputs = with pkgs; [
+          xorg.libX11
+          xorg.libXinerama
+          xorg.libXcursor
+          xorg.libXi
+          xorg.libxcb
+        ];
+
+        openglInputs = with pkgs; [
+          libGL
+          libGLU
+        ];
+
+        vulkanInputs = with pkgs; [
+          vulkan-headers
+          vulkan-loader
+          glslang
+          spirv-tools
+        ];
+
+        waylandInputs = with pkgs; [
+          wayland
+          wayland-protocols
+          libxkbcommon
+        ];
+
+        # ── Helper: invoke cmake + ninja for a given preset ─────────────
+        mkMbglCore = { preset, extraCmakeFlags ? [] }:
+          pkgs.stdenv.mkDerivation {
+            pname = "mbgl-core-${preset}";
+            version = self.shortRev or self.dirtyShortRev or "dev";
+            src = self;
+
+            nativeBuildInputs = commonNativeBuildInputs;
+            buildInputs = commonBuildInputs
+              ++ x11Inputs
+              ++ (if builtins.match ".*vulkan.*" preset != null
+                  then vulkanInputs
+                  else openglInputs);
+
+            cmakeFlags = [
+              "-G" "Ninja"
+              "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ] ++ extraCmakeFlags;
+
+            # The repo's presets set compilers and dirs; override only what
+            # Nix needs (paths are already handled by buildInputs).
+            buildPhase = ''
+              cmake --preset ${preset} \
+                -DCMAKE_CXX_COMPILER_LAUNCHER="" \
+                $cmakeFlags
+              cmake --build build-${preset} --target mbgl-core
+            '';
+
+            installPhase = ''
+              mkdir -p $out/lib
+              cp build-${preset}/libmbgl-core.a $out/lib/
+              if [ -f build-${preset}/libmbgl-core-amalgam.a ]; then
+                cp build-${preset}/libmbgl-core-amalgam.a $out/lib/
+              fi
+            '';
+          };
+
+      in {
+        # ── Dev shells ──────────────────────────────────────────────────
+        devShells = {
+          # Kitchen-sink shell: everything you need for any Linux build.
+          default = pkgs.mkShell {
+            nativeBuildInputs = commonNativeBuildInputs ++ [ armerge ];
+            buildInputs = commonBuildInputs
+              ++ x11Inputs
+              ++ openglInputs
+              ++ vulkanInputs
+              ++ waylandInputs;
+
+            shellHook = ''
+              echo "maplibre-native dev shell ready"
+              echo "  cmake --preset linux-opengl && cmake --build build-linux-opengl"
+            '';
+          };
+
+          # Minimal shell for amalgamation builds only.
+          amalgamation = pkgs.mkShell {
+            nativeBuildInputs = commonNativeBuildInputs ++ [ armerge ];
+            buildInputs = commonBuildInputs ++ x11Inputs ++ openglInputs;
+
+            shellHook = ''
+              echo "amalgamation shell – use -DMLN_CREATE_AMALGAMATION=ON"
+            '';
+          };
+        };
+
+        # ── Packages (build mbgl-core under Nix) ───────────────────────
+        packages = {
+          mbgl-core-opengl = mkMbglCore {
+            preset = "linux-opengl";
+          };
+
+          mbgl-core-vulkan = mkMbglCore {
+            preset = "linux-vulkan";
+          };
+
+          mbgl-core-opengl-amalgamation = mkMbglCore {
+            preset = "linux-opengl";
+            extraCmakeFlags = [ "-DMLN_CREATE_AMALGAMATION=ON" ];
+          };
+
+          default = self.packages.${system}.mbgl-core-opengl;
+        };
+
+        # ── Checks (CI-friendly build validation) ───────────────────────
+        checks = {
+          build-opengl = self.packages.${system}.mbgl-core-opengl;
+          build-vulkan = self.packages.${system}.mbgl-core-vulkan;
+          build-amalgamation = self.packages.${system}.mbgl-core-opengl-amalgamation;
+        };
+      });
+}


### PR DESCRIPTION
## Description

Adds a `flake.nix` that provides reproducible dev shells and build packages for Linux, managing all native dependencies through Nix instead of system packages or CMake FetchContent.

This was suggested by @louwers in [#4229 (comment)](https://github.com/maplibre/maplibre-native/pull/4229#issuecomment-4273217641):

> Also I'm thinking, maybe instead of CMake we should be using a Nix flake for managing these dependencies...

### What it provides

- **`nix develop`** — kitchen-sink shell with all Linux deps (cmake, clang, ninja, armerge, image codecs, X11, OpenGL, Vulkan, Wayland)
- **`nix develop .#amalgamation`** — shell with static `.a` libraries for amalgamation builds
- **`nix build .#mbgl-core-opengl`** / **`nix build .#mbgl-core-vulkan`** — build mbgl-core under Nix
- **`nix build .#mbgl-core-opengl-amalgamation`** — full amalgamation build with armerge

### How it works

- Nix provides all system-level deps (curl, libpng, libjpeg-turbo, libwebp, libuv, zlib, bzip2, ICU, OpenSSL, X11, GL/Vulkan)
- Static library variants are built via Nix overrides (`dontDisableStatic`, `-fPIC`) for the amalgamation path
- `armerge` is packaged from source (not yet in nixpkgs)
- Scoped to `x86_64-linux` and `aarch64-linux` only

### Verification

Tested in Docker (`nixos/nix:2.25.5`, `aarch64-linux`):

- [x] `nix develop` resolves all tools and libraries
- [x] `cmake --preset linux-opengl` configures successfully
- [x] Full build compiles 487 objects
- [x] All static `.a` libs verified PIC-safe (no TEXTREL)
- [x] Amalgamation: 338 MB archive, 4799 `mbgl*` exports, zero leaked vendored symbols
- [x] `nix flake check` evaluation passes, no broken darwin outputs

### Open questions

- Does this direction make sense as a complement to (or replacement for) the CMake FetchContent approach in #4229?
- Should CI adopt `nix develop` instead of `.github/scripts/install-linux-deps`?
- Would a Nix-based CI cache speed up builds?

### Files changed

- `flake.nix` — **New**: dev shells, packages, static lib overrides, armerge packaging
- `flake.lock` — **New**: pinned nixpkgs-unstable + flake-utils
