### PR TITLE
[core] Keep `BackendScope` and context valid when closing the thread pool

### DIFF
--- a/src/mbgl/vulkan/context.cpp
+++ b/src/mbgl/vulkan/context.cpp
@@ -68,8 +68,6 @@ Context::Context(RendererBackend& backend_)
 Context::~Context() noexcept {
     MBGL_VERIFY_THREAD(tid);
 
-    backend.getThreadPool().runRenderJobs(true /* closeQueue */);
-
     destroyResources();
 
     {

--- a/src/mbgl/vulkan/renderer_backend.cpp
+++ b/src/mbgl/vulkan/renderer_backend.cpp
@@ -634,6 +634,9 @@ void RendererBackend::initCommandPool() {
 void RendererBackend::destroyResources() {
     if (device) device->waitIdle(dispatcher);
 
+    gfx::BackendScope scope(*this, gfx::BackendScope::ScopeType::Implicit);
+    getThreadPool().runRenderJobs(true /* closeQueue */);
+
     context.reset();
     commandPool.reset();
 


### PR DESCRIPTION
Reordering a few lines to keep [RendererBackend::getContext](https://github.com/maplibre/maplibre-native/blob/9e11772fa809b7fea459f592b8d7c2503cf29f4e/src/mbgl/gfx/renderer_backend.cpp#L18) calls valid during cleanup.

Closes https://github.com/maplibre/maplibre-native/issues/4303.