### PR TITLE
fix(vulkan): recreate staging texture in HeadlessBackend::readStillImage on size change

### DIFF
--- a/platform/default/src/mbgl/vulkan/headless_backend.cpp
+++ b/platform/default/src/mbgl/vulkan/headless_backend.cpp
@@ -82,7 +82,7 @@ PremultipliedImage HeadlessBackend::readStillImage() {
     auto& contextImpl = static_cast<Context&>(*context);
     auto& resourceImpl = static_cast<HeadlessRenderableResource&>(*resource);
 
-    if (!texture) {
+    if (!texture || texture->getSize() != size) {
         texture = std::make_unique<Texture2D>(contextImpl);
         texture->setFormat(gfx::TexturePixelType::RGBA, gfx::TextureChannelDataType::UnsignedByte);
         texture->setUsage(Texture2DUsage::Read);


### PR DESCRIPTION
Closes #4260.

## What

`mbgl::vulkan::HeadlessBackend::readStillImage` lazy-creates a staging
`Texture2D` on first call and never recreates it. Subsequent calls to
`HeadlessBackend::setSize` reset `resource` (the framebuffer) but leave
the staging texture pinned at its original size, so any `readStillImage`
after a resize returns pixels at the **old** dimensions.

Fix: also reallocate the staging texture when the backend's `size` has
diverged from the texture's `size`. One-line change.

```diff
-    if (!texture) {
+    if (!texture || texture->getSize() != size) {
         texture = std::make_unique<Texture2D>(contextImpl);
         texture->setFormat(gfx::TexturePixelType::RGBA, gfx::TextureChannelDataType::UnsignedByte);
         texture->setSize(size);
         texture->setUsage(Texture2DUsage::Read);
     }
```

`Texture2D::getSize()` is `noexcept`; the steady-state cost on the
cache-hit path is two integer compares.

## Why this only affects Vulkan

- **OpenGL**: `readFramebuffer<PremultipliedImage>(size)` reads at the
  current `size` each call, no caching.
- **Metal**: delegates to `offscreenTexture->readStillImage()` where
  `offscreenTexture` is tied to `resource`, which the shared
  `gfx::HeadlessBackend::setSize` already resets.

## Reproduction

Surfaced through [`maplibre-native-rs`](https://github.com/maplibre/maplibre-native-rs)'s
`ImageRenderer::set_map_size` in `Static` mode: works on the first
render, silently no-ops on every subsequent render — output stays
pinned at the first-render size. See #4260 for the full debug write-up
and a Rust-side regression test.

The contract test on the C++ side could be: render at size A, call
`setSize(B)`, render again, assert the result is at B's resolution. I
haven't added that test in this PR because the test surface for
HeadlessBackend in the upstream tree wasn't immediately obvious to me —
happy to add one with a pointer to the right harness.

## Risk

The guard now recreates `texture` whenever the backend's size has
changed. Existing behaviour (no resize, single allocation) is preserved
because the `getSize() != size` branch is taken only when an actual
size change happened. The new allocation/free pattern is identical to
what the destructor already does on backend teardown, so no new
lifetime invariants.