### PR TITLE
fix(android): guard stale layer remove path

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -1154,11 +1154,20 @@ jni::jboolean NativeMapView::removeLayerAt(JNIEnv& env, jni::jint index) {
 /**
  * Remove with wrapper object id. Ownership is transferred back to the wrapper
  */
-jni::jboolean NativeMapView::removeLayer(JNIEnv&, jlong layerPtr) {
-    assert(layerPtr != 0);
+jni::jboolean NativeMapView::removeLayer(JNIEnv& env, jlong layerPtr) {
+    if (layerPtr == 0) {
+        Log::Warning(Event::JNI, "Cannot remove layer: native layer pointer is null");
+        return jni::jni_false;
+    }
 
     mbgl::android::Layer* layer = reinterpret_cast<mbgl::android::Layer*>(layerPtr);
-    std::unique_ptr<mbgl::style::Layer> coreLayer = map->getStyle().removeLayer(layer->get().getID());
+    const auto layerId = jni::Make<std::string>(env, layer->getId(env));
+    if (layerId.empty()) {
+        Log::Warning(Event::JNI, "Cannot remove layer: layer reference is detached or invalid");
+        return jni::jni_false;
+    }
+
+    std::unique_ptr<mbgl::style::Layer> coreLayer = map->getStyle().removeLayer(layerId);
     if (coreLayer) {
         layer->setLayer(std::move(coreLayer));
         return jni::jni_true;

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/NativeMapView.java
@@ -1000,7 +1000,17 @@ final class NativeMapView implements NativeMap {
     if (checkState("removeLayer")) {
       return false;
     }
-    return nativeRemoveLayer(layer.getNativePtr());
+    if (layer.isDetached()) {
+      Logger.w(TAG, "Ignoring removeLayer() call on detached layer reference.");
+      return false;
+    }
+
+    final long nativePtr = layer.getNativePtr();
+    if (nativePtr == 0L) {
+      Logger.w(TAG, "Ignoring removeLayer() call on released layer pointer.");
+      return false;
+    }
+    return nativeRemoveLayer(nativePtr);
   }
 
   @Override

--- a/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/testapp/style/RuntimeStyleTests.java
+++ b/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/testapp/style/RuntimeStyleTests.java
@@ -9,6 +9,7 @@ import androidx.test.espresso.ViewAction;
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
 
 import org.maplibre.android.style.layers.CannotAddLayerException;
+import org.maplibre.android.style.layers.BackgroundLayer;
 import org.maplibre.android.style.layers.CircleLayer;
 import org.maplibre.android.style.layers.FillLayer;
 import org.maplibre.android.style.layers.Layer;
@@ -22,6 +23,7 @@ import org.maplibre.android.style.sources.Source;
 import org.maplibre.android.style.sources.VectorSource;
 import org.maplibre.android.testapp.R;
 import org.maplibre.android.testapp.activity.EspressoTest;
+import org.maplibre.android.maps.Style;
 
 import org.hamcrest.Matcher;
 import org.junit.Assert;
@@ -297,6 +299,53 @@ public class RuntimeStyleTests extends EspressoTest {
       assertTrue(maplibreMap.getStyle().removeLayer(firstLayer.getId()));
 
       assertTrue(maplibreMap.getStyle().removeLayerAt(0));
+    });
+  }
+
+  @Test
+  public void testRemoveStaleLayerReferenceDoesNotCrash() {
+    validateTestSetup();
+    onView(withId(R.id.mapView)).perform(new BaseViewAction() {
+      @Override
+      public void perform(UiController uiController, View view) {
+        final Layer[] staleLayerHolder = new Layer[1];
+        final Throwable[] errorHolder = new Throwable[1];
+        final Boolean[] removeResultHolder = new Boolean[1];
+        final boolean[] finished = new boolean[] { false };
+
+        Style.Builder styleABuilder = new Style.Builder()
+            .withLayer(new BackgroundLayer("stale-layer-a")
+                .withProperties(PropertyFactory.backgroundColor(Color.BLUE)));
+        Style.Builder styleBBuilder = new Style.Builder()
+            .withLayer(new BackgroundLayer("style-b-background")
+                .withProperties(PropertyFactory.backgroundColor(Color.DKGRAY)));
+
+        maplibreMap.setStyle(styleABuilder, styleA -> {
+          staleLayerHolder[0] = styleA.getLayer("stale-layer-a");
+
+          maplibreMap.setStyle(styleBBuilder, styleB -> {
+            try {
+              removeResultHolder[0] = styleB.removeLayer(staleLayerHolder[0]);
+            } catch (Throwable error) {
+              errorHolder[0] = error;
+            } finally {
+              finished[0] = true;
+            }
+          });
+        });
+
+        long timeoutMs = 5000;
+        long startMs = System.currentTimeMillis();
+        while (!finished[0] && System.currentTimeMillis() - startMs < timeoutMs) {
+          uiController.loopMainThreadForAtLeast(50);
+        }
+
+        assertTrue("Style switch did not finish in time", finished[0]);
+        assertNotNull("Stale layer should have been captured", staleLayerHolder[0]);
+        assertNull("Removing stale layer reference should not throw", errorHolder[0]);
+        assertFalse("Removing stale layer reference should fail gracefully",
+            Boolean.TRUE.equals(removeResultHolder[0]));
+      }
     });
   }
 


### PR DESCRIPTION
This issue is found in Grab app recently, the root cause is if we can A Layer from AA style, then change the style to BB style, and call style .remove(ALayer), it will cause a crash.
The fix is made by cursor/codex 5.3, I have reproduced the issue and also verify the fix. Change includes:
- guard Android removeLayer(Layer) against detached/invalid layer references
- avoid stale-layer pointer dereference in native NativeMapView::removeLayer
- add instrumentation test for stale layer removal graceful failure (no crash)

The stacktrace we found is 
```
null pointer dereference: SIGSEGV  0x0000000000000008
#00 pc 0xc55ba0 libmaplibre.so (__aarch64_ldadd8_acq_rel) (BuildId: 5c075ee53873df222320b7021e9c60d97899e255)
#01 pc 0x5d518c libmaplibre.so (mbgl::android::Layer::get() [shared_ptr.h:110]) (BuildId: 5c075ee53873df222320b7021e9c60d97899e255)
#02 pc 0x570150 libmaplibre.so (mbgl::android::NativeMapView::removeLayer(_JNIEnv&, long) [native_map_view.cpp:1159]) (BuildId: 5c075ee53873df222320b7021e9c60d97899e255)
#03 pc 0x585bdc libmaplibre.so (auto jni::NativeMethodMaker<unsigned char (auto jni::NativePeerMemberFunctionMethod<unsigned char (mbgl::android::NativeMapView::*)(_JNIEnv&, long), &mbgl::android::NativeMapView::removeLayer(_JNIEnv&, long)>::operator()<mbgl::android::NativeMapView, mbgl::android::NativeMapView, void>(jni::Field<mbgl::android::NativeMapView, long> const&)::'lambda'(_JNIEnv&, jni::Object<mbgl::android::NativeMapView>&, long)::*)(_JNIEnv&, jni::Object<mbgl::android::NativeMapView>&, long) const>::operator()<auto jni::NativePeerMemberFunctionMethod<unsigned char (mbgl::android::NativeMapView::*)(_JNIEnv&, long), &mbgl::android::NativeMapView::removeLayer(_JNIEnv&, long)>::operator()<mbgl::android::NativeMapView, mbgl::android::NativeMapView, void>(jni::Field<mbgl::android::NativeMapView, long> const&)::'lambda'(_JNIEnv&, jni::Object<mbgl::android::NativeMapView>&, long)>(char const*, auto jni::NativePeerMemberFunctionMethod<unsigned char (mbgl::android::NativeMapView::*)(_JNIEnv&, long), &mbgl::android::NativeMapView::removeLayer(_JNIEnv&, long)>::operator()<mbgl::android::NativeMapView, mbgl::android::NativeMapView, void>(jni::Field<mbgl::android::NativeMapView, long> const&)::'lambda'(_JNIEnv&, jni::Object<mbgl::android::NativeMapView>&, long) const&)::'lambda'(_JNIEnv*, jni::jobject*, long)::__invoke(_JNIEnv*, jni::jobject*, long) [native_method.hpp:277]) (BuildId: 5c075ee53873df222320b7021e9c60d97899e255)
#04 pc 0x585c80 libmaplibre.so (auto auto jni::MakeNativeMethod<auto jni::NativeMethodMaker<unsigned char (auto jni::NativePeerMemberFunctionMethod<unsigned char (mbgl::android::NativeMapView::*)(_JNIEnv&, long), &mbgl::android::NativeMapView::removeLayer(_JNIEnv&, long)>::operator()<mbgl::android::NativeMapView, mbgl::android::NativeMapView, void>(jni::Field<mbgl::android::NativeMapView, long> const&)::'lambda'(_JNIEnv&, jni::Object<mbgl::android::NativeMapView>&, long)::*)(_JNIEnv&, jni::Object<mbgl::android::NativeMapView>&, long) const>::operator()<auto jni::NativePeerMemberFunctionMethod<unsigned char (mbgl::android::NativeMapView::*)(_JNIEnv&, long), &mbgl::android::NativeMapView::removeLayer(_JNIEnv&, long)>::operator()<mbgl::android::NativeMapView, mbgl::android::NativeMapView, void>(jni::Field<mbgl::android::NativeMapView, long> const&)::'lambda'(_JNIEnv&, jni::Object<mbgl::android::NativeMapView>&, long)>(char const*, auto jni::NativePeerMemberFunctionMethod<unsigned char (mbgl::android::NativeMapView::*)(_JNIEnv&, long), &mbgl::android::NativeMapView::removeLayer(_JNIEnv&, long)>::operator()<mbgl::android::NativeMapView, mbgl::android::NativeMapView, void>(jni::Field<mbgl::android::NativeMapView, long> const&)::'lambda'(_JNIEnv&, jni::Object<mbgl::android::NativeMapView>&, long) const&)::'lambda'(_JNIEnv*, jni::jobject*, long)>(char const*, char const*, auto jni::NativePeerMemberFunctionMethod<unsigned char (mbgl::android::NativeMapView::*)(_JNIEnv&, long), &mbgl::android::NativeMapView::removeLayer(_JNIEnv&, long)>::operator()<mbgl::android::NativeMapView, mbgl::android::NativeMapView, void>(jni::Field<mbgl::android::NativeMapView, long> const&)::'lambda'(_JNIEnv&, jni::Object<mbgl::android::NativeMapView>&, long) const&, std::__ndk1::enable_if<std::is_class<auto jni::NativePeerMemberFunctionMethod<unsigned char (mbgl::android::NativeMapView::*)(_JNIEnv&, long), &mbgl::android::NativeMapView::removeLayer(_JNIEnv&, long)>::operator()<mbgl::android::NativeMapView, mbgl::android::NativeMapView, void>(jni::Field<mbgl::android::NativeMapView, long> const&)::'lambda'(_JNIEnv&, jni::Object<mbgl::android::NativeMapView>&, long)>::value, void>::type*)::'lambda'(_JNIEnv*, auto...)::__invoke<jni::jobject*, long>(_JNIEnv*, auto...) [native_method.hpp:57]) (BuildId: 5c075ee53873df222320b7021e9c60d97899e255)
#05 pc 0x7549859e14
#06 pc 0x75403e57b0
#07 pc 0x2851f0 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#08 pc 0x3e1254 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#09 pc 0xa16ffc libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#10 pc 0xd36bc libc.so (BuildId: 88b933fc529619f5e58bc6d5510017ee)
#11 pc 0x3e26ac libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#12 pc 0x298f58 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#13 pc 0x298f68 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#14 pc 0x75e3a8 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#15 pc 0xa16ffc libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#16 pc 0x77609c libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#17 pc 0x203a14 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#18 pc 0xa16ffc libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#19 pc 0x2000fc libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#20 pc 0xa16ffc libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#21 pc 0x3d98e0 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#22 pc 0x746eb0 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#23 pc 0x74657c libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#24 pc 0x208cfc libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#25 pc 0x80d28c libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#26 pc 0x208cfc libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#27 pc 0x222378 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#28 pc 0x209cac libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#29 pc 0x2133bc libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#30 pc 0x208cfc libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#31 pc 0x2139bc libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#32 pc 0x218964 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#33 pc 0x2851f0 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#34 pc 0x3e70f0 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#35 pc 0xd36bc libc.so (BuildId: 88b933fc529619f5e58bc6d5510017ee)
#36 pc 0x3e26c8 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
#37 pc 0x677434 libart.so (BuildId: 1724d2edb620afb8c3e8c5ea6c61ac19)
```