### PR TITLE
Hide vendored HarfBuzz symbols on Apple

### DIFF
--- a/vendor/BUILD.bazel
+++ b/vendor/BUILD.bazel
@@ -722,6 +722,13 @@ cc_library(
         # "HB_NO_WIN1256",
         "HB_TINY",
     ],
+    # Keep bundled HarfBuzz symbols private so they do not interpose symbols from
+    # app dependencies. See https://github.com/maplibre/maplibre-native/issues/3777.
+    copts = select({
+        "@platforms//os:ios": ["-fvisibility=hidden"],
+        "@platforms//os:macos": ["-fvisibility=hidden"],
+        "//conditions:default": [],
+    }),
     includes = [
         "freetype/include",
         "harfbuzz/src",

--- a/vendor/harfbuzz.cmake
+++ b/vendor/harfbuzz.cmake
@@ -15,6 +15,12 @@ if (MLN_TEXT_SHAPING_HARFBUZZ)
     target_include_directories(mbgl-harfbuzz PRIVATE ${CMAKE_CURRENT_LIST_DIR}/freetype/include)
     target_compile_definitions(mbgl-harfbuzz PRIVATE -DHAVE_FREETYPE)
 
+    if(APPLE)
+        # Keep bundled HarfBuzz symbols private so they do not interpose symbols from
+        # app dependencies. See https://github.com/maplibre/maplibre-native/issues/3777.
+        target_compile_options(mbgl-harfbuzz PRIVATE -fvisibility=hidden)
+    endif()
+
     set_target_properties(
         mbgl-harfbuzz
         PROPERTIES


### PR DESCRIPTION
_Created using OpenCode with GPT-5.5_

Fixes https://github.com/maplibre/maplibre-native/issues/3777.

This hides the vendored HarfBuzz symbols in Apple builds to avoid `_hb_*` symbol conflicts with app dependencies such as Compose/Skia.

Validation:
- Built `//platform/ios:MapLibre.dynamic` locally with Bazel.
- Confirmed exported `_hb_*` symbols dropped from 342 to 0 in the simulator framework.
- Confirmed the MapLibre Compose demo using the [original MapLibre-first linker order](https://github.com/maplibre/maplibre-compose/issues/551#issuecomment-4323283345) renders text correctly with the patched framework.