### PR TITLE
doc: fix mdbook links

### DIFF
--- a/docs/mdbook/src/platforms/README.md
+++ b/docs/mdbook/src/platforms/README.md
@@ -57,4 +57,4 @@ In 2023 we co-opted Bazel as a build tool (generator), mostly due to it having b
 | Qt | ✅ | ❌ |
 
 
-[^3]: Some targets are supported, see [here](ios/README.md#cmake).
+[^3]: Some targets are supported, see [here](ios/#cmake).

--- a/docs/mdbook/src/platforms/android/README.md
+++ b/docs/mdbook/src/platforms/android/README.md
@@ -55,4 +55,4 @@ $ ./gradlew formatKotlin
 
 ## Profiling
 
-See [Tracy Profiling](/profiling/tracy-profiling.md) to understand how Tracy can be used for profiling.
+See [Tracy Profiling](../../profiling/tracy-profiling.md) to understand how Tracy can be used for profiling.

--- a/docs/mdbook/src/platforms/android/release.md
+++ b/docs/mdbook/src/platforms/android/release.md
@@ -2,7 +2,7 @@
 
 We make MapLibre Android releases as a downloadable asset on [GitHub](https://github.com/maplibre/maplibre-native/releases?q=android&expanded=true) as well as to [Maven Central](https://central.sonatype.com/artifact/org.maplibre.gl/android-sdk/versions). Specifically we make use of a Sonatype OSSHR repository provided by Maven Central.
 
-Also see the current [release policy](../release-policy.md).
+Also see the current [release policy](../../release-policy.md).
 
 ## Making a release
 

--- a/docs/mdbook/src/platforms/ios/README.md
+++ b/docs/mdbook/src/platforms/ios/README.md
@@ -71,7 +71,7 @@ It is also possible to build and run the test application in a simulator from th
 bazel run //platform/ios:App --//:renderer=metal
 ```
 
-You can also build targets from the command line. For example, if you want to build your own XCFramework, see the 'Build XCFramework' step in the [iOS CI workflow](../../.github/workflows/ios-ci.yml).
+You can also build targets from the command line. For example, if you want to build your own XCFramework, see the 'Build XCFramework' step in the [iOS CI workflow](https://github.com/maplibre/maplibre-native/blob/main/.github/workflows/ios-ci.yml).
 
 ## CMake
 

--- a/docs/mdbook/src/platforms/ios/dev-apps.md
+++ b/docs/mdbook/src/platforms/ios/dev-apps.md
@@ -4,7 +4,7 @@ There are two iOS apps available in the repo that you can use for MapLibre Nativ
 
 ## Objective-C App
 
-This app is available as "App" in the [generated Xcode project](./README.md).
+This app is available as "App" in the [generated Xcode project](./).
 
 The source code lives in `platform/ios/app`.
 
@@ -22,7 +22,7 @@ bazel run --//:renderer=metal //platform/ios:App
 
 The Swift App is mainly used to demo usage patterns in the [example documentation](./ios-documentation.md#examples).
 
-This app is available as "MapLibreApp" in the [generated Xcode project](./README.md).
+This app is available as "MapLibreApp" in the [generated Xcode project](./).
 
 The source code lives in `platform/ios/swift-app`.
 

--- a/docs/mdbook/src/platforms/ios/release.md
+++ b/docs/mdbook/src/platforms/ios/release.md
@@ -2,7 +2,7 @@
 
 We make iOS releases to GitHub (a downloadable XCFramework), the [Swift Package Index](https://swiftpackageindex.com/maplibre/maplibre-gl-native-distribution) and [CocoaPods](https://cocoapods.org/). Everyone with write access to the repository is able to make releases using the instructions below.
 
-Also see the current [release policy](../release-policy.md).
+Also see the current [release policy](../../release-policy.md).
 
 ## Making a release
 

--- a/docs/mdbook/src/platforms/linux/using-docker.md
+++ b/docs/mdbook/src/platforms/linux/using-docker.md
@@ -1,6 +1,6 @@
 # Building with Docker
 
-These steps will allow you to compile code as described [here](./README.md) using a Docker container. All the steps should be executed from the root of the repository.
+These steps will allow you to compile code as described [here](./) using a Docker container. All the steps should be executed from the root of the repository.
 
 > [!IMPORTANT]
 > Not all platform builds are currently supported. Docker builds are a work in progress.

--- a/docs/mdbook/src/release-policy.md
+++ b/docs/mdbook/src/release-policy.md
@@ -6,7 +6,7 @@
 - We use [semantic versioning](https://semver.org/). Breaking changes will always result in a major release.
 - Despite having extensive tests in place, as a FOSS project we have limited QA testing capabilities. When major changes took place we may opt to put out a pre-release to let the community help with testing.
 - In principle the `main` branch should always be in a releasable state.
-- The release process is automated and documented (see [Release MapLibre iOS](./ios/release.md) and [Release MapLibre Android](./android/release.md)). Anyone with write access should be able to push out a release.
+- The release process is automated and documented (see [Release MapLibre iOS](./platforms/ios/release.md) and [Release MapLibre Android](./platforms/android/release.md)). Anyone with write access should be able to push out a release.
 - There is no fixed release cadence, but you are welcome to request a release on any of the communication channels.
 - We do not have long-term support (LTS) releases.
 - If you need a feature or a bugfix ported to and old version of MapLibre, you need to do the backporting yourself (see steps below).

--- a/docs/mdbook/src/render-tests.md
+++ b/docs/mdbook/src/render-tests.md
@@ -1,7 +1,7 @@
 # Render Tests
 
 > [!NOTE]
-> See also [Android Tests](./android/android-tests.md#render-tests) and [iOS Tests](./ios/ios-tests.md#render-tests) for some platform-specific information on the render tests.
+> See also [Android Tests](./platforms/android/android-tests.md#render-tests) and [iOS Tests](./platforms/ios/ios-tests.md#render-tests) for some platform-specific information on the render tests.
 
 Render tests verify the correctness and consistency of MapLibre Native's rendering. Note that 'render test' is a bit of a misnomer, because there are various types of tests that do not really test rendering behavior that we sometimes call render tests. Examples are [expression tests and query tests](#metricsintergration). In addition, these 'render tests' allow a wide variety of operations and probes (which write out metrics) for things like GPU memory allocations, memory usage, network requests, FPS, so these tests are really quite a bit more versatile than just verifying rendering behavior.
 

--- a/docs/mdbook/src/rust.md
+++ b/docs/mdbook/src/rust.md
@@ -34,7 +34,7 @@ Set `-DMLN_USE_RUST=ON` when generating a configuration with CMake.
 
 Pass the `--//:use_rust` flag to Bazel commands.
 
-Note that when [generating an Xcode project](./ios/README.md) you should not pass this option to Bazel directly, but as follows:
+Note that when [generating an Xcode project](./platforms/ios/) you should not pass this option to Bazel directly, but as follows:
 
 ```shell
 bazel run //platform/ios:xcodeproj --@rules_xcodeproj//xcodeproj:extra_common_flags="--//:renderer=metal --//:use_rust"


### PR DESCRIPTION
Many of them were due to https://github.com/rust-lang/mdBook/issues/984 

Most of the rest seem due to re-organzing the docs into a platforms/ subdir