### PR TITLE
Fix mlt and icu not included in the macOS amalgamation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
+- [macos] Fix `mlt-cpp` and `mbgl-vendor-icu` not being included in the amalgamation
 - [core] Fix memory access violation exception in vector_tile_data.cpp [#632](https://github.com/maplibre/maplibre-native/pull/632)
 - [iOS] Fix a bug where the compass was determined to be misplaced when hidden [#498](https://github.com/maplibre/maplibre-native/pull/498).
 - [core] `MaptilerFileSource` renamed to `MBTilesFileSource` [#198](https://github.com/maplibre/maplibre-native/pull/198).

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -167,6 +167,8 @@ if(MLN_CREATE_AMALGAMATION)
             $<TARGET_FILE:mbgl-vendor-csscolorparser>
             $<TARGET_FILE:mbgl-harfbuzz>
             $<TARGET_FILE:mbgl-vendor-parsedate>
+            $<TARGET_FILE:mbgl-vendor-icu>
+            $<TARGET_FILE:mlt-cpp>
             ${STATIC_LIBS}
     )
 


### PR DESCRIPTION
`mbgl-core` on Darwin links `mlt-cpp` and `mbgl-vendor-icu`, but neither was merged into the amalgamation on macOS.