### PR TITLE
core: Fix heatmap drawable updates

### DIFF
--- a/src/mbgl/renderer/layers/render_heatmap_layer.cpp
+++ b/src/mbgl/renderer/layers/render_heatmap_layer.cpp
@@ -253,7 +253,6 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
             }
             return true;
         };
-#if MLN_RENDER_BACKEND_WEBGPU
         bool anyUpdated = false;
         bool skippedDrawables = false;
         tileLayerGroup->visitDrawables(renderPass, tileID, [&](gfx::Drawable& drawable) {
@@ -271,11 +270,6 @@ void RenderHeatmapLayer::update(gfx::ShaderRegistry& shaders,
         if (anyUpdated) {
             continue;
         }
-#else
-        if (updateTile(renderPass, tileID, std::move(updateExisting))) {
-            continue;
-        }
-#endif
 
         if (!propertiesAsUniforms) {
             propertiesAsUniforms.emplace();


### PR DESCRIPTION
Resolves #4069.

_Created using OpenCode with GPT-5.5_

I reproduced this on an Android emulator using the OpenGL Android SDK variant.

The repro used one GeoJSON source with both a circle layer and a heatmap layer. It crashed on the render thread with a SIGSEGV in `libmaplibre.so`:

```text
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x002827b710e114d0 (read)
tid: 3862, name: RenderThread 56  >>> org.maplibre.compose.demoapp <<<
```

Symbolicating the crash with the `android-v13.0.2` OpenGL release debug symbols pointed to `RenderHeatmapLayer::update()`:

```text
std::__hash_table<...TileLayerGroup...>::find
mbgl::RenderHeatmapLayer::update(...)
mbgl::RenderOrchestrator::updateLayers(...)
mbgl::Renderer::Impl::render(...)
mbgl::android::MapRenderer::render(...)
```

The crashing path called `RenderLayer::updateTile()`:

```cpp
if (updateTile(renderPass, tileID, std::move(updateExisting))) {
    continue;
}
```

`RenderLayer::updateTile()` visits drawables through `layerGroup`:

```cpp
if (const auto tileGroup = static_cast<TileLayerGroup*>(layerGroup.get())) {
    tileGroup->visitDrawables(renderPass, tileID, ...);
}
```

For heatmaps, this function also has a local `tileLayerGroup` from the render target:

```cpp
auto* tileLayerGroup = static_cast<TileLayerGroup*>(renderTarget->getLayerGroup(0).get());
```

The WebGPU path already used this local `tileLayerGroup` directly. This PR uses the same path for all backends.

I confirmed the fix by building a locally patched `android-sdk-opengl:13.0.2` artifact and running the same emulator repro. The app stayed running, and logcat no longer showed the SIGSEGV.