### PR TITLE
core: ambient cache for pmtile sources

### DIFF
--- a/platform/android/docs/data/PMTiles.md
+++ b/platform/android/docs/data/PMTiles.md
@@ -2,7 +2,7 @@
 
 Starting MapLibre Android 11.7.0, using [PMTiles](https://docs.protomaps.com/pmtiles/) as a data source is supported. You can prefix your vector tile source with `pmtiles://` to load a PMTiles file. The rest of the URL continue with be `https://` to load a remote PMTiles file, `asset://` to load an asset or `file://` to load a local PMTiles file.
 
-> Note: PMTiles sources currently do not support caching or offline pack downloads.
+> Note: PMTiles sources do not currently support offline pack downloads.
 
 Oliver Wipfli has made a style available that combines a [Protomaps]() basemap togehter with Foursquare's POI dataset. It is available in the [wipfli/foursquare-os-places-pmtiles](https://github.com/wipfli/foursquare-os-places-pmtiles) repository on GitHub. The style to use is
 

--- a/platform/default/include/mbgl/storage/offline_database.hpp
+++ b/platform/default/include/mbgl/storage/offline_database.hpp
@@ -97,6 +97,9 @@ public:
 
     void reopenDatabaseReadOnly(bool readOnly);
 
+    // Builds the offline-cache key for a resource. Exposed for testing.
+    static std::string cacheKey(const Resource&);
+
 private:
     class DatabaseSizeChangeStats;
 

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -13,18 +13,16 @@
 
 namespace mbgl {
 
-namespace {
-// PMTiles and other range-aware sources issue multiple sub-requests against
-// the same URL with different byte ranges. The `resources` table has a UNIQUE
-// constraint on `url`, so we encode the range into the cache key so each range
-// gets its own row instead of overwriting the previous one.
-std::string cacheKey(const Resource& resource) {
+// Single-point transformer for offline storage keys. For sources where the URL is
+// not enough to guarantee uniqueness (eg. PMTiles where all requests resolve to
+// the same URL), this function creates a synthetic key based on the requested
+// data range. Can be expanded in the future to accommodate other formats.
+std::string OfflineDatabase::cacheKey(const Resource& resource) {
     if (!resource.dataRange) return resource.url;
     const auto sep = resource.url.find('?') == std::string::npos ? '?' : '&';
     return resource.url + sep + "_mlnRange=" + std::to_string(resource.dataRange->first) + "-" +
            std::to_string(resource.dataRange->second);
 }
-} // namespace
 
 OfflineDatabase::OfflineDatabase(std::string path_, const TileServerOptions& options)
     : path(std::move(path_)),
@@ -391,10 +389,6 @@ std::optional<std::pair<Response, uint64_t>> OfflineDatabase::getResource(const 
     query.bind(1, cacheKey(resource));
 
     if (!query.run()) {
-        if (resource.dataRange) {
-            // TODO: Remove after PR review
-            Log::Info(Event::Database, "[ambient cache] miss: " + cacheKey(resource));
-        }
         return std::nullopt;
     }
 
@@ -415,12 +409,6 @@ std::optional<std::pair<Response, uint64_t>> OfflineDatabase::getResource(const 
     } else {
         response.data = std::make_shared<std::string>(*data);
         size = data->length();
-    }
-
-    if (resource.dataRange) {
-        // TODO: Remove after PR review
-        Log::Info(Event::Database,
-                  "[ambient cache] hit: " + cacheKey(resource) + " (" + std::to_string(size) + " bytes)");
     }
 
     return std::make_pair(response, size);
@@ -457,10 +445,6 @@ bool OfflineDatabase::putResource(const Resource& resource,
         notModifiedQuery.bind(3, response.mustRevalidate);
         notModifiedQuery.bind(4, cacheKey(resource));
         notModifiedQuery.run();
-        if (resource.dataRange) {
-            // TODO: Remove after PR review
-            Log::Info(Event::Database, "[ambient cache] revalidated (304): " + cacheKey(resource));
-        }
         return false;
     }
 
@@ -497,12 +481,6 @@ bool OfflineDatabase::putResource(const Resource& resource,
 
     updateQuery.run();
     if (updateQuery.changes() != 0) {
-        if (resource.dataRange) {
-            // TODO: Remove after PR review
-            Log::Info(
-                Event::Database,
-                "[ambient cache] refresh: " + cacheKey(resource) + " (" + std::to_string(data.size()) + " bytes)");
-        }
         return false;
     }
 
@@ -529,12 +507,6 @@ bool OfflineDatabase::putResource(const Resource& resource,
     }
 
     insertQuery.run();
-
-    if (resource.dataRange) {
-        // TODO: Remove after PR review
-        Log::Info(Event::Database,
-                  "[ambient cache] insert: " + cacheKey(resource) + " (" + std::to_string(data.size()) + " bytes)");
-    }
 
     return true;
 }

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -13,6 +13,19 @@
 
 namespace mbgl {
 
+namespace {
+// PMTiles and other range-aware sources issue multiple sub-requests against
+// the same URL with different byte ranges. The `resources` table has a UNIQUE
+// constraint on `url`, so we encode the range into the cache key so each range
+// gets its own row instead of overwriting the previous one.
+std::string cacheKey(const Resource& resource) {
+    if (!resource.dataRange) return resource.url;
+    const auto sep = resource.url.find('?') == std::string::npos ? '?' : '&';
+    return resource.url + sep + "_mlnRange=" + std::to_string(resource.dataRange->first) + "-" +
+           std::to_string(resource.dataRange->second);
+}
+} // namespace
+
 OfflineDatabase::OfflineDatabase(std::string path_, const TileServerOptions& options)
     : path(std::move(path_)),
       tileServerOptions(options) {
@@ -354,7 +367,7 @@ std::optional<std::pair<Response, uint64_t>> OfflineDatabase::getResource(const 
         try {
             mapbox::sqlite::Query accessedQuery{getStatement("UPDATE resources SET accessed = ?1 WHERE url = ?2")};
             accessedQuery.bind(1, util::now());
-            accessedQuery.bind(2, resource.url);
+            accessedQuery.bind(2, cacheKey(resource));
             accessedQuery.run();
         } catch (const mapbox::sqlite::Exception& ex) {
             if (ex.code == mapbox::sqlite::ResultCode::NotADB || ex.code == mapbox::sqlite::ResultCode::Corrupt) {
@@ -375,9 +388,13 @@ std::optional<std::pair<Response, uint64_t>> OfflineDatabase::getResource(const 
         "WHERE url = ?") };
     // clang-format on
 
-    query.bind(1, resource.url);
+    query.bind(1, cacheKey(resource));
 
     if (!query.run()) {
+        if (resource.dataRange) {
+            // TODO: Remove after PR review
+            Log::Info(Event::Database, "[ambient cache] miss: " + cacheKey(resource));
+        }
         return std::nullopt;
     }
 
@@ -400,12 +417,18 @@ std::optional<std::pair<Response, uint64_t>> OfflineDatabase::getResource(const 
         size = data->length();
     }
 
+    if (resource.dataRange) {
+        // TODO: Remove after PR review
+        Log::Info(Event::Database,
+                  "[ambient cache] hit: " + cacheKey(resource) + " (" + std::to_string(size) + " bytes)");
+    }
+
     return std::make_pair(response, size);
 }
 
 std::optional<int64_t> OfflineDatabase::hasResource(const Resource& resource) {
     mapbox::sqlite::Query query{getStatement("SELECT length(data) FROM resources WHERE url = ?")};
-    query.bind(1, resource.url);
+    query.bind(1, cacheKey(resource));
     if (!query.run()) {
         return std::nullopt;
     }
@@ -432,8 +455,12 @@ bool OfflineDatabase::putResource(const Resource& resource,
         notModifiedQuery.bind(1, util::now());
         notModifiedQuery.bind(2, response.expires);
         notModifiedQuery.bind(3, response.mustRevalidate);
-        notModifiedQuery.bind(4, resource.url);
+        notModifiedQuery.bind(4, cacheKey(resource));
         notModifiedQuery.run();
+        if (resource.dataRange) {
+            // TODO: Remove after PR review
+            Log::Info(Event::Database, "[ambient cache] revalidated (304): " + cacheKey(resource));
+        }
         return false;
     }
 
@@ -458,7 +485,7 @@ bool OfflineDatabase::putResource(const Resource& resource,
     updateQuery.bind(4, response.mustRevalidate);
     updateQuery.bind(5, response.modified);
     updateQuery.bind(6, util::now());
-    updateQuery.bind(9, resource.url);
+    updateQuery.bind(9, cacheKey(resource));
 
     if (response.noContent) {
         updateQuery.bind(7, nullptr);
@@ -470,6 +497,12 @@ bool OfflineDatabase::putResource(const Resource& resource,
 
     updateQuery.run();
     if (updateQuery.changes() != 0) {
+        if (resource.dataRange) {
+            // TODO: Remove after PR review
+            Log::Info(Event::Database,
+                      "[ambient cache] refresh: " + cacheKey(resource) + " (" + std::to_string(data.size()) +
+                          " bytes)");
+        }
         return false;
     }
 
@@ -479,7 +512,7 @@ bool OfflineDatabase::putResource(const Resource& resource,
         "VALUES                (?1,  ?2,   ?3,   ?4,      ?5,              ?6,       ?7,       ?8,   ?9) ") };
     // clang-format on
 
-    insertQuery.bind(1, resource.url);
+    insertQuery.bind(1, cacheKey(resource));
     insertQuery.bind(2, int(resource.kind));
     insertQuery.bind(3, response.etag);
     insertQuery.bind(4, response.expires);
@@ -496,6 +529,13 @@ bool OfflineDatabase::putResource(const Resource& resource,
     }
 
     insertQuery.run();
+
+    if (resource.dataRange) {
+        // TODO: Remove after PR review
+        Log::Info(Event::Database,
+                  "[ambient cache] insert: " + cacheKey(resource) + " (" + std::to_string(data.size()) +
+                      " bytes)");
+    }
 
     return true;
 }
@@ -1155,7 +1195,7 @@ bool OfflineDatabase::markUsed(int64_t regionID, const Resource& resource) {
         // clang-format on
 
         insertQuery.bind(1, regionID);
-        insertQuery.bind(2, resource.url);
+        insertQuery.bind(2, cacheKey(resource));
         insertQuery.run();
 
         if (insertQuery.changes() == 0) {
@@ -1172,7 +1212,7 @@ bool OfflineDatabase::markUsed(int64_t regionID, const Resource& resource) {
         // clang-format on
 
         selectQuery.bind(1, regionID);
-        selectQuery.bind(2, resource.url);
+        selectQuery.bind(2, cacheKey(resource));
         return !selectQuery.run();
     }
 }

--- a/platform/default/src/mbgl/storage/offline_database.cpp
+++ b/platform/default/src/mbgl/storage/offline_database.cpp
@@ -499,9 +499,9 @@ bool OfflineDatabase::putResource(const Resource& resource,
     if (updateQuery.changes() != 0) {
         if (resource.dataRange) {
             // TODO: Remove after PR review
-            Log::Info(Event::Database,
-                      "[ambient cache] refresh: " + cacheKey(resource) + " (" + std::to_string(data.size()) +
-                          " bytes)");
+            Log::Info(
+                Event::Database,
+                "[ambient cache] refresh: " + cacheKey(resource) + " (" + std::to_string(data.size()) + " bytes)");
         }
         return false;
     }
@@ -533,8 +533,7 @@ bool OfflineDatabase::putResource(const Resource& resource,
     if (resource.dataRange) {
         // TODO: Remove after PR review
         Log::Info(Event::Database,
-                  "[ambient cache] insert: " + cacheKey(resource) + " (" + std::to_string(data.size()) +
-                      " bytes)");
+                  "[ambient cache] insert: " + cacheKey(resource) + " (" + std::to_string(data.size()) + " bytes)");
     }
 
     return true;

--- a/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
@@ -95,7 +95,7 @@ public:
                 return;
             }
 
-            pmtiles::headerv3 header = header_cache.at(url).header;
+            pmtiles::headerv3 header = header_cache.at(url);
 
             if (resource.tileData->z < header.min_zoom || resource.tileData->z > header.max_zoom) {
                 Response response;
@@ -143,10 +143,11 @@ public:
                     }
 
                     Resource tileResource(Resource::Kind::Source, url);
+                    tileResource.loadingMethod = Resource::LoadingMethod::All;
                     tileResource.dataRange = std::make_pair(tileAddress.first,
                                                             tileAddress.first + tileAddress.second - 1);
 
-                    cacheFirstThenNetwork(req, tileResource, [=](const Response& tileResponse) {
+                    tasks[req] = getFileSource()->request(tileResource, [=](const Response& tileResponse) {
                         Response response;
                         response.noContent = true;
 
@@ -155,6 +156,10 @@ public:
                                 tileResponse.error->reason,
                                 std::string("Error fetching PMTiles tile: ") + tileResponse.error->message);
                             ref.invoke(&FileSourceRequest::setResponse, response);
+                            return;
+                        }
+
+                        if (tileResponse.notModified) {
                             return;
                         }
 
@@ -220,26 +225,11 @@ private:
     ClientOptions clientOptions;
 
     std::shared_ptr<FileSource> fileSource;
-
-    struct CachedHeader {
-        pmtiles::headerv3 header;
-        std::optional<std::string> etag;
-    };
-    std::map<std::string, CachedHeader> header_cache;
+    std::map<std::string, pmtiles::headerv3> header_cache;
     std::map<std::string, std::string> metadata_cache;
     std::map<std::string, std::map<std::string, std::vector<pmtiles::entryv3>>> directory_cache;
     std::map<std::string, std::vector<std::string>> directory_cache_control;
     std::map<AsyncRequest*, std::unique_ptr<AsyncRequest>> tasks;
-
-    // Clears all in-memory caches for a URL. Called when ETag-mismatch detection in
-    // `cacheFirstThenNetwork` notices the upstream archive has been replaced. The next
-    // request triggers a fresh `getHeader()` which repopulates with the new archive.
-    void invalidateArchive(const std::string& url) {
-        header_cache.erase(url);
-        directory_cache.erase(url);
-        directory_cache_control.erase(url);
-        metadata_cache.erase(url);
-    }
 
     std::shared_ptr<FileSource> getFileSource() {
         if (!fileSource) {
@@ -250,49 +240,6 @@ private:
         return fileSource;
     }
 
-    // Cache-first-then-network helper to handle fetches. `LoadingMethod::All` fires
-    // cache revalidation requests when tiles are served from the SQLite cache,
-    // which are wasteful in the context of PMTiles sources. This helper emulates
-    // the behavior of `LoadingMethod::All`, but without cache revalidation requests.
-    void cacheFirstThenNetwork(AsyncRequest* req,
-                               Resource resource,
-                               std::function<void(const Response&)> userCallback) {
-        Resource cacheResource = resource;
-        cacheResource.loadingMethod = Resource::LoadingMethod::CacheOnly;
-
-        tasks[req] = getFileSource()->request(cacheResource, [=, this](const Response& cacheResponse) {
-            if (cacheResponse.data && !cacheResponse.error) {
-                userCallback(cacheResponse);
-                return;
-            }
-
-            Resource networkResource = resource;
-            networkResource.loadingMethod = Resource::LoadingMethod::NetworkOnly;
-
-            auto cacheReqKeepAlive = std::shared_ptr<AsyncRequest>(std::move(tasks[req]));
-            tasks[req] = getFileSource()->request(
-                networkResource, [=, this, keepAlive = std::move(cacheReqKeepAlive)](const Response& netResponse) {
-                    // Upstream archive-replacement detection: if the server's ETag on this
-                    // sub-request differs from the ETag we observed when the archive header
-                    // was parsed, the archive has been replaced. Invalidate the in-memory
-                    // caches and surface an error so the renderer's retry path triggers a
-                    // fresh getHeader().
-                    auto it = header_cache.find(resource.url);
-                    if (it != header_cache.end() && it->second.etag && netResponse.etag &&
-                        *it->second.etag != *netResponse.etag) {
-                        invalidateArchive(resource.url);
-                        Response err;
-                        err.error = std::make_unique<Response::Error>(
-                            Response::Error::Reason::Other, "PMTiles archive replaced upstream; retry needed");
-                        userCallback(err);
-                        return;
-                    }
-                    userCallback(netResponse);
-                });
-        });
-    }
-
-    // PMTiles archives are immutable per upload, so we only revalidate the header on first call
     void getHeader(const std::string& url, AsyncRequest* req, AsyncCallback callback) {
         if (header_cache.contains(url)) {
             callback(std::unique_ptr<Response::Error>());
@@ -301,6 +248,7 @@ private:
 
         Resource resource(Resource::Kind::Source, url);
         resource.loadingMethod = Resource::LoadingMethod::All;
+
         resource.dataRange = std::make_pair<uint64_t, uint64_t>(pmtilesHeaderOffset,
                                                                 pmtilesHeaderOffset + pmtilesHeaderLength - 1);
 
@@ -324,6 +272,10 @@ private:
                     return;
                 }
 
+                if (response.notModified) {
+                    return;
+                }
+
                 if (!response.data) {
                     callback(std::make_unique<Response::Error>(Response::Error::Reason::Other,
                                                                "PMTiles header response has no data"));
@@ -340,7 +292,7 @@ private:
                         throw std::runtime_error("Compression method not supported");
                     }
 
-                    header_cache.insert_or_assign(url, CachedHeader{header, response.etag});
+                    header_cache.emplace(url, header);
 
                     callback(std::unique_ptr<Response::Error>());
                 } catch (const std::exception& e) {
@@ -365,7 +317,7 @@ private:
                     return;
                 }
 
-                pmtiles::headerv3 header = header_cache.at(url).header;
+                pmtiles::headerv3 header = header_cache.at(url);
 
                 auto parse_callback = [=, this](const std::string& data) {
                     Document doc;
@@ -461,17 +413,18 @@ private:
                     doc["maxzoom"] = maxzoom;
 
                     std::string metadata = serialize(doc);
-                    metadata_cache.insert_or_assign(url, metadata);
+                    metadata_cache.emplace(url, metadata);
 
                     callback(std::unique_ptr<Response::Error>());
                 };
 
                 if (header.json_metadata_bytes > 0) {
                     Resource resource(Resource::Kind::Source, url);
+                    resource.loadingMethod = Resource::LoadingMethod::All;
                     resource.dataRange = std::make_pair(header.json_metadata_offset,
                                                         header.json_metadata_offset + header.json_metadata_bytes - 1);
 
-                    cacheFirstThenNetwork(req, resource, [=](const Response& responseMetadata) {
+                    tasks[req] = getFileSource()->request(resource, [=](const Response& responseMetadata) {
                         if (responseMetadata.error) {
                             callback(std::make_unique<Response::Error>(
                                 responseMetadata.error->reason,
@@ -480,17 +433,16 @@ private:
                             return;
                         }
 
+                        if (responseMetadata.notModified) {
+                            return;
+                        }
+
                         if (!responseMetadata.data) {
-                            std::string detail = "PMTiles metadata response has no data (noContent=";
-                            detail += responseMetadata.noContent ? "true" : "false";
-                            detail += ", notModified=";
-                            detail += responseMetadata.notModified ? "true" : "false";
-                            detail += ", range=";
-                            detail += std::to_string(header.json_metadata_offset) + "-" +
-                                      std::to_string(header.json_metadata_offset + header.json_metadata_bytes - 1);
-                            detail += ")";
-                            callback(
-                                std::make_unique<Response::Error>(Response::Error::Reason::Other, std::move(detail)));
+                            callback(std::make_unique<Response::Error>(
+                                Response::Error::Reason::Other,
+                                "PMTiles metadata response has no data (range=" +
+                                    std::to_string(header.json_metadata_offset) + "-" +
+                                    std::to_string(header.json_metadata_offset + header.json_metadata_bytes - 1) + ")"));
                             return;
                         }
 
@@ -561,17 +513,22 @@ private:
                 return;
             }
 
-            pmtiles::headerv3 header = header_cache.at(url).header;
+            pmtiles::headerv3 header = header_cache.at(url);
 
             Resource resource(Resource::Kind::Source, url);
+            resource.loadingMethod = Resource::LoadingMethod::All;
             resource.dataRange = std::make_pair(directoryOffset, directoryOffset + directoryLength - 1);
 
-            cacheFirstThenNetwork(req, resource, [=, this](const Response& response) {
+            tasks[req] = getFileSource()->request(resource, [=, this](const Response& response) {
                 if (response.error) {
                     callback(std::make_unique<Response::Error>(
                         response.error->reason,
                         std::string("Error fetching PMTiles directory: ") + response.error->message));
 
+                    return;
+                }
+
+                if (response.notModified) {
                     return;
                 }
 
@@ -627,18 +584,7 @@ private:
                     return;
                 }
 
-                // A concurrent request may have detected upstream archive replacement and
-                // cleared `header_cache` since this request started. Bail with a retry-needed
-                // error rather than dereferencing a missing entry.
-                auto headerIt = header_cache.find(url);
-                if (headerIt == header_cache.end()) {
-                    callback(std::make_pair(0, 0),
-                             std::make_unique<Response::Error>(
-                                 Response::Error::Reason::Other,
-                                 "PMTiles header cache invalidated mid-request; retry needed"));
-                    return;
-                }
-                pmtiles::headerv3 header = headerIt->second.header;
+                pmtiles::headerv3 header = header_cache.at(url);
                 std::vector<pmtiles::entryv3> directory = directory_cache.at(url).at(
                     url + "|" + std::to_string(directoryOffset) + "|" + std::to_string(directoryLength));
 

--- a/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
@@ -160,8 +160,7 @@ public:
 
                         if (!tileResponse.data) {
                             response.error = std::make_unique<Response::Error>(
-                                Response::Error::Reason::Other,
-                                "Error fetching PMTiles tile: response has no data");
+                                Response::Error::Reason::Other, "Error fetching PMTiles tile: response has no data");
                             ref.invoke(&FileSourceRequest::setResponse, response);
                             return;
                         }
@@ -255,8 +254,7 @@ private:
 
             auto cacheReqKeepAlive = std::shared_ptr<AsyncRequest>(std::move(tasks[req]));
             tasks[req] = getFileSource()->request(
-                networkResource,
-                [userCallback, keepAlive = std::move(cacheReqKeepAlive)](const Response& netResponse) {
+                networkResource, [userCallback, keepAlive = std::move(cacheReqKeepAlive)](const Response& netResponse) {
                     userCallback(netResponse);
                 });
         });
@@ -459,8 +457,8 @@ private:
                             detail += std::to_string(header.json_metadata_offset) + "-" +
                                       std::to_string(header.json_metadata_offset + header.json_metadata_bytes - 1);
                             detail += ")";
-                            callback(std::make_unique<Response::Error>(Response::Error::Reason::Other,
-                                                                       std::move(detail)));
+                            callback(
+                                std::make_unique<Response::Error>(Response::Error::Reason::Other, std::move(detail)));
                             return;
                         }
 
@@ -546,8 +544,8 @@ private:
                 }
 
                 if (!response.data) {
-                    callback(std::make_unique<Response::Error>(
-                        Response::Error::Reason::Other, "PMTiles directory response has no data"));
+                    callback(std::make_unique<Response::Error>(Response::Error::Reason::Other,
+                                                               "PMTiles directory response has no data"));
                     return;
                 }
 

--- a/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
@@ -310,7 +310,7 @@ private:
                         throw std::runtime_error("Compression method not supported");
                     }
 
-                    header_cache.emplace(url, header);
+                    header_cache.insert_or_assign(url, header);
 
                     callback(std::unique_ptr<Response::Error>());
                 } catch (const std::exception& e) {
@@ -431,7 +431,7 @@ private:
                     doc["maxzoom"] = maxzoom;
 
                     std::string metadata = serialize(doc);
-                    metadata_cache.emplace(url, metadata);
+                    metadata_cache.insert_or_assign(url, metadata);
 
                     callback(std::unique_ptr<Response::Error>());
                 };

--- a/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
@@ -143,7 +143,6 @@ public:
                     }
 
                     Resource tileResource(Resource::Kind::Source, url);
-                    // loadingMethod is overridden inside cacheFirstThenNetwork (Cache, then Network).
                     tileResource.dataRange = std::make_pair(tileAddress.first,
                                                             tileAddress.first + tileAddress.second - 1);
 
@@ -159,10 +158,10 @@ public:
                             return;
                         }
 
-                        // A `notModified` revalidation response carries no body — the cached data
-                        // lives elsewhere. Tolerate it by leaving `noContent=true` and returning
-                        // a non-error response so the lambda doesn't deref a null `data` below.
                         if (!tileResponse.data) {
+                            response.error = std::make_unique<Response::Error>(
+                                Response::Error::Reason::Other,
+                                "Error fetching PMTiles tile: response has no data");
                             ref.invoke(&FileSourceRequest::setResponse, response);
                             return;
                         }
@@ -237,20 +236,8 @@ private:
         return fileSource;
     }
 
-    // Issue a sub-request that prefers cache and skips conditional revalidation on hit.
-    // Used for PMTiles byte-range sub-requests (metadata, directories, tiles) after
-    // `getHeader()` has validated the archive once per session. Skipping revalidation
-    // is safe because PMTiles archives are content-addressable per upload: if the
-    // header is unchanged, every other byte range still corresponds to the same bytes.
-    //
-    // On cache hit, the cached response is forwarded immediately — no network call.
-    // On cache miss, a NetworkOnly sub-request is fired (no priorEtag/priorData, so
-    // the server returns a full body, not a 304). The response is cached as usual
-    // via `databaseFileSource->forward()` inside MainResourceLoader.
-    //
-    // Caller must ensure `header_cache.contains(resource.url)` before calling this.
-    // In current code structure that's always true because every call site is inside
-    // a `getHeader()` success callback.
+    // Cache-first byte-range fetch that skips conditional revalidation on hit, since
+    // PMTiles archives are immutable per upload (validated once by `getHeader()`)
     void cacheFirstThenNetwork(AsyncRequest* req,
                                Resource resource,
                                std::function<void(const Response&)> userCallback) {
@@ -263,20 +250,19 @@ private:
                 return;
             }
 
-            // Cache miss — fetch fresh, no revalidation.
             Resource networkResource = resource;
             networkResource.loadingMethod = Resource::LoadingMethod::NetworkOnly;
 
-            // Keep the (now-finished) cache AsyncRequest alive until the network
-            // call completes, matching the pattern in MainResourceLoader.
             auto cacheReqKeepAlive = std::shared_ptr<AsyncRequest>(std::move(tasks[req]));
             tasks[req] = getFileSource()->request(
-                networkResource, [userCallback, keepAlive = std::move(cacheReqKeepAlive)](const Response& netResponse) {
+                networkResource,
+                [userCallback, keepAlive = std::move(cacheReqKeepAlive)](const Response& netResponse) {
                     userCallback(netResponse);
                 });
         });
     }
 
+    // PMTiles archives are immutable per upload, so we only revalidate the header on first call
     void getHeader(const std::string& url, AsyncRequest* req, AsyncCallback callback) {
         if (header_cache.contains(url)) {
             callback(std::unique_ptr<Response::Error>());
@@ -284,12 +270,7 @@ private:
         }
 
         Resource resource(Resource::Kind::Source, url);
-        // The header sub-request is the once-per-session validation point: if the
-        // SQLite cache has it, we still revalidate (via LoadingMethod::All -> 304
-        // path) so future-session archive replacements are noticed. All other
-        // sub-requests skip revalidation via `cacheFirstThenNetwork` below.
         resource.loadingMethod = Resource::LoadingMethod::All;
-
         resource.dataRange = std::make_pair<uint64_t, uint64_t>(pmtilesHeaderOffset,
                                                                 pmtilesHeaderOffset + pmtilesHeaderLength - 1);
 
@@ -314,8 +295,6 @@ private:
                 }
 
                 if (!response.data) {
-                    // 304/no-data revalidation came back with the body absent. Report as error so
-                    // the caller doesn't proceed assuming a parseable header is present.
                     callback(std::make_unique<Response::Error>(Response::Error::Reason::Other,
                                                                "PMTiles header response has no data"));
                     return;
@@ -459,7 +438,6 @@ private:
 
                 if (header.json_metadata_bytes > 0) {
                     Resource resource(Resource::Kind::Source, url);
-                    // loadingMethod is overridden inside cacheFirstThenNetwork.
                     resource.dataRange = std::make_pair(header.json_metadata_offset,
                                                         header.json_metadata_offset + header.json_metadata_bytes - 1);
 
@@ -481,8 +459,8 @@ private:
                             detail += std::to_string(header.json_metadata_offset) + "-" +
                                       std::to_string(header.json_metadata_offset + header.json_metadata_bytes - 1);
                             detail += ")";
-                            callback(
-                                std::make_unique<Response::Error>(Response::Error::Reason::Other, std::move(detail)));
+                            callback(std::make_unique<Response::Error>(Response::Error::Reason::Other,
+                                                                       std::move(detail)));
                             return;
                         }
 
@@ -556,7 +534,6 @@ private:
             pmtiles::headerv3 header = header_cache.at(url);
 
             Resource resource(Resource::Kind::Source, url);
-            // loadingMethod is overridden inside cacheFirstThenNetwork.
             resource.dataRange = std::make_pair(directoryOffset, directoryOffset + directoryLength - 1);
 
             cacheFirstThenNetwork(req, resource, [=, this](const Response& response) {
@@ -569,8 +546,8 @@ private:
                 }
 
                 if (!response.data) {
-                    callback(std::make_unique<Response::Error>(Response::Error::Reason::Other,
-                                                               "PMTiles directory response has no data"));
+                    callback(std::make_unique<Response::Error>(
+                        Response::Error::Reason::Other, "PMTiles directory response has no data"));
                     return;
                 }
 

--- a/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
@@ -95,7 +95,7 @@ public:
                 return;
             }
 
-            pmtiles::headerv3 header = header_cache.at(url);
+            pmtiles::headerv3 header = header_cache.at(url).header;
 
             if (resource.tileData->z < header.min_zoom || resource.tileData->z > header.max_zoom) {
                 Response response;
@@ -220,11 +220,26 @@ private:
     ClientOptions clientOptions;
 
     std::shared_ptr<FileSource> fileSource;
-    std::map<std::string, pmtiles::headerv3> header_cache;
+
+    struct CachedHeader {
+        pmtiles::headerv3 header;
+        std::optional<std::string> etag;
+    };
+    std::map<std::string, CachedHeader> header_cache;
     std::map<std::string, std::string> metadata_cache;
     std::map<std::string, std::map<std::string, std::vector<pmtiles::entryv3>>> directory_cache;
     std::map<std::string, std::vector<std::string>> directory_cache_control;
     std::map<AsyncRequest*, std::unique_ptr<AsyncRequest>> tasks;
+
+    // Clears all in-memory caches for a URL. Called when ETag-mismatch detection in
+    // `cacheFirstThenNetwork` notices the upstream archive has been replaced. The next
+    // request triggers a fresh `getHeader()` which repopulates with the new archive.
+    void invalidateArchive(const std::string& url) {
+        header_cache.erase(url);
+        directory_cache.erase(url);
+        directory_cache_control.erase(url);
+        metadata_cache.erase(url);
+    }
 
     std::shared_ptr<FileSource> getFileSource() {
         if (!fileSource) {
@@ -256,7 +271,24 @@ private:
 
             auto cacheReqKeepAlive = std::shared_ptr<AsyncRequest>(std::move(tasks[req]));
             tasks[req] = getFileSource()->request(
-                networkResource, [userCallback, keepAlive = std::move(cacheReqKeepAlive)](const Response& netResponse) {
+                networkResource,
+                [=, this, keepAlive = std::move(cacheReqKeepAlive)](const Response& netResponse) {
+                    // Upstream archive-replacement detection: if the server's ETag on this
+                    // sub-request differs from the ETag we observed when the archive header
+                    // was parsed, the archive has been replaced. Invalidate the in-memory
+                    // caches and surface an error so the renderer's retry path triggers a
+                    // fresh getHeader().
+                    auto it = header_cache.find(resource.url);
+                    if (it != header_cache.end() && it->second.etag && netResponse.etag &&
+                        *it->second.etag != *netResponse.etag) {
+                        invalidateArchive(resource.url);
+                        Response err;
+                        err.error = std::make_unique<Response::Error>(
+                            Response::Error::Reason::Other,
+                            "PMTiles archive replaced upstream; retry needed");
+                        userCallback(err);
+                        return;
+                    }
                     userCallback(netResponse);
                 });
         });
@@ -310,7 +342,7 @@ private:
                         throw std::runtime_error("Compression method not supported");
                     }
 
-                    header_cache.insert_or_assign(url, header);
+                    header_cache.insert_or_assign(url, CachedHeader{header, response.etag});
 
                     callback(std::unique_ptr<Response::Error>());
                 } catch (const std::exception& e) {
@@ -335,7 +367,7 @@ private:
                     return;
                 }
 
-                pmtiles::headerv3 header = header_cache.at(url);
+                pmtiles::headerv3 header = header_cache.at(url).header;
 
                 auto parse_callback = [=, this](const std::string& data) {
                     Document doc;
@@ -531,7 +563,7 @@ private:
                 return;
             }
 
-            pmtiles::headerv3 header = header_cache.at(url);
+            pmtiles::headerv3 header = header_cache.at(url).header;
 
             Resource resource(Resource::Kind::Source, url);
             resource.dataRange = std::make_pair(directoryOffset, directoryOffset + directoryLength - 1);
@@ -597,7 +629,18 @@ private:
                     return;
                 }
 
-                pmtiles::headerv3 header = header_cache.at(url);
+                // A concurrent request may have detected upstream archive replacement and
+                // cleared `header_cache` since this request started. Bail with a retry-needed
+                // error rather than dereferencing a missing entry.
+                auto headerIt = header_cache.find(url);
+                if (headerIt == header_cache.end()) {
+                    callback(std::make_pair(0, 0),
+                             std::make_unique<Response::Error>(
+                                 Response::Error::Reason::Other,
+                                 "PMTiles header cache invalidated mid-request; retry needed"));
+                    return;
+                }
+                pmtiles::headerv3 header = headerIt->second.header;
                 std::vector<pmtiles::entryv3> directory = directory_cache.at(url).at(
                     url + "|" + std::to_string(directoryOffset) + "|" + std::to_string(directoryLength));
 

--- a/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
@@ -442,7 +442,8 @@ private:
                                 Response::Error::Reason::Other,
                                 "PMTiles metadata response has no data (range=" +
                                     std::to_string(header.json_metadata_offset) + "-" +
-                                    std::to_string(header.json_metadata_offset + header.json_metadata_bytes - 1) + ")"));
+                                    std::to_string(header.json_metadata_offset + header.json_metadata_bytes - 1) +
+                                    ")"));
                             return;
                         }
 

--- a/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
@@ -271,8 +271,7 @@ private:
 
             auto cacheReqKeepAlive = std::shared_ptr<AsyncRequest>(std::move(tasks[req]));
             tasks[req] = getFileSource()->request(
-                networkResource,
-                [=, this, keepAlive = std::move(cacheReqKeepAlive)](const Response& netResponse) {
+                networkResource, [=, this, keepAlive = std::move(cacheReqKeepAlive)](const Response& netResponse) {
                     // Upstream archive-replacement detection: if the server's ETag on this
                     // sub-request differs from the ETag we observed when the archive header
                     // was parsed, the archive has been replaced. Invalidate the in-memory
@@ -284,8 +283,7 @@ private:
                         invalidateArchive(resource.url);
                         Response err;
                         err.error = std::make_unique<Response::Error>(
-                            Response::Error::Reason::Other,
-                            "PMTiles archive replaced upstream; retry needed");
+                            Response::Error::Reason::Other, "PMTiles archive replaced upstream; retry needed");
                         userCallback(err);
                         return;
                     }

--- a/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
@@ -271,8 +271,7 @@ private:
             // call completes, matching the pattern in MainResourceLoader.
             auto cacheReqKeepAlive = std::shared_ptr<AsyncRequest>(std::move(tasks[req]));
             tasks[req] = getFileSource()->request(
-                networkResource,
-                [userCallback, keepAlive = std::move(cacheReqKeepAlive)](const Response& netResponse) {
+                networkResource, [userCallback, keepAlive = std::move(cacheReqKeepAlive)](const Response& netResponse) {
                     userCallback(netResponse);
                 });
         });
@@ -482,8 +481,8 @@ private:
                             detail += std::to_string(header.json_metadata_offset) + "-" +
                                       std::to_string(header.json_metadata_offset + header.json_metadata_bytes - 1);
                             detail += ")";
-                            callback(std::make_unique<Response::Error>(Response::Error::Reason::Other,
-                                                                       std::move(detail)));
+                            callback(
+                                std::make_unique<Response::Error>(Response::Error::Reason::Other, std::move(detail)));
                             return;
                         }
 
@@ -570,8 +569,8 @@ private:
                 }
 
                 if (!response.data) {
-                    callback(std::make_unique<Response::Error>(
-                        Response::Error::Reason::Other, "PMTiles directory response has no data"));
+                    callback(std::make_unique<Response::Error>(Response::Error::Reason::Other,
+                                                               "PMTiles directory response has no data"));
                     return;
                 }
 

--- a/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
@@ -143,11 +143,11 @@ public:
                     }
 
                     Resource tileResource(Resource::Kind::Source, url);
-                    tileResource.loadingMethod = Resource::LoadingMethod::Network;
+                    // loadingMethod is overridden inside cacheFirstThenNetwork (Cache, then Network).
                     tileResource.dataRange = std::make_pair(tileAddress.first,
                                                             tileAddress.first + tileAddress.second - 1);
 
-                    tasks[req] = getFileSource()->request(tileResource, [=](const Response& tileResponse) {
+                    cacheFirstThenNetwork(req, tileResource, [=](const Response& tileResponse) {
                         Response response;
                         response.noContent = true;
 
@@ -155,6 +155,14 @@ public:
                             response.error = std::make_unique<Response::Error>(
                                 tileResponse.error->reason,
                                 std::string("Error fetching PMTiles tile: ") + tileResponse.error->message);
+                            ref.invoke(&FileSourceRequest::setResponse, response);
+                            return;
+                        }
+
+                        // A `notModified` revalidation response carries no body — the cached data
+                        // lives elsewhere. Tolerate it by leaving `noContent=true` and returning
+                        // a non-error response so the lambda doesn't deref a null `data` below.
+                        if (!tileResponse.data) {
                             ref.invoke(&FileSourceRequest::setResponse, response);
                             return;
                         }
@@ -229,13 +237,59 @@ private:
         return fileSource;
     }
 
+    // Issue a sub-request that prefers cache and skips conditional revalidation on hit.
+    // Used for PMTiles byte-range sub-requests (metadata, directories, tiles) after
+    // `getHeader()` has validated the archive once per session. Skipping revalidation
+    // is safe because PMTiles archives are content-addressable per upload: if the
+    // header is unchanged, every other byte range still corresponds to the same bytes.
+    //
+    // On cache hit, the cached response is forwarded immediately — no network call.
+    // On cache miss, a NetworkOnly sub-request is fired (no priorEtag/priorData, so
+    // the server returns a full body, not a 304). The response is cached as usual
+    // via `databaseFileSource->forward()` inside MainResourceLoader.
+    //
+    // Caller must ensure `header_cache.contains(resource.url)` before calling this.
+    // In current code structure that's always true because every call site is inside
+    // a `getHeader()` success callback.
+    void cacheFirstThenNetwork(AsyncRequest* req,
+                               Resource resource,
+                               std::function<void(const Response&)> userCallback) {
+        Resource cacheResource = resource;
+        cacheResource.loadingMethod = Resource::LoadingMethod::CacheOnly;
+
+        tasks[req] = getFileSource()->request(cacheResource, [=, this](const Response& cacheResponse) {
+            if (cacheResponse.data && !cacheResponse.error) {
+                userCallback(cacheResponse);
+                return;
+            }
+
+            // Cache miss — fetch fresh, no revalidation.
+            Resource networkResource = resource;
+            networkResource.loadingMethod = Resource::LoadingMethod::NetworkOnly;
+
+            // Keep the (now-finished) cache AsyncRequest alive until the network
+            // call completes, matching the pattern in MainResourceLoader.
+            auto cacheReqKeepAlive = std::shared_ptr<AsyncRequest>(std::move(tasks[req]));
+            tasks[req] = getFileSource()->request(
+                networkResource,
+                [userCallback, keepAlive = std::move(cacheReqKeepAlive)](const Response& netResponse) {
+                    userCallback(netResponse);
+                });
+        });
+    }
+
     void getHeader(const std::string& url, AsyncRequest* req, AsyncCallback callback) {
         if (header_cache.contains(url)) {
             callback(std::unique_ptr<Response::Error>());
+            return;
         }
 
         Resource resource(Resource::Kind::Source, url);
-        resource.loadingMethod = Resource::LoadingMethod::Network;
+        // The header sub-request is the once-per-session validation point: if the
+        // SQLite cache has it, we still revalidate (via LoadingMethod::All -> 304
+        // path) so future-session archive replacements are noticed. All other
+        // sub-requests skip revalidation via `cacheFirstThenNetwork` below.
+        resource.loadingMethod = Resource::LoadingMethod::All;
 
         resource.dataRange = std::make_pair<uint64_t, uint64_t>(pmtilesHeaderOffset,
                                                                 pmtilesHeaderOffset + pmtilesHeaderLength - 1);
@@ -257,6 +311,14 @@ private:
 
                     callback(std::make_unique<Response::Error>(response.error->reason, message));
 
+                    return;
+                }
+
+                if (!response.data) {
+                    // 304/no-data revalidation came back with the body absent. Report as error so
+                    // the caller doesn't proceed assuming a parseable header is present.
+                    callback(std::make_unique<Response::Error>(Response::Error::Reason::Other,
+                                                               "PMTiles header response has no data"));
                     return;
                 }
 
@@ -283,6 +345,7 @@ private:
     void getMetadata(std::string& url, AsyncRequest* req, AsyncCallback callback) {
         if (metadata_cache.contains(url)) {
             callback(std::unique_ptr<Response::Error>());
+            return;
         }
 
         getHeader(
@@ -397,16 +460,30 @@ private:
 
                 if (header.json_metadata_bytes > 0) {
                     Resource resource(Resource::Kind::Source, url);
-                    resource.loadingMethod = Resource::LoadingMethod::Network;
+                    // loadingMethod is overridden inside cacheFirstThenNetwork.
                     resource.dataRange = std::make_pair(header.json_metadata_offset,
                                                         header.json_metadata_offset + header.json_metadata_bytes - 1);
 
-                    tasks[req] = getFileSource()->request(resource, [=](const Response& responseMetadata) {
+                    cacheFirstThenNetwork(req, resource, [=](const Response& responseMetadata) {
                         if (responseMetadata.error) {
                             callback(std::make_unique<Response::Error>(
                                 responseMetadata.error->reason,
                                 std::string("Error fetching PMTiles metadata: ") + responseMetadata.error->message));
 
+                            return;
+                        }
+
+                        if (!responseMetadata.data) {
+                            std::string detail = "PMTiles metadata response has no data (noContent=";
+                            detail += responseMetadata.noContent ? "true" : "false";
+                            detail += ", notModified=";
+                            detail += responseMetadata.notModified ? "true" : "false";
+                            detail += ", range=";
+                            detail += std::to_string(header.json_metadata_offset) + "-" +
+                                      std::to_string(header.json_metadata_offset + header.json_metadata_bytes - 1);
+                            detail += ")";
+                            callback(std::make_unique<Response::Error>(Response::Error::Reason::Other,
+                                                                       std::move(detail)));
                             return;
                         }
 
@@ -480,15 +557,21 @@ private:
             pmtiles::headerv3 header = header_cache.at(url);
 
             Resource resource(Resource::Kind::Source, url);
-            resource.loadingMethod = Resource::LoadingMethod::Network;
+            // loadingMethod is overridden inside cacheFirstThenNetwork.
             resource.dataRange = std::make_pair(directoryOffset, directoryOffset + directoryLength - 1);
 
-            tasks[req] = getFileSource()->request(resource, [=, this](const Response& response) {
+            cacheFirstThenNetwork(req, resource, [=, this](const Response& response) {
                 if (response.error) {
                     callback(std::make_unique<Response::Error>(
                         response.error->reason,
                         std::string("Error fetching PMTiles directory: ") + response.error->message));
 
+                    return;
+                }
+
+                if (!response.data) {
+                    callback(std::make_unique<Response::Error>(
+                        Response::Error::Reason::Other, "PMTiles directory response has no data"));
                     return;
                 }
 

--- a/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
+++ b/platform/default/src/mbgl/storage/pmtiles_file_source.cpp
@@ -235,8 +235,10 @@ private:
         return fileSource;
     }
 
-    // Cache-first byte-range fetch that skips conditional revalidation on hit, since
-    // PMTiles archives are immutable per upload (validated once by `getHeader()`)
+    // Cache-first-then-network helper to handle fetches. `LoadingMethod::All` fires
+    // cache revalidation requests when tiles are served from the SQLite cache,
+    // which are wasteful in the context of PMTiles sources. This helper emulates
+    // the behavior of `LoadingMethod::All`, but without cache revalidation requests.
     void cacheFirstThenNetwork(AsyncRequest* req,
                                Resource resource,
                                std::function<void(const Response&)> userCallback) {

--- a/platform/ios/MapLibre.docc/PMTiles.md
+++ b/platform/ios/MapLibre.docc/PMTiles.md
@@ -4,7 +4,7 @@ Working with PMTiles
 
 Starting MapLibre iOS 6.10.0, using [PMTiles](https://docs.protomaps.com/pmtiles/) as a data source is supported. You can prefix your vector tile source with `pmtiles://` to load a PMTiles file. The rest of the URL continue with be `https://` to load a remote PMTiles file, `asset://` to load an asset or `file://` to load a local PMTiles file.
 
-> Note: PMTiles sources currently do not support caching or offline pack downloads.
+> Note: PMTiles sources do not currently support offline pack downloads.
 
 Oliver Wipfli has made a style available that combines a [Protomaps]() basemap togehter with Foursquare's POI dataset. It is available in the [wipfli/foursquare-os-places-pmtiles](https://github.com/wipfli/foursquare-os-places-pmtiles) repository on GitHub. The style to use is
 

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -396,6 +396,70 @@ TEST(OfflineDatabase, PutTile) {
     EXPECT_EQ(0u, log.uncheckedCount());
 }
 
+// Resources that differ only by their byte range — e.g. PMTiles header vs. directory vs.
+// tile sub-requests against the same .pmtiles URL — must each occupy their own cache row
+// instead of overwriting one another. See https://github.com/maplibre/maplibre-native/issues/3690.
+TEST(OfflineDatabase, PutGetResourceWithDataRange) {
+    FixtureLog log;
+    OfflineDatabase db(":memory:", fixture::tileServerOptions);
+
+    Resource r1{Resource::Kind::Source, "https://example.com/x.pmtiles"};
+    r1.dataRange = std::make_pair<uint64_t, uint64_t>(0, 126);
+    Resource r2{Resource::Kind::Source, "https://example.com/x.pmtiles"};
+    r2.dataRange = std::make_pair<uint64_t, uint64_t>(200, 399);
+
+    Response resp1;
+    resp1.data = std::make_shared<std::string>("HEADER");
+    Response resp2;
+    resp2.data = std::make_shared<std::string>("DIR");
+
+    db.put(r1, resp1);
+    db.put(r2, resp2);
+
+    auto g1 = db.get(r1);
+    auto g2 = db.get(r2);
+    ASSERT_TRUE(g1);
+    ASSERT_TRUE(g2);
+    EXPECT_EQ("HEADER", *g1->data);
+    EXPECT_EQ("DIR", *g2->data);
+
+    // A query-string URL should still produce a distinct key per range.
+    Resource r3{Resource::Kind::Source, "https://example.com/y.pmtiles?token=abc"};
+    r3.dataRange = std::make_pair<uint64_t, uint64_t>(0, 126);
+    Response resp3;
+    resp3.data = std::make_shared<std::string>("Q_HEADER");
+    db.put(r3, resp3);
+    auto g3 = db.get(r3);
+    ASSERT_TRUE(g3);
+    EXPECT_EQ("Q_HEADER", *g3->data);
+
+    EXPECT_EQ(0u, log.uncheckedCount());
+}
+
+// A resource with no `dataRange` must still be stored and looked up under its bare URL,
+// so existing (non-PMTiles) sources keep round-tripping through the cache unchanged.
+TEST(OfflineDatabase, PutGetResourceWithoutDataRange) {
+    FixtureLog log;
+    OfflineDatabase db(":memory:", fixture::tileServerOptions);
+
+    Resource resource{Resource::Style, "https://example.com/style.json"};
+    Response response;
+    response.data = std::make_shared<std::string>("style-body");
+    db.put(resource, response);
+
+    auto got = db.get(resource);
+    ASSERT_TRUE(got);
+    EXPECT_EQ("style-body", *got->data);
+
+    // A ranged lookup against the same URL must miss — the bare entry and the ranged entry
+    // live under different keys.
+    Resource ranged{Resource::Style, "https://example.com/style.json"};
+    ranged.dataRange = std::make_pair<uint64_t, uint64_t>(0, 9);
+    EXPECT_FALSE(db.get(ranged));
+
+    EXPECT_EQ(0u, log.uncheckedCount());
+}
+
 TEST(OfflineDatabase, PutResourceNoContent) {
     FixtureLog log;
     OfflineDatabase db(":memory:", fixture::tileServerOptions);

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -409,8 +409,7 @@ TEST(OfflineDatabase, CacheKey) {
 
     Resource rangedWithQuery{Resource::Kind::Source, "https://example.com/x.pmtiles?token=abc"};
     rangedWithQuery.dataRange = std::make_pair<uint64_t, uint64_t>(200, 399);
-    EXPECT_EQ("https://example.com/x.pmtiles?token=abc&_mlnRange=200-399",
-              OfflineDatabase::cacheKey(rangedWithQuery));
+    EXPECT_EQ("https://example.com/x.pmtiles?token=abc&_mlnRange=200-399", OfflineDatabase::cacheKey(rangedWithQuery));
 }
 
 TEST(OfflineDatabase, PutResourceNoContent) {

--- a/test/storage/offline_database.test.cpp
+++ b/test/storage/offline_database.test.cpp
@@ -396,68 +396,21 @@ TEST(OfflineDatabase, PutTile) {
     EXPECT_EQ(0u, log.uncheckedCount());
 }
 
-// Resources that differ only by their byte range — e.g. PMTiles header vs. directory vs.
-// tile sub-requests against the same .pmtiles URL — must each occupy their own cache row
-// instead of overwriting one another. See https://github.com/maplibre/maplibre-native/issues/3690.
-TEST(OfflineDatabase, PutGetResourceWithDataRange) {
-    FixtureLog log;
-    OfflineDatabase db(":memory:", fixture::tileServerOptions);
+// Cache-key encoding for byte-range sources (eg. PMTiles). The range is appended
+// to the URL so distinct ranges occupy distinct cache rows under the resources
+// table's UNIQUE(url) constraint.
+TEST(OfflineDatabase, CacheKey) {
+    Resource bare{Resource::Kind::Source, "https://example.com/x.pmtiles"};
+    EXPECT_EQ("https://example.com/x.pmtiles", OfflineDatabase::cacheKey(bare));
 
-    Resource r1{Resource::Kind::Source, "https://example.com/x.pmtiles"};
-    r1.dataRange = std::make_pair<uint64_t, uint64_t>(0, 126);
-    Resource r2{Resource::Kind::Source, "https://example.com/x.pmtiles"};
-    r2.dataRange = std::make_pair<uint64_t, uint64_t>(200, 399);
+    Resource ranged{Resource::Kind::Source, "https://example.com/x.pmtiles"};
+    ranged.dataRange = std::make_pair<uint64_t, uint64_t>(0, 126);
+    EXPECT_EQ("https://example.com/x.pmtiles?_mlnRange=0-126", OfflineDatabase::cacheKey(ranged));
 
-    Response resp1;
-    resp1.data = std::make_shared<std::string>("HEADER");
-    Response resp2;
-    resp2.data = std::make_shared<std::string>("DIR");
-
-    db.put(r1, resp1);
-    db.put(r2, resp2);
-
-    auto g1 = db.get(r1);
-    auto g2 = db.get(r2);
-    ASSERT_TRUE(g1);
-    ASSERT_TRUE(g2);
-    EXPECT_EQ("HEADER", *g1->data);
-    EXPECT_EQ("DIR", *g2->data);
-
-    // A query-string URL should still produce a distinct key per range.
-    Resource r3{Resource::Kind::Source, "https://example.com/y.pmtiles?token=abc"};
-    r3.dataRange = std::make_pair<uint64_t, uint64_t>(0, 126);
-    Response resp3;
-    resp3.data = std::make_shared<std::string>("Q_HEADER");
-    db.put(r3, resp3);
-    auto g3 = db.get(r3);
-    ASSERT_TRUE(g3);
-    EXPECT_EQ("Q_HEADER", *g3->data);
-
-    EXPECT_EQ(0u, log.uncheckedCount());
-}
-
-// A resource with no `dataRange` must still be stored and looked up under its bare URL,
-// so existing (non-PMTiles) sources keep round-tripping through the cache unchanged.
-TEST(OfflineDatabase, PutGetResourceWithoutDataRange) {
-    FixtureLog log;
-    OfflineDatabase db(":memory:", fixture::tileServerOptions);
-
-    Resource resource{Resource::Style, "https://example.com/style.json"};
-    Response response;
-    response.data = std::make_shared<std::string>("style-body");
-    db.put(resource, response);
-
-    auto got = db.get(resource);
-    ASSERT_TRUE(got);
-    EXPECT_EQ("style-body", *got->data);
-
-    // A ranged lookup against the same URL must miss — the bare entry and the ranged entry
-    // live under different keys.
-    Resource ranged{Resource::Style, "https://example.com/style.json"};
-    ranged.dataRange = std::make_pair<uint64_t, uint64_t>(0, 9);
-    EXPECT_FALSE(db.get(ranged));
-
-    EXPECT_EQ(0u, log.uncheckedCount());
+    Resource rangedWithQuery{Resource::Kind::Source, "https://example.com/x.pmtiles?token=abc"};
+    rangedWithQuery.dataRange = std::make_pair<uint64_t, uint64_t>(200, 399);
+    EXPECT_EQ("https://example.com/x.pmtiles?token=abc&_mlnRange=200-399",
+              OfflineDatabase::cacheKey(rangedWithQuery));
 }
 
 TEST(OfflineDatabase, PutResourceNoContent) {

--- a/test/storage/pmtiles_file_source.test.cpp
+++ b/test/storage/pmtiles_file_source.test.cpp
@@ -124,6 +124,41 @@ TEST(PMTilesFileSource, CorruptGzipTile) {
     loop.run();
 }
 
+// Regression test for https://github.com/maplibre/maplibre-native/issues/3690 — the loading
+// method for PMTiles sub-requests changed from `Network` to `All` so that http(s)-hosted
+// archives flow through the ambient cache. The file:// path bypasses the cache by design,
+// so this test can only confirm that issuing the same tile twice still succeeds; a true
+// cache-hit assertion requires an http(s) PMTiles fixture and a mock server.
+TEST(PMTilesFileSource, RepeatedTileRequest) {
+    util::RunLoop loop;
+
+    PMTilesFileSource pmtiles(ResourceOptions::Default(), ClientOptions());
+
+    std::unique_ptr<AsyncRequest> req1;
+    std::unique_ptr<AsyncRequest> req2;
+
+    req1 = pmtiles.request(
+        Resource::tile(toAbsoluteURL("geography-class-png.pmtiles"), 1.0, 0, 0, 0, Tileset::Scheme::XYZ),
+        [&](Response res1) {
+            req1.reset();
+            ASSERT_EQ(nullptr, res1.error);
+            ASSERT_TRUE(res1.data.get());
+            const auto firstSize = res1.data->size();
+
+            req2 = pmtiles.request(
+                Resource::tile(toAbsoluteURL("geography-class-png.pmtiles"), 1.0, 0, 0, 0, Tileset::Scheme::XYZ),
+                [&, firstSize](Response res2) {
+                    req2.reset();
+                    EXPECT_EQ(nullptr, res2.error);
+                    ASSERT_TRUE(res2.data.get());
+                    EXPECT_EQ(firstSize, res2.data->size());
+                    loop.stop();
+                });
+        });
+
+    loop.run();
+}
+
 // An archive whose header flags tile_compression=GZIP but whose individual tiles are stored
 // without compression must be served without error (uncompressed bytes passed through as-is).
 TEST(PMTilesFileSource, UncompressedTile) {


### PR DESCRIPTION
### AI Usage Disclaimer
The changes in this PR were created by Claude Code (Opus 4.7, Extra High effort). The architectural implementation was created by a human (me).

---

### Description
This PR enables ambient caching for PMTile sources with as little disruption to other parts of the library as possible, and additionally the main goal being to avoid changing the SQLite schema.

To do this, the byte range of the HTTP requests is appended on the offline storage URL as a mock parameter, creating a synthetic unique key. Before beginning work on this feature, I verified that the current Maplibre Native implementation does not perform multi-tile/clustered requests.

### Noteworthy file changes
#### offline_database.cpp
- A `cacheKey()` helper is added that appends a `_mlnRange=` URL parameter if the queried resource has a data range. If it doesn't, it simply returns `resource.url` as before. Sites that previously used `resource.url` are now routed through this helper instead.

#### pmtiles_file_source.cpp
- Changed LoadingMethod to All across the board.
- Added early `return`s in `getHeader()` and `getMetadata()` cache checks. This seems to be an oversight with the original implementation since it didn't have caching anyway.
- Added a few guards.

### Testing
- I have verified that bazel compiles on macOS targeting iOS. I was not able to check Android due to the long build times.
- I have verified that the new feature works on an iOS simulator via the helper logs.
- I have included a couple of new tests to validate to cover the added logic.

Resolves #3690