### PR TITLE
core: Fix specialized location indicator puck scaling

### DIFF
--- a/src/mbgl/renderer/layers/render_location_indicator_layer.cpp
+++ b/src/mbgl/renderer/layers/render_location_indicator_layer.cpp
@@ -706,7 +706,7 @@ protected:
         Point<double> verticalShift = hatShadowShiftVector(params.puckPosition, params);
         const float horizontalScaleFactor =
             (1.0f - params.perspectiveCompensation) +
-            util::clamp(pixelSizeToWorldSizeH(params.puckPosition, s), 0.8f, 100.1f) *
+            util::clamp(pixelSizeToWorldSizeH(params.puckPosition, s), 0.8f, 10.1f) *
                 params.perspectiveCompensation; // Compensation factor for the perspective deformation
         //     ^ clamping this to 0.8 to avoid growing the puck too much close to the camera.
 

--- a/src/mbgl/renderer/layers/render_location_indicator_layer.cpp
+++ b/src/mbgl/renderer/layers/render_location_indicator_layer.cpp
@@ -466,7 +466,7 @@ public:
                 textureInfo.assign(*sharedImage);
                 updated = true;
             }
-        } else if (textureInfo.image) {
+        } else if (textureInfo.image || textureInfo.texture) {
             textureInfo.reset();
             updated = true;
         }


### PR DESCRIPTION
Fix puck scaling behavior in the specialized location layer. In navigation scenarios, particularly with a tilted map when the puck moves in and out of the viewport, the puck could scale excessively and eventually grow large enough to cover most of the map.

<img width="300" alt="Screenshot_20260603_163156" src="https://github.com/user-attachments/assets/8cb23d6a-bee0-4dc1-9a40-52ca10992077" />

[Video (bottom map)](https://github.com/user-attachments/assets/565996ae-da15-4be0-b3b8-2e322e313281)
