### PR TITLE
Reduce Android runtime symbol resolution

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/CMakeLists.txt
+++ b/platform/android/MapLibreAndroid/src/cpp/CMakeLists.txt
@@ -252,7 +252,10 @@ target_link_libraries(maplibre
                               $<$<CONFIG:Release>:-Wl,--icf=all>
                               $<$<CONFIG:Release>:-Wl,--gc-sections>
                               $<$<CONFIG:Release>:-flto>
-                              $<$<CONFIG:Release>:-fuse-ld=gold>
+                              $<$<CONFIG:Release>:-fuse-ld=lld>
+                              $<$<CONFIG:Release>:-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/../../../version-script>
+                              #$<$<CONFIG:Release>:-Wl,-Bsymbolic>
+                              $<$<CONFIG:Release>:-Wl,-Bsymbolic-functions>
                               MapLibreNative::Base::jni.hpp
                               mbgl-core
                               mbgl-vendor-unique_resource)


### PR DESCRIPTION
Small experiment to reduce the number of symbol lookups (`soinfo_do_lookup_impl`) and overall relocations during dynamic library loading. 

```
Metric	                    Before	After	Reduction
Dynamic symbols	            9,825	236	    97.6%
Exported symbols	        9,556	1	    99.9% (just JNI_OnLoad) -> using version-script that was ignored
R_AARCH64_GLOB_DAT	        4,347	5	    99.9% symbol lookup
R_AARCH64_JUMP_SLOT	        2,710	214	    92.1% symbol lookup
R_AARCH64_ABS64	            4,970	22	    99.6% symbol lookup
R_AARCH64_RELATIVE	        18,166	26,419	+45%  address math
```

The small `version-script` was already present in the repo, but never used for cmake builds (only buck?). I'm not sure if this was intentional or not since there are some breaking changes tied to it (dynamic lookups, linking/loading the .so directly, no rtti?).