### PR TITLE
DRAFT: (FEAT) implement progressive tile loading to reduce white-screen time Open

### DIFF
--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -332,12 +332,21 @@ void GeometryTile::setShowCollisionBoxes(const bool showCollisionBoxes_) {
     }
 }
 
-void GeometryTile::onLayout(std::shared_ptr<LayoutResult> result, const uint64_t resultCorrelationID) {
+void GeometryTile::onLayout(std::shared_ptr<LayoutResult> result,
+                            const uint64_t resultCorrelationID,
+                            bool isPartialResult) {
     MLN_TRACE_FUNC();
+
+    // Partial progressive updates are optional visual improvements. Ignore stale
+    // partial callbacks to avoid applying outdated buckets and triggering
+    // redundant tile updates while a newer parse cycle is already in progress.
+    if (isPartialResult && resultCorrelationID != correlationID) {
+        return;
+    }
 
     loaded = true;
     renderable = true;
-    if (resultCorrelationID == correlationID) {
+    if (!isPartialResult && resultCorrelationID == correlationID) {
         pending = false;
         observer->onTileAction(id, sourceID, TileOperation::EndParse);
     }

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -89,7 +89,9 @@ public:
 
         ~LayoutResult();
     };
-    void onLayout(std::shared_ptr<LayoutResult>, uint64_t correlationID);
+    // isPartialResult=true means only geometry (fill/line/circle) buckets are present;
+    // symbol buckets are still pending and will arrive in a subsequent full onLayout call.
+    void onLayout(std::shared_ptr<LayoutResult>, uint64_t correlationID, bool isPartialResult = false);
 
     void onError(std::exception_ptr, uint64_t correlationID);
 

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -519,6 +519,9 @@ void GeometryTileWorker::parse() {
                                    << " SourceID: " << sourceID.c_str()
                                    << " Canonical: " << static_cast<int>(id.canonical.z) << "/" << id.canonical.x << "/"
                                    << id.canonical.y << " Time");
+    // Mark that the upcoming finalizeLayout() call is triggered directly by parse so
+    // it can emit a partial (geometry-only) result for progressive rendering.
+    comingFromParse = true;
     finalizeLayout();
 }
 
@@ -538,7 +541,35 @@ bool GeometryTileWorker::hasPendingParseResult() const {
 void GeometryTileWorker::finalizeLayout() {
     MLN_TRACE_FUNC();
 
-    if (!data || !layers || !hasPendingParseResult() || hasPendingDependencies()) {
+    if (!data || !layers || !hasPendingParseResult()) {
+        comingFromParse = false;
+        return;
+    }
+
+    if (hasPendingDependencies()) {
+        // Progressive early render: on the first load of a tile, if parse just completed
+        // (comingFromParse=true) but symbol glyph/image dependencies are still pending,
+        // emit a partial LayoutResult containing only the geometry (fill/line/circle)
+        // buckets that are already ready. This lets the tile appear on screen immediately
+        // without waiting for text/icon resources, reducing white-screen time.
+        //
+        // The symbol buckets will arrive in a subsequent full onLayout call once all
+        // dependencies have been resolved.
+        if (firstLoad && comingFromParse && !renderData.empty()) {
+            // renderData holds only non-symbol buckets at this point: symbol layouts
+            // with dependencies were deferred into `layouts` rather than being added to
+            // renderData directly. Copy the map cheaply — buckets are shared_ptr.
+            auto partialRenderData = renderData;
+            parent.invoke(&GeometryTile::onLayout,
+                          std::make_shared<GeometryTile::LayoutResult>(std::move(partialRenderData),
+                                                                       nullptr,
+                                                                       gfx::GlyphAtlas{},
+                                                                       gfx::ImageAtlas{},
+                                                                       nullptr),
+                          correlationID,
+                          /*isPartialResult=*/true);
+        }
+        comingFromParse = false;
         return;
     }
 
@@ -557,6 +588,7 @@ void GeometryTileWorker::finalizeLayout() {
             if (obsolete) {
                 dynamicTextureAtlas->removeTextures(glyphAtlas.textureHandles, glyphAtlas.dynamicTexture);
                 dynamicTextureAtlas->removeTextures(imageAtlas.textureHandles, imageAtlas.dynamicTexture);
+                comingFromParse = false;
                 return;
             }
 
@@ -566,7 +598,7 @@ void GeometryTileWorker::finalizeLayout() {
                 continue;
             }
 
-            // layout adds the bucket to buckets
+            // layout adds the bucket to renderData
             layout->createBucket(
                 imageAtlas.patternPositions, featureIndex, renderData, firstLoad, showCollisionBoxes, id.canonical);
         }
@@ -575,6 +607,7 @@ void GeometryTileWorker::finalizeLayout() {
     layouts.clear();
 
     firstLoad = false;
+    comingFromParse = false;
 
     MBGL_TIMING_FINISH(watch,
                        " Action: " << "SymbolLayout,"
@@ -588,7 +621,8 @@ void GeometryTileWorker::finalizeLayout() {
                                                                std::move(glyphAtlas),
                                                                std::move(imageAtlas),
                                                                dynamicTextureAtlas),
-                  correlationID);
+                  correlationID,
+                  /*isPartialResult=*/false);
 }
 
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -561,11 +561,8 @@ void GeometryTileWorker::finalizeLayout() {
             // renderData directly. Copy the map cheaply — buckets are shared_ptr.
             auto partialRenderData = renderData;
             parent.invoke(&GeometryTile::onLayout,
-                          std::make_shared<GeometryTile::LayoutResult>(std::move(partialRenderData),
-                                                                       nullptr,
-                                                                       gfx::GlyphAtlas{},
-                                                                       gfx::ImageAtlas{},
-                                                                       nullptr),
+                          std::make_shared<GeometryTile::LayoutResult>(
+                              std::move(partialRenderData), nullptr, gfx::GlyphAtlas{}, gfx::ImageAtlas{}, nullptr),
                           correlationID,
                           /*isPartialResult=*/true);
         }

--- a/src/mbgl/tile/geometry_tile_worker.hpp
+++ b/src/mbgl/tile/geometry_tile_worker.hpp
@@ -119,6 +119,11 @@ private:
 
     bool showCollisionBoxes;
     bool firstLoad = true;
+    // Set to true at the end of parse() and reset after finalizeLayout() returns.
+    // When true, finalizeLayout() will emit a partial (geometry-only) LayoutResult
+    // immediately without waiting for symbol glyph/image dependencies to resolve,
+    // reducing the white-screen time on first tile load.
+    bool comingFromParse = false;
 
     gfx::DynamicTextureAtlasPtr dynamicTextureAtlas;
 


### PR DESCRIPTION
## Summary

  This PR implements two-phase (progressive) tile loading to reduce white-screen
  time when panning or zooming to unloaded areas.

  Previously, a tile remained invisible (`renderable=false`) until **all** layout
  work completed — including network fetches for glyphs/images required by symbol
  layers (text labels, icons). On slow networks or cold cache this could leave
  large blank areas for several seconds, even though fill/line/circle geometry was
  already parsed and ready to draw.

  **After this change**, geometry buckets are emitted to the render thread
  immediately after `parse()` completes. Symbol buckets follow in a second
  `onLayout` call once all glyph/image dependencies are resolved.

  ## Demo

| before | after |
|---|---|
| <video src="https://github.com/user-attachments/assets/7fd6460a-f45f-468c-a0df-1a412f1c0434" width="225" controls></video> | <video src="https://github.com/user-attachments/assets/66bf70a3-451a-442c-ab66-a4abe30d65e5" width="225" controls></video> |

  ## How it works

  ### `GeometryTileWorker`

  - Adds a `comingFromParse` boolean flag (reset after each `finalizeLayout()`
    call).
  - `parse()` sets `comingFromParse = true` before calling `finalizeLayout()`.
  - `finalizeLayout()` gains an early-exit path: when dependencies are still
    pending **and** `firstLoad && comingFromParse && !renderData.empty()`, it
    copies the already-populated `renderData` (geometry-only buckets, cheap
    `shared_ptr` copy) and invokes `GeometryTile::onLayout` with
    `isPartialResult=true`. This partial result is skipped when `renderData` is
    empty (symbol-only tilesets) to avoid marking a tile as renderable with
    nothing to show.

  ### `GeometryTile`

  - `onLayout()` gains a `bool isPartialResult = false` parameter.
  - For partial results: sets `loaded = true` and `renderable = true` so the tile
    appears on screen immediately, but **does not** clear `pending` or fire the
    `EndParse` event — the tile stays pending until the full symbol result arrives.
  - The full result (`isPartialResult=false`) replaces `layoutResult` normally and
    clears `pending` as before.

  ## Behaviour unchanged for

  - Non-first loads (reload / style change) — `firstLoad` is false, progressive
    path is skipped entirely.
  - Tiles with no pending symbol dependencies — `hasPendingDependencies()` returns
    false, existing code path taken unchanged.
  - Symbol-only tiles — `renderData.empty()` guard prevents an empty partial
    result from being sent.
  - Still-mode rendering — correlation ID handling is unchanged; `pending` is only
    cleared on the full result.

  ## Testing

  Verified on Android (arm64) with a style containing road labels and POI icons:
  geometry (roads, water, buildings) appears within the first render frame after
  tile data arrives; text and icons fade in once glyphs are downloaded.