### PR TITLE
fix(android): Add missing benchmark app module

### DIFF
--- a/platform/android/MapLibreAndroidTestApp/build.gradle.kts
+++ b/platform/android/MapLibreAndroidTestApp/build.gradle.kts
@@ -169,6 +169,8 @@ dependencies {
     androidTestImplementation(libs.androidxTestExtJUnit)
     androidTestImplementation(libs.androidxTestCoreKtx)
     androidTestImplementation(libs.kotlinxCoroutinesTest)
+
+    // version conflict when using androidTestImplementation
 }
 
 apply<SentryConditionalPlugin>()

--- a/platform/android/MapLibreAndroidTestApp/build.gradle.kts
+++ b/platform/android/MapLibreAndroidTestApp/build.gradle.kts
@@ -171,6 +171,7 @@ dependencies {
     androidTestImplementation(libs.kotlinxCoroutinesTest)
 
     // version conflict when using androidTestImplementation
+    implementation(libs.androidxTracing)
 }
 
 apply<SentryConditionalPlugin>()

--- a/platform/android/MapLibreAndroidTestApp/proguard-rules.pro
+++ b/platform/android/MapLibreAndroidTestApp/proguard-rules.pro
@@ -3,6 +3,9 @@
 
 # Kotlin
 -dontnote kotlin.**
+-keep class kotlin.LazyKt { *; }
+-keep class kotlin.LazyKt__LazyJVMKt { *; }
+-keep class kotlin.LazyKt__LazyKt { *; }
 
 # LeakCanary
 -dontnote com.squareup.leakcanary.internal.**
@@ -15,6 +18,7 @@
 
 -keep class org.maplibre.android.testapp.model.customlayer.ExampleCustomLayer { *; }
 
+-keep class androidx.tracing.** { *; }
 
  # okhttp
 -dontwarn org.bouncycastle.jsse.BCSSLSocket

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/benchmark/BenchmarkActivity.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/benchmark/BenchmarkActivity.kt
@@ -51,6 +51,7 @@ import kotlin.coroutines.resume
 class BenchmarkActivity : AppCompatActivity() {
     private val TAG = "BenchmarkActivity"
     private val useAdvancedMetrics = false
+    private val skipFailingStyles = true
 
     private lateinit var mapView: MapView
     private var handler: Handler? = null
@@ -225,7 +226,15 @@ class BenchmarkActivity : AppCompatActivity() {
         }
 
         mapView.addOnDidFinishRenderingFrameListener(listener)
-        mapView.setStyleSuspend(benchmarkRun.styleURL)
+        val styleResult = mapView.setStyleSuspend(benchmarkRun.styleURL)
+
+        if (skipFailingStyles && !styleResult) {
+            mapView.removeOnDidFinishRenderingFrameListener(listener)
+            metrics?.stop()
+
+            return BenchmarkRunResult(0.0, encodingTimeStore, renderingTimeStore, getThermalStatus(), metrics)
+        }
+
         numFrames = 0
 
         val startTime = System.nanoTime()

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/benchmark/BenchmarkActivity.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/benchmark/BenchmarkActivity.kt
@@ -115,16 +115,17 @@ class BenchmarkActivity : AppCompatActivity() {
         // return default
         return BenchmarkInputData(
             styleNames = listOf(
-                "AWS Open Data Standard Light",
-//                "Facebook Light",
+//                "AWS Open Data Standard Light",
+                "Facebook Light",
                 "Americana",
 //                "Protomaps Light",
 //                "Versatiles Colorful",
                "OpenFreeMap Bright"
             ),
             styleURLs = listOf(
-                "https://maps.geo.us-east-2.amazonaws.com/maps/v0/maps/OpenDataStyle/style-descriptor?key=v1.public.eyJqdGkiOiI1NjY5ZTU4My0yNWQwLTQ5MjctODhkMS03OGUxOTY4Y2RhMzgifR_7GLT66TNRXhZJ4KyJ-GK1TPYD9DaWuc5o6YyVmlikVwMaLvEs_iqkCIydspe_vjmgUVsIQstkGoInXV_nd5CcmqRMMa-_wb66SxDdbeRDvmmkpy2Ow_LX9GJDgL2bbiCws0wupJPFDwWCWFLwpK9ICmzGvNcrPbX5uczOQL0N8V9iUvziA52a1WWkZucIf6MUViFRf3XoFkyAT15Ll0NDypAzY63Bnj8_zS8bOaCvJaQqcXM9lrbTusy8Ftq8cEbbK5aMFapXRjug7qcrzUiQ5sr0g23qdMvnKJQFfo7JuQn8vwAksxrQm6A0ByceEXSfyaBoVpFcTzEclxUomhY.NjAyMWJkZWUtMGMyOS00NmRkLThjZTMtODEyOTkzZTUyMTBi",
-//                "https://external.xx.fbcdn.net/maps/vt/style/canterbury_1_0/?locale=en_US",
+//                {"message":"User is not authorized to access this resource with an explicit deny in an identity-based policy"}
+//                "https://maps.geo.us-east-2.amazonaws.com/maps/v0/maps/OpenDataStyle/style-descriptor?key=v1.public.eyJqdGkiOiI1NjY5ZTU4My0yNWQwLTQ5MjctODhkMS03OGUxOTY4Y2RhMzgifR_7GLT66TNRXhZJ4KyJ-GK1TPYD9DaWuc5o6YyVmlikVwMaLvEs_iqkCIydspe_vjmgUVsIQstkGoInXV_nd5CcmqRMMa-_wb66SxDdbeRDvmmkpy2Ow_LX9GJDgL2bbiCws0wupJPFDwWCWFLwpK9ICmzGvNcrPbX5uczOQL0N8V9iUvziA52a1WWkZucIf6MUViFRf3XoFkyAT15Ll0NDypAzY63Bnj8_zS8bOaCvJaQqcXM9lrbTusy8Ftq8cEbbK5aMFapXRjug7qcrzUiQ5sr0g23qdMvnKJQFfo7JuQn8vwAksxrQm6A0ByceEXSfyaBoVpFcTzEclxUomhY.NjAyMWJkZWUtMGMyOS00NmRkLThjZTMtODEyOTkzZTUyMTBi",
+                "https://external.xx.fbcdn.net/maps/vt/style/canterbury_1_0/?locale=en_US",
                 "https://americanamap.org/style.json",
 //                "https://api.protomaps.com/styles/v2/light.json?key=e761cc7daedf832a",
 //                "https://tiles.versatiles.org/assets/styles/colorful.json",

--- a/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/utils/CoroutineUtils.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/utils/CoroutineUtils.kt
@@ -7,23 +7,36 @@ import org.maplibre.android.maps.MapLibreMap.CancelableCallback
 import org.maplibre.android.maps.MapView
 import kotlin.coroutines.resume
 
-suspend fun MapView.setStyleSuspend(styleUrl: String): Unit =
+suspend fun MapView.setStyleSuspend(styleUrl: String): Boolean =
     suspendCancellableCoroutine { continuation ->
-        var listener: MapView.OnDidFinishLoadingStyleListener? = null
+        lateinit var listener: MapView.OnDidFinishLoadingStyleListener
+        lateinit var errorListener: MapView.OnDidFailLoadingMapListener
 
         var resumed = false
-        listener = MapView.OnDidFinishLoadingStyleListener {
+        val resume: (Boolean) -> Unit = { result ->
             if (!resumed) {
                 resumed = true
-                listener?.let { removeOnDidFinishLoadingStyleListener(it) }
-                continuation.resume(Unit)
+                removeOnDidFinishLoadingStyleListener(listener)
+                removeOnDidFailLoadingMapListener(errorListener)
+                continuation.resume(result)
             }
         }
+
+        listener = MapView.OnDidFinishLoadingStyleListener {
+            resume(true)
+        }
+
+        errorListener = MapView.OnDidFailLoadingMapListener {
+            resume(false)
+        }
+
         addOnDidFinishLoadingStyleListener(listener)
+        addOnDidFailLoadingMapListener(errorListener)
         getMapAsync { map -> map.setStyle(styleUrl) }
 
         continuation.invokeOnCancellation {
             removeOnDidFinishLoadingStyleListener(listener)
+            removeOnDidFailLoadingMapListener(errorListener)
         }
 
     }

--- a/platform/android/gradle/libs.versions.toml
+++ b/platform/android/gradle/libs.versions.toml
@@ -69,6 +69,7 @@ lintTests = { group = "com.android.tools.lint", name = "lint-tests", version.ref
 
 androidxTestExtJUnit = { group = "androidx.test.ext", name = "junit", version = "1.3.0" }
 androidxTestCoreKtx = { group = "androidx.test", name = "core-ktx", version = "1.7.0" }
+androidxTracing = { group = "androidx.tracing", name = "tracing", version = "1.3.0" }
 kotlinxSerializationJson = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.11.0" }
 
 [plugins]


### PR DESCRIPTION
Android benchmark runs are failing due to `NoClassDefFoundError`.

```
Process: org.maplibre.android.testapp, PID: 31952
java.lang.NoClassDefFoundError: Failed resolution of: Landroidx/tracing/Trace;
```