### PR TITLE
[core] Fix buffer versioning

### DIFF
--- a/src/mbgl/vulkan/buffer_resource.cpp
+++ b/src/mbgl/vulkan/buffer_resource.cpp
@@ -188,6 +188,9 @@ void BufferResource::update(const void* newData, std::size_t updateSize, std::si
     uint8_t* data = static_cast<uint8_t*>(bufferAllocation->mappedBuffer) + getVulkanBufferOffset() + offset;
 
     if (memcmp(data, newData, updateSize) == 0) {
+        if (bufferWindowSize) {
+            bufferWindowVersions[context.getCurrentFrameResourceIndex()] = version;
+        }
         return;
     }
 
@@ -209,8 +212,7 @@ void BufferResource::update(const void* newData, std::size_t updateSize, std::si
     }
 
     if (bufferWindowSize) {
-        const auto frameIndex = context.getCurrentFrameResourceIndex();
-        bufferWindowVersions[frameIndex] = version;
+        bufferWindowVersions[context.getCurrentFrameResourceIndex()] = version;
     }
 }
 


### PR DESCRIPTION
Set buffer version to the latest when updating with the same content (`memcmp() == 0`) to avoid uploading the previous frame contents.
Possible fix for https://github.com/maplibre/maplibre-native/issues/4277