### PR TITLE
core: Render hillshade prepare pass past tile interior to fix overzoom seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
+- [core] Fix overzoom seam in hillshade rendering by extending the prepare-pass output past the tile interior and widening the DEMData neighbour border to 2 pixels ([#4282](https://github.com/maplibre/maplibre-native/pull/4282)).
 - [core] Fix memory access violation exception in vector_tile_data.cpp [#632](https://github.com/maplibre/maplibre-native/pull/632)
 - [iOS] Fix a bug where the compass was determined to be misplaced when hidden [#498](https://github.com/maplibre/maplibre-native/pull/498).
 - [core] `MaptilerFileSource` renamed to `MBTilesFileSource` [#198](https://github.com/maplibre/maplibre-native/pull/198).

--- a/include/mbgl/shaders/mtl/hillshade_prepare.hpp
+++ b/include/mbgl/shaders/mtl/hillshade_prepare.hpp
@@ -61,9 +61,14 @@ FragmentStage vertex vertexMain(thread const VertexStage vertx [[stage_in]],
 
     const float4 position = drawable.matrix * float4(float2(vertx.pos), 0, 1);
 
-    float2 epsilon = 1.0 / tileProps.dimension;
-    float scale = (tileProps.dimension.x - 2.0) / tileProps.dimension.x;
-    float2 pos = (float2(vertx.texture_pos) / 8192.0) * scale + epsilon;
+    // See shaders/hillshade_prepare.vertex.glsl for the derivation. With a
+    // 2-pixel DEM border (stride = dim+4) and a (dim+1)² render target,
+    // output pixel i (i ∈ [0, dim]) lands on buffer texel i+2 — including
+    // the inner east-border cell at i=dim. Adjacent tiles' boundary
+    // outputs reference identical source pixels and produce identical
+    // slope values, so the rendered hillshade has no seam at overzoom.
+    float scale = (tileProps.dimension.x - 3.0) / tileProps.dimension.x;
+    float2 pos = (float2(vertx.texture_pos) / 8192.0) * scale + 2.0 / tileProps.dimension;
 
     return {
         .position    = position,
@@ -87,7 +92,9 @@ half4 fragment fragmentMain(FragmentStage in [[stage_in]],
 #endif
 
     float2 epsilon = 1.0 / tileProps.dimension;
-    float tileSize = tileProps.dimension.x - 2.0;
+    // dimension is the DEM buffer stride (interior + 2 * 2-pixel border),
+    // so the actual interior tile size is stride - 4.
+    float tileSize = tileProps.dimension.x - 4.0;
 
     // queried pixels (using Sobel operator kernel):
     // +-----------+

--- a/shaders/hillshade_prepare.fragment.glsl
+++ b/shaders/hillshade_prepare.fragment.glsl
@@ -20,7 +20,9 @@ float getElevation(vec2 coord, float bias) {
 
 void main() {
     vec2 epsilon = 1.0 / u_dimension;
-    float tileSize = u_dimension.x - 2.0;
+    // u_dimension is the DEM buffer stride (interior + 2 * 2-pixel border),
+    // so the actual interior tile size is stride - 4.
+    float tileSize = u_dimension.x - 4.0;
 
     // queried pixels (using Sobel operator kernel):
     // +-----------+

--- a/shaders/hillshade_prepare.vertex.glsl
+++ b/shaders/hillshade_prepare.vertex.glsl
@@ -17,7 +17,28 @@ out vec2 v_pos;
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 
-    highp vec2 epsilon = 1.0 / u_dimension;
-    float scale = (u_dimension.x - 2.0) / u_dimension.x;
-    v_pos = (a_texture_pos / 8192.0) * scale + epsilon;
+    // u_dimension is the DEM buffer stride (interior + 2 * border).
+    // The buffer has `border = 2` so stride = dim + 4.
+    //
+    // Render target is (dim+1) × (dim+1). Output pixel i (i ∈ [0, dim])
+    // computes the Sobel-derived slope centred on buffer texel index i+2
+    // (the first interior cell at i=0 through the second-east-border
+    // cell at i=dim). The east-border cells hold the eastern neighbour's
+    // first two interior columns, so the output pixel at i=dim of tile A
+    // and the output pixel at i=0 of tile B reference identical source
+    // pixels and produce identical slope values — which is what makes
+    // the rendered hillshade seamless at the tile boundary.
+    //
+    // Quad corners have a_texture_pos ∈ {0, EXTENT}². At the rendered
+    // framebuffer corner (0, 0) we want v_pos at the texel-2 centre,
+    // i.e. 2.5 / stride. At the opposite corner (EXTENT, EXTENT) we
+    // want v_pos at the texel-(dim+2) centre, i.e. (dim + 2.5) / stride.
+    // Given output pixel i sits at framebuffer-coord (i + 0.5)/(dim+1),
+    // the linear interpolation that lands those endpoints is:
+    //
+    //   v_pos = (a_texture_pos / EXTENT) * (dim + 1)/stride + 2/stride
+    //
+    // Or, in terms of u_dimension = stride = dim + 4:
+    float scale = (u_dimension.x - 3.0) / u_dimension.x;
+    v_pos = (a_texture_pos / 8192.0) * scale + 2.0 / u_dimension;
 }

--- a/src/mbgl/geometry/dem_data.cpp
+++ b/src/mbgl/geometry/dem_data.cpp
@@ -5,15 +5,17 @@ namespace mbgl {
 
 DEMData::DEMData(const PremultipliedImage& _image, Tileset::RasterEncoding _encoding)
     : dim(_image.size.height),
-      // extra two pixels per row for border backfilling on either edge
-      stride(dim + 2),
+      // `border` extra pixels per side around the interior, used to backfill
+      // the slow-path neighbour data the prepare pass / contour algorithm
+      // needs at tile boundaries. See `DEMData::border` for the rationale.
+      stride(dim + 2 * border),
       encoding(_encoding) {
     image = std::make_shared<PremultipliedImage>(Size(static_cast<uint32_t>(stride), static_cast<uint32_t>(stride)));
     if (_image.size.height != _image.size.width) {
         throw std::runtime_error("raster-dem tiles must be square.");
     }
 
-    auto* dest = reinterpret_cast<uint32_t*>(image->data.get()) + stride + 1;
+    auto* dest = reinterpret_cast<uint32_t*>(image->data.get()) + stride * border + border;
     auto* source = reinterpret_cast<uint32_t*>(_image.data.get());
     for (int32_t y = 0; y < dim; y++) {
         memcpy(dest, source, dim * 4);
@@ -21,58 +23,70 @@ DEMData::DEMData(const PremultipliedImage& _image, Tileset::RasterEncoding _enco
         source += dim;
     }
 
-    // in order to avoid flashing seams between tiles, here we are initially
-    // populating a 1px border of pixels around the image with the data of the
-    // nearest pixel from the image. this data is eventually replaced when the
-    // tile's neighboring tiles are loaded and the accurate data can be
-    // backfilled using DEMData#backfillBorder
+    // To avoid flashing seams between tiles, populate the `border`-wide
+    // ring around the interior with the nearest-edge pixel value. This
+    // gets overwritten with real neighbour data once the surrounding tiles
+    // arrive and `backfillBorder` runs.
 
     auto* data = reinterpret_cast<uint32_t*>(image->data.get());
-    for (int32_t x = 0; x < dim; x++) {
-        auto rowOffset = stride * (x + 1);
-        // left vertical border
-        data[rowOffset] = data[rowOffset + 1];
-
-        // right vertical border
-        data[rowOffset + dim + 1] = data[rowOffset + dim];
+    for (int32_t y = 0; y < dim; y++) {
+        auto rowOffset = stride * (y + border);
+        for (int32_t b = 0; b < border; b++) {
+            // left vertical border (columns 0..border-1)
+            data[rowOffset + b] = data[rowOffset + border];
+            // right vertical border (columns dim+border..stride-1)
+            data[rowOffset + dim + border + b] = data[rowOffset + dim + border - 1];
+        }
     }
 
-    // top horizontal border with corners
-    memcpy(data, data + stride, stride * 4);
-    // bottom horizontal border with corners
-    memcpy(data + (dim + 1) * stride, data + dim * stride, stride * 4);
+    // Top + bottom horizontal borders, including the four corners. Each row
+    // of the border ring is a copy of the nearest interior row.
+    for (int32_t b = 0; b < border; b++) {
+        // top
+        memcpy(data + b * stride, data + border * stride, stride * 4);
+        // bottom
+        memcpy(data + (dim + border + b) * stride, data + (dim + border - 1) * stride, stride * 4);
+    }
 }
 
 // This function takes the DEMData from a neighboring tile and backfills the
-// edge/corner data in order to create a one pixel "buffer" of image data around
-// the tile. This is necessary because the hillshade formula calculates the
-// dx/dz, dy/dz derivatives at each pixel of the tile by querying the 8
-// surrounding pixels, and if we don't have the pixel buffer we get seams at
+// `border`-wide ring of image data around the tile. Necessary because the
+// hillshade formula calculates dx/dz, dy/dz derivatives at each pixel by
+// querying its 8 neighbours, and without the buffered ring we get seams at
 // tile boundaries.
+//
+// At overzoom (display zoom > raster-dem maxzoom) the prepare pass extends
+// one pixel past the tile interior so adjacent tiles share an identical
+// edge value. That requires `border` to be at least 2 — the outermost
+// boundary-aligned output pixel on tile A reads into B's first two
+// interior columns, and vice versa. With `border == 1` the boundary
+// outputs would have to fall back to a different kernel and would no
+// longer be exactly equal across the seam.
 void DEMData::backfillBorder(const DEMData& borderTileData, int8_t dx, int8_t dy) {
     auto& o = borderTileData;
 
     // Tiles from the same source should always be of the same dimensions.
     assert(dim == o.dim);
 
-    // We determine the pixel range to backfill based which corner/edge
-    // `borderTileData` represents. For example, dx = -1, dy = -1 represents the
-    // upper left corner of the base tile, so we only need to backfill one pixel
-    // at coordinates (-1, -1) of the tile image.
+    // We determine the pixel range to backfill based on which corner/edge
+    // `borderTileData` represents. For an axis-aligned neighbour the range
+    // is the full tile's worth on the matching axis and `border` pixels
+    // wide on the orthogonal axis. For a diagonal neighbour the range is
+    // a `border × border` square at the relevant corner.
     int32_t xMin = dx * dim;
     int32_t xMax = dx * dim + dim;
     int32_t yMin = dy * dim;
     int32_t yMax = dy * dim + dim;
 
     if (dx == -1)
-        xMin = xMax - 1;
+        xMin = xMax - border;
     else if (dx == 1)
-        xMax = xMin + 1;
+        xMax = xMin + border;
 
     if (dy == -1)
-        yMin = yMax - 1;
+        yMin = yMax - border;
     else if (dy == 1)
-        yMax = yMin + 1;
+        yMax = yMin + border;
 
     int32_t ox = -dx * dim;
     int32_t oy = -dy * dim;

--- a/src/mbgl/geometry/dem_data.hpp
+++ b/src/mbgl/geometry/dem_data.hpp
@@ -13,6 +13,16 @@ namespace mbgl {
 
 class DEMData {
 public:
+    /// Width of the per-side neighbour border on the buffered image. The
+    /// hillshade prepare pass and the contour algorithm both look up to one
+    /// pixel beyond a tile's interior to compute Sobel kernels at the
+    /// world boundary between adjacent tiles. With a 2-pixel border every
+    /// boundary-aligned output pixel reaches into the neighbour's first
+    /// two interior columns/rows, which lets adjacent prepare outputs
+    /// share an identical edge value and eliminates the visible 1-pixel
+    /// step (seam) at overzoomed tile boundaries.
+    static constexpr int32_t border = 2;
+
     DEMData(const PremultipliedImage& image, Tileset::RasterEncoding encoding);
     void backfillBorder(const DEMData& borderTileData, int8_t dx, int8_t dy);
 
@@ -30,11 +40,11 @@ private:
     std::shared_ptr<PremultipliedImage> image;
 
     size_t idx(const int32_t x, const int32_t y) const {
-        assert(x >= -1);
-        assert(x < dim + 1);
-        assert(y >= -1);
-        assert(y < dim + 1);
-        return (y + 1) * stride + (x + 1);
+        assert(x >= -border);
+        assert(x < dim + border);
+        assert(y >= -border);
+        assert(y < dim + border);
+        return (y + border) * stride + (x + border);
     }
 };
 

--- a/src/mbgl/renderer/layers/render_hillshade_layer.cpp
+++ b/src/mbgl/renderer/layers/render_hillshade_layer.cpp
@@ -250,8 +250,14 @@ void RenderHillshadeLayer::update(gfx::ShaderRegistry& shaders,
         setRenderTileBucketID(tileID, bucket.getID());
 
         if (!bucket.renderTargetPrepared) {
-            // Set up tile render target
-            const uint16_t tilesize = bucket.getDEMData().dim;
+            // Set up tile render target. We render one pixel past the tile
+            // interior on each side (output is (dim+1)²) so adjacent tiles'
+            // boundary-aligned output pixels coincide in absolute world
+            // space and compute identical Sobel values from the same source
+            // DEM samples. This eliminates the visible 1-pixel step at
+            // tile boundaries when the hillshade is overzoomed past the
+            // raster-dem source's maxzoom.
+            const uint16_t tilesize = static_cast<uint16_t>(bucket.getDEMData().dim + 1);
             auto renderTarget = context.createRenderTarget({tilesize, tilesize},
                                                            gfx::TextureChannelDataType::UnsignedByte);
             if (!renderTarget) {

--- a/test/geometry/dem_data.test.cpp
+++ b/test/geometry/dem_data.test.cpp
@@ -15,13 +15,19 @@ auto fakeImage = [](Size s) {
     return img;
 };
 
+// DEMData uses a 2-pixel border on each side so the hillshade prepare pass
+// can reach one pixel past the tile interior at the world boundary, which
+// is what makes adjacent prepare outputs share an identical edge value at
+// overzoom (no seam). The tests below pin both the storage layout and the
+// border content.
+
 TEST(DEMData, ConstructorMapbox) {
     PremultipliedImage image = fakeImage({16, 16});
     DEMData demdata(image, Tileset::RasterEncoding::Mapbox);
 
     EXPECT_EQ(demdata.dim, 16);
-    EXPECT_EQ(demdata.stride, 18);
-    EXPECT_EQ(demdata.getImage()->bytes(), size_t(18 * 18 * 4));
+    EXPECT_EQ(demdata.stride, 16 + 2 * DEMData::border);
+    EXPECT_EQ(demdata.getImage()->bytes(), size_t(demdata.stride * demdata.stride * 4));
 };
 
 TEST(DEMData, ConstructorTerrarium) {
@@ -29,19 +35,22 @@ TEST(DEMData, ConstructorTerrarium) {
     DEMData demdata(image, Tileset::RasterEncoding::Terrarium);
 
     EXPECT_EQ(demdata.dim, 16);
-    EXPECT_EQ(demdata.stride, 18);
-    EXPECT_EQ(demdata.getImage()->bytes(), size_t(18 * 18 * 4));
+    EXPECT_EQ(demdata.stride, 16 + 2 * DEMData::border);
+    EXPECT_EQ(demdata.getImage()->bytes(), size_t(demdata.stride * demdata.stride * 4));
 };
 
 TEST(DEMData, InitialBackfill) {
     PremultipliedImage image1 = fakeImage({4, 4});
     DEMData dem1(image1, Tileset::RasterEncoding::Mapbox);
 
+    constexpr int border = DEMData::border;
+    constexpr int dim = 4;
+
     bool nonempty = true;
-    // checking that a 1 px border around the fake image has been populated
-    // with a non-empty pixel value
-    for (int x = -1; x < 5; x++) {
-        for (int y = -1; y < 5; y++) {
+    // checking that the `border`-wide ring around the fake image has been
+    // populated with a non-empty pixel value
+    for (int x = -border; x < dim + border; x++) {
+        for (int y = -border; y < dim + border; y++) {
             if (dem1.get(x, y) == -65536) {
                 nonempty = false;
                 break;
@@ -50,41 +59,34 @@ TEST(DEMData, InitialBackfill) {
     }
     EXPECT_TRUE(nonempty);
 
-    bool verticalBorderMatch = true;
-    int vertx[] = {-1, 4};
-    for (int x : vertx) {
-        for (int y = 0; y < 4; y++) {
-            if (dem1.get(x, y) != dem1.get(x < 0 ? x + 1 : x - 1, y)) {
-                verticalBorderMatch = false;
-                break;
-            }
+    // Vertical border ring: every column at x ∈ [-border, -1] is initially
+    // equal to the leftmost interior column; every column at x ∈ [dim, dim
+    // + border − 1] is equal to the rightmost interior column.
+    for (int b = 1; b <= border; b++) {
+        for (int y = 0; y < dim; y++) {
+            EXPECT_EQ(dem1.get(-b, y), dem1.get(0, y));
+            EXPECT_EQ(dem1.get(dim + b - 1, y), dem1.get(dim - 1, y));
         }
     }
-    // vertical border of DEM data is initially equal to next column of data
-    EXPECT_TRUE(verticalBorderMatch);
 
-    // horizontal borders empty
-    bool horizontalBorderMatch = true;
-    int horiz[] = {-1, 4};
-    for (int y : horiz) {
-        for (int x = 0; x < 4; x++) {
-            if (dem1.get(x, y) != dem1.get(x, y < 0 ? y + 1 : y - 1)) {
-                horizontalBorderMatch = false;
-                break;
-            }
+    // Horizontal border ring: same shape, transposed.
+    for (int b = 1; b <= border; b++) {
+        for (int x = 0; x < dim; x++) {
+            EXPECT_EQ(dem1.get(x, -b), dem1.get(x, 0));
+            EXPECT_EQ(dem1.get(x, dim + b - 1), dem1.get(x, dim - 1));
         }
     }
-    // horizontal border of DEM data is initially equal to next row of data
 
-    EXPECT_TRUE(horizontalBorderMatch);
-    // -1, 1 corner initially equal to closest corner data
-    EXPECT_TRUE(dem1.get(-1, 4) == dem1.get(0, 3));
-    // 1, 1 corner initially equal to closest corner data
-    EXPECT_TRUE(dem1.get(4, 4) == dem1.get(3, 3));
-    // -1, -1 corner initially equal to closest corner data
-    EXPECT_TRUE(dem1.get(-1, -1) == dem1.get(0, 0));
-    // -1, 1 corner initially equal to closest corner data
-    EXPECT_TRUE(dem1.get(4, -1) == dem1.get(3, 0));
+    // Corners: the entire border × border square at each corner is seeded
+    // from the nearest interior corner pixel.
+    for (int dy = 1; dy <= border; dy++) {
+        for (int dx = 1; dx <= border; dx++) {
+            EXPECT_EQ(dem1.get(-dx, -dy), dem1.get(0, 0));
+            EXPECT_EQ(dem1.get(dim + dx - 1, -dy), dem1.get(dim - 1, 0));
+            EXPECT_EQ(dem1.get(-dx, dim + dy - 1), dem1.get(0, dim - 1));
+            EXPECT_EQ(dem1.get(dim + dx - 1, dim + dy - 1), dem1.get(dim - 1, dim - 1));
+        }
+    }
 };
 
 TEST(DEMData, BackfillNeighbor) {
@@ -94,44 +96,68 @@ TEST(DEMData, BackfillNeighbor) {
     PremultipliedImage image2 = fakeImage({4, 4});
     DEMData dem1(image2, Tileset::RasterEncoding::Mapbox);
 
+    constexpr int border = DEMData::border;
+    constexpr int dim = 4;
+
+    // West neighbour: dem1 sits to the left of dem0, so dem1's right
+    // `border` columns become dem0's left border.
     dem0.backfillBorder(dem1, -1, 0);
-    for (int y = 0; y < 4; y++) {
-        // dx = -1, dy = 0, so the left edge of dem1 should equal the right edge
-        // of dem0 backfills Left neighbor
-        EXPECT_TRUE(dem0.get(-1, y) == dem1.get(3, y));
+    for (int b = 1; b <= border; b++) {
+        for (int y = 0; y < dim; y++) {
+            EXPECT_EQ(dem0.get(-b, y), dem1.get(dim - b, y));
+        }
     }
 
+    // North neighbour
     dem0.backfillBorder(dem1, 0, -1);
-    // backfills TopCenter neighbor
-    for (int x = 0; x < 4; x++) {
-        EXPECT_TRUE(dem0.get(x, -1) == dem1.get(x, 3));
+    for (int b = 1; b <= border; b++) {
+        for (int x = 0; x < dim; x++) {
+            EXPECT_EQ(dem0.get(x, -b), dem1.get(x, dim - b));
+        }
     }
 
+    // East neighbour
     dem0.backfillBorder(dem1, 1, 0);
-    // backfills Right neighbor
-    for (int y = 0; y < 4; y++) {
-        EXPECT_TRUE(dem0.get(4, y) == dem1.get(0, y));
+    for (int b = 0; b < border; b++) {
+        for (int y = 0; y < dim; y++) {
+            EXPECT_EQ(dem0.get(dim + b, y), dem1.get(b, y));
+        }
     }
 
+    // South neighbour
     dem0.backfillBorder(dem1, 0, 1);
-    // backfills BottomCenter neighbor
-    for (int x = 0; x < 4; x++) {
-        EXPECT_TRUE(dem0.get(x, 4) == dem1.get(x, 0));
+    for (int b = 0; b < border; b++) {
+        for (int x = 0; x < dim; x++) {
+            EXPECT_EQ(dem0.get(x, dim + b), dem1.get(x, b));
+        }
     }
 
+    // Diagonals — `border × border` square at each corner.
     dem0.backfillBorder(dem1, -1, 1);
-    // backfulls TopRight neighbor
-    EXPECT_TRUE(dem0.get(-1, 4) == dem1.get(3, 0));
+    for (int dy = 0; dy < border; dy++) {
+        for (int dx = 1; dx <= border; dx++) {
+            EXPECT_EQ(dem0.get(-dx, dim + dy), dem1.get(dim - dx, dy));
+        }
+    }
 
     dem0.backfillBorder(dem1, 1, 1);
-    // backfulls BottomRight neighbor
-    EXPECT_TRUE(dem0.get(4, 4) == dem1.get(0, 0));
+    for (int dy = 0; dy < border; dy++) {
+        for (int dx = 0; dx < border; dx++) {
+            EXPECT_EQ(dem0.get(dim + dx, dim + dy), dem1.get(dx, dy));
+        }
+    }
 
     dem0.backfillBorder(dem1, -1, -1);
-    // backfulls TopLeft neighbor
-    EXPECT_TRUE(dem0.get(-1, -1) == dem1.get(3, 3));
+    for (int dy = 1; dy <= border; dy++) {
+        for (int dx = 1; dx <= border; dx++) {
+            EXPECT_EQ(dem0.get(-dx, -dy), dem1.get(dim - dx, dim - dy));
+        }
+    }
 
     dem0.backfillBorder(dem1, 1, -1);
-    // backfulls BottomLeft neighbor
-    EXPECT_TRUE(dem0.get(4, -1) == dem1.get(0, 3));
+    for (int dy = 1; dy <= border; dy++) {
+        for (int dx = 0; dx < border; dx++) {
+            EXPECT_EQ(dem0.get(dim + dx, -dy), dem1.get(dx, dim - dy));
+        }
+    }
 };


### PR DESCRIPTION
**Human note**

After working with Claude on #4279, we noticed another separate bug causing discontinuities at the edges of tiles in the DEM hill shading layer. Our DEM data tops out at zoom 12, But when zooming in further than that, we see seams between the tiles. I'm not familiar with the internals of the MapLibre codebase, but Claude seems to have worked out what's going on, and fixed the problem. This is a little bit more code than our earlier fix, so probably needs a bit more of a detailed look. The rest of this was written by Claude:

Fixes #4281.

The hillshade prepare pass renders a `dim²` derivative texture sampled by the per-frame hillshade shader. With `dim²` outputs, each output pixel computes Sobel slope at the centre of an interior DEM cell — half a DEM-pixel inside the tile boundary on each side. Adjacent tiles compute slopes at world positions one DEM-pixel apart at the seam, and the per-tile `Clamp`-wrap sampling at the boundary returns two different edge values. At native zoom this is sub-screen-pixel; once overzoomed (display zoom > source maxzoom) it becomes a visible discontinuity — a sharp step between adjacent screen pixels — traced along every tile boundary.

This PR extends the prepare output by one pixel on the south and east — render to `(dim+1)²`. The new `i = dim` output pixel computes Sobel centred on the inner east-border cell, which after neighbour backfill holds tile B's first interior column. Tile B's `i = 0` output uses the same three source columns from the matching west-border backfill on its side. Same Sobel inputs → same output → continuous shading across the boundary.

To make `i = dim` reachable without the kernel running off the buffer, `DEMData::border` is widened from 1 to 2 pixels. `backfillBorder` copies two columns/rows of neighbour data per axis-aligned side and a 2×2 block for diagonals. The interior content and `DEMData::dim` / `get(x, y)` semantics are unchanged.

Both the GLSL and Metal `hillshade_prepare` vertex shaders pick the new boundary outputs with `v_pos = (a_texture_pos / EXTENT) · (dim+1) / stride + 2 / stride` so the corner outputs land on buffer texels 2 and `dim+2`. The fragment shader's `tileSize` derivation switches from `dimension - 2` to `dimension - 4` to match the wider stride.

## Tests

`test/geometry/dem_data.test.cpp` is updated to cover the 2-pixel border layout end-to-end:
- `ConstructorMapbox` / `ConstructorTerrarium`: stride is `dim + 2 · border`, image bytes match.
- `InitialBackfill`: every cell of the border ring is non-empty, edge columns / rows are edge-clamped two-deep, all four corner blocks are seeded from the nearest interior corner.
- `BackfillNeighbor`: each of the 8 neighbour directions populates the expected `border`-deep stripe (or `border × border` corner) with the matching opposite slice from the neighbour DEMData.

Existing render tests covering the hillshade pipeline pass unchanged.

## Cost

- DEM tile memory: stride `dim + 2 → dim + 4` ⇒ ~1.6 % more bytes per tile (~16 KB for a 256² Terrarium tile)
- Prepare-pass GPU: `(dim + 1)² / dim² ≈ 0.8 %` more fragments per prepare invocation
- Per-frame rendering: zero change

Prepare runs once per tile load and once per neighbour backfill, never per frame, so the GPU cost is unobservable in practice.

## Visual evidence

Before / after screenshots to follow on the linked issue.