### PR TITLE
core: Release finished WebGPU command encoders

### DIFF
--- a/src/mbgl/webgpu/command_encoder.cpp
+++ b/src/mbgl/webgpu/command_encoder.cpp
@@ -73,6 +73,8 @@ void CommandEncoder::submitCommandBuffer() {
     WGPUStringView label = {"Command Buffer", strlen("Command Buffer")};
     cmdBufferDesc.label = label;
     WGPUCommandBuffer cmdBuffer = wgpuCommandEncoderFinish(encoder, &cmdBufferDesc);
+    wgpuCommandEncoderRelease(encoder);
+    encoder = nullptr;
 
     if (cmdBuffer) {
         wgpuQueueSubmit(queue, 1, &cmdBuffer);


### PR DESCRIPTION
After `wgpuCommandEncoderFinish`, the old code immediately replaced that member with a new encoder, but never released the finished encoder handle first. Once overwritten, nothing could release that old handle later; the destructor only sees the replacement.

Here we release the command encoder handle immediately after `wgpuCommandEncoderFinish` before storing a replacement encoder.

AI disclosure: used multiple models, primarily gpt-5.5, to explore and prototype a browser webgpu build, then extract these targeted upstream fixes. 