### PR TITLE
core: clear vulkan allocator handle after destruction

### DIFF
--- a/src/mbgl/vulkan/renderer_backend.cpp
+++ b/src/mbgl/vulkan/renderer_backend.cpp
@@ -638,6 +638,7 @@ void RendererBackend::destroyResources() {
     commandPool.reset();
 
     vmaDestroyAllocator(allocator);
+    allocator = nullptr;
 
     usingSharedContext ? void(device.release()) : device.reset();
 


### PR DESCRIPTION
`RendererBackend::destroyResources()` destroys the VMA allocator but leaves the member pointing at the released allocator object. This isn't currently a problem as `destroyResources` is only called in the destructor, but if it ever gets called in another path it risks a use-after-free bug without this `= nullptr` patch.

Previously I thought I needed this PR to fix a bug in MLN-FFI, but I was chasing a red herring. Feel free to close or merge this minor defensive cleanup.