### PR TITLE
fix(core): Update image descriptor sets when removing textures

### DIFF
--- a/include/mbgl/gfx/drawable.hpp
+++ b/include/mbgl/gfx/drawable.hpp
@@ -111,13 +111,13 @@ public:
 
     /// @brief Set the collection of textures bound to this drawable
     /// @param textures_ A Textures collection to set
-    void setTextures(const Textures& textures_) noexcept { textures = textures_; }
-    void setTextures(Textures&& textures_) noexcept { textures = std::move(textures_); }
+    virtual void setTextures(const Textures& textures_) noexcept { textures = textures_; }
+    virtual void setTextures(Textures&& textures_) noexcept { textures = std::move(textures_); }
 
     /// @brief Attach the given texture to this drawable at the given internal ID.
     /// @param texture Texture2D instance
     /// @param id Internal ID of the texture.
-    void setTexture(gfx::Texture2DPtr texture, size_t id);
+    virtual void setTexture(gfx::Texture2DPtr texture, size_t id);
 
     /// Whether the drawble should be drawn
     bool getEnabled() const { return enabled; }

--- a/include/mbgl/vulkan/drawable.hpp
+++ b/include/mbgl/vulkan/drawable.hpp
@@ -52,6 +52,10 @@ public:
                                 const SegmentBase* segments,
                                 std::size_t segmentCount) override;
 
+    void setTextures(const Textures& textures_) noexcept override;
+    void setTextures(Textures&& textures_) noexcept override;
+    void setTexture(gfx::Texture2DPtr texture, size_t id) override;
+
 protected:
     void setSharedBuffers(const gfx::VertexAttributeArray&, const gfx::AttributeBindingArray&);
     void buildVulkanInputBindings();

--- a/src/mbgl/vulkan/drawable.cpp
+++ b/src/mbgl/vulkan/drawable.cpp
@@ -129,6 +129,47 @@ void Drawable::updateVertexAttributes(gfx::VertexAttributeArrayPtr vertices,
     impl->segments = std::move(drawSegs);
 }
 
+void Drawable::setTextures(const Textures& textures_) noexcept {
+    if (textures_ == textures) {
+        return;
+    }
+
+    gfx::Drawable::setTextures(textures_);
+
+    if (impl->imageDescriptorSet) {
+        impl->imageDescriptorSet->markDirty();
+    }
+}
+
+void Drawable::setTextures(Textures&& textures_) noexcept {
+    if (textures_ == textures) {
+        return;
+    }
+
+    gfx::Drawable::setTextures(textures_);
+
+    if (impl->imageDescriptorSet) {
+        impl->imageDescriptorSet->markDirty();
+    }
+}
+
+void Drawable::setTexture(gfx::Texture2DPtr texture, size_t id) {
+    assert(id < textures.size());
+    if (id >= textures.size()) {
+        return;
+    }
+
+    if (textures[id] == texture) {
+        return;
+    }
+
+    textures[id] = std::move(texture);
+
+    if (impl->imageDescriptorSet) {
+        impl->imageDescriptorSet->markDirty();
+    }
+}
+
 void Drawable::upload(gfx::UploadPass& uploadPass_) {
     MLN_TRACE_FUNC();
 
@@ -474,8 +515,12 @@ bool Drawable::bindDescriptors(CommandEncoder& encoder) const {
             impl->imageDescriptorSet = std::make_unique<ImageDescriptorSet>(encoder.getContext());
         }
 
+        // check if textures were updated via external pointers (after setTexture call)
         for (const auto& texture : textures) {
-            if (!texture) continue;
+            if (!texture) {
+                continue;
+            }
+
             const auto textureImpl = static_cast<const Texture2D*>(texture.get());
             if (textureImpl->isModifiedAfter(impl->imageDescriptorSet->getLastModified())) {
                 impl->imageDescriptorSet->markDirty();


### PR DESCRIPTION
https://github.com/maplibre/maplibre-native/pull/4327 exposed an issue where image descriptor sets were not being updated when a drawable texture was removed. Forcing an update in `Drawable::setTexture` removes stale references for this scenario.