### PR TITLE
replace node-pre-gyp-github with gh release

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -279,7 +279,7 @@ jobs:
 
   publish_npm:
     runs-on: ubuntu-latest
-    needs: publish_binaries
+    needs: [publish_binaries, release-check]
     defaults:
       run:
         shell: bash
@@ -295,12 +295,6 @@ jobs:
           node-version-file: 'platform/node/.nvmrc'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Get version
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b # v1.3.1
-        with:
-          path: platform/node
-
       - name: npm ci
         working-directory: platform/node
         run: npm ci --ignore-scripts
@@ -309,7 +303,7 @@ jobs:
         id: prepare_release
         working-directory: platform/node
         run: |
-          RELEASE_TYPE="$(node -e "console.log(require('semver').prerelease('${{ steps.package-version.outputs.current-version }}') ? 'prerelease' : 'regular')")"
+          RELEASE_TYPE="$(node -e "console.log(require('semver').prerelease('${{ needs.release-check.outputs.version }}') ? 'prerelease' : 'regular')")"
           if [[ $RELEASE_TYPE == 'regular' ]]; then
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           else
@@ -319,7 +313,7 @@ jobs:
       - name: Extract changelog for version
         working-directory: platform/node
         run: |
-          awk -v ver="## ${{ steps.package-version.outputs.current-version }}" 'BEGIN{p=0} $0==ver{p=1; next} /^## / && p==1{exit} p==1{print}' CHANGELOG.md > changelog_for_version.md
+          awk -v ver="## ${{ needs.release-check.outputs.version }}" 'BEGIN{p=0} $0==ver{p=1; next} /^## / && p==1{exit} p==1{print}' CHANGELOG.md > changelog_for_version.md
           cat changelog_for_version.md
 
       - name: Update Release Notes
@@ -328,8 +322,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag: node-v${{ steps.package-version.outputs.current-version }}
-          name: node-v${{ steps.package-version.outputs.current-version }}
+          tag: node-v${{ needs.release-check.outputs.version }}
+          name: node-v${{ needs.release-check.outputs.version }}
           bodyFile: platform/node/changelog_for_version.md
           allowUpdates: true
           draft: true

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Check if prerelease
         id: prerelease-check
         run: |
-          if [[ "${{ needs.release-check.outputs.version }}" == *"-"* ]]; then
+          version="${{ needs.release-check.outputs.version }}"
+          if [[ "$version" == *-* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -34,10 +34,12 @@ jobs:
           currentVersion="$( node -e "console.log(require('./package.json').version)" )"
           isPublished="$( npm view "$packageName" versions --json | jq -c --arg cv "$currentVersion" 'any(. == $cv)' )"
           echo "published=$isPublished" >> "$GITHUB_OUTPUT"
+          echo "version=$currentVersion" >> "$GITHUB_OUTPUT"
           echo "currentVersion: $currentVersion"
           echo "isPublished: $isPublished"
     outputs:
       published: ${{ steps.check.outputs.published }}
+      version: ${{ steps.check.outputs.version }}
 
   create_release:
     name: Create draft release
@@ -48,20 +50,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
-        with:
-          persist-credentials: false
-
-      - name: Get version
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b # v1.3.1
-        with:
-          path: platform/node
-
       - name: Check if prerelease
         id: prerelease-check
         run: |
-          if [[ "${{ steps.package-version.outputs.current-version }}" == *"-"* ]]; then
+          if [[ "${{ needs.release-check.outputs.version }}" == *"-"* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
@@ -70,8 +62,8 @@ jobs:
       - name: Create draft release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          tag: node-v${{ steps.package-version.outputs.current-version }}
-          name: node-v${{ steps.package-version.outputs.current-version }}
+          tag: node-v${{ needs.release-check.outputs.version }}
+          name: node-v${{ needs.release-check.outputs.version }}
           draft: true
           allowUpdates: true
           prerelease: ${{ steps.prerelease-check.outputs.prerelease }}

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -39,8 +39,47 @@ jobs:
     outputs:
       published: ${{ steps.check.outputs.published }}
 
-  publish_binaries:
+  create_release:
+    name: Create draft release
     needs: release-check
+    if: ${{ needs.release-check.outputs.published == 'false' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
+
+      - name: Get version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b # v1.3.1
+        with:
+          path: platform/node
+
+      - name: Check if prerelease
+        id: prerelease-check
+        run: |
+          if [[ "${{ steps.package-version.outputs.current-version }}" == *"-"* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create draft release
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+        with:
+          tag: node-v${{ steps.package-version.outputs.current-version }}
+          name: node-v${{ steps.package-version.outputs.current-version }}
+          draft: true
+          allowUpdates: true
+          prerelease: ${{ steps.prerelease-check.outputs.prerelease }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish_binaries:
+    needs: [release-check, create_release]
     if: ${{ needs.release-check.outputs.published == 'false' }}
     runs-on: ${{ matrix.runs-on }}
     permissions:
@@ -232,7 +271,7 @@ jobs:
         env:
           PUBLISH: true
           BUILDTYPE: RelWithDebInfo
-          NODE_PRE_GYP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./scripts/publish.sh
 
@@ -242,7 +281,7 @@ jobs:
         env:
           PUBLISH: true
           BUILDTYPE: RelWithDebInfo
-          NODE_PRE_GYP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./scripts/publish.sh --target_arch=arm64
 

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -50,6 +50,10 @@ jobs:
       run:
         shell: bash
     steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
+
       - name: Check if prerelease
         id: prerelease-check
         run: |
@@ -60,11 +64,18 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Extract changelog for version
+        working-directory: platform/node
+        run: |
+          awk -v ver="## ${{ needs.release-check.outputs.version }}" 'BEGIN{p=0} $0==ver{p=1; next} /^## / && p==1{exit} p==1{print}' CHANGELOG.md > changelog_for_version.md
+          cat changelog_for_version.md
+
       - name: Create draft release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: node-v${{ needs.release-check.outputs.version }}
           name: node-v${{ needs.release-check.outputs.version }}
+          bodyFile: platform/node/changelog_for_version.md
           draft: true
           allowUpdates: true
           prerelease: ${{ steps.prerelease-check.outputs.prerelease }}
@@ -302,33 +313,13 @@ jobs:
 
       - name: Prepare release
         id: prepare_release
-        working-directory: platform/node
         run: |
-          RELEASE_TYPE="$(node -e "console.log(require('semver').prerelease('${{ needs.release-check.outputs.version }}') ? 'prerelease' : 'regular')")"
-          if [[ $RELEASE_TYPE == 'regular' ]]; then
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-          else
+          version="${{ needs.release-check.outputs.version }}"
+          if [[ "$version" == *-* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Extract changelog for version
-        working-directory: platform/node
-        run: |
-          awk -v ver="## ${{ needs.release-check.outputs.version }}" 'BEGIN{p=0} $0==ver{p=1; next} /^## / && p==1{exit} p==1{print}' CHANGELOG.md > changelog_for_version.md
-          cat changelog_for_version.md
-
-      - name: Update Release Notes
-        id: update_release_notes
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag: node-v${{ needs.release-check.outputs.version }}
-          name: node-v${{ needs.release-check.outputs.version }}
-          bodyFile: platform/node/changelog_for_version.md
-          allowUpdates: true
-          draft: true
-          prerelease: ${{ steps.prepare_release.outputs.prerelease }}
 
       - name: Publish to NPM (release)
         if: ${{ steps.prepare_release.outputs.prerelease == 'false' }}

--- a/platform/node/package-lock.json
+++ b/platform/node/package-lock.json
@@ -34,7 +34,6 @@
         "pixelmatch": "^5.3.0",
         "pngjs": "^7.0.0",
         "pretty-bytes": "^6.1.1",
-        "semver": "^7.6.0",
         "shuffle-seed": "1.1.6",
         "st": "3.0.0",
         "tape": "5.9.0",

--- a/platform/node/package-lock.json
+++ b/platform/node/package-lock.json
@@ -11,7 +11,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "@acalcutt/node-pre-gyp": "2.0.5",
-        "@acalcutt/node-pre-gyp-github": "2.0.3",
         "minimatch": "^10.2.2",
         "npm-run-all": "4.1.5"
       },
@@ -65,35 +64,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@acalcutt/node-pre-gyp-github": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@acalcutt/node-pre-gyp-github/-/node-pre-gyp-github-2.0.3.tgz",
-      "integrity": "sha512-Z3vkqXN7hMTX2pKCFbEuLe4fXC1SQTJdBWJJNlnARFMjHrKEiyuFhGaNH8tqyMWSbeYH1dDJPwn/+4TAwtNjog==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/rest": "22.0.1",
-        "commander": "15.0.0",
-        "semver": "^7.8.1"
-      },
-      "bin": {
-        "node-pre-gyp-github": "bin/node-pre-gyp-github.js"
-      }
-    },
-    "node_modules/@acalcutt/node-pre-gyp-github/node_modules/@octokit/rest": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
-      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/core": "^7.0.6",
-        "@octokit/plugin-paginate-rest": "^14.0.0",
-        "@octokit/plugin-request-log": "^6.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1188,6 +1158,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
       "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -1197,8 +1168,8 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1216,12 +1187,14 @@
       "version": "27.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
       "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/core/node_modules/@octokit/types": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
       "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
@@ -1231,18 +1204,21 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@octokit/core/node_modules/universal-user-agent": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@octokit/endpoint": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
       "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^16.0.0",
@@ -1256,12 +1232,14 @@
       "version": "27.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
       "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
       "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
@@ -1271,12 +1249,14 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@octokit/graphql": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
       "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/request": "^10.0.6",
@@ -1291,12 +1271,14 @@
       "version": "27.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
       "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/graphql/node_modules/@octokit/types": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
       "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
@@ -1306,6 +1288,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@octokit/openapi-types": {
@@ -1314,78 +1297,6 @@
       "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
-      }
-    },
-    "node_modules/@octokit/plugin-request-log": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
-      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
-      }
     },
     "node_modules/@octokit/plugin-retry": {
       "version": "7.1.0",
@@ -1438,6 +1349,7 @@
       "version": "10.0.8",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
       "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^11.0.3",
@@ -1455,6 +1367,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
       "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^16.0.0"
@@ -1467,12 +1380,14 @@
       "version": "27.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
       "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/request-error/node_modules/@octokit/types": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
       "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
@@ -1482,12 +1397,14 @@
       "version": "27.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
       "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/request/node_modules/@octokit/types": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
       "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
@@ -1497,6 +1414,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@octokit/rest": {
@@ -2963,15 +2881,6 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "license": "MIT"
     },
-    "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.12.0"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3656,6 +3565,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
       "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4603,6 +4513,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.3.tgz",
       "integrity": "sha512-QObKu6nxy7NsxqR0VK4rkXnsNr5L9ElJaGEg+ucJ6J7/suoKZ0n+p76cu9aCqowytxEbwYNzvrMerfMkXneF5A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonwebtoken": {

--- a/platform/node/package.json
+++ b/platform/node/package.json
@@ -22,7 +22,6 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "@acalcutt/node-pre-gyp": "2.0.5",
-    "@acalcutt/node-pre-gyp-github": "2.0.3",
     "minimatch": "^10.2.2",
     "npm-run-all": "4.1.5"
   },

--- a/platform/node/package.json
+++ b/platform/node/package.json
@@ -45,7 +45,6 @@
     "pixelmatch": "^5.3.0",
     "pngjs": "^7.0.0",
     "pretty-bytes": "^6.1.1",
-    "semver": "^7.6.0",
     "shuffle-seed": "1.1.6",
     "st": "3.0.0",
     "tape": "5.9.0",

--- a/platform/node/scripts/publish.sh
+++ b/platform/node/scripts/publish.sh
@@ -4,8 +4,9 @@ set -e
 set -o pipefail
 
 PACKAGE_JSON_VERSION=`node -e "console.log(require('./package.json').version)"`
+RELEASE_TAG="node-v${PACKAGE_JSON_VERSION}"
 
-if [[ "${CIRCLE_TAG}" == "node-v${PACKAGE_JSON_VERSION}" ]] || [[ "${PUBLISH:-}" == true ]]; then
+if [[ "${CIRCLE_TAG}" == "${RELEASE_TAG}" ]] || [[ "${PUBLISH:-}" == true ]]; then
     # Changes to the version targets here should happen in tandem with updates to the
     # EXCLUDE_NODE_ABIS property in cmake/node.cmake and the "node" engines property in
     # package.json.
@@ -14,13 +15,13 @@ if [[ "${CIRCLE_TAG}" == "node-v${PACKAGE_JSON_VERSION}" ]] || [[ "${PUBLISH:-}"
 
         if [[ "${BUILDTYPE}" == "RelWithDebInfo" ]]; then
             ./node_modules/.bin/node-pre-gyp package --target="${TARGET}" $@
-            ./node_modules/.bin/node-pre-gyp-github publish
         elif [[ "${BUILDTYPE}" == "Debug" ]]; then
             ./node_modules/.bin/node-pre-gyp package --target="${TARGET}" --debug $@
-            ./node_modules/.bin/node-pre-gyp-github publish
         else
             echo "error: must provide either Debug or RelWithDebInfo for BUILDTYPE"
             exit 1
         fi
+
+        gh release upload "${RELEASE_TAG}" build/stage/${RELEASE_TAG}/*.tar.gz --clobber
     done
 fi


### PR DESCRIPTION
This PR attempts to fix the publishing issue found when publishing the last node release where multiple releases were made. This removes the custom node-pre-gyp-github, which I have been maintaining, with standard gh release commands

Testing: I have tested this release workflow on my test branch https://github.com/WifiDB/maplibre-native/tree/test-node-gh-release and created the test release https://github.com/WifiDB/maplibre-native/releases/tag/node-v6.5.0-pre.0, which seemed to work as expected

AI Use: I used Claude AI here and asked it to remove node-pre-gyp-github which I have been maintaining. I also asked it to replace the version actions with the version we are pulling in the first job