### PR TITLE
iOS: Fix case image expression crash

### DIFF
--- a/platform/darwin/src/NSExpression+MLNAdditions.mm
+++ b/platform/darwin/src/NSExpression+MLNAdditions.mm
@@ -1559,7 +1559,7 @@ NSArray *MLNSubexpressionsWithJSONObjects(NSArray *objects) {
     firstCondition = self.operand;
   }
 
-  if ([firstCondition respondsToSelector:@selector(constantValue)] &&
+  if (firstCondition.expressionType == NSConstantValueExpressionType &&
       [firstCondition.constantValue isKindOfClass:[NSComparisonPredicate class]]) {
     NSPredicate *predicate = (NSPredicate *)firstCondition.constantValue;
     condition = predicate.mgl_jsonExpressionObject;
@@ -1572,7 +1572,7 @@ NSArray *MLNSubexpressionsWithJSONObjects(NSArray *objects) {
       isAftermarketFunction ? self.arguments : self.arguments[minimumIndex].constantValue;
 
   for (NSUInteger index = minimumIndex; index < arguments.count; index++) {
-    if ([arguments[index] respondsToSelector:@selector(constantValue)] &&
+    if (arguments[index].expressionType == NSConstantValueExpressionType &&
         [arguments[index].constantValue isKindOfClass:[NSComparisonPredicate class]]) {
       NSPredicate *predicate = (NSPredicate *)arguments[index].constantValue;
       [expressionObject addObject:predicate.mgl_jsonExpressionObject];

--- a/platform/darwin/test/MLNStyleTests.mm
+++ b/platform/darwin/test/MLNStyleTests.mm
@@ -321,15 +321,14 @@
 - (void)testSymbolLayerIconImageNameWithMultiCaseImageExpression {
   MLNPointFeature *feature = [[MLNPointFeature alloc] init];
   MLNShapeSource *source = [[MLNShapeSource alloc] initWithIdentifier:@"sourceID"
-                                                               shape:feature
-                                                             options:nil];
+                                                                shape:feature
+                                                              options:nil];
   MLNSymbolStyleLayer *layer = [[MLNSymbolStyleLayer alloc] initWithIdentifier:@"layerID"
                                                                         source:source];
   // Reproduces https://github.com/maplibre/maplibre-native/issues/3477.
   NSArray *jsonExpression = @[
     @"case", @[ @"==", @[ @"get", @"icon" ], @"1" ], @[ @"image", @"icon1" ],
-    @[ @"==", @[ @"get", @"icon" ], @"2" ], @[ @"image", @"icon2" ],
-    @[ @"image", @"icon3" ]
+    @[ @"==", @[ @"get", @"icon" ], @"2" ], @[ @"image", @"icon2" ], @[ @"image", @"icon3" ]
   ];
   NSExpression *expression = [NSExpression expressionWithMLNJSONObject:jsonExpression];
 

--- a/platform/darwin/test/MLNStyleTests.mm
+++ b/platform/darwin/test/MLNStyleTests.mm
@@ -318,6 +318,24 @@
       NSException, @"MLNRedundantLayerIdentifierException");
 }
 
+- (void)testSymbolLayerIconImageNameWithMultiCaseImageExpression {
+  MLNPointFeature *feature = [[MLNPointFeature alloc] init];
+  MLNShapeSource *source = [[MLNShapeSource alloc] initWithIdentifier:@"sourceID"
+                                                               shape:feature
+                                                             options:nil];
+  MLNSymbolStyleLayer *layer = [[MLNSymbolStyleLayer alloc] initWithIdentifier:@"layerID"
+                                                                        source:source];
+  // Reproduces https://github.com/maplibre/maplibre-native/issues/3477.
+  NSArray *jsonExpression = @[
+    @"case", @[ @"==", @[ @"get", @"icon" ], @"1" ], @[ @"image", @"icon1" ],
+    @[ @"==", @[ @"get", @"icon" ], @"2" ], @[ @"image", @"icon2" ],
+    @[ @"image", @"icon3" ]
+  ];
+  NSExpression *expression = [NSExpression expressionWithMLNJSONObject:jsonExpression];
+
+  XCTAssertNoThrow(layer.iconImageName = expression);
+}
+
 - (void)testRemovingLayerBeforeAddingSameLayer {
   {
     MLNShapeSource *source =


### PR DESCRIPTION
Resolves #3477.

_Created using OpenCode with GPT-5.5_

The previous check used `respondsToSelector:@selector(constantValue)`, but `constantValue` is declared on `NSExpression` itself, so function expressions also pass that check. Calling it on a function expression raises the exception from #3477.

This PR adds a failing test, then fixes it by checking the expression type before reading `constantValue`.