### PR TITLE
Revert "Link AI Policy from CONTRIBUTING.md"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,6 @@ If you want to contribute code:
 
 1. Pull requests are gladly accepted. If there are any changes that developers using one of the platforms should be aware of, please update the **main** section of the relevant `CHANGELOG.md`.
 
-## Note on AI usage
-
-If you are using any kind of AI assistance for your contributions, please take a moment to review [MapLibre's AI Policy](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md). tl;dr: do not let AI speak for you, verify all generated content before requesting a review and disclose AI usage in pull requests.
-
 ## Design Proposals
 
 If you would like to change MapLibre Native in a substantial way, we recommend that you write a Design Proposal. Examples for substantial changes could be if you would like to split the mono-repo or if you would like to introduce shaders written in Metal.


### PR DESCRIPTION
Reverts maplibre/maplibre-native#4249.   Yes, Feedback is still welcome on the AI policy *mea culpa*