### PR TITLE
android: fix infinite recursion causing Stack Overflow in TileSet.kt setBounds()

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/sources/TileSet.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/sources/TileSet.kt
@@ -204,7 +204,7 @@ class TileSet(val tilejson: String, vararg tiles: String) {
      * @param top the Float top bound
      */
     fun setBounds(left: Float, bottom: Float, right: Float, top: Float) {
-        setBounds(left, bottom, right, top)
+        this.bounds = arrayOf(left, bottom, right, top)
     }
 
     /**

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/style/sources/TileSetTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/style/sources/TileSetTest.kt
@@ -1,0 +1,105 @@
+package org.maplibre.android.style.sources
+
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.maplibre.android.geometry.LatLngBounds
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Test for TileSet class to validate bounds setting functionality
+ */
+@RunWith(RobolectricTestRunner::class)
+class TileSetTest {
+
+    @Test
+    fun testSetBoundsWithFourFloats() {
+        val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
+        
+        // Test setting bounds with four float parameters
+        tileSet.setBounds(-180f, -90f, 180f, 90f)
+        
+        assertNotNull("Bounds should be set", tileSet.bounds)
+        assertEquals("Bounds should have 4 elements", 4, tileSet.bounds?.size)
+        assertEquals("Left bound should be -180", -180f, tileSet.bounds?.get(0))
+        assertEquals("Bottom bound should be -90", -90f, tileSet.bounds?.get(1))
+        assertEquals("Right bound should be 180", 180f, tileSet.bounds?.get(2))
+        assertEquals("Top bound should be 90", 90f, tileSet.bounds?.get(3))
+    }
+
+    @Test
+    fun testSetBoundsWithVarargFloats() {
+        val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
+        
+        // Test setting bounds with vararg floats
+        tileSet.setBounds(-10f, -20f, 30f, 40f)
+        
+        assertNotNull("Bounds should be set", tileSet.bounds)
+        assertEquals("Bounds should have 4 elements", 4, tileSet.bounds?.size)
+        assertEquals("Left bound should be -10", -10f, tileSet.bounds?.get(0))
+        assertEquals("Bottom bound should be -20", -20f, tileSet.bounds?.get(1))
+        assertEquals("Right bound should be 30", 30f, tileSet.bounds?.get(2))
+        assertEquals("Top bound should be 40", 40f, tileSet.bounds?.get(3))
+    }
+
+    @Test
+    fun testSetBoundsWithArray() {
+        val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
+        
+        // Test setting bounds with array
+        val boundsArray = arrayOf(12f, 34f, 56f, 78f)
+        tileSet.setBounds(boundsArray)
+        
+        assertNotNull("Bounds should be set", tileSet.bounds)
+        assertEquals("Bounds should have 4 elements", 4, tileSet.bounds?.size)
+        assertArrayEquals("Bounds should match input array", boundsArray, tileSet.bounds)
+    }
+
+    @Test
+    fun testSetBoundsWithLatLngBounds() {
+        val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
+        
+        // Test setting bounds with LatLngBounds
+        val latLngBounds = LatLngBounds.Builder()
+            .include(org.maplibre.android.geometry.LatLng(12.0, 34.0))
+            .include(org.maplibre.android.geometry.LatLng(56.0, 78.0))
+            .build()
+        
+        tileSet.setBounds(latLngBounds)
+        
+        assertNotNull("Bounds should be set", tileSet.bounds)
+        assertEquals("Bounds should have 4 elements", 4, tileSet.bounds?.size)
+        assertEquals("Left bound should match", latLngBounds.longitudeWest.toFloat(), tileSet.bounds?.get(0))
+        assertEquals("Bottom bound should match", latLngBounds.latitudeSouth.toFloat(), tileSet.bounds?.get(1))
+        assertEquals("Right bound should match", latLngBounds.longitudeEast.toFloat(), tileSet.bounds?.get(2))
+        assertEquals("Top bound should match", latLngBounds.latitudeNorth.toFloat(), tileSet.bounds?.get(3))
+    }
+
+    @Test
+    fun testSetBoundsNoStackOverflow() {
+        val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
+        
+        // This test verifies the fix for the infinite recursion bug
+        // If the bug still exists, this will cause a StackOverflowError
+        tileSet.setBounds(1f, 2f, 3f, 4f)
+        
+        assertNotNull("Bounds should be set without stack overflow", tileSet.bounds)
+        assertEquals("Should have 4 elements", 4, tileSet.bounds?.size)
+    }
+
+    @Test
+    fun testMultipleSetBoundsCalls() {
+        val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
+        
+        // Test multiple calls to setBounds
+        tileSet.setBounds(-180f, -90f, 180f, 90f)
+        assertNotNull("First bounds should be set", tileSet.bounds)
+        
+        tileSet.setBounds(-10f, -20f, 30f, 40f)
+        assertNotNull("Second bounds should be set", tileSet.bounds)
+        assertEquals("Left bound should be updated", -10f, tileSet.bounds?.get(0))
+        assertEquals("Bottom bound should be updated", -20f, tileSet.bounds?.get(1))
+        assertEquals("Right bound should be updated", 30f, tileSet.bounds?.get(2))
+        assertEquals("Top bound should be updated", 40f, tileSet.bounds?.get(3))
+    }
+}

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/style/sources/TileSetTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/style/sources/TileSetTest.kt
@@ -15,10 +15,10 @@ class TileSetTest {
     @Test
     fun testSetBoundsWithFourFloats() {
         val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
-        
+
         // Test setting bounds with four float parameters
         tileSet.setBounds(-180f, -90f, 180f, 90f)
-        
+
         assertNotNull("Bounds should be set", tileSet.bounds)
         assertEquals("Bounds should have 4 elements", 4, tileSet.bounds?.size)
         assertEquals("Left bound should be -180", -180f, tileSet.bounds?.get(0))
@@ -30,10 +30,10 @@ class TileSetTest {
     @Test
     fun testSetBoundsWithVarargFloats() {
         val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
-        
+
         // Test setting bounds with vararg floats
         tileSet.setBounds(-10f, -20f, 30f, 40f)
-        
+
         assertNotNull("Bounds should be set", tileSet.bounds)
         assertEquals("Bounds should have 4 elements", 4, tileSet.bounds?.size)
         assertEquals("Left bound should be -10", -10f, tileSet.bounds?.get(0))
@@ -45,11 +45,11 @@ class TileSetTest {
     @Test
     fun testSetBoundsWithArray() {
         val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
-        
+
         // Test setting bounds with array
         val boundsArray = arrayOf(12f, 34f, 56f, 78f)
         tileSet.setBounds(boundsArray)
-        
+
         assertNotNull("Bounds should be set", tileSet.bounds)
         assertEquals("Bounds should have 4 elements", 4, tileSet.bounds?.size)
         assertArrayEquals("Bounds should match input array", boundsArray, tileSet.bounds)
@@ -58,15 +58,15 @@ class TileSetTest {
     @Test
     fun testSetBoundsWithLatLngBounds() {
         val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
-        
+
         // Test setting bounds with LatLngBounds
         val latLngBounds = LatLngBounds.Builder()
             .include(org.maplibre.android.geometry.LatLng(12.0, 34.0))
             .include(org.maplibre.android.geometry.LatLng(56.0, 78.0))
             .build()
-        
+
         tileSet.setBounds(latLngBounds)
-        
+
         assertNotNull("Bounds should be set", tileSet.bounds)
         assertEquals("Bounds should have 4 elements", 4, tileSet.bounds?.size)
         assertEquals("Left bound should match", latLngBounds.longitudeWest.toFloat(), tileSet.bounds?.get(0))
@@ -78,11 +78,11 @@ class TileSetTest {
     @Test
     fun testSetBoundsNoStackOverflow() {
         val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
-        
+
         // This test verifies the fix for the infinite recursion bug
         // If the bug still exists, this will cause a StackOverflowError
         tileSet.setBounds(1f, 2f, 3f, 4f)
-        
+
         assertNotNull("Bounds should be set without stack overflow", tileSet.bounds)
         assertEquals("Should have 4 elements", 4, tileSet.bounds?.size)
     }
@@ -90,11 +90,11 @@ class TileSetTest {
     @Test
     fun testMultipleSetBoundsCalls() {
         val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
-        
+
         // Test multiple calls to setBounds
         tileSet.setBounds(-180f, -90f, 180f, 90f)
         assertNotNull("First bounds should be set", tileSet.bounds)
-        
+
         tileSet.setBounds(-10f, -20f, 30f, 40f)
         assertNotNull("Second bounds should be set", tileSet.bounds)
         assertEquals("Left bound should be updated", -10f, tileSet.bounds?.get(0))

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/style/sources/TileSetTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/style/sources/TileSetTest.kt
@@ -78,9 +78,6 @@ class TileSetTest {
     @Test
     fun testSetBoundsNoStackOverflow() {
         val tileSet = TileSet("2.1.0", "https://example.com/{z}/{x}/{y}.png")
-
-        // This test verifies the fix for the infinite recursion bug
-        // If the bug still exists, this will cause a StackOverflowError
         tileSet.setBounds(1f, 2f, 3f, 4f)
 
         assertNotNull("Bounds should be set without stack overflow", tileSet.bounds)


### PR DESCRIPTION
The `setBounds(left: Float, bottom: Float, right: Float, top: Float)` method in `TileSet.kt` was calling itself recursively, causing a StackOverflowError.

```
fun setBounds(left: Float, bottom: Float, right: Float, top: Float) {
    setBounds(left, bottom, right, top)  // ❌ Infinite recursion!
}
```

This resulted in crashes like:
```
java.lang.StackOverflowError: stack size 8188KB
    at org.maplibre.android.style.sources.TileSet.setBounds(TileSet.kt:207)
    at org.maplibre.android.style.sources.TileSet.setBounds(TileSet.kt:207)
    at org.maplibre.android.style.sources.TileSet.setBounds(TileSet.kt:207)
    ...
```

## Solution
Fixed the method to directly assign the bounds array instead of calling itself:

```
fun setBounds(left: Float, bottom: Float, right: Float, top: Float) {
    this.bounds = arrayOf(left, bottom, right, top)
}
```

This is consistent with the other setBounds overloads in the class.

## Test Coverage
Added unit tests (`TileSetTest.kt`).

## AI Disclosure

Written by Copilot