### PR TITLE
fix: accept single-color expressions for colorArray properties

### DIFF
--- a/src/mbgl/style/conversion/property_value.cpp
+++ b/src/mbgl/style/conversion/property_value.cpp
@@ -3,6 +3,10 @@
 #include <mbgl/style/conversion/rotation.hpp>
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/style/conversion.hpp>
+#include <mbgl/util/color.hpp>
+
+#include <type_traits>
+#include <vector>
 
 namespace mbgl {
 namespace style {
@@ -22,11 +26,32 @@ std::optional<PropertyValue<T>> Converter<PropertyValue<T>>::operator()(const Co
     std::optional<PropertyExpression<T>> expression;
 
     if (isExpression(value)) {
-        ParsingContext ctx(valueTypeToExpressionType<T>());
-        ParseResult parsed = ctx.parseLayerPropertyExpression(value);
-        if (!parsed) {
-            error.message = ctx.getCombinedErrors();
-            return std::nullopt;
+        ParseResult parsed;
+        if constexpr (std::is_same_v<T, std::vector<Color>>) {
+            // `colorArray` paint properties (hillshade-shadow-color and
+            // hillshade-highlight-color, promoted from `color` to `colorArray` in
+            // PR #3965 to support multidirectional hillshade) accept a single color
+            // value as their spec-default shape (defaults are "#000000" / "#FFFFFF").
+            // Try parsing as a single Color first; ValueConverter<std::vector<Color>>
+            // already wraps a single Color into a one-element vector at evaluation
+            // time. Fall back to array<color> for explicit multidirectional users.
+            ParsingContext colorCtx(type::Color);
+            parsed = colorCtx.parseLayerPropertyExpression(value);
+            if (!parsed) {
+                ParsingContext arrayCtx{type::Array(type::Color)};
+                parsed = arrayCtx.parseLayerPropertyExpression(value);
+                if (!parsed) {
+                    error.message = arrayCtx.getCombinedErrors();
+                    return std::nullopt;
+                }
+            }
+        } else {
+            ParsingContext ctx(valueTypeToExpressionType<T>());
+            parsed = ctx.parseLayerPropertyExpression(value);
+            if (!parsed) {
+                error.message = ctx.getCombinedErrors();
+                return std::nullopt;
+            }
         }
         expression = PropertyExpression<T>(std::move(*parsed));
     } else if (isObject(value)) {

--- a/src/mbgl/style/conversion/property_value.cpp
+++ b/src/mbgl/style/conversion/property_value.cpp
@@ -27,18 +27,13 @@ std::optional<PropertyValue<T>> Converter<PropertyValue<T>>::operator()(const Co
 
     if (isExpression(value)) {
         ParseResult parsed;
-        if constexpr (std::is_same_v<T, std::vector<Color>>) {
-            // `colorArray` paint properties (hillshade-shadow-color and
-            // hillshade-highlight-color, promoted from `color` to `colorArray` in
-            // PR #3965 to support multidirectional hillshade) accept a single color
-            // value as their spec-default shape (defaults are "#000000" / "#FFFFFF").
-            // Try parsing as a single Color first; ValueConverter<std::vector<Color>>
-            // already wraps a single Color into a one-element vector at evaluation
-            // time. Fall back to array<color> for explicit multidirectional users.
-            ParsingContext colorCtx(type::Color);
-            parsed = colorCtx.parseLayerPropertyExpression(value);
+        if constexpr (std::is_same_v<T, std::vector<Color>> || std::is_same_v<T, std::vector<float>>) {
+            using Element = typename T::value_type;
+            const auto scalarType = valueTypeToExpressionType<Element>();
+            ParsingContext scalarCtx(scalarType);
+            parsed = scalarCtx.parseLayerPropertyExpression(value);
             if (!parsed) {
-                ParsingContext arrayCtx{type::Array(type::Color)};
+                ParsingContext arrayCtx{type::Array(scalarType)};
                 parsed = arrayCtx.parseLayerPropertyExpression(value);
                 if (!parsed) {
                     error.message = arrayCtx.getCombinedErrors();

--- a/src/mbgl/style/expression/value.cpp
+++ b/src/mbgl/style/expression/value.cpp
@@ -258,6 +258,25 @@ std::optional<std::vector<T>> ValueConverter<std::vector<T>>::fromExpressionValu
         [&](const auto&) { return std::optional<std::vector<T>>(); });
 }
 
+template <>
+std::optional<std::vector<float>> ValueConverter<std::vector<float>>::fromExpressionValue(const Value& value) {
+    if (value.is<std::vector<Value>>()) {
+        const auto& values = value.get<std::vector<Value>>();
+        std::vector<float> result;
+        result.reserve(values.size());
+        for (const auto& v : values) {
+            auto num = ValueConverter<float>::fromExpressionValue(v);
+            if (!num) return std::nullopt;
+            result.push_back(*num);
+        }
+        return result;
+    }
+
+    auto num = ValueConverter<float>::fromExpressionValue(value);
+    if (!num) return std::nullopt;
+    return std::vector<float>{*num};
+}
+
 Value ValueConverter<Position>::toExpressionValue(const mbgl::style::Position& value) {
     return ValueConverter<std::array<float, 3>>::toExpressionValue(value.getSpherical());
 }

--- a/test/style/conversion/property_value.test.cpp
+++ b/test/style/conversion/property_value.test.cpp
@@ -2,7 +2,10 @@
 
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion/property_value.hpp>
+#include <mbgl/util/color.hpp>
 #include <mbgl/util/rapidjson.hpp>
+
+#include <vector>
 
 using namespace mbgl;
 using namespace mbgl::style;
@@ -19,4 +22,48 @@ TEST(StyleConversion, PropertyValue) {
     ASSERT_TRUE(result);
     ASSERT_TRUE(result->isConstant());
     ASSERT_EQ(result->asConstant(), expected);
+}
+
+// Regression: PR #3965 promoted hillshade-shadow-color and hillshade-highlight-color
+// from PaintProperty<Color> to PaintProperty<std::vector<Color>> to support
+// multidirectional hillshade. The style-spec types them as `colorArray` with
+// single-color defaults ("#000000" / "#FFFFFF"), and maplibre-gl-js accepts both
+// `color` and `array<color>` expression outputs for these properties.
+//
+// Before the fix in src/mbgl/style/conversion/property_value.cpp, parsing an
+// `interpolate` expression over single-color outputs against a
+// `PropertyValue<std::vector<Color>>` failed with
+// "Expected array<color> but found string instead." — breaking nearly every
+// published topographic basemap that animates hillshade color over zoom.
+
+TEST(StyleConversion, PropertyValueVectorColor_SingleColorInterpolate) {
+    Error error;
+    JSDocument doc;
+    doc.Parse<0>(R"(["interpolate", ["linear"], ["zoom"], 0, "#000000", 17, "#666666"])");
+    auto result = convert<PropertyValue<std::vector<Color>>>(doc, error, false, false);
+    ASSERT_TRUE(result) << "single-color interpolate must parse for colorArray properties: " << error.message;
+    ASSERT_TRUE(result->isExpression());
+}
+
+TEST(StyleConversion, PropertyValueVectorColor_MultidirectionalConstant) {
+    // Spec-defined multidirectional shape: a JSON array of color strings used as
+    // a constant. Flows through the non-expression conversion path; must still
+    // parse correctly after the single-color expression fallback was added.
+    Error error;
+    JSDocument doc;
+    doc.Parse<0>(R"(["#000000", "#222222"])");
+    auto result = convert<PropertyValue<std::vector<Color>>>(doc, error, false, false);
+    ASSERT_TRUE(result) << "multidirectional constant array<color> must parse: " << error.message;
+    ASSERT_TRUE(result->isConstant());
+    ASSERT_EQ(result->asConstant().size(), 2u);
+}
+
+TEST(StyleConversion, PropertyValueVectorColor_PlainColorConstant) {
+    Error error;
+    JSDocument doc;
+    doc.Parse<0>(R"("#222222")");
+    auto result = convert<PropertyValue<std::vector<Color>>>(doc, error, false, false);
+    ASSERT_TRUE(result) << "plain color constant must parse: " << error.message;
+    ASSERT_TRUE(result->isConstant());
+    ASSERT_EQ(result->asConstant().size(), 1u);
 }

--- a/test/style/conversion/property_value.test.cpp
+++ b/test/style/conversion/property_value.test.cpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/style/conversion/json.hpp>
 #include <mbgl/style/conversion/property_value.hpp>
+#include <mbgl/style/property_expression.hpp>
 #include <mbgl/util/color.hpp>
 #include <mbgl/util/rapidjson.hpp>
 
@@ -58,12 +59,76 @@ TEST(StyleConversion, PropertyValueVectorColor_MultidirectionalConstant) {
     ASSERT_EQ(result->asConstant().size(), 2u);
 }
 
-TEST(StyleConversion, PropertyValueVectorColor_PlainColorConstant) {
+// PR #3965 also promoted hillshade-illumination-direction and
+// hillshade-illumination-altitude from PaintProperty<float> to
+// PaintProperty<std::vector<float>>. The style-spec types them as `numberArray`
+// with single-number defaults (335 and 45). The same compile-time check that
+// broke colorArray expressions also rejects spec-valid single-number
+// interpolate expressions for these properties.
+
+TEST(StyleConversion, PropertyValueVectorFloat_SingleNumberInterpolate) {
     Error error;
     JSDocument doc;
-    doc.Parse<0>(R"("#222222")");
-    auto result = convert<PropertyValue<std::vector<Color>>>(doc, error, false, false);
-    ASSERT_TRUE(result) << "plain color constant must parse: " << error.message;
+    doc.Parse<0>(R"(["interpolate", ["linear"], ["zoom"], 0, 335, 17, 200])");
+    auto result = convert<PropertyValue<std::vector<float>>>(doc, error, false, false);
+    ASSERT_TRUE(result) << "single-number interpolate must parse for numberArray properties: " << error.message;
+    ASSERT_TRUE(result->isExpression());
+}
+
+TEST(StyleConversion, PropertyValueVectorFloat_MultidirectionalConstant) {
+    Error error;
+    JSDocument doc;
+    doc.Parse<0>(R"([335, 45])");
+    auto result = convert<PropertyValue<std::vector<float>>>(doc, error, false, false);
+    ASSERT_TRUE(result) << "multidirectional constant array<number> must parse: " << error.message;
     ASSERT_TRUE(result->isConstant());
-    ASSERT_EQ(result->asConstant().size(), 1u);
+    ASSERT_EQ(result->asConstant().size(), 2u);
+}
+
+// Evaluation smoke tests: a parse-time success isn't useful if the runtime
+// conversion path silently returns nullopt at every frame. These exercise the
+// ValueConverter<std::vector<X>>::fromExpressionValue wrap for scalar outputs.
+
+TEST(StyleConversion, PropertyValueVectorColor_SingleColorInterpolate_Evaluates) {
+    Error error;
+    JSDocument doc;
+    doc.Parse<0>(R"(["interpolate", ["linear"], ["zoom"], 0, "#000000", 10, "#FFFFFF"])");
+    auto result = convert<PropertyValue<std::vector<Color>>>(doc, error, false, false);
+    ASSERT_TRUE(result) << error.message;
+    ASSERT_TRUE(result->isExpression());
+
+    const auto& expr = result->asExpression();
+    auto v0 = expr.evaluate(0.0f);
+    ASSERT_EQ(v0.size(), 1u);
+    EXPECT_FLOAT_EQ(v0[0].r, 0.0f);
+    EXPECT_FLOAT_EQ(v0[0].g, 0.0f);
+    EXPECT_FLOAT_EQ(v0[0].b, 0.0f);
+
+    auto v10 = expr.evaluate(10.0f);
+    ASSERT_EQ(v10.size(), 1u);
+    EXPECT_FLOAT_EQ(v10[0].r, 1.0f);
+    EXPECT_FLOAT_EQ(v10[0].g, 1.0f);
+    EXPECT_FLOAT_EQ(v10[0].b, 1.0f);
+}
+
+TEST(StyleConversion, PropertyValueVectorFloat_SingleNumberInterpolate_Evaluates) {
+    Error error;
+    JSDocument doc;
+    doc.Parse<0>(R"(["interpolate", ["linear"], ["zoom"], 0, 335, 10, 200])");
+    auto result = convert<PropertyValue<std::vector<float>>>(doc, error, false, false);
+    ASSERT_TRUE(result) << error.message;
+    ASSERT_TRUE(result->isExpression());
+
+    const auto& expr = result->asExpression();
+    auto v0 = expr.evaluate(0.0f);
+    ASSERT_EQ(v0.size(), 1u);
+    EXPECT_FLOAT_EQ(v0[0], 335.0f);
+
+    auto v5 = expr.evaluate(5.0f);
+    ASSERT_EQ(v5.size(), 1u);
+    EXPECT_FLOAT_EQ(v5[0], 267.5f);
+
+    auto v10 = expr.evaluate(10.0f);
+    ASSERT_EQ(v10.size(), 1u);
+    EXPECT_FLOAT_EQ(v10[0], 200.0f);
 }


### PR DESCRIPTION
This is a fix for issue https://github.com/maplibre/maplibre-native/issues/4296. There's an overly restrictive validation step that is preventing animated hillshade layers from rendering (e.g. animating opacity during a zoom between levels).

AI Disclosure: I used AI to create the minimal reproduction & the fix here, I am confident it fixes the underlying issue (I've tested it on my personal device).

Repro of bug: https://gitlab.com/dts1/maplibre-native-hillshade-repro