### PR TITLE
feat(core): Include platform/default/include in headers tarball

### DIFF
--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           tar czf maplibre-native-headers.tar.gz \
             include \
+            platform/default/include \
             vendor/maplibre-native-base/include \
             vendor/maplibre-native-base/deps/variant/include \
             vendor/maplibre-native-base/deps/geometry.hpp/include \


### PR DESCRIPTION
The `maplibre-native-headers.tar.gz` published by this workflow doesn't contain `platform/default/include`. That directory has `HeadlessFrontend` and the headless backends, which is how you do offscreen rendering. So right now if you only have the prebuilt core lib + this headers tarball, you can't include `<mbgl/gfx/headless_frontend.hpp>` and it fails to compile.

This adds the directory to the tarball. It's about 90KB / 16 headers, so it doesn't really change the artifact size.