### PR TITLE
Fix: unconditionally rewriting contentScaleFactor/drawableSize every layout pass caused a feedback loop under iOS 26 Smart Display Zoom

### DIFF
--- a/platform/darwin/src/headless_backend_eagl.mm
+++ b/platform/darwin/src/headless_backend_eagl.mm
@@ -7,7 +7,7 @@
 namespace mbgl {
 namespace gl {
 
-class EAGLBackendImpl : public HeadlessBackend::Impl {
+class EAGLBackendImpl final : public HeadlessBackend::Impl {
 public:
   EAGLBackendImpl() {
     glContext = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];

--- a/platform/ios/src/MLNMapView+Metal.mm
+++ b/platform/ios/src/MLNMapView+Metal.mm
@@ -106,6 +106,11 @@ public:
   id<MTLCommandQueue> commandQueue;
   bool presentsWithTransaction = false;
 
+  // Cached last-applied values comparing against MTKView's reflected state round-trips
+  // through UIKit and can defeat the no-op guard under non-integer scale factors.
+  CGFloat lastAppliedScaleFactor = 0;
+  CGSize lastAppliedDrawableSize = CGSizeZero;
+
   // We count how often the context was activated/deactivated so that we can truly deactivate it
   // after the activation count drops to 0.
   NSUInteger activationCount = 0;
@@ -161,6 +166,9 @@ void MLNMapViewMetalImpl::createView() {
   resource.mtlView.delegate = resource.delegate;
   resource.mtlView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  // We own drawable sizing in layoutChanged(); disable MTKView's automatic recompute so
+  // setting contentScaleFactor cannot race with explicit drawableSize assignment.
+  resource.mtlView.autoResizeDrawable = NO;
   resource.mtlView.contentScaleFactor = scaleFactor;
   resource.mtlView.contentMode = UIViewContentModeCenter;
   resource.mtlView.colorPixelFormat = MTLPixelFormatBGRA8Unorm;
@@ -215,17 +223,29 @@ UIImage* MLNMapViewMetalImpl::snapshot() {
 }
 
 void MLNMapViewMetalImpl::layoutChanged() {
-  const auto scaleFactor = MLNEffectiveScaleFactorForView(mapView);
-  const auto screenSize = mapView.bounds.size;
-
+  // Fix: unconditionally rewriting contentScaleFactor/drawableSize every
+  // layout pass caused a feedback loop under iOS 26 Smart Display Zoom (non-integer scale).
+  // Also skip pre-layout/detached passes — MLNEffectiveScaleFactorForView falls back to
+  // mainScreen without a window, wrong for CarPlay.
   auto& resource = getResource<MLNMapViewMetalRenderableResource>();
+  const auto viewSize = mapView.bounds.size;
+  if (!resource.mtlView || viewSize.width <= 0 || viewSize.height <= 0 || !mapView.window) {
+    return;
+  }
 
-  resource.mtlView.contentScaleFactor = scaleFactor;
-  resource.mtlView.drawableSize =
-      CGSizeMake(screenSize.width * scaleFactor, screenSize.height * scaleFactor);
+  const auto scaleFactor = MLNEffectiveScaleFactorForView(mapView);
+  const CGSize target = CGSizeMake(std::round(viewSize.width * scaleFactor),
+                                   std::round(viewSize.height * scaleFactor));
 
-  size = {static_cast<uint32_t>(resource.mtlView.drawableSize.width),
-          static_cast<uint32_t>(resource.mtlView.drawableSize.height)};
+  if (scaleFactor != resource.lastAppliedScaleFactor) {
+    resource.mtlView.contentScaleFactor = resource.lastAppliedScaleFactor = scaleFactor;
+  }
+  if (!CGSizeEqualToSize(target, resource.lastAppliedDrawableSize)) {
+    resource.mtlView.drawableSize = resource.lastAppliedDrawableSize = target;
+  }
+
+  size = {static_cast<uint32_t>(target.width),
+          static_cast<uint32_t>(target.height)};
 }
 
 MLNBackendResource* MLNMapViewMetalImpl::getObject() {

--- a/platform/ios/src/MLNMapView+Metal.mm
+++ b/platform/ios/src/MLNMapView+Metal.mm
@@ -244,8 +244,7 @@ void MLNMapViewMetalImpl::layoutChanged() {
     resource.mtlView.drawableSize = resource.lastAppliedDrawableSize = target;
   }
 
-  size = {static_cast<uint32_t>(target.width),
-          static_cast<uint32_t>(target.height)};
+  size = {static_cast<uint32_t>(target.width), static_cast<uint32_t>(target.height)};
 }
 
 MLNBackendResource* MLNMapViewMetalImpl::getObject() {


### PR DESCRIPTION
Map stutters/freezes on CarPlay with Smart Display Zoom enabled (iOS 26, default on).

Introduced: #3890.

- Fix: unconditionally rewriting `contentScaleFactor`/`drawableSize` every layout pass caused a feedback loop under iOS 26 Smart Display Zoom (non-integer scale).
- Also skip pre-layout/detached passes — `MLNEffectiveScaleFactorForView` falls back to mainScreen without a window, wrong for CarPlay.
- Disable MTKView's automatic recompute so setting `contentScaleFactor` cannot race with explicit `drawableSize` assignment.

Before: https://github.com/user-attachments/assets/64482bc5-4d5d-4921-ab83-9ac6ae077235
After:  https://github.com/user-attachments/assets/a96414ff-a608-4d71-a54f-7ad9abd0d250

**AI assistance disclosure:**
Parts of this fix were made with AI assistance (Claude Opus 4.7). It is reviewed, tested, and tweaked by me before opening the PR. I validated the fix on a real physical device and CarPlay simulator. Inline comments and this PR description are my own.