### PR TITLE
core: Add source location fallback

### DIFF
--- a/bazel/core.bzl
+++ b/bazel/core.bzl
@@ -586,6 +586,7 @@ MLN_CORE_SOURCE = [
     "src/mbgl/util/quaternion.hpp",
     "src/mbgl/util/rapidjson.cpp",
     "src/mbgl/util/rapidjson.hpp",
+    "src/mbgl/util/source_location.hpp",
     "src/mbgl/util/std.hpp",
     "src/mbgl/util/stopwatch.cpp",
     "src/mbgl/util/stopwatch.hpp",

--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -235,7 +235,7 @@ std::optional<size_t> SymbolInstance::getDefaultHorizontalPlacedTextIndex() cons
 }
 
 #if MLN_SYMBOL_GUARDS
-bool SymbolInstance::check(const SourceLocation& source) const {
+bool SymbolInstance::check(const source_location& source) const {
     return !isFailed && check(check01, 1, source) && check(check02, 2, source) && check(check03, 3, source) &&
            check(check04, 4, source) && check(check05, 5, source) && check(check06, 6, source) &&
            check(check07, 7, source) && check(check08, 8, source) && check(check09, 9, source) &&
@@ -251,7 +251,7 @@ bool SymbolInstance::check(const SourceLocation& source) const {
 bool SymbolInstance::checkIndexes(std::size_t textCount,
                                   std::size_t iconSize,
                                   std::size_t sdfSize,
-                                  const SourceLocation& source) const {
+                                  const source_location& source) const {
     return !isFailed && checkIndex(placedRightTextIndex, textCount, source) &&
            checkIndex(placedCenterTextIndex, textCount, source) && checkIndex(placedLeftTextIndex, textCount, source) &&
            checkIndex(placedVerticalTextIndex, textCount, source) &&
@@ -260,12 +260,12 @@ bool SymbolInstance::checkIndexes(std::size_t textCount,
 }
 
 namespace {
-inline std::string locationSuffix(const SourceLocation& source) {
+inline std::string locationSuffix(const source_location& source) {
     return std::string(" from ") + source.function_name() + " (" + source.file_name() + ":" +
            util::toString(source.line()) + ")";
 }
 } // namespace
-bool SymbolInstance::check(std::uint64_t v, int n, const SourceLocation& source) const {
+bool SymbolInstance::check(std::uint64_t v, int n, const source_location& source) const {
     if (!isFailed && v != checkVal) {
         isFailed = true;
         Log::Error(Event::Crash,
@@ -275,7 +275,7 @@ bool SymbolInstance::check(std::uint64_t v, int n, const SourceLocation& source)
     return !isFailed;
 }
 
-bool SymbolInstance::checkKey(const SourceLocation& source) const {
+bool SymbolInstance::checkKey(const source_location& source) const {
     if (!isFailed && key.size() > 10000) { // largest observed value=62
         isFailed = true;
         Log::Error(Event::Crash,
@@ -286,7 +286,7 @@ bool SymbolInstance::checkKey(const SourceLocation& source) const {
 
 bool SymbolInstance::checkIndex(const std::optional<std::size_t>& index,
                                 std::size_t size,
-                                const SourceLocation& source) const {
+                                const source_location& source) const {
     if (index.has_value() && *index >= size) {
         isFailed = true;
         Log::Error(Event::Crash,

--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -235,7 +235,7 @@ std::optional<size_t> SymbolInstance::getDefaultHorizontalPlacedTextIndex() cons
 }
 
 #if MLN_SYMBOL_GUARDS
-bool SymbolInstance::check(const std::source_location& source) const {
+bool SymbolInstance::check(const SourceLocation& source) const {
     return !isFailed && check(check01, 1, source) && check(check02, 2, source) && check(check03, 3, source) &&
            check(check04, 4, source) && check(check05, 5, source) && check(check06, 6, source) &&
            check(check07, 7, source) && check(check08, 8, source) && check(check09, 9, source) &&
@@ -251,7 +251,7 @@ bool SymbolInstance::check(const std::source_location& source) const {
 bool SymbolInstance::checkIndexes(std::size_t textCount,
                                   std::size_t iconSize,
                                   std::size_t sdfSize,
-                                  const std::source_location& source) const {
+                                  const SourceLocation& source) const {
     return !isFailed && checkIndex(placedRightTextIndex, textCount, source) &&
            checkIndex(placedCenterTextIndex, textCount, source) && checkIndex(placedLeftTextIndex, textCount, source) &&
            checkIndex(placedVerticalTextIndex, textCount, source) &&
@@ -260,12 +260,12 @@ bool SymbolInstance::checkIndexes(std::size_t textCount,
 }
 
 namespace {
-inline std::string locationSuffix(const std::source_location& source) {
+inline std::string locationSuffix(const SourceLocation& source) {
     return std::string(" from ") + source.function_name() + " (" + source.file_name() + ":" +
            util::toString(source.line()) + ")";
 }
 } // namespace
-bool SymbolInstance::check(std::uint64_t v, int n, const std::source_location& source) const {
+bool SymbolInstance::check(std::uint64_t v, int n, const SourceLocation& source) const {
     if (!isFailed && v != checkVal) {
         isFailed = true;
         Log::Error(Event::Crash,
@@ -275,7 +275,7 @@ bool SymbolInstance::check(std::uint64_t v, int n, const std::source_location& s
     return !isFailed;
 }
 
-bool SymbolInstance::checkKey(const std::source_location& source) const {
+bool SymbolInstance::checkKey(const SourceLocation& source) const {
     if (!isFailed && key.size() > 10000) { // largest observed value=62
         isFailed = true;
         Log::Error(Event::Crash,
@@ -286,7 +286,7 @@ bool SymbolInstance::checkKey(const std::source_location& source) const {
 
 bool SymbolInstance::checkIndex(const std::optional<std::size_t>& index,
                                 std::size_t size,
-                                const std::source_location& source) const {
+                                const SourceLocation& source) const {
     if (index.has_value() && *index >= size) {
         isFailed = true;
         Log::Error(Event::Crash,

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -19,7 +19,7 @@
 #endif
 
 #if MLN_SYMBOL_GUARDS
-#define SYM_GUARD_LOC MBGL_CURRENT_SOURCE_LOCATION
+#define SYM_GUARD_LOC MLN_CURRENT_SOURCE_LOCATION
 #else
 #define SYM_GUARD_LOC \
     {                 \
@@ -116,11 +116,11 @@ public:
 
 #if MLN_SYMBOL_GUARDS
     /// Check all guard blocks
-    bool check(const SourceLocation&) const;
+    bool check(const source_location&) const;
     /// Check that an index is in the valid range
-    bool checkIndex(const std::optional<std::size_t>& index, std::size_t size, const SourceLocation&) const;
+    bool checkIndex(const std::optional<std::size_t>& index, std::size_t size, const source_location&) const;
     /// Check all indexes
-    bool checkIndexes(std::size_t textCount, std::size_t iconSize, std::size_t sdfSize, const SourceLocation&) const;
+    bool checkIndexes(std::size_t textCount, std::size_t iconSize, std::size_t sdfSize, const source_location&) const;
     /// Mark this item as failed (due to some external check) so that it cannot be used later
     void forceFail() const;
 #else
@@ -180,8 +180,8 @@ public:
 
 protected:
 #if MLN_SYMBOL_GUARDS
-    bool check(std::uint64_t v, int n, const SourceLocation&) const;
-    bool checkKey(const SourceLocation&) const;
+    bool check(std::uint64_t v, int n, const source_location&) const;
+    bool checkKey(const source_location&) const;
     void forceFailInternal(); // this is just to avoid warnings about the values never being set
 #else
     bool checkKey(std::string_view) const { return true; }

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -4,8 +4,9 @@
 #include <mbgl/text/collision_feature.hpp>
 #include <mbgl/style/layers/symbol_layer_properties.hpp>
 #include <mbgl/util/bitmask_operations.hpp>
+#include <mbgl/util/source_location.hpp>
 
-#include <source_location>
+#include <cstdint>
 
 #ifndef MLN_SYMBOL_GUARDS
 #define MLN_SYMBOL_GUARDS 1
@@ -17,32 +18,8 @@
 #define SYM_GUARD_VALUE(N)
 #endif
 
-// A temporary shim for partial C++20 support
 #if MLN_SYMBOL_GUARDS
-#ifdef __clang__
-#if __cplusplus <= 201703L || !__has_builtin(__builtin_source_location)
-namespace std {
-struct source_location {
-    const char* fileName_;
-    const char* functionName_;
-    unsigned line_;
-
-    constexpr uint_least32_t line() const noexcept { return line_; }
-    constexpr uint_least32_t column() const noexcept { return 0; }
-    constexpr const char* file_name() const noexcept { return fileName_; }
-    constexpr const char* function_name() const noexcept { return functionName_; }
-};
-} // namespace std
-#define SYM_GUARD_LOC                    \
-    std::source_location {               \
-        __FILE__, __FUNCTION__, __LINE__ \
-    }
-#else
-#define SYM_GUARD_LOC std::source_location::current()
-#endif
-#else
-#define SYM_GUARD_LOC std::source_location::current()
-#endif
+#define SYM_GUARD_LOC MBGL_CURRENT_SOURCE_LOCATION
 #else
 #define SYM_GUARD_LOC \
     {                 \
@@ -139,14 +116,11 @@ public:
 
 #if MLN_SYMBOL_GUARDS
     /// Check all guard blocks
-    bool check(const std::source_location&) const;
+    bool check(const SourceLocation&) const;
     /// Check that an index is in the valid range
-    bool checkIndex(const std::optional<std::size_t>& index, std::size_t size, const std::source_location&) const;
+    bool checkIndex(const std::optional<std::size_t>& index, std::size_t size, const SourceLocation&) const;
     /// Check all indexes
-    bool checkIndexes(std::size_t textCount,
-                      std::size_t iconSize,
-                      std::size_t sdfSize,
-                      const std::source_location&) const;
+    bool checkIndexes(std::size_t textCount, std::size_t iconSize, std::size_t sdfSize, const SourceLocation&) const;
     /// Mark this item as failed (due to some external check) so that it cannot be used later
     void forceFail() const;
 #else
@@ -206,8 +180,8 @@ public:
 
 protected:
 #if MLN_SYMBOL_GUARDS
-    bool check(std::uint64_t v, int n, const std::source_location&) const;
-    bool checkKey(const std::source_location&) const;
+    bool check(std::uint64_t v, int n, const SourceLocation&) const;
+    bool checkKey(const SourceLocation&) const;
     void forceFailInternal(); // this is just to avoid warnings about the values never being set
 #else
     bool checkKey(std::string_view) const { return true; }

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -71,7 +71,7 @@ public:
     const util::SimpleIdentity& getID() const { return bucketID; }
 
 #if MLN_SYMBOL_GUARDS
-    virtual bool check(SourceLocation) { return true; }
+    virtual bool check(source_location) { return true; }
 #else
     bool check(std::string_view = {}) { return true; }
 #endif

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -71,7 +71,7 @@ public:
     const util::SimpleIdentity& getID() const { return bucketID; }
 
 #if MLN_SYMBOL_GUARDS
-    virtual bool check(std::source_location) { return true; }
+    virtual bool check(SourceLocation) { return true; }
 #else
     bool check(std::string_view = {}) { return true; }
 #endif

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -235,7 +235,7 @@ SymbolInstanceReferences SymbolBucket::getSymbols(const std::optional<SortKeyRan
 }
 
 #if MLN_SYMBOL_GUARDS
-bool SymbolBucket::check(std::source_location source) {
+bool SymbolBucket::check(SourceLocation source) {
     if (text.vertices().elements() != text.dynamicVertices().elements() ||
         text.vertices().elements() != text.opacityVertices().elements() ||
         icon.vertices().elements() != icon.dynamicVertices().elements() ||

--- a/src/mbgl/renderer/buckets/symbol_bucket.cpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.cpp
@@ -235,7 +235,7 @@ SymbolInstanceReferences SymbolBucket::getSymbols(const std::optional<SortKeyRan
 }
 
 #if MLN_SYMBOL_GUARDS
-bool SymbolBucket::check(SourceLocation source) {
+bool SymbolBucket::check(source_location source) {
     if (text.vertices().elements() != text.dynamicVertices().elements() ||
         text.vertices().elements() != text.opacityVertices().elements() ||
         icon.vertices().elements() != icon.dynamicVertices().elements() ||

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -251,7 +251,7 @@ public:
     SymbolInstanceReferences getSymbols(const std::optional<SortKeyRange>& sortKeyRange = std::nullopt) const;
 
 #if MLN_SYMBOL_GUARDS
-    bool check(SourceLocation) override;
+    bool check(source_location) override;
 #endif
 
     static SymbolLayoutVertex layoutVertex(Point<float> labelAnchor,

--- a/src/mbgl/renderer/buckets/symbol_bucket.hpp
+++ b/src/mbgl/renderer/buckets/symbol_bucket.hpp
@@ -251,7 +251,7 @@ public:
     SymbolInstanceReferences getSymbols(const std::optional<SortKeyRange>& sortKeyRange = std::nullopt) const;
 
 #if MLN_SYMBOL_GUARDS
-    bool check(std::source_location) override;
+    bool check(SourceLocation) override;
 #endif
 
     static SymbolLayoutVertex layoutVertex(Point<float> labelAnchor,

--- a/src/mbgl/util/source_location.hpp
+++ b/src/mbgl/util/source_location.hpp
@@ -11,12 +11,12 @@
 namespace mbgl {
 
 #if defined(__cpp_lib_source_location) && __cpp_lib_source_location >= 201907L
-using SourceLocation = std::source_location;
-#define MBGL_CURRENT_SOURCE_LOCATION ::mbgl::SourceLocation::current()
+using source_location = std::source_location;
+#define MLN_CURRENT_SOURCE_LOCATION ::mbgl::source_location::current()
 #else
-class SourceLocation final {
+class source_location final {
 public:
-    constexpr SourceLocation(const char* fileName_ = "",
+    constexpr source_location(const char* fileName_ = "",
                              const char* functionName_ = "",
                              std::uint_least32_t line_ = 0) noexcept
         : fileName(fileName_),
@@ -33,8 +33,8 @@ private:
     const char* functionName;
     std::uint_least32_t lineNumber;
 };
-#define MBGL_CURRENT_SOURCE_LOCATION \
-    ::mbgl::SourceLocation {         \
+#define MLN_CURRENT_SOURCE_LOCATION  \
+    ::mbgl::source_location {        \
         __FILE__, __func__, __LINE__ \
     }
 #endif

--- a/src/mbgl/util/source_location.hpp
+++ b/src/mbgl/util/source_location.hpp
@@ -17,8 +17,8 @@ using source_location = std::source_location;
 class source_location final {
 public:
     constexpr source_location(const char* fileName_ = "",
-                             const char* functionName_ = "",
-                             std::uint_least32_t line_ = 0) noexcept
+                              const char* functionName_ = "",
+                              std::uint_least32_t line_ = 0) noexcept
         : fileName(fileName_),
           functionName(functionName_),
           lineNumber(line_) {}

--- a/src/mbgl/util/source_location.hpp
+++ b/src/mbgl/util/source_location.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdint>
+
+#if defined(__has_include)
+#if __has_include(<source_location>)
+#include <source_location>
+#endif
+#endif
+
+namespace mbgl {
+
+#if defined(__cpp_lib_source_location) && __cpp_lib_source_location >= 201907L
+using SourceLocation = std::source_location;
+#define MBGL_CURRENT_SOURCE_LOCATION ::mbgl::SourceLocation::current()
+#else
+class SourceLocation final {
+public:
+    constexpr SourceLocation(const char* fileName_ = "",
+                             const char* functionName_ = "",
+                             std::uint_least32_t line_ = 0) noexcept
+        : fileName(fileName_),
+          functionName(functionName_),
+          lineNumber(line_) {}
+
+    constexpr std::uint_least32_t line() const noexcept { return lineNumber; }
+    constexpr std::uint_least32_t column() const noexcept { return 0; }
+    constexpr const char* file_name() const noexcept { return fileName; }
+    constexpr const char* function_name() const noexcept { return functionName; }
+
+private:
+    const char* fileName;
+    const char* functionName;
+    std::uint_least32_t lineNumber;
+};
+#define MBGL_CURRENT_SOURCE_LOCATION \
+    ::mbgl::SourceLocation {         \
+        __FILE__, __func__, __LINE__ \
+    }
+#endif
+
+} // namespace mbgl


### PR DESCRIPTION
To support https://github.com/maplibre/maplibre-native/pull/4315, I added a fallback source location helper.

OpenHarmony's build environment lacks the `<source_location>` header. We previously had "A temporary shim for partial C++20 support" that patched the struct into the `std` namespace ([which is undefined behavior)](https://timsong-cpp.github.io/cppwp/n3337/namespace.std), but even that wasn't sufficient as the header itself was included unconditionally.

Here I replace that shim with a custom `mbgl::SourceLocation`, which aliases to `std::source_location` when available and falls back to file/function/line otherwise.

Coded with Codex CLI / GPT-5.5 as part of #4315; see that PR for AI usage details.