### PR TITLE
feat: specify layer/property that has a parse error when logging

### DIFF
--- a/src/mbgl/style/conversion/layer.cpp
+++ b/src/mbgl/style/conversion/layer.cpp
@@ -27,7 +27,7 @@ std::optional<Error> setPaintProperties(Layer& layer, const Convertible& value) 
         return std::nullopt;
     }
     if (!isObject(*paintValue)) {
-        return {{"paint must be an object"}};
+        return {{"layer '" + layer.getID() + "': paint must be an object"}};
     }
     return eachMember(*paintValue, [&](const std::string& k, const Convertible& v) { return layer.setProperty(k, v); });
 }
@@ -76,7 +76,7 @@ std::optional<std::unique_ptr<Layer>> Converter<std::unique_ptr<Layer>>::operato
     auto layoutValue = objectMember(value, "layout");
     if (layoutValue) {
         if (!isObject(*layoutValue)) {
-            error.message = "layout must be an object";
+            error.message = "layer '" + *id + "': layout must be an object";
             return std::nullopt;
         }
         auto error_ = eachMember(*layoutValue,

--- a/src/mbgl/style/layers/background_layer.cpp
+++ b/src/mbgl/style/layers/background_layer.cpp
@@ -216,7 +216,7 @@ Value BackgroundLayer::serialize() const {
 
 std::optional<Error> BackgroundLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
+    if (it == layerProperties.end()) return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 
     auto property = static_cast<Property>(it->second);
 
@@ -272,7 +272,7 @@ std::optional<Error> BackgroundLayer::setPropertyInternal(const std::string& nam
         return std::nullopt;
     }
 
-    return Error{"layer doesn't support this property"};
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty BackgroundLayer::getProperty(const std::string& name) const {

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -516,7 +516,7 @@ Value CircleLayer::serialize() const {
 
 std::optional<Error> CircleLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
+    if (it == layerProperties.end()) return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 
     auto property = static_cast<Property>(it->second);
 
@@ -678,7 +678,7 @@ std::optional<Error> CircleLayer::setPropertyInternal(const std::string& name, c
         return std::nullopt;
     }
 
-    return Error{"layer doesn't support this property"};
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty CircleLayer::getProperty(const std::string& name) const {

--- a/src/mbgl/style/layers/color_relief_layer.cpp
+++ b/src/mbgl/style/layers/color_relief_layer.cpp
@@ -181,7 +181,7 @@ Value ColorReliefLayer::serialize() const {
 
 std::optional<Error> ColorReliefLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
+    if (it == layerProperties.end()) return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 
     auto property = static_cast<Property>(it->second);
 
@@ -222,7 +222,7 @@ std::optional<Error> ColorReliefLayer::setPropertyInternal(const std::string& na
         return std::nullopt;
     }
 
-    return Error{"layer doesn't support this property"};
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty ColorReliefLayer::getProperty(const std::string& name) const {

--- a/src/mbgl/style/layers/custom_drawable_layer.cpp
+++ b/src/mbgl/style/layers/custom_drawable_layer.cpp
@@ -69,8 +69,8 @@ std::unique_ptr<Layer> CustomDrawableLayer::cloneRef(const std::string&) const {
 
 using namespace conversion;
 
-std::optional<Error> CustomDrawableLayer::setPropertyInternal(const std::string&, const Convertible&) {
-    return Error{"layer doesn't support this property"};
+std::optional<Error> CustomDrawableLayer::setPropertyInternal(const std::string& name, const Convertible&) {
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty CustomDrawableLayer::getProperty(const std::string&) const {

--- a/src/mbgl/style/layers/custom_layer.cpp
+++ b/src/mbgl/style/layers/custom_layer.cpp
@@ -36,8 +36,8 @@ std::unique_ptr<Layer> CustomLayer::cloneRef(const std::string&) const {
 
 using namespace conversion;
 
-std::optional<Error> CustomLayer::setPropertyInternal(const std::string&, const Convertible&) {
-    return Error{"layer doesn't support this property"};
+std::optional<Error> CustomLayer::setPropertyInternal(const std::string& name, const Convertible&) {
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty CustomLayer::getProperty(const std::string&) const {

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -411,7 +411,7 @@ Value FillExtrusionLayer::serialize() const {
 
 std::optional<Error> FillExtrusionLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
+    if (it == layerProperties.end()) return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 
     auto property = static_cast<Property>(it->second);
 
@@ -546,7 +546,7 @@ std::optional<Error> FillExtrusionLayer::setPropertyInternal(const std::string& 
         return std::nullopt;
     }
 
-    return Error{"layer doesn't support this property"};
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty FillExtrusionLayer::getProperty(const std::string& name) const {

--- a/src/mbgl/style/layers/fill_layer.cpp
+++ b/src/mbgl/style/layers/fill_layer.cpp
@@ -376,7 +376,7 @@ Value FillLayer::serialize() const {
 
 std::optional<Error> FillLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
+    if (it == layerProperties.end()) return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 
     auto property = static_cast<Property>(it->second);
 
@@ -496,7 +496,7 @@ std::optional<Error> FillLayer::setPropertyInternal(const std::string& name, con
         return std::nullopt;
     }
 
-    return Error{"layer doesn't support this property"};
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty FillLayer::getProperty(const std::string& name) const {

--- a/src/mbgl/style/layers/heatmap_layer.cpp
+++ b/src/mbgl/style/layers/heatmap_layer.cpp
@@ -288,7 +288,7 @@ Value HeatmapLayer::serialize() const {
 
 std::optional<Error> HeatmapLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
+    if (it == layerProperties.end()) return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 
     auto property = static_cast<Property>(it->second);
 
@@ -368,7 +368,7 @@ std::optional<Error> HeatmapLayer::setPropertyInternal(const std::string& name, 
         return std::nullopt;
     }
 
-    return Error{"layer doesn't support this property"};
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty HeatmapLayer::getProperty(const std::string& name) const {

--- a/src/mbgl/style/layers/hillshade_layer.cpp
+++ b/src/mbgl/style/layers/hillshade_layer.cpp
@@ -391,7 +391,7 @@ Value HillshadeLayer::serialize() const {
 
 std::optional<Error> HillshadeLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
+    if (it == layerProperties.end()) return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 
     auto property = static_cast<Property>(it->second);
 
@@ -516,7 +516,7 @@ std::optional<Error> HillshadeLayer::setPropertyInternal(const std::string& name
         return std::nullopt;
     }
 
-    return Error{"layer doesn't support this property"};
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty HillshadeLayer::getProperty(const std::string& name) const {

--- a/src/mbgl/style/layers/layer.cpp.ejs
+++ b/src/mbgl/style/layers/layer.cpp.ejs
@@ -296,7 +296,7 @@ Value <%- camelize(type) %>Layer::serialize() const {
 
 std::optional<Error> <%- camelize(type) %>Layer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
+    if (it == layerProperties.end()) return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 
     auto property = static_cast<Property>(it->second);
 
@@ -349,7 +349,7 @@ std::optional<Error> <%- camelize(type) %>Layer::setPropertyInternal(const std::
         return std::nullopt;
     }
 <% } %>
-    return Error{"layer doesn't support this property"};
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty <%- camelize(type) %>Layer::getProperty(const std::string& name) const {

--- a/src/mbgl/style/layers/line_layer.cpp
+++ b/src/mbgl/style/layers/line_layer.cpp
@@ -593,7 +593,7 @@ Value LineLayer::serialize() const {
 
 std::optional<Error> LineLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
+    if (it == layerProperties.end()) return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 
     auto property = static_cast<Property>(it->second);
 
@@ -794,7 +794,7 @@ std::optional<Error> LineLayer::setPropertyInternal(const std::string& name, con
         return std::nullopt;
     }
 
-    return Error{"layer doesn't support this property"};
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty LineLayer::getProperty(const std::string& name) const {

--- a/src/mbgl/style/layers/location_indicator_layer.cpp
+++ b/src/mbgl/style/layers/location_indicator_layer.cpp
@@ -519,7 +519,7 @@ Value LocationIndicatorLayer::serialize() const {
 
 std::optional<Error> LocationIndicatorLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
+    if (it == layerProperties.end()) return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 
     auto property = static_cast<Property>(it->second);
 
@@ -678,7 +678,7 @@ std::optional<Error> LocationIndicatorLayer::setPropertyInternal(const std::stri
         return std::nullopt;
     }
 
-    return Error{"layer doesn't support this property"};
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty LocationIndicatorLayer::getProperty(const std::string& name) const {

--- a/src/mbgl/style/layers/raster_layer.cpp
+++ b/src/mbgl/style/layers/raster_layer.cpp
@@ -391,7 +391,7 @@ Value RasterLayer::serialize() const {
 
 std::optional<Error> RasterLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
+    if (it == layerProperties.end()) return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 
     auto property = static_cast<Property>(it->second);
 
@@ -497,7 +497,7 @@ std::optional<Error> RasterLayer::setPropertyInternal(const std::string& name, c
         return std::nullopt;
     }
 
-    return Error{"layer doesn't support this property"};
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty RasterLayer::getProperty(const std::string& name) const {

--- a/src/mbgl/style/layers/symbol_layer.cpp
+++ b/src/mbgl/style/layers/symbol_layer.cpp
@@ -1419,7 +1419,7 @@ Value SymbolLayer::serialize() const {
 
 std::optional<Error> SymbolLayer::setPropertyInternal(const std::string& name, const Convertible& value) {
     const auto it = layerProperties.find(name.c_str());
-    if (it == layerProperties.end()) return Error{"layer doesn't support this property"};
+    if (it == layerProperties.end()) return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 
     auto property = static_cast<Property>(it->second);
 
@@ -1926,7 +1926,7 @@ std::optional<Error> SymbolLayer::setPropertyInternal(const std::string& name, c
         return std::nullopt;
     }
 
-    return Error{"layer doesn't support this property"};
+    return Error{"layer '" + getID() + "' doesn't support property '" + name + "'"};
 }
 
 StyleProperty SymbolLayer::getProperty(const std::string& name) const {

--- a/test/fixtures/style_parser/paint-nonobject.info.json
+++ b/test/fixtures/style_parser/paint-nonobject.info.json
@@ -1,7 +1,7 @@
 {
     "default": {
         "log": [
-            [1, "WARNING", "ParseStyle", "paint must be an object"]
+            [1, "WARNING", "ParseStyle", "layer 'background': paint must be an object"]
         ]
     }
 }


### PR DESCRIPTION
Earlier today, I was testing a new style in MapLibre Native. It worked fine in MapLibre GL JS, but some layers would be entirely missing in a native map. I saw these warnings in my Android logcat, but it was very difficult to work out which of the 30 layers and their many properties was the source.

I thought it would be helpful and easier to debug if these logs included details about which layer and which property caused the parse error.

C++ isn't a language I'm familiar with, so please tell me if I'm being stupid with any of my changes.