### PR TITLE
fix(proguard): overly broad enum keep rule

### DIFF
--- a/platform/android/MapLibreAndroid/proguard-rules.pro
+++ b/platform/android/MapLibreAndroid/proguard-rules.pro
@@ -12,7 +12,11 @@
 -keep enum org.maplibre.android.tile.TileOperation
 -keep class org.maplibre.android.maps.RenderingStats { *; }
 -keep class org.maplibre.android.maps.NativeMapOptions { *; }
-
+-keepclassmembers class org.maplibre.android.** extends java.lang.Enum {
+    <fields>;
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
 # dontnote for keeps the entry point x but not the descriptor class y
 -dontnote org.maplibre.android.maps.MapLibreMap$OnFpsChangedListener
 -dontnote org.maplibre.android.style.layers.PropertyValue

--- a/platform/android/MapLibreAndroid/proguard-rules.pro
+++ b/platform/android/MapLibreAndroid/proguard-rules.pro
@@ -12,11 +12,6 @@
 -keep enum org.maplibre.android.tile.TileOperation
 -keep class org.maplibre.android.maps.RenderingStats { *; }
 -keep class org.maplibre.android.maps.NativeMapOptions { *; }
--keepclassmembers class * extends java.lang.Enum {
-    <fields>;
-    public static **[] values();
-    public static ** valueOf(java.lang.String);
-}
 
 # dontnote for keeps the entry point x but not the descriptor class y
 -dontnote org.maplibre.android.maps.MapLibreMap$OnFpsChangedListener


### PR DESCRIPTION
The existing R8/Proguard rule applies to all enums, including those in other libraries used by any app which uses MapLibre, and the consumer app itself. The R8 rule within the library need only apply to enums defined within the library.

This rule was originally added in https://github.com/maplibre/maplibre-native/pull/2819, an unrelated PR, but was mentioned in comments as being a fix for https://github.com/maplibre/maplibre-native/issues/2826.

I don't think this rule was necessarily needed at all given the `TileOperation` keep rule a few lines above it, and that Android's default config (from AGP) will retain values() and valueOf(String) of enums by default with its own rule:

```
-keepclassmembers enum * {
    public static **[] values();
    public static ** valueOf(java.lang.String);
}
```

None of the enums within the Java/Kotlin code have fields, so the only additional item in this config appears redundant.

---

This arose while I was using the new [R8 Configuration Analyzer tool](https://developer.android.com/topic/performance/app-optimization/r8-configuration-analyzer) to debug our app's optimisation, which highlighted this overly broad rule applying to 2.1% of all kept items within our release builds.

<img width="1477" height="255" alt="Screenshot 2026-06-27 at 03 16 38" src="https://github.com/user-attachments/assets/ad122013-34f3-419e-8c2c-f2328fca4601" />
