### PR TITLE
core: Enable Vulkan surface transforms by capability

### DIFF
--- a/src/mbgl/vulkan/renderable_resource.cpp
+++ b/src/mbgl/vulkan/renderable_resource.cpp
@@ -265,11 +265,7 @@ const vk::Semaphore& SurfaceRenderableResource::getPresentSemaphore() const {
 }
 
 bool SurfaceRenderableResource::hasSurfaceTransformSupport() const {
-#ifdef __ANDROID__
     return surface && capabilities.supportedTransforms != vk::SurfaceTransformFlagBitsKHR::eIdentity;
-#else
-    return false;
-#endif
 }
 
 bool SurfaceRenderableResource::didSurfaceTransformUpdate() const {


### PR DESCRIPTION
When working on #4315, I noticed when the device was rotated to portrait, tile clipping on vector layers was broken because the surface reported a transform, but we had hardcoded `false` here on non-android platforms.

Rather than expand "if android" to "if android or openharmony", I think the right fix is to trust the capabilities reported by the device. If that's wrong on some device, we should work around for that target, rather than making capability detected the exception.

I check the git blame and didn't find any particular reason to hardcode false for non-android targets.

Explored with GPT-5.5 / Codex CLI, but this patch was coded by me because I didn't like the AI's workaround (expand the ifdef guard, add defensive call in getRotation)