### PR TITLE
fix(core): notify layer observer when source-layer or source-id changes

### DIFF
--- a/src/mbgl/style/layer.cpp
+++ b/src/mbgl/style/layer.cpp
@@ -54,6 +54,7 @@ void Layer::setSourceLayer(const std::string& sourceLayer) {
     auto impl_ = mutableBaseImpl();
     impl_->sourceLayer = sourceLayer;
     baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
 }
 
 void Layer::setSourceID(const std::string& sourceID) {
@@ -61,6 +62,7 @@ void Layer::setSourceID(const std::string& sourceID) {
     auto impl_ = mutableBaseImpl();
     impl_->source = sourceID;
     baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
 };
 
 const Filter& Layer::getFilter() const {

--- a/test/style/style_layer.test.cpp
+++ b/test/style/style_layer.test.cpp
@@ -285,6 +285,44 @@ TEST(Layer, Observer) {
     };
     layer->setLineCap(lineCap);
     EXPECT_FALSE(layoutPropertyChanged);
+
+    // Notifies observer on source-layer change.
+    // This is required so that the render orchestrator re-evaluates already-loaded
+    // tiles when a layer's source-layer is changed at runtime (e.g. after addLayer).
+    bool sourceLayerChanged = false;
+    observer.layerChanged = [&](Layer& layer_) {
+        EXPECT_EQ(layer.get(), &layer_);
+        sourceLayerChanged = true;
+    };
+    layer->setSourceLayer("roads");
+    EXPECT_TRUE(sourceLayerChanged);
+
+    // Does not notify observer on no-op source-layer change.
+    sourceLayerChanged = false;
+    observer.layerChanged = [&](Layer& layer_) {
+        EXPECT_EQ(layer.get(), &layer_);
+        sourceLayerChanged = true;
+    };
+    layer->setSourceLayer("roads");
+    EXPECT_FALSE(sourceLayerChanged);
+
+    // Notifies observer on source ID change.
+    bool sourceIDChanged = false;
+    observer.layerChanged = [&](Layer& layer_) {
+        EXPECT_EQ(layer.get(), &layer_);
+        sourceIDChanged = true;
+    };
+    layer->setSourceID("other-source");
+    EXPECT_TRUE(sourceIDChanged);
+
+    // Does not notify observer on no-op source ID change.
+    sourceIDChanged = false;
+    observer.layerChanged = [&](Layer& layer_) {
+        EXPECT_EQ(layer.get(), &layer_);
+        sourceIDChanged = true;
+    };
+    layer->setSourceID("other-source");
+    EXPECT_FALSE(sourceIDChanged);
 }
 
 TEST(Layer, DuplicateLayer) {


### PR DESCRIPTION
This PR is a fix for a source-layer change not triggering a re-layout issue I am working around in https://github.com/acalcutt/maplibre-maui/pull/12 . I have worked around this in my project for now by toggling visibility in maplibre-maui c abi after source/source id changes, but from working with claude ai, it recommends that it really should be fixed here.

AI Used: Claude Opus/Sonnet

**AI Summary**
Layer::setSourceLayer() and Layer::setSourceID() were the only mutating layer setters that did not call observer->onLayerChanged() after updating the layer impl. setFilter(), setVisibility(), setMinZoom() and setMaxZoom() all notify; these two silently did not.

**Problem**
If a layer's source-layer (or source id) is changed after the layer has already been added to the style — i.e. the runtime sequence addLayer(layer) then layer.setSourceLayer(...) — the render orchestrator is never told to re-evaluate the layer. Tiles that were already loaded are not re-laid-out against the new source-layer, so the layer renders zero features, even though getSourceLayer() correctly returns the new value and the tile data is valid.

Calling any notifying setter afterwards (e.g. setFilter) makes the layer suddenly appear, which tends to misdiagnose this as a paint/filter bug rather than a source-layer bug.

**Root cause**
Missing observer->onLayerChanged(*this) at the end of setSourceLayer() / setSourceID().

Why this hasn't surfaced before
The official bindings all set source-layer before adding the layer to the style, where the layer's observer is still the default no-op nullObserver and the subsequent addLayer() performs the initial layout:

Style JSON: source-layer is applied during conversion::convert<Layer> before addLayer.
Android: builder pattern new XLayer(id, source).withSourceLayer(...) then style.addLayer(...).
iOS/macOS: sourceLayerIdentifier set on the pending layer before addToMapView.
Consumers that add the layer first and set source-layer afterwards (e.g. flat C-ABI bindings whose add entry point only takes id+source) hit the latent bug.

**Fix**
Add observer->onLayerChanged(*this) to both setters, matching every other mutating setter. No-op changes (setting the same value) still early-return and do not notify.

**Tests**
Extended TEST(Layer, Observer) in test/style/style_layer.test.cpp:

notifies on source-layer change / does not notify on no-op source-layer change
notifies on source-id change / does not notify on no-op source-id change