### PR TITLE
core: Update Vulkan headers

### DIFF
--- a/include/mbgl/vulkan/renderer_backend.hpp
+++ b/include/mbgl/vulkan/renderer_backend.hpp
@@ -31,6 +31,11 @@ class ProgramParameters;
 
 namespace vulkan {
 
+using DynamicLoader = vk::detail::DynamicLoader;
+using DispatchLoaderDynamic = VULKAN_HPP_DISPATCH_LOADER_DYNAMIC_TYPE;
+template <typename OwnerType>
+using ObjectDestroy = vk::detail::ObjectDestroy<OwnerType, DispatchLoaderDynamic>;
+
 class RendererBackend : public gfx::RendererBackend {
 public:
     RendererBackend(gfx::ContextMode);
@@ -40,7 +45,7 @@ public:
     void initShaders(gfx::ShaderRegistry&, const ProgramParameters& programParameters) override;
     void init();
 
-    const vk::DispatchLoaderDynamic& getDispatcher() const { return dispatcher; }
+    const DispatchLoaderDynamic& getDispatcher() const { return dispatcher; }
     const vk::UniqueInstance& getInstance() const { return instance; }
     const vk::PhysicalDevice& getPhysicalDevice() const { return physicalDevice; }
     const vk::UniqueDevice& getDevice() const { return device; }
@@ -97,8 +102,8 @@ protected:
     void destroyResources();
 
 protected:
-    vk::DynamicLoader dynamicLoader;
-    vk::DispatchLoaderDynamic dispatcher;
+    DynamicLoader dynamicLoader;
+    DispatchLoaderDynamic dispatcher;
 
     vk::UniqueInstance instance;
     vk::UniqueDebugUtilsMessengerEXT debugUtilsCallback;

--- a/platform/glfw/glfw_vulkan_backend.cpp
+++ b/platform/glfw/glfw_vulkan_backend.cpp
@@ -82,7 +82,6 @@ public:
             return device.get();
         }
 
-        const std::vector<const char*> layers = {"VK_LAYER_KHRONOS_validation"};
         const std::vector<const char*> extensions = {
             VK_KHR_SWAPCHAIN_EXTENSION_NAME,
 #ifdef __APPLE__
@@ -93,10 +92,8 @@ public:
         float queuePriority = 1.0f;
         vk::DeviceQueueCreateInfo queueCreateInfo(vk::DeviceQueueCreateFlags(), getQueueIndex(), 1, &queuePriority);
 
-        auto createInfo = vk::DeviceCreateInfo()
-                              .setQueueCreateInfos(queueCreateInfo)
-                              .setPEnabledExtensionNames(extensions)
-                              .setPEnabledLayerNames(layers);
+        auto createInfo =
+            vk::DeviceCreateInfo().setQueueCreateInfos(queueCreateInfo).setPEnabledExtensionNames(extensions);
 
         device = physicalDevice.createDeviceUnique(createInfo, nullptr, dispatcher);
         dispatcher.init(device.get());
@@ -107,8 +104,8 @@ public:
     uint32_t getQueueIndex() { return graphicsQueueIndex; }
 
 private:
-    vk::DynamicLoader dynamicLoader;
-    vk::DispatchLoaderDynamic dispatcher;
+    mbgl::vulkan::DynamicLoader dynamicLoader;
+    mbgl::vulkan::DispatchLoaderDynamic dispatcher;
 
     vk::UniqueInstance instance;
     vk::PhysicalDevice physicalDevice;
@@ -136,7 +133,7 @@ public:
         if (result != VK_SUCCESS) throw std::runtime_error("Failed to create glfw window surface");
 
         surface = vk::UniqueSurfaceKHR(surface_,
-                                       vk::ObjectDestroy<vk::Instance, vk::DispatchLoaderDynamic>(
+                                       mbgl::vulkan::ObjectDestroy<vk::Instance>(
                                            backendImpl.getInstance().get(), nullptr, backendImpl.getDispatcher()));
     }
 
@@ -190,7 +187,7 @@ void GLFWVulkanBackend::initInstance() {
 
     // this method is required to set `instance` to a valid vkInstance
     instance = vk::UniqueInstance(VkContext::shared().getInstance(),
-                                  vk::ObjectDestroy<vk::NoParent, vk::DispatchLoaderDynamic>(nullptr, dispatcher));
+                                  mbgl::vulkan::ObjectDestroy<vk::NoParent>(nullptr, dispatcher));
 
     // debug builds also require:
     // - enabling either `VK_EXT_debug_utils` (and updating `debugUtilsEnabled`) or `VK_EXT_debug_report` extension
@@ -207,7 +204,7 @@ void GLFWVulkanBackend::initDevice() {
 
     physicalDevice = VkContext::shared().getPhysicalDevice();
     device = vk::UniqueDevice(VkContext::shared().getDevice(),
-                              vk::ObjectDestroy<vk::NoParent, vk::DispatchLoaderDynamic>(nullptr, dispatcher));
+                              mbgl::vulkan::ObjectDestroy<vk::NoParent>(nullptr, dispatcher));
 
     graphicsQueueIndex = presentQueueIndex = VkContext::shared().getQueueIndex();
     physicalDeviceFeatures = vk::PhysicalDeviceFeatures();

--- a/src/mbgl/vulkan/renderer_backend.cpp
+++ b/src/mbgl/vulkan/renderer_backend.cpp
@@ -271,26 +271,26 @@ void RendererBackend::triggerFrameCapture([[maybe_unused]] uint32_t frameCount, 
 
 #ifdef ENABLE_VULKAN_VALIDATION
 
-static VKAPI_ATTR VkBool32 VKAPI_CALL vkDebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
-                                                           VkDebugUtilsMessageTypeFlagsEXT,
-                                                           const VkDebugUtilsMessengerCallbackDataEXT* callbackData,
-                                                           void*) {
+static VKAPI_ATTR vk::Bool32 VKAPI_CALL vkDebugUtilsCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
+                                                             vk::DebugUtilsMessageTypeFlagsEXT,
+                                                             const vk::DebugUtilsMessengerCallbackDataEXT* callbackData,
+                                                             void*) {
     EventSeverity mbglSeverity = EventSeverity::Debug;
 
     switch (messageSeverity) {
-        case VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT:
+        case vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose:
             mbglSeverity = EventSeverity::Debug;
             break;
 
-        case VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT:
+        case vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo:
             mbglSeverity = EventSeverity::Info;
             break;
 
-        case VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT:
+        case vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning:
             mbglSeverity = EventSeverity::Warning;
             break;
 
-        case VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT:
+        case vk::DebugUtilsMessageSeverityFlagBitsEXT::eError:
             mbglSeverity = EventSeverity::Error;
             break;
 
@@ -303,25 +303,25 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL vkDebugUtilsCallback(VkDebugUtilsMessageSe
     return VK_FALSE;
 }
 
-static VKAPI_ATTR VkBool32 vkDebugReportCallback(VkDebugReportFlagsEXT flags,
-                                                 VkDebugReportObjectTypeEXT objectType,
-                                                 [[maybe_unused]] uint64_t object,
-                                                 [[maybe_unused]] size_t location,
-                                                 int32_t messageCode,
-                                                 const char* pLayerPrefix,
-                                                 const char* pMessage,
-                                                 [[maybe_unused]] void* pUserData) {
+static VKAPI_ATTR vk::Bool32 VKAPI_CALL vkDebugReportCallback(vk::DebugReportFlagsEXT flags,
+                                                              vk::DebugReportObjectTypeEXT objectType,
+                                                              [[maybe_unused]] uint64_t object,
+                                                              [[maybe_unused]] size_t location,
+                                                              int32_t messageCode,
+                                                              const char* pLayerPrefix,
+                                                              const char* pMessage,
+                                                              [[maybe_unused]] void* pUserData) {
     EventSeverity mbglSeverity = EventSeverity::Debug;
 
-    if (flags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT) {
+    if (flags & vk::DebugReportFlagBitsEXT::eInformation) {
         mbglSeverity = EventSeverity::Info;
-    } else if (flags & VK_DEBUG_REPORT_WARNING_BIT_EXT) {
+    } else if (flags & vk::DebugReportFlagBitsEXT::eWarning) {
         mbglSeverity = EventSeverity::Warning;
-    } else if (flags & VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT) {
+    } else if (flags & vk::DebugReportFlagBitsEXT::ePerformanceWarning) {
         mbglSeverity = EventSeverity::Warning;
-    } else if (flags & VK_DEBUG_REPORT_ERROR_BIT_EXT) {
+    } else if (flags & vk::DebugReportFlagBitsEXT::eError) {
         mbglSeverity = EventSeverity::Error;
-    } else if (flags & VK_DEBUG_REPORT_DEBUG_BIT_EXT) {
+    } else if (flags & vk::DebugReportFlagBitsEXT::eDebug) {
         mbglSeverity = EventSeverity::Debug;
     }
 
@@ -507,7 +507,6 @@ void RendererBackend::initAllocator() {
 
 void RendererBackend::initDevice() {
     const auto& extensions = getDeviceExtensions();
-    const auto& layers = getLayers();
     const auto& surface = getDefaultRenderable().getResource<SurfaceRenderableResource>().getPlatformSurface().get();
 
     const auto& isPhysicalDeviceCompatible = [&](const vk::PhysicalDevice& candidate) -> bool {
@@ -600,9 +599,6 @@ void RendererBackend::initDevice() {
                           .setQueueCreateInfos(queueCreateInfos)
                           .setPEnabledExtensionNames(extensions)
                           .setPEnabledFeatures(&physicalDeviceFeatures);
-
-    // this is not needed for newer implementations
-    createInfo.setPEnabledLayerNames(layers);
 
     device = physicalDevice.createDeviceUnique(createInfo, nullptr, dispatcher);
 }


### PR DESCRIPTION
To support https://github.com/maplibre/maplibre-native/pull/4315, I updated the Vulkan-Headers submodule to the latest v1.4.x patch to get the official VK_OHOS_surface declarations.

This required dealing with some deprecations, as we were previously on v1.3.x. My understanding is this upgrade doesn't have significant runtime or compatibility implications on our other targets, but I'm not at all an expert here—please check me.

Coded with Codex CLI / GPT-5.5 as part of #4315; see that PR for AI usage details.