### PR TITLE
Metal: fix clip masks drawn with a stale UBO buffer after bind-cache ddress reuse

### DIFF
--- a/include/mbgl/gfx/rendering_stats.hpp
+++ b/include/mbgl/gfx/rendering_stats.hpp
@@ -37,6 +37,10 @@ struct RenderingStats {
     int numTextureBindings = 0;
     /// Number of times a texture was updated
     int numTextureUpdates = 0;
+
+    /// Number of vertex buffer bindings issued to the command encoder
+    /// (full binds, not offset-only updates). Metal backend only.
+    int numVertexBufferBinds = 0;
     /// Number of bytes used in texture updates
     std::size_t textureUpdateBytes = 0;
 

--- a/src/mbgl/gfx/rendering_stats.cpp
+++ b/src/mbgl/gfx/rendering_stats.cpp
@@ -38,6 +38,7 @@ RenderingStats& RenderingStats::operator+=(const RenderingStats& r) {
     numActiveTextures += r.numActiveTextures;
     numTextureBindings += r.numTextureBindings;
     numTextureUpdates += r.numTextureUpdates;
+    numVertexBufferBinds += r.numVertexBufferBinds;
     textureUpdateBytes += r.textureUpdateBytes;
     totalBuffers += r.totalBuffers;
     totalBufferObjs += r.totalBufferObjs;
@@ -84,6 +85,7 @@ std::string RenderingStats::toString(std::string_view sep) const {
     optionalStatLine(ss, numActiveTextures, "numActiveTextures", sep);
     optionalStatLine(ss, numTextureBindings, "numTextureBindings", sep);
     optionalStatLine(ss, numTextureUpdates, "numTextureUpdates", sep);
+    optionalStatLine(ss, numVertexBufferBinds, "numVertexBufferBinds", sep);
     optionalStatLine(ss, textureUpdateBytes, "textureUpdateBytes", sep);
     optionalStatLine(ss, totalBuffers, "totalBuffers", sep);
     optionalStatLine(ss, totalBufferObjs, "totalBufferObjs", sep);

--- a/src/mbgl/mtl/buffer_resource.cpp
+++ b/src/mbgl/mtl/buffer_resource.cpp
@@ -169,6 +169,7 @@ void BufferResource::bindVertex(const MTLRenderCommandEncoderPtr& encoder,
                                 const std::size_t offset,
                                 const std::size_t index,
                                 std::size_t size_) const noexcept {
+    context.renderingStats().numVertexBufferBinds++;
     assert(offset + size_ <= size);
     if (const auto* mtlBuf = buffer.get()) {
         encoder->setVertexBuffer(mtlBuf, static_cast<NS::UInteger>(offset), static_cast<NS::UInteger>(index));

--- a/src/mbgl/mtl/context.cpp
+++ b/src/mbgl/mtl/context.cpp
@@ -423,6 +423,20 @@ bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,
 
     mtlRenderPass.bindVertex(vertexRes, /*offset=*/0, ShaderClass::attributes[0].bufferIndex);
 
+    // The second and subsequent clip-mask rebuilds within a frame store
+    // their UBOs in a stack-local temporary `BufferResource`. Consecutive
+    // rebuilds reallocate that temporary at the same stack address with
+    // the same initial version (0), so `RenderPass`'s vertex-bind cache
+    // (`bind->buf == &buf && !buf.needReBind(bind->version)`) takes a
+    // dangling-pointer cache hit and skips `setVertexBuffer` -- leaving
+    // the previous rebuild's `MTLBuffer` bound while this rebuild's mask
+    // quads are drawn. The masks land with stale tile matrices and
+    // stencil refs, and every stencil-clipped fill in the layer group
+    // disappears in tile-aligned regions that shift with small camera
+    // moves. Drop the cached binding so each rebuild re-binds its own
+    // buffer.
+    mtlRenderPass.unbindVertex(shaders::idClippingMaskUBO);
+
     // Instancing is disabled for now because the `[[stencil]]` attribute in the fragment shader output
     // that we need to apply a different stencil value for each tile causes a problem on some older (A8-A11)
     // devices, specifically `XPC_ERROR_CONNECTION_INTERRUPTED` when creating a render pipeline state.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -151,6 +151,14 @@ if(MLN_WITH_OPENGL)
     )
 endif()
 
+if(MLN_WITH_METAL)
+    target_sources(
+        mbgl-test
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/test/mtl/clip_mask.test.cpp
+    )
+endif()
+
 
 if(MLN_WITH_VULKAN)
     target_sources(

--- a/test/mtl/clip_mask.test.cpp
+++ b/test/mtl/clip_mask.test.cpp
@@ -88,10 +88,9 @@ TEST(MetalClipMask, RebuildBindsFreshBufferAfterAddressReuse) {
     ASSERT_TRUE(context.renderTileClippingMasks(*renderPass, staticData, third));
     const auto bindsAfter = context.renderingStats().numVertexBufferBinds;
 
-    EXPECT_GT(bindsAfter, bindsBefore)
-        << "the third clip-mask rebuild was encoded with the previous rebuild's "
-           "UBO buffer (stale tile matrix + stencil ref): the vertex-bind cache "
-           "took a dangling-pointer cache hit on the recycled stack temporary";
+    EXPECT_GT(bindsAfter, bindsBefore) << "the third clip-mask rebuild was encoded with the previous rebuild's "
+                                          "UBO buffer (stale tile matrix + stencil ref): the vertex-bind cache "
+                                          "took a dangling-pointer cache hit on the recycled stack temporary";
 }
 
 #endif // MLN_RENDER_BACKEND_METAL

--- a/test/mtl/clip_mask.test.cpp
+++ b/test/mtl/clip_mask.test.cpp
@@ -1,0 +1,97 @@
+#if MLN_RENDER_BACKEND_METAL
+
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/gfx/backend_scope.hpp>
+#include <mbgl/gfx/command_encoder.hpp>
+#include <mbgl/gfx/render_pass.hpp>
+#include <mbgl/gfx/shader_registry.hpp>
+#include <mbgl/mtl/context.hpp>
+#include <mbgl/mtl/headless_backend.hpp>
+#include <mbgl/shaders/program_parameters.hpp>
+#include <mbgl/renderer/render_static_data.hpp>
+#include <mbgl/shaders/mtl/clipping_mask.hpp>
+
+#include <array>
+#include <vector>
+
+using namespace mbgl;
+
+namespace {
+
+shaders::ClipUBO makeClipUBO(float scale, std::uint32_t stencilRef) {
+    shaders::ClipUBO ubo{};
+    // A simple scaled identity is enough: the test never reads pixels, it
+    // only verifies which buffer the encoder was given.
+    ubo.matrix = {scale, 0, 0, 0, 0, scale, 0, 0, 0, 0, scale, 0, 0, 0, 0, 1};
+    ubo.stencil_ref = stencilRef;
+    return ubo;
+}
+
+} // namespace
+
+// Regression test for clip masks being encoded with a STALE UBO buffer.
+//
+// The second and subsequent renderTileClippingMasks calls within a frame
+// keep their ClipUBO data in a stack-local temporary BufferResource.
+// Consecutive rebuilds reallocate that temporary at the same stack address
+// with the same initial version, so RenderPass's vertex-bind cache
+// (`bind->buf == &buf && !buf.needReBind(bind->version)`) took a
+// dangling-pointer cache hit and skipped the bind when the offset also
+// matched (which it does whenever the previous rebuild contained a single
+// tile). The skipped rebuild's masks were then encoded with the previous
+// rebuild's tile matrices and stencil refs, so every stencil-clipped fill
+// in that layer group vanished in tile-aligned regions that shifted with
+// small camera moves.
+//
+// The single-tile / single-tile sequence below reproduces the exact
+// collision: call 1 uses the persistent clip UBO buffer, calls 2 and 3 use
+// the recycled stack temporary with bind offset 0. Call 3's bind must
+// reach the encoder.
+TEST(MetalClipMask, RebuildBindsFreshBufferAfterAddressReuse) {
+    if (gfx::Backend::GetType() != gfx::Backend::Type::Metal) {
+        return;
+    }
+
+    mtl::HeadlessBackend backend({64, 64});
+    gfx::BackendScope scope{backend};
+    auto& context = static_cast<mtl::Context&>(backend.getContext());
+
+    RenderStaticData staticData{std::make_unique<gfx::ShaderRegistry>()};
+    backend.initShaders(*staticData.shaders, ProgramParameters{1.0f, false});
+
+    const auto encoder = context.createCommandEncoder();
+    const gfx::RenderPassDescriptor descriptor{
+        .renderable = backend.getDefaultRenderable(),
+        .clearColor = Color::black(),
+        .clearDepth = 1.0f,
+        .clearStencil = 0,
+    };
+    const auto renderPass = encoder->createRenderPass("clip-mask-test", descriptor);
+
+    const std::vector<shaders::ClipUBO> first = {makeClipUBO(1.0f, 1)};
+    const std::vector<shaders::ClipUBO> second = {makeClipUBO(2.0f, 2)};
+    const std::vector<shaders::ClipUBO> third = {makeClipUBO(3.0f, 3)};
+
+    // Call 1: first rebuild of the "frame", uses the persistent buffer.
+    ASSERT_TRUE(context.renderTileClippingMasks(*renderPass, staticData, first));
+    // Call 2: first stack-temporary rebuild; binds fresh (the persistent
+    // buffer's address is cached, the temporary's differs).
+    ASSERT_TRUE(context.renderTileClippingMasks(*renderPass, staticData, second));
+
+    // Call 3: the temporary is recycled at the same stack address as call
+    // 2's (identical call path), with the same initial version and the
+    // same bind offset (0, single tile). Without the unbind in
+    // renderTileClippingMasks, the bind cache skips the encoder call and
+    // these masks are encoded with call 2's UBO data.
+    const auto bindsBefore = context.renderingStats().numVertexBufferBinds;
+    ASSERT_TRUE(context.renderTileClippingMasks(*renderPass, staticData, third));
+    const auto bindsAfter = context.renderingStats().numVertexBufferBinds;
+
+    EXPECT_GT(bindsAfter, bindsBefore)
+        << "the third clip-mask rebuild was encoded with the previous rebuild's "
+           "UBO buffer (stale tile matrix + stencil ref): the vertex-bind cache "
+           "took a dangling-pointer cache hit on the recycled stack temporary";
+}
+
+#endif // MLN_RENDER_BACKEND_METAL


### PR DESCRIPTION
First, great project, thanks for all of the years of hard work on it. This fixes an issue I ran into when putting lots of overlapping sources on the map at once. Also, I did use Claude to help make this PR. Test is red without the fix.

Fill layers intermittently vanish in tile-aligned regions on Metal (lines/labels in the same tiles unaffected; small camera moves toggle it; MLNMapSnapshotter renders the same style correctly). My app is a marine chart plotter layering a worldwide basemap with coastal-only and ocean-only sources — the differing coverage/maxzooms make clip masks rebuild many times per frame, often for a single tile.

The 2nd+ renderTileClippingMasks calls in a frame keep their ClipUBOs in a stack-local temporary BufferResource. Consecutive rebuilds recycle the same stack address with the same initial version, so RenderPass's vertex-bind cache (bind->buf == &buf && !buf.needReBind(bind->version)) takes a dangling-pointer cache hit and skips the bind when the offset also matches (always, after a single-tile rebuild). Those masks get encoded with the previous rebuild's tile matrix + stencil ref, so the group's fills are stencil-clipped to nothing.

Fix: unbind the clip-UBO slot before re-binding (one line). MetalClipMask.RebuildBindsFreshBufferAfterAddressReuse reproduces the exact sequence and fails on main. This might impact other areas and the bigger fix is probably a pointer+version cache identity.

<img width="1025" height="2000" alt="maplibre-fill-drop-band" src="https://github.com/user-attachments/assets/b193d61d-2a7c-4c18-bdc3-ad067cfddbb0" />
