### PR TITLE
qt: clamp timer interval to INT_MAX ms

### DIFF
--- a/platform/qt/src/mbgl/timer.cpp
+++ b/platform/qt/src/mbgl/timer.cpp
@@ -3,10 +3,29 @@
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/timer.hpp>
 
+#include <algorithm>
+#include <limits>
 #include <memory>
 
 namespace mbgl {
 namespace util {
+
+namespace {
+// QTimer stores its millisecond interval in an int, so any value above
+// INT_MAX (~24.85 days) is clamped by Qt and produces a runtime warning:
+//   "QTimer::start: interval exceeds maximum allowed interval, it will be
+//    clamped to INT_MAX ms (about 24 days)."
+// MapLibre core can legitimately schedule timers far in the future, e.g.
+// when a tile arrives with a long-lived `Cache-Control: max-age=31536000`
+// (one year) header and the cache expiry timer is armed from it. Cap the
+// value here so Qt stays silent; anything beyond INT_MAX ms is effectively
+// "never fires" for any practical map session anyway.
+constexpr uint64_t kMaxIntervalMs = static_cast<uint64_t>(std::numeric_limits<int>::max());
+
+std::chrono::milliseconds clampInterval(uint64_t value) {
+    return std::chrono::milliseconds(std::min(value, kMaxIntervalMs));
+}
+} // namespace
 
 Timer::Impl::Impl() {
     timer.setTimerType(Qt::PreciseTimer);
@@ -18,7 +37,7 @@ void Timer::Impl::start(uint64_t timeout, uint64_t repeat_, std::function<void()
     callback = std::move(cb);
 
     timer.setSingleShot(true);
-    timer.start(static_cast<std::chrono::milliseconds>(timeout));
+    timer.start(clampInterval(timeout));
 }
 
 void Timer::Impl::stop() {
@@ -28,7 +47,7 @@ void Timer::Impl::stop() {
 void Timer::Impl::timerFired() {
     if (repeat) {
         timer.setSingleShot(false);
-        timer.start(static_cast<std::chrono::milliseconds>(repeat));
+        timer.start(clampInterval(repeat));
     }
 
     callback();


### PR DESCRIPTION
## Summary

`platform/qt/src/mbgl/timer.cpp` passes the requested `uint64_t` interval straight to `QTimer::start(std::chrono::milliseconds)`. Qt stores the interval in an `int`, so any value above `INT_MAX` ms (~24.85 days) is silently clamped by Qt **and** triggers a runtime warning:

```
QTimer::start: interval exceeds maximum allowed interval, it will be clamped to INT_MAX ms (about 24 days).
```

In practice, this fires every time a tile arrives with a long-lived `Cache-Control: max-age=31536000` (one year) header. That cache-control value is the default on most major basemap tile services (OpenStreetMap, OpenSeaMap, MapTiler, etc.), and MapLibre arms a cache-expiry timer from the header. So a typical map render or zoom produces 9–11 of these warnings in a row, polluting downstream Qt application logs.

## Fix

Clamp the requested interval to `INT_MAX` ms before handing it to Qt, in both call sites (`Timer::Impl::start` and the repeat path in `Timer::Impl::timerFired`). Anything beyond `INT_MAX` ms is already effectively "never fires" for any practical map session, so the runtime behaviour is unchanged from Qt's own clamp — just silent.

The clamp helper lives in an anonymous namespace inside `timer.cpp` so it stays a local implementation detail of the Qt platform timer.

## How to reproduce

1. Build any Qt application that embeds MapLibre Native (QMapLibre, custom integration, etc.).
2. Load a map style that pulls tiles from a server returning `Cache-Control: max-age=31536000` (Maptiler, OpenStreetMap, OpenSeaMap).
3. Pan or zoom — observe the warning burst in the application log immediately after each fresh tile fetch.

## Verification

- The patched Qt platform compiles cleanly (MSVC 2022, Qt 6.11).
- After rebuilding QMapLibre with this change and relinking the host app, the warning is gone on map render and zoom.
- No behavioural change: the only intervals affected are those already being clamped silently by Qt to the same value.