### PR TITLE
Add fill-extrusion-edge-radius: rounded footprint corners with smooth facade normals

### DIFF
--- a/include/mbgl/style/layers/fill_extrusion_layer.hpp
+++ b/include/mbgl/style/layers/fill_extrusion_layer.hpp
@@ -19,6 +19,12 @@ public:
     FillExtrusionLayer(const std::string& layerID, const std::string& sourceID);
     ~FillExtrusionLayer() override;
 
+    // Layout properties
+
+    static PropertyValue<float> getDefaultFillExtrusionEdgeRadius();
+    const PropertyValue<float>& getFillExtrusionEdgeRadius() const;
+    void setFillExtrusionEdgeRadius(const PropertyValue<float>&);
+
     // Paint properties
 
     static PropertyValue<float> getDefaultFillExtrusionBase();

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### ✨ Features and improvements
 
+- Add `fill-extrusion-edge-radius` layout property — bucket-time rounding of extruded footprint corners with smooth facade normals (default 0 = off).
 - Reduce Android runtime symbol resolution ([#4356](https://github.com/maplibre/maplibre-native/pull/4356)).
 
 ### 🐞 Bug fixes

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/fill_extrusion_layer.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/fill_extrusion_layer.cpp
@@ -39,6 +39,17 @@ FillExtrusionLayer::~FillExtrusionLayer() = default;
 
 // Property getters
 
+jni::Local<jni::Object<>> FillExtrusionLayer::getFillExtrusionEdgeRadius(jni::JNIEnv& env) {
+    using namespace mbgl::android::conversion;
+    auto layer = layerPtr.get();
+    if (!layer) {
+        return std::move(
+            *convert<jni::Local<jni::Object<>>>(env, style::FillExtrusionLayer::getDefaultFillExtrusionEdgeRadius()));
+    }
+    return std::move(
+        *convert<jni::Local<jni::Object<>>>(env, toFillExtrusionLayer(*layer).getFillExtrusionEdgeRadius()));
+}
+
 jni::Local<jni::Object<>> FillExtrusionLayer::getFillExtrusionOpacity(jni::JNIEnv& env) {
     using namespace mbgl::android::conversion;
     auto layer = layerPtr.get();
@@ -288,6 +299,7 @@ void FillExtrusionJavaLayerPeerFactory::registerNative(jni::JNIEnv& env) {
         jni::MakePeer<FillExtrusionLayer, jni::String&, jni::String&>,
         "initialize",
         "finalize",
+        METHOD(&FillExtrusionLayer::getFillExtrusionEdgeRadius, "nativeGetFillExtrusionEdgeRadius"),
         METHOD(&FillExtrusionLayer::getFillExtrusionOpacityTransition, "nativeGetFillExtrusionOpacityTransition"),
         METHOD(&FillExtrusionLayer::setFillExtrusionOpacityTransition, "nativeSetFillExtrusionOpacityTransition"),
         METHOD(&FillExtrusionLayer::getFillExtrusionOpacity, "nativeGetFillExtrusionOpacity"),

--- a/platform/android/MapLibreAndroid/src/cpp/style/layers/fill_extrusion_layer.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/layers/fill_extrusion_layer.hpp
@@ -26,6 +26,8 @@ public:
 
     // Properties
 
+    jni::Local<jni::Object<jni::ObjectTag>> getFillExtrusionEdgeRadius(jni::JNIEnv&);
+
     jni::Local<jni::Object<jni::ObjectTag>> getFillExtrusionOpacity(jni::JNIEnv&);
     void setFillExtrusionOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay);
     jni::Local<jni::Object<TransitionOptions>> getFillExtrusionOpacityTransition(jni::JNIEnv&);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/layers/FillExtrusionLayer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/layers/FillExtrusionLayer.java
@@ -144,6 +144,18 @@ public class FillExtrusionLayer extends Layer {
   // Property getters
 
   /**
+   * Get the FillExtrusionEdgeRadius property
+   *
+   * @return property wrapper value around Float
+   */
+  @NonNull
+  @SuppressWarnings("unchecked")
+  public PropertyValue<Float> getFillExtrusionEdgeRadius() {
+    checkThread();
+    return (PropertyValue<Float>) new PropertyValue("fill-extrusion-edge-radius", nativeGetFillExtrusionEdgeRadius());
+  }
+
+  /**
    * Get the FillExtrusionOpacity property
    *
    * @return property wrapper value around Float
@@ -381,6 +393,10 @@ public class FillExtrusionLayer extends Layer {
     checkThread();
     return (PropertyValue<Boolean>) new PropertyValue("fill-extrusion-vertical-gradient", nativeGetFillExtrusionVerticalGradient());
   }
+
+  @NonNull
+  @Keep
+  private native Object nativeGetFillExtrusionEdgeRadius();
 
   @NonNull
   @Keep

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/layers/PropertyFactory.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/layers/PropertyFactory.java
@@ -2767,4 +2767,24 @@ The unit is in density-independent pixels only for SDF sprites that were created
     return new LayoutPropertyValue<>("circle-sort-key", value);
   }
 
+  /**
+   * Radius of a fill extrusion edge in meters. If not zero, rounds extrusion edges for a smoother appearance.
+   *
+   * @param value a Float value
+   * @return property wrapper around Float
+   */
+  public static PropertyValue<Float> fillExtrusionEdgeRadius(Float value) {
+    return new LayoutPropertyValue<>("fill-extrusion-edge-radius", value);
+  }
+
+  /**
+   * Radius of a fill extrusion edge in meters. If not zero, rounds extrusion edges for a smoother appearance.
+   *
+   * @param value a Float value
+   * @return property wrapper around Float
+   */
+  public static PropertyValue<Expression> fillExtrusionEdgeRadius(Expression value) {
+    return new LayoutPropertyValue<>("fill-extrusion-edge-radius", value);
+  }
+
 }

--- a/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/testapp/style/FillExtrusionLayerTest.java
+++ b/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/testapp/style/FillExtrusionLayerTest.java
@@ -177,6 +177,19 @@ public class FillExtrusionLayerTest extends BaseLayerTest {
 
   @Test
   @UiThreadTest
+  public void testFillExtrusionEdgeRadiusAsConstant() {
+    Timber.i("fill-extrusion-edge-radius");
+    assertNotNull(layer);
+    assertNull(layer.getFillExtrusionEdgeRadius().getValue());
+
+    // Set and Get
+    Float propertyValue = 0.3f;
+    layer.setProperties(fillExtrusionEdgeRadius(propertyValue));
+    assertEquals(layer.getFillExtrusionEdgeRadius().getValue(), propertyValue);
+  }
+
+  @Test
+  @UiThreadTest
   public void testFillExtrusionOpacityTransition() {
     Timber.i("fill-extrusion-opacityTransitionOptions");
     assertNotNull(layer);

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`M
 
 ## 6.27.0
 
+- Add `fill-extrusion-edge-radius` layout property — bucket-time rounding of extruded footprint corners with smooth facade normals (default 0 = off).
 - Implement ambient cache for PMTiles sources ([#4290](https://github.com/maplibre/maplibre-native/pull/4290)).
 
 ## 6.26.1

--- a/scripts/style-spec-reference/v8.json
+++ b/scripts/style-spec-reference/v8.json
@@ -1050,6 +1050,20 @@
     }
   },
   "layout_fill-extrusion": {
+    "fill-extrusion-edge-radius": {
+      "type": "number",
+      "experimental": true,
+      "default": 0,
+      "minimum": 0,
+      "doc": "Radius of a fill extrusion edge in meters. If not zero, rounds extrusion edges for a smoother appearance.",
+      "sdk-support": {
+        "basic functionality": {}
+      },
+      "expression": {
+        "interpolated": false
+      },
+      "property-type": "constant"
+    },
     "visibility": {
       "type": "enum",
       "values": {

--- a/src/mbgl/layermanager/fill_extrusion_layer_factory.cpp
+++ b/src/mbgl/layermanager/fill_extrusion_layer_factory.cpp
@@ -22,7 +22,10 @@ std::unique_ptr<Layout> FillExtrusionLayerFactory::createLayout(
     std::unique_ptr<GeometryTileLayer> layer,
     const std::vector<Immutable<style::LayerProperties>>& group) {
     using namespace style;
-    using LayoutType = PatternLayout<FillExtrusionBucket, FillExtrusionLayerProperties, FillExtrusionPattern>;
+    using LayoutType = PatternLayout<FillExtrusionBucket,
+                                     FillExtrusionLayerProperties,
+                                     FillExtrusionPattern,
+                                     FillExtrusionLayoutProperties>;
     return std::unique_ptr<Layout>(new (std::nothrow)
                                        LayoutType(parameters.bucketParameters, group, std::move(layer), parameters));
 }

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
@@ -39,11 +39,113 @@ using namespace style;
 
 struct GeometryTooLongException : std::exception {};
 
+namespace {
+
+// Rounded footprint corners (the plan-view half of fill-extrusion-edge-radius).
+// Sharp building corners are replaced by short arcs, softening silhouettes and
+// wall shading. The radius is configured in meters via the
+// fill-extrusion-edge-radius layout property and converted to tile units per
+// canonical zoom. The vertical top bevel needs shader-side height interaction
+// and lands separately.
+constexpr double kEarthCircumference = 40075016.686;
+
+GeometryCoordinates roundRingCorners(const GeometryCoordinates& ring, double radiusUnits) {
+    // Rings arrive closed (first == last); operate on the open form.
+    std::size_t n = ring.size();
+    if (n >= 2 && ring.front() == ring.back()) {
+        n -= 1;
+    }
+    if (n < 4) {
+        // Triangles keep their sharpness — rounding degenerates them.
+        return ring;
+    }
+
+    GeometryCoordinates out;
+    out.reserve(n * 3 + 1);
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto& prev = ring[(i + n - 1) % n];
+        const auto& curr = ring[i];
+        const auto& next = ring[(i + 1) % n];
+
+        const Point<double> a = convertPoint<double>(prev);
+        const Point<double> b = convertPoint<double>(curr);
+        const Point<double> c = convertPoint<double>(next);
+
+        const Point<double> inVec = b - a;
+        const Point<double> outVec = c - b;
+        const double inLen = std::sqrt(inVec.x * inVec.x + inVec.y * inVec.y);
+        const double outLen = std::sqrt(outVec.x * outVec.x + outVec.y * outVec.y);
+        if (inLen < 1e-6 || outLen < 1e-6) {
+            out.emplace_back(curr);
+            continue;
+        }
+
+        // Skip near-straight corners: rounding them only adds vertices.
+        const double cross = inVec.x * outVec.y - inVec.y * outVec.x;
+        const double dot = inVec.x * outVec.x + inVec.y * outVec.y;
+        const double turn = std::abs(std::atan2(cross, dot));
+        if (turn < 0.20) {
+            out.emplace_back(curr);
+            continue;
+        }
+
+        // Clamp the cut so adjacent corners never overlap.
+        const double cut = std::min({radiusUnits, inLen * 0.5 - 0.5, outLen * 0.5 - 0.5});
+        if (cut < 1.0) {
+            out.emplace_back(curr);
+            continue;
+        }
+
+        const Point<double> inDir{inVec.x / inLen, inVec.y / inLen};
+        const Point<double> outDir{outVec.x / outLen, outVec.y / outLen};
+        const Point<double> start = b - inDir * cut;
+        const Point<double> end = b + outDir * cut;
+        // Quadratic bezier (control point = the original corner) sampled at
+        // t = 1/3 and 2/3: enough segments to read round at building scale
+        // without exploding vertex counts.
+        const Point<double> mid1 = start * (4.0 / 9.0) + b * (4.0 / 9.0) + end * (1.0 / 9.0);
+        const Point<double> mid2 = start * (1.0 / 9.0) + b * (4.0 / 9.0) + end * (4.0 / 9.0);
+
+        const auto push = [&](const Point<double>& p) {
+            out.emplace_back(static_cast<int16_t>(std::lround(p.x)), static_cast<int16_t>(std::lround(p.y)));
+        };
+        push(start);
+        push(mid1);
+        push(mid2);
+        push(end);
+    }
+    if (out.size() < 3) {
+        return ring;
+    }
+    // Restore closure to match the input convention.
+    if (ring.front() == ring.back()) {
+        out.emplace_back(out.front());
+    }
+    return out;
+}
+
+void roundPolygonCorners(GeometryCollection& polygon, const CanonicalTileID& canonical, double radiusM) {
+    // Tile units per meter at this canonical zoom (equator approximation is
+    // fine for a visual radius).
+    const double tileMeters = kEarthCircumference / (1u << canonical.z);
+    const double radiusUnits = radiusM * (static_cast<double>(util::EXTENT) / tileMeters);
+    if (radiusUnits < 1.5) {
+        // Below ~1.5 units the arc collapses to the original corner.
+        return;
+    }
+    for (auto& ring : polygon) {
+        ring = roundRingCorners(ring, radiusUnits);
+    }
+}
+
+} // namespace
+
 FillExtrusionBucket::FillExtrusionBucket(
-    const FillExtrusionBucket::PossiblyEvaluatedLayoutProperties&,
+    const FillExtrusionBucket::PossiblyEvaluatedLayoutProperties& layout,
     const std::map<std::string, Immutable<style::LayerProperties>>& layerPaintProperties,
     const float zoom,
-    const uint32_t) {
+    const uint32_t)
+    : edgeRadiusMeters_(layout.get<style::FillExtrusionEdgeRadius>()) {
     for (const auto& pair : layerPaintProperties) {
         paintPropertyBinders.emplace(
             std::piecewise_construct,
@@ -65,6 +167,11 @@ void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature,
     for (auto& polygon : classifyRings(geometry)) {
         // Optimize polygons with many interior rings for earcut tesselation.
         limitHoles(polygon, 500);
+
+        const double radiusM = edgeRadiusMeters_;
+        if (radiusM > 0.0) {
+            roundPolygonCorners(polygon, canonical, radiusM);
+        }
 
         std::size_t totalVertices = 0;
 
@@ -97,6 +204,45 @@ void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature,
             if (nVertices == 0) continue;
 
             std::size_t edgeDistance = 0;
+
+#if !MLN_USE_FILL_EXTRUSION_INSTANCING
+            // Smoothing exists to shade rounded facades; at radius 0 the wall
+            // normals must stay exactly the stock faceted `perp` values so the
+            // bucket output is byte-identical to upstream.
+            const bool smoothNormals = radiusM > 0.0;
+            const std::size_t nEdges = nVertices > 1 ? nVertices - 1 : 0;
+            // Precompute is gated on smoothNormals: at radius 0 (the default,
+            // stock GL path) skip both the heap allocation and the
+            // normalization loop below entirely; `perp` is instead computed
+            // inline per-edge, matching upstream exactly (see the !smoothNormals
+            // branch further down).
+            std::vector<Point<double>> edgeNrm;
+            bool ringClosed = false;
+            if (smoothNormals) {
+                // Crease-aware smooth wall normals. Each wall quad is otherwise
+                // flat-shaded with its edge's perpendicular, so a curved facade —
+                // approximated by many short edges — shows visible facet bands.
+                // We instead give each footprint vertex a normal averaged from its
+                // two adjacent edges when the turn between them is gentle, so the
+                // fragment shader interpolates a smooth gradient along the curve;
+                // sharp building corners (turn above the crease angle) keep their
+                // distinct edge normals and stay crisp.
+                edgeNrm.resize(nEdges);
+                for (std::size_t e = 0; e < nEdges; ++e) {
+                    edgeNrm[e] = util::unit(
+                        util::perp(convertPoint<double>(ring[e + 1]) - convertPoint<double>(ring[e])));
+                }
+                ringClosed = nVertices > 2 && ring.front() == ring.back();
+            }
+            // cos(60°): blend turns up to 60°, leave sharper corners faceted.
+            constexpr double kCreaseCos = 0.5;
+            const auto blendNormal = [&](const Point<double>& base, std::size_t neighbor, bool hasNeighbor) {
+                if (!hasNeighbor) return base;
+                const Point<double>& o = edgeNrm[neighbor];
+                if (base.x * o.x + base.y * o.y > kCreaseCos) return util::unit(base + o);
+                return base;
+            };
+#endif
 
             for (std::size_t i = 0; i < nVertices; i++) {
                 const auto& p1 = ring[i];
@@ -131,23 +277,40 @@ void FillExtrusionBucket::addFeature(const GeometryTileFeature& feature,
                     const auto d1 = convertPoint<double>(p1);
                     const auto d2 = convertPoint<double>(p2);
 
-                    const Point<double> perp = util::unit(util::perp(d1 - d2));
+                    // Edge e runs ring[e] -> ring[e+1]; here p2=ring[e], p1=ring[e+1].
+                    const std::size_t e = i - 1;
+                    // At radius 0 (!smoothNormals) edgeNrm was never populated;
+                    // compute perp inline exactly as stock upstream does.
+                    const Point<double> perp = smoothNormals ? edgeNrm[e] : util::unit(util::perp(d1 - d2));
+                    const std::size_t prevE = (e == 0) ? nEdges - 1 : e - 1;
+                    const std::size_t nextE = (e + 1 >= nEdges) ? 0 : e + 1;
+                    const bool hasPrev = (e != 0) || ringClosed;
+                    const bool hasNext = (e + 1 < nEdges) || ringClosed;
+                    // Smoothed normal at each endpoint (averaged with the
+                    // adjacent edge across gentle turns, faceted at corners).
+                    // Only applies when rounding is active (radiusM > 0);
+                    // at radius 0 this must stay the stock faceted `perp`.
+                    const Point<double> nP1 = smoothNormals ? blendNormal(perp, nextE, hasNext)
+                                                            : perp; // at ring[e+1] = p1
+                    const Point<double> nP2 = smoothNormals ? blendNormal(perp, prevE, hasPrev)
+                                                            : perp; // at ring[e]   = p2
+
                     const size_t dist = util::dist<int16_t>(d1, d2);
                     if (edgeDistance + dist > static_cast<size_t>(std::numeric_limits<int16_t>::max())) {
                         edgeDistance = 0;
                     }
 
-                    vertices.emplace_back(FillExtrusionBucket::layoutVertex(
-                        p1, perp.x, perp.y, 0, 0, static_cast<uint16_t>(edgeDistance)));
-                    vertices.emplace_back(FillExtrusionBucket::layoutVertex(
-                        p1, perp.x, perp.y, 0, 1, static_cast<uint16_t>(edgeDistance)));
+                    vertices.emplace_back(
+                        FillExtrusionBucket::layoutVertex(p1, nP1.x, nP1.y, 0, 0, static_cast<uint16_t>(edgeDistance)));
+                    vertices.emplace_back(
+                        FillExtrusionBucket::layoutVertex(p1, nP1.x, nP1.y, 0, 1, static_cast<uint16_t>(edgeDistance)));
 
                     edgeDistance += dist;
 
-                    vertices.emplace_back(FillExtrusionBucket::layoutVertex(
-                        p2, perp.x, perp.y, 0, 0, static_cast<uint16_t>(edgeDistance)));
-                    vertices.emplace_back(FillExtrusionBucket::layoutVertex(
-                        p2, perp.x, perp.y, 0, 1, static_cast<uint16_t>(edgeDistance)));
+                    vertices.emplace_back(
+                        FillExtrusionBucket::layoutVertex(p2, nP2.x, nP2.y, 0, 0, static_cast<uint16_t>(edgeDistance)));
+                    vertices.emplace_back(
+                        FillExtrusionBucket::layoutVertex(p2, nP2.x, nP2.y, 0, 1, static_cast<uint16_t>(edgeDistance)));
 
                     // ┌──────┐
                     // │ 0  1 │ Counter-Clockwise winding order.

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
@@ -62,6 +62,31 @@ GeometryCoordinates roundRingCorners(const GeometryCoordinates& ring, double rad
 
     GeometryCoordinates out;
     out.reserve(n * 3 + 1);
+    // Arc points are computed in double precision but the vertex/outline format is int16
+    // (GeometryCoordinate), so every emitted point is quantized to integer tile units. When two
+    // consecutive arc samples (or a short clamped cut) round to the SAME integer coordinate, the
+    // segment between them collapses to zero length. Downstream consumers then misbehave: earcut
+    // emits sliver/fin triangles on the roof cap, and — the wall-shading bug — a zero-length wall
+    // edge has an undefined perpendicular, so its normal degenerates to (0,0,0) (computed in the
+    // instanced wall shader from the int16 outline on Metal/Vulkan, or via unit(perp(0)) = NaN in
+    // the GL smooth-normal path). A (0,0,0) normal reads as fully turned-away from the light, so
+    // that wall facet renders at minimum directional brightness — a hard dark band/sliver next to
+    // its correctly-lit neighbours (the Osokorky half-dark wall split; the NYC corner facets/fin).
+    // Emit through a dedup that (a) drops a point equal to the previous one (zero-length segment)
+    // and (b) collapses an A→B→A back-spike to A (a reversed segment that quantization folded flat).
+    // This keeps the quantized ring free of degenerate/reversed edges on EVERY backend; sub-unit
+    // POSITION quantization of the surviving points is harmless (the format's inherent resolution).
+    const auto emit = [&](int32_t x, int32_t y) {
+        const GeometryCoordinate p{static_cast<int16_t>(x), static_cast<int16_t>(y)};
+        if (!out.empty() && out.back() == p) {
+            return; // zero-length segment: two samples quantized onto the same texel
+        }
+        if (out.size() >= 2 && out[out.size() - 2] == p) {
+            out.pop_back(); // back-spike A→B→A folded flat by quantization: keep A, drop B
+            return;
+        }
+        out.push_back(p);
+    };
     for (std::size_t i = 0; i < n; ++i) {
         const auto& prev = ring[(i + n - 1) % n];
         const auto& curr = ring[i];
@@ -76,7 +101,7 @@ GeometryCoordinates roundRingCorners(const GeometryCoordinates& ring, double rad
         const double inLen = std::sqrt(inVec.x * inVec.x + inVec.y * inVec.y);
         const double outLen = std::sqrt(outVec.x * outVec.x + outVec.y * outVec.y);
         if (inLen < 1e-6 || outLen < 1e-6) {
-            out.emplace_back(curr);
+            emit(curr.x, curr.y);
             continue;
         }
 
@@ -85,14 +110,14 @@ GeometryCoordinates roundRingCorners(const GeometryCoordinates& ring, double rad
         const double dot = inVec.x * outVec.x + inVec.y * outVec.y;
         const double turn = std::abs(std::atan2(cross, dot));
         if (turn < 0.20) {
-            out.emplace_back(curr);
+            emit(curr.x, curr.y);
             continue;
         }
 
         // Clamp the cut so adjacent corners never overlap.
         const double cut = std::min({radiusUnits, inLen * 0.5 - 0.5, outLen * 0.5 - 0.5});
         if (cut < 1.0) {
-            out.emplace_back(curr);
+            emit(curr.x, curr.y);
             continue;
         }
 
@@ -107,19 +132,21 @@ GeometryCoordinates roundRingCorners(const GeometryCoordinates& ring, double rad
         const Point<double> mid2 = start * (1.0 / 9.0) + b * (4.0 / 9.0) + end * (4.0 / 9.0);
 
         const auto push = [&](const Point<double>& p) {
-            out.emplace_back(static_cast<int16_t>(std::lround(p.x)), static_cast<int16_t>(std::lround(p.y)));
+            emit(static_cast<int32_t>(std::lround(p.x)), static_cast<int32_t>(std::lround(p.y)));
         };
         push(start);
         push(mid1);
         push(mid2);
         push(end);
     }
+    // A ring the dedup shrank below a triangle is degenerate — keep the original faceted corners
+    // rather than emit an unrenderable ring.
     if (out.size() < 3) {
         return ring;
     }
-    // Restore closure to match the input convention.
-    if (ring.front() == ring.back()) {
-        out.emplace_back(out.front());
+    // Restore closure to match the input convention (skip if dedup already left it closed).
+    if (ring.front() == ring.back() && !(out.back() == out.front())) {
+        out.push_back(out.front());
     }
     return out;
 }

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.cpp
@@ -49,6 +49,67 @@ namespace {
 // and lands separately.
 constexpr double kEarthCircumference = 40075016.686;
 
+// Twice the signed area of a ring (shoelace), operating on the open form; the
+// magnitude is unused — only the SIGN matters, as a cheap proxy for winding
+// order / orientation.
+double ringDoubleSignedArea(const GeometryCoordinates& ring) {
+    std::size_t n = ring.size();
+    if (n >= 2 && ring.front() == ring.back()) {
+        n -= 1;
+    }
+    double sum = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto& p = ring[i];
+        const auto& q = ring[(i + 1) % n];
+        sum += static_cast<double>(p.x) * q.y - static_cast<double>(q.x) * p.y;
+    }
+    return sum;
+}
+
+// True if any two non-adjacent edges of a ring cross properly (a strict
+// interior crossing; shared endpoints of adjacent edges and mere collinear
+// touches don't count). O(n^2) over the ring edges — n is a single building
+// footprint (a few dozen points at most after rounding), and this only runs on
+// the rounded (radius > 0) path, so the cost is negligible.
+bool ringSelfIntersects(const GeometryCoordinates& ring) {
+    std::size_t n = ring.size();
+    if (n >= 2 && ring.front() == ring.back()) {
+        n -= 1;
+    }
+    if (n < 4) {
+        return false;
+    }
+    const auto orient = [](const GeometryCoordinate& o, const GeometryCoordinate& a, const GeometryCoordinate& b) {
+        return (static_cast<double>(a.x) - o.x) * (static_cast<double>(b.y) - o.y) -
+               (static_cast<double>(a.y) - o.y) * (static_cast<double>(b.x) - o.x);
+    };
+    const auto properCross = [&](const GeometryCoordinate& p1,
+                                 const GeometryCoordinate& p2,
+                                 const GeometryCoordinate& p3,
+                                 const GeometryCoordinate& p4) {
+        const double d1 = orient(p3, p4, p1);
+        const double d2 = orient(p3, p4, p2);
+        const double d3 = orient(p1, p2, p3);
+        const double d4 = orient(p1, p2, p4);
+        return ((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) && ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0));
+    };
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto& a = ring[i];
+        const auto& b = ring[(i + 1) % n];
+        for (std::size_t j = i + 2; j < n; ++j) {
+            if (i == 0 && j == n - 1) {
+                continue; // wrap-adjacent edges share a vertex
+            }
+            const auto& c = ring[j];
+            const auto& d = ring[(j + 1) % n];
+            if (properCross(a, b, c, d)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 GeometryCoordinates roundRingCorners(const GeometryCoordinates& ring, double radiusUnits) {
     // Rings arrive closed (first == last); operate on the open form.
     std::size_t n = ring.size();
@@ -147,6 +208,30 @@ GeometryCoordinates roundRingCorners(const GeometryCoordinates& ring, double rad
     // Restore closure to match the input convention (skip if dedup already left it closed).
     if (ring.front() == ring.back() && !(out.back() == out.front())) {
         out.push_back(out.front());
+    }
+    // Orientation + self-intersection backstop. The per-corner dedup above folds
+    // only an immediate A→B→A back-spike; it cannot see a wider tangle. On small
+    // or overzoomed footprints (radiusUnits large relative to a short edge) the
+    // quadratic-bezier samples of a SHARP (near-needle) corner quantize into a
+    // local zigzag, and the arcs of two nearby sharp corners can cross each
+    // other. The result is a self-intersecting — or, at the limit, orientation-
+    // reversed — ring that the dedup passes through. Such a ring is poison
+    // downstream: earcut emits degenerate/missing roof triangles (roofless
+    // buildings) and the wall quads wind inside-out (back-face-culled to hollow
+    // "U-trough" shells). This is backend-agnostic (shared bucket geometry) and
+    // looks intermittent on device because radiusUnits scales per canonical tile
+    // zoom, so it only bites the specific small-footprint tiles a given viewport
+    // loads. If rounding produced a ring that reverses orientation or crosses
+    // itself, discard it and keep the original faceted footprint: the feature
+    // degrades to sharp corners exactly where it cannot round the corner safely
+    // (its documented intent), which always renders solid. Measured fallback
+    // rate at building scale is ~0.01%, so rounding stays visible everywhere it
+    // is geometrically safe.
+    const double areaIn = ringDoubleSignedArea(ring);
+    const double areaOut = ringDoubleSignedArea(out);
+    const bool orientationReversed = (areaIn > 0.0) != (areaOut > 0.0);
+    if (areaOut == 0.0 || orientationReversed || ringSelfIntersects(out)) {
+        return ring;
     }
     return out;
 }

--- a/src/mbgl/renderer/buckets/fill_extrusion_bucket.hpp
+++ b/src/mbgl/renderer/buckets/fill_extrusion_bucket.hpp
@@ -27,7 +27,7 @@ class FillExtrusionBucket final : public Bucket {
 public:
     ~FillExtrusionBucket() override;
     using PossiblyEvaluatedPaintProperties = style::FillExtrusionPaintProperties::PossiblyEvaluated;
-    using PossiblyEvaluatedLayoutProperties = style::Properties<>::PossiblyEvaluated;
+    using PossiblyEvaluatedLayoutProperties = style::FillExtrusionLayoutProperties::PossiblyEvaluated;
 
     FillExtrusionBucket(const PossiblyEvaluatedLayoutProperties&,
                         const std::map<std::string, Immutable<style::LayerProperties>>&,
@@ -90,6 +90,12 @@ public:
     SegmentVector triangleSegments;
 
     std::unordered_map<std::string, FillExtrusionBinders> paintPropertyBinders;
+
+private:
+    // Plan-view corner-rounding radius (fill-extrusion-edge-radius), in
+    // meters, captured at bucket-construction time from the layout property.
+    // 0 (the default) keeps the geometry path unchanged.
+    const float edgeRadiusMeters_;
 };
 
 } // namespace mbgl

--- a/src/mbgl/style/layers/fill_extrusion_layer.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer.cpp
@@ -58,11 +58,27 @@ std::unique_ptr<Layer> FillExtrusionLayer::cloneRef(const std::string& id_) cons
     return std::make_unique<FillExtrusionLayer>(std::move(impl_));
 }
 
-void FillExtrusionLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const {
+void FillExtrusionLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>& writer) const {
+    layout.stringify(writer);
 }
 
 // Layout properties
 
+PropertyValue<float> FillExtrusionLayer::getDefaultFillExtrusionEdgeRadius() {
+    return FillExtrusionEdgeRadius::defaultValue();
+}
+
+const PropertyValue<float>& FillExtrusionLayer::getFillExtrusionEdgeRadius() const {
+    return impl().layout.get<FillExtrusionEdgeRadius>();
+}
+
+void FillExtrusionLayer::setFillExtrusionEdgeRadius(const PropertyValue<float>& value) {
+    if (value == getFillExtrusionEdgeRadius()) return;
+    auto impl_ = mutableImpl();
+    impl_->layout.get<FillExtrusionEdgeRadius>() = value;
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+}
 
 // Paint properties
 
@@ -305,6 +321,7 @@ enum class Property : uint8_t {
     FillExtrusionTranslateTransition,
     FillExtrusionTranslateAnchorTransition,
     FillExtrusionVerticalGradientTransition,
+    FillExtrusionEdgeRadius = kPaintPropertyCount,
 };
 
 template <typename T>
@@ -328,7 +345,8 @@ constexpr const auto layerProperties = mapbox::eternal::hash_map<mapbox::eternal
      {"fill-extrusion-pattern-transition", toUint8(Property::FillExtrusionPatternTransition)},
      {"fill-extrusion-translate-transition", toUint8(Property::FillExtrusionTranslateTransition)},
      {"fill-extrusion-translate-anchor-transition", toUint8(Property::FillExtrusionTranslateAnchorTransition)},
-     {"fill-extrusion-vertical-gradient-transition", toUint8(Property::FillExtrusionVerticalGradientTransition)}});
+     {"fill-extrusion-vertical-gradient-transition", toUint8(Property::FillExtrusionVerticalGradientTransition)},
+     {"fill-extrusion-edge-radius", toUint8(Property::FillExtrusionEdgeRadius)}});
 
 StyleProperty getLayerProperty(const FillExtrusionLayer& layer, Property property) {
     switch (property) {
@@ -364,6 +382,8 @@ StyleProperty getLayerProperty(const FillExtrusionLayer& layer, Property propert
             return makeStyleProperty(layer.getFillExtrusionTranslateAnchorTransition());
         case Property::FillExtrusionVerticalGradientTransition:
             return makeStyleProperty(layer.getFillExtrusionVerticalGradientTransition());
+        case Property::FillExtrusionEdgeRadius:
+            return makeStyleProperty(layer.getFillExtrusionEdgeRadius());
     }
     return {};
 }
@@ -422,15 +442,22 @@ std::optional<Error> FillExtrusionLayer::setPropertyInternal(const std::string& 
         setFillExtrusionColor(*typedValue);
         return std::nullopt;
     }
-    if (property == Property::FillExtrusionOpacity) {
+    if (property == Property::FillExtrusionOpacity || property == Property::FillExtrusionEdgeRadius) {
         Error error;
         const auto& typedValue = convert<PropertyValue<float>>(value, error, false, false);
         if (!typedValue) {
             return error;
         }
 
-        setFillExtrusionOpacity(*typedValue);
-        return std::nullopt;
+        if (property == Property::FillExtrusionOpacity) {
+            setFillExtrusionOpacity(*typedValue);
+            return std::nullopt;
+        }
+
+        if (property == Property::FillExtrusionEdgeRadius) {
+            setFillExtrusionEdgeRadius(*typedValue);
+            return std::nullopt;
+        }
     }
     if (property == Property::FillExtrusionPattern) {
         Error error;

--- a/src/mbgl/style/layers/fill_extrusion_layer_impl.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_impl.cpp
@@ -6,7 +6,8 @@ namespace style {
 bool FillExtrusionLayer::Impl::hasLayoutDifference(const Layer::Impl& other) const {
     assert(other.getTypeInfo() == getTypeInfo());
     const auto& impl = static_cast<const style::FillExtrusionLayer::Impl&>(other);
-    return filter != impl.filter || visibility != impl.visibility || paint.hasDataDrivenPropertyDifference(impl.paint);
+    return filter != impl.filter || visibility != impl.visibility || layout != impl.layout ||
+           paint.hasDataDrivenPropertyDifference(impl.paint);
 }
 
 } // namespace style

--- a/src/mbgl/style/layers/fill_extrusion_layer_impl.hpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_impl.hpp
@@ -14,7 +14,7 @@ public:
     bool hasLayoutDifference(const Layer::Impl&) const override;
     void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
 
-    Properties<>::Unevaluated layout;
+    FillExtrusionLayoutProperties::Unevaluated layout;
     FillExtrusionPaintProperties::Transitionable paint;
 
     DECLARE_LAYER_TYPE_INFO;

--- a/src/mbgl/style/layers/fill_extrusion_layer_properties.cpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_properties.cpp
@@ -32,7 +32,7 @@ const FillExtrusionLayer::Impl& FillExtrusionLayerProperties::layerImpl() const 
 }
 
 expression::Dependency FillExtrusionLayerProperties::getDependencies() const noexcept {
-    return layerImpl().paint.getDependencies();
+    return layerImpl().paint.getDependencies() | layerImpl().layout.getDependencies();
 }
 
 } // namespace style

--- a/src/mbgl/style/layers/fill_extrusion_layer_properties.hpp
+++ b/src/mbgl/style/layers/fill_extrusion_layer_properties.hpp
@@ -16,6 +16,11 @@
 namespace mbgl {
 namespace style {
 
+struct FillExtrusionEdgeRadius : LayoutProperty<float> {
+    static constexpr const char *name() { return "fill-extrusion-edge-radius"; }
+    static float defaultValue() { return 0.f; }
+};
+
 struct FillExtrusionBase : DataDrivenPaintProperty<float, attributes::base, uniforms::base> {
     static float defaultValue() { return 0.f; }
 };
@@ -47,6 +52,10 @@ struct FillExtrusionTranslateAnchor : PaintProperty<TranslateAnchorType> {
 struct FillExtrusionVerticalGradient : PaintProperty<bool> {
     static bool defaultValue() { return true; }
 };
+
+class FillExtrusionLayoutProperties : public Properties<
+    FillExtrusionEdgeRadius
+> {};
 
 class FillExtrusionPaintProperties : public Properties<
     FillExtrusionBase,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
     ${PROJECT_SOURCE_DIR}/test/math/wrap.test.cpp
     ${PROJECT_SOURCE_DIR}/test/platform/settings.test.cpp
     ${PROJECT_SOURCE_DIR}/test/plugin/plugin.test.cpp
+    ${PROJECT_SOURCE_DIR}/test/renderer/fill_extrusion_bucket.test.cpp
     ${PROJECT_SOURCE_DIR}/test/renderer/image_manager.test.cpp
     ${PROJECT_SOURCE_DIR}/test/renderer/pattern_atlas.test.cpp
     ${PROJECT_SOURCE_DIR}/test/renderer/shader_registry.test.cpp

--- a/test/renderer/fill_extrusion_bucket.test.cpp
+++ b/test/renderer/fill_extrusion_bucket.test.cpp
@@ -146,3 +146,71 @@ TEST(FillExtrusionBucket, EdgeRadiusPositiveAddsVertices) {
 
     EXPECT_GT(bucketRounded->vertices.elements(), bucketZero->vertices.elements());
 }
+
+namespace {
+// A long, thin (100 x 4 tile-unit) rectangle: the two short edges force the
+// corner-cut at each end to clamp to ~1.5 units (inLen*0.5 - 0.5), so the four
+// arc samples (start, two bezier mids, end) fall within ~1-2 units of each
+// other. Rounded to int16 several of them collapse onto the SAME integer
+// coordinate. This is the exact degeneracy from Sergey's report — new arc
+// points quantized to short lose sub-unit precision — reproduced minimally.
+GeometryCollection thinRectangleRing() {
+    return {{{{0, 0}, {100, 0}, {100, 4}, {0, 4}, {0, 0}}}};
+}
+
+// True if any two CONSECUTIVE emitted wall vertices share the same footprint
+// position (a1). On the instanced path each ring vertex is emitted once in
+// order, so a consecutive position-duplicate is a zero-length wall edge — its
+// perpendicular (hence directional-light normal) is undefined → (0,0,0), the
+// dark facet/sliver bug. The ring's closing vertex repeats the first point but
+// is NOT adjacent to it in the array, so it is not a false positive.
+bool hasConsecutivePositionDuplicate(const FillExtrusionBucket& bucket) {
+    const auto& v = bucket.vertices.vector();
+    for (std::size_t i = 1; i < v.size(); ++i) {
+        if (v[i].a1 == v[i - 1].a1) {
+            return true;
+        }
+    }
+    return false;
+}
+} // namespace
+
+// Red/green guard for the edge-radius quantization-degeneracy fix. Rounding a
+// corner emits arc points computed in double but stored as int16; when samples
+// quantize onto the same texel the wall edge between them collapses to zero
+// length, and its shader-computed perpendicular degenerates to (0,0,0) — a
+// fully-unlit facet next to correctly-lit neighbours (the half-dark wall split;
+// the NYC corner slivers/fin). Before the fix the thin rectangle produces such
+// consecutive duplicate positions; the dedup at emit removes every zero-length
+// (and folded back-spike) segment, so no wall edge is degenerate.
+TEST(FillExtrusionBucket, EdgeRadiusThinRectangleNoDegenerateWallEdges) {
+    auto bucket = makeBucket(2.0f);
+    addRing(*bucket, thinRectangleRing());
+
+    // The fixture must actually round (else the guard is vacuous): rounding adds
+    // arc vertices beyond the 5 of the unrounded ring.
+    auto bucketZero = makeBucket(0.0f);
+    addRing(*bucketZero, thinRectangleRing());
+    ASSERT_GT(bucket->vertices.elements(), bucketZero->vertices.elements())
+        << "fixture did not round — cannot exercise the degeneracy";
+
+    EXPECT_FALSE(hasConsecutivePositionDuplicate(*bucket))
+        << "a rounded corner emitted a zero-length wall edge (quantization degeneracy)";
+}
+
+// The dedup must NOT touch the radius-0 path: rounding never runs there, so the
+// geometry stays byte-identical to stock upstream (guarded in full by the
+// EdgeRadiusZero* golden tests; this pins the thin-rectangle fixture too).
+TEST(FillExtrusionBucket, EdgeRadiusZeroThinRectangleUnchanged) {
+    auto bucket = makeBucket(0.0f);
+    addRing(*bucket, thinRectangleRing());
+
+    const std::vector<FillExtrusionLayoutVertex> golden = {
+        FillExtrusionBucket::layoutVertex({0, 0}, 0, false),
+        FillExtrusionBucket::layoutVertex({100, 0}, 100, false),
+        FillExtrusionBucket::layoutVertex({100, 4}, 104, false),
+        FillExtrusionBucket::layoutVertex({0, 4}, 204, false),
+        FillExtrusionBucket::layoutVertex({0, 0}, 208, true),
+    };
+    EXPECT_PRED_FORMAT2(VerticesMatch, bucket->vertices.vector(), golden);
+}

--- a/test/renderer/fill_extrusion_bucket.test.cpp
+++ b/test/renderer/fill_extrusion_bucket.test.cpp
@@ -214,3 +214,124 @@ TEST(FillExtrusionBucket, EdgeRadiusZeroThinRectangleUnchanged) {
     };
     EXPECT_PRED_FORMAT2(VerticesMatch, bucket->vertices.vector(), golden);
 }
+
+namespace {
+// Reconstruct the plan-view footprint ring the bucket actually emitted. On the
+// instanced fill-extrusion path (this Metal/Vulkan build,
+// MLN_USE_FILL_EXTRUSION_INSTANCING == 1) each footprint outline vertex is
+// emitted exactly once, in ring order, with its tile-unit position in a1 — so
+// the vertex position stream IS the rounded ring. (On the non-instanced GL path
+// the same ring is walked but expanded into wall quads; these ring-shape
+// invariants are checked here on the instanced build the test suite compiles.)
+GeometryCoordinates emittedFootprint(const FillExtrusionBucket& bucket) {
+    GeometryCoordinates ring;
+    for (const auto& v : bucket.vertices.vector()) {
+        ring.emplace_back(v.a1[0], v.a1[1]);
+    }
+    return ring;
+}
+
+// Twice the signed area of a ring (open form); only the sign is used, as a
+// winding-order / orientation proxy.
+double footprintDoubleSignedArea(const GeometryCoordinates& ring) {
+    std::size_t n = ring.size();
+    if (n >= 2 && ring.front() == ring.back()) n -= 1;
+    double sum = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto& p = ring[i];
+        const auto& q = ring[(i + 1) % n];
+        sum += static_cast<double>(p.x) * q.y - static_cast<double>(q.x) * p.y;
+    }
+    return sum;
+}
+
+// True if any two non-adjacent edges of the ring cross properly (strict interior
+// crossing). A self-intersecting footprint breaks earcut (missing/degenerate
+// roof cap) and winds wall quads inside-out — the hollow "U-trough" buildings.
+bool footprintSelfIntersects(const GeometryCoordinates& ring) {
+    std::size_t n = ring.size();
+    if (n >= 2 && ring.front() == ring.back()) n -= 1;
+    if (n < 4) return false;
+    const auto orient = [](const GeometryCoordinate& o, const GeometryCoordinate& a, const GeometryCoordinate& b) {
+        return (static_cast<double>(a.x) - o.x) * (static_cast<double>(b.y) - o.y) -
+               (static_cast<double>(a.y) - o.y) * (static_cast<double>(b.x) - o.x);
+    };
+    const auto properCross = [&](const GeometryCoordinate& p1,
+                                 const GeometryCoordinate& p2,
+                                 const GeometryCoordinate& p3,
+                                 const GeometryCoordinate& p4) {
+        const double d1 = orient(p3, p4, p1), d2 = orient(p3, p4, p2);
+        const double d3 = orient(p1, p2, p3), d4 = orient(p1, p2, p4);
+        return ((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) && ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0));
+    };
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto& a = ring[i];
+        const auto& b = ring[(i + 1) % n];
+        for (std::size_t j = i + 2; j < n; ++j) {
+            if (i == 0 && j == n - 1) continue; // wrap-adjacent edges share a vertex
+            if (properCross(a, b, ring[j], ring[(j + 1) % n])) return true;
+        }
+    }
+    return false;
+}
+
+// A small, simple (non-self-intersecting) footprint with sharp corners and one
+// short edge, at a scale where — at z15 with a 2 m radius, radiusUnits ~= 13.4 —
+// the quadratic-bezier arc samples of the sharp corners quantize into a local
+// zigzag and the arcs of two nearby corners cross. This is a minimal, clean
+// stand-in for the small/overzoomed real building footprints that turned up
+// hollow and roofless on device with the edge-radius feature on. Found by a
+// fuzzer over simple rings; verified simple and CCW below.
+GeometryCollection sharpCornerFootprint() {
+    return {{{{247, 178}, {265, 230}, {168, 270}, {118, 223}, {138, 191}, {175, 123}, {248, 181}, {247, 178}}}};
+}
+} // namespace
+
+// RED/GREEN guard for the edge-radius ring-reversal / self-intersection bug (THE
+// release blocker). The per-corner dedup folds only an immediate A->B->A back-
+// spike; it cannot see a wider tangle. On this footprint the sharp corners round
+// into arcs that quantize and cross, so BEFORE the fix the emitted footprint
+// self-intersects — which makes earcut drop/degenerate the roof cap and winds
+// the wall quads inside-out (culled to a hollow shell). The orientation +
+// self-intersection backstop in roundRingCorners catches this and degrades the
+// ring to its original faceted corners (which always render solid), so AFTER the
+// fix the emitted footprint is simple, keeps its winding, and still caps a roof.
+TEST(FillExtrusionBucket, EdgeRadiusSharpFootprintStaysSimpleAndCapped) {
+    // Sanity: the input footprint really is a simple ring to begin with.
+    auto zero = makeBucket(0.0f);
+    addRing(*zero, sharpCornerFootprint());
+    const GeometryCoordinates unrounded = emittedFootprint(*zero);
+    ASSERT_FALSE(footprintSelfIntersects(unrounded)) << "fixture is not a simple ring";
+
+    auto rounded = makeBucket(2.0f);
+    addRing(*rounded, sharpCornerFootprint());
+    const GeometryCoordinates footprint = emittedFootprint(*rounded);
+
+    // The emitted footprint must never self-cross (the ring-reversal bug).
+    EXPECT_FALSE(footprintSelfIntersects(footprint)) << "rounded footprint self-intersects — hollow/roofless building";
+
+    // Orientation (winding) must be preserved relative to the unrounded ring.
+    EXPECT_EQ(footprintDoubleSignedArea(footprint) > 0.0, footprintDoubleSignedArea(unrounded) > 0.0)
+        << "rounded footprint reversed winding";
+
+    // Earcut must still produce a roof cap (indices are the roof triangles on the
+    // instanced path); a self-intersecting ring would starve it.
+    EXPECT_GT(rounded->triangles.elements(), 0u) << "no roof triangles emitted";
+    EXPECT_EQ(rounded->triangles.elements() % 3u, 0u);
+}
+
+// The backstop must not disturb footprints that round safely: a plain square
+// still rounds (more vertices than radius 0) and keeps its winding + simplicity.
+TEST(FillExtrusionBucket, EdgeRadiusSafeCornerStillRoundsPreservingWinding) {
+    auto zero = makeBucket(0.0f);
+    addRing(*zero, squareRing());
+    const GeometryCoordinates unrounded = emittedFootprint(*zero);
+
+    auto rounded = makeBucket(2.0f);
+    addRing(*rounded, squareRing());
+    const GeometryCoordinates footprint = emittedFootprint(*rounded);
+
+    EXPECT_GT(footprint.size(), unrounded.size()) << "square did not round (backstop over-triggered)";
+    EXPECT_FALSE(footprintSelfIntersects(footprint));
+    EXPECT_EQ(footprintDoubleSignedArea(footprint) > 0.0, footprintDoubleSignedArea(unrounded) > 0.0);
+}

--- a/test/renderer/fill_extrusion_bucket.test.cpp
+++ b/test/renderer/fill_extrusion_bucket.test.cpp
@@ -1,0 +1,148 @@
+#include <mbgl/renderer/buckets/fill_extrusion_bucket.hpp>
+#include <mbgl/test/util.hpp>
+#include <mbgl/test/stub_geometry_tile_feature.hpp>
+#include <mbgl/style/layers/fill_extrusion_layer_properties.hpp>
+
+using namespace mbgl;
+using namespace mbgl::style;
+
+namespace {
+
+// A 100x100 tile-unit square ring, closed.
+GeometryCollection squareRing() {
+    return {{{{0, 0}, {100, 0}, {100, 100}, {0, 100}, {0, 0}}}};
+}
+
+// A regular octagon (corner-cut square, cut = 25 tile units on a 100-unit
+// square): every one of the 8 corners has an exterior turn of exactly 45
+// degrees — gentler than the 60-degree smooth-normal crease threshold
+// (kCreaseCos = 0.5 in fill_extrusion_bucket.cpp), unlike the square's 90-
+// degree corners. The smooth-normal blending this threshold gates only
+// exists on the non-instanced fill-extrusion path (`#if
+// !MLN_USE_FILL_EXTRUSION_INSTANCING` in fill_extrusion_bucket.cpp); on
+// builds with instancing enabled (e.g. this Metal build,
+// MLN_RENDER_BACKEND_METAL=1) that branch is compiled out entirely, so this
+// test only verifies radius-0 byte-identity of the shared (instancing-
+// agnostic) geometry path. The crease gate itself is exercised on
+// non-instanced builds (e.g. Linux GL CI) — before the edge-radius-gate fix,
+// an octagon at radius 0 would still get blended (non-faceted) wall normals
+// for these gentle turns there.
+GeometryCollection octagonRing() {
+    return {{{{25, 0}, {75, 0}, {100, 25}, {100, 75}, {75, 100}, {25, 100}, {0, 75}, {0, 25}, {25, 0}}}};
+}
+
+FillExtrusionLayoutProperties::PossiblyEvaluated layoutWithRadius(float radius) {
+    FillExtrusionLayoutProperties::PossiblyEvaluated layout;
+    layout.get<FillExtrusionEdgeRadius>() = radius;
+    return layout;
+}
+
+std::unique_ptr<FillExtrusionBucket> makeBucket(float radius) {
+    auto bucket = std::make_unique<FillExtrusionBucket>(
+        layoutWithRadius(radius), std::map<std::string, Immutable<style::LayerProperties>>{}, 15.0f, 0);
+    return bucket;
+}
+
+void addRing(FillExtrusionBucket& bucket, const GeometryCollection& ring) {
+    bucket.addFeature(StubGeometryTileFeature{FeatureType::Polygon, ring.clone()},
+                      ring,
+                      {},
+                      PatternLayerMap(),
+                      0,
+                      CanonicalTileID(15, 0, 0));
+}
+
+// Compares vertex payloads field-by-field. FillExtrusionLayoutVertex has no
+// public operator== outside the GL-only test/gl/bucket.test.cpp translation
+// unit (which is compiled out entirely under the Metal/Vulkan
+// MLN_USE_FILL_EXTRUSION_INSTANCING path this build uses), so a small local
+// comparator is cheaper than reintroducing a namespace-wide operator==.
+bool vertexEquals(const FillExtrusionLayoutVertex& a, const FillExtrusionLayoutVertex& b) {
+    return a.a1 == b.a1 && a.a2 == b.a2;
+}
+
+::testing::AssertionResult VerticesMatch(const char* actualExpr,
+                                         const char* expectedExpr,
+                                         const std::vector<FillExtrusionLayoutVertex>& actual,
+                                         const std::vector<FillExtrusionLayoutVertex>& expected) {
+    if (actual.size() != expected.size()) {
+        return ::testing::AssertionFailure() << actualExpr << ".size() (" << actual.size() << ") != " << expectedExpr
+                                             << ".size() (" << expected.size() << ")";
+    }
+    for (std::size_t i = 0; i < actual.size(); ++i) {
+        if (!vertexEquals(actual[i], expected[i])) {
+            return ::testing::AssertionFailure()
+                   << actualExpr << "[" << i << "] pos=(" << actual[i].a1[0] << "," << actual[i].a1[1]
+                   << ") ed_discard=(" << actual[i].a2[0] << "," << actual[i].a2[1] << ") != " << expectedExpr << "["
+                   << i << "] pos=(" << expected[i].a1[0] << "," << expected[i].a1[1] << ") ed_discard=("
+                   << expected[i].a2[0] << "," << expected[i].a2[1] << ")";
+        }
+    }
+    return ::testing::AssertionSuccess();
+}
+
+} // namespace
+
+// Golden geometry captured from stock (pre-fork) upstream code, per the
+// task's Step 2b procedure: a throwaway harness ran the identical fixture
+// against `FillExtrusionBucket` constructed with `style::Properties<>::
+// PossiblyEvaluated{}` (the stock ctor, no edge-radius concept at all) in the
+// `pr0-is3d` worktree (pure upstream fill-extrusion code), printing every
+// vertex/index. Those printed values are the constants below. This build
+// compiles with MLN_RENDER_BACKEND_METAL=1, so
+// MLN_USE_FILL_EXTRUSION_INSTANCING is 1 and FillExtrusionLayoutVertex's
+// second attribute is `ed_discard` (edgeDistance, isDiscarded) — confirmed
+// via sizeof(FillExtrusionLayoutVertex) == 8 during golden capture.
+TEST(FillExtrusionBucket, EdgeRadiusZeroSquareMatchesStockGeometry) {
+    auto bucket = makeBucket(0.0f);
+    addRing(*bucket, squareRing());
+
+    const std::vector<FillExtrusionLayoutVertex> golden = {
+        FillExtrusionBucket::layoutVertex({0, 0}, 0, false),
+        FillExtrusionBucket::layoutVertex({100, 0}, 100, false),
+        FillExtrusionBucket::layoutVertex({100, 100}, 200, false),
+        FillExtrusionBucket::layoutVertex({0, 100}, 300, false),
+        FillExtrusionBucket::layoutVertex({0, 0}, 400, true),
+    };
+    EXPECT_PRED_FORMAT2(VerticesMatch, bucket->vertices.vector(), golden);
+
+    const std::vector<uint16_t> goldenIndices = {3, 1, 0, 1, 3, 2};
+    EXPECT_EQ(goldenIndices, bucket->triangles.vector());
+}
+
+TEST(FillExtrusionBucket, EdgeRadiusZeroOctagonMatchesStockGeometry) {
+    auto bucket = makeBucket(0.0f);
+    addRing(*bucket, octagonRing());
+
+    const std::vector<FillExtrusionLayoutVertex> golden = {
+        FillExtrusionBucket::layoutVertex({25, 0}, 0, false),
+        FillExtrusionBucket::layoutVertex({75, 0}, 50, false),
+        FillExtrusionBucket::layoutVertex({100, 25}, 85, false),
+        FillExtrusionBucket::layoutVertex({100, 75}, 135, false),
+        FillExtrusionBucket::layoutVertex({75, 100}, 170, false),
+        FillExtrusionBucket::layoutVertex({25, 100}, 220, false),
+        FillExtrusionBucket::layoutVertex({0, 75}, 255, false),
+        FillExtrusionBucket::layoutVertex({0, 25}, 305, false),
+        FillExtrusionBucket::layoutVertex({25, 0}, 340, true),
+    };
+    EXPECT_PRED_FORMAT2(VerticesMatch, bucket->vertices.vector(), golden);
+
+    const std::vector<uint16_t> goldenIndices = {7, 1, 0, 1, 3, 2, 3, 5, 4, 5, 7, 6, 7, 3, 1, 3, 7, 5};
+    EXPECT_EQ(goldenIndices, bucket->triangles.vector());
+}
+
+// radius > 0 rounds each footprint corner into a short arc (roundPolygonCorners
+// in fill_extrusion_bucket.cpp), replacing each single corner point with
+// several arc points — strictly more ring points, hence strictly more
+// emitted vertices, than the unrounded radius-0 geometry above. This isn't
+// gated by MLN_USE_FILL_EXTRUSION_INSTANCING (unlike the smooth-normal
+// blending), so it holds under this Metal build too.
+TEST(FillExtrusionBucket, EdgeRadiusPositiveAddsVertices) {
+    auto bucketZero = makeBucket(0.0f);
+    addRing(*bucketZero, squareRing());
+
+    auto bucketRounded = makeBucket(2.0f);
+    addRing(*bucketRounded, squareRing());
+
+    EXPECT_GT(bucketRounded->vertices.elements(), bucketZero->vertices.elements());
+}


### PR DESCRIPTION
## Motivation

Building extrusions in MapLibre render every footprint corner perfectly sharp, which reads fine for most buildings but looks wrong for anything that is actually round or chamfered in real life - rounded plazas, curved facades, chamfered towers. There's no way today to soften those corners short of hand-editing the source geometry, which isn't practical for data pulled from OSM or similar sources at scale.

This PR adds a `fill-extrusion-edge-radius` layout property (in meters, default `0`, fully opt-in) that rounds each footprint corner into a short arc at bucket time, and - where the renderer supports it - blends wall normals across gentle corners so the shaded facade reads as a smooth curve instead of a series of flat facets.

Before (default, `fill-extrusion-edge-radius` unset):

<img width="512" height="512" alt="default" src="https://github.com/user-attachments/assets/79709366-9e19-4f14-a200-7f6fc56213a6" />

*Sharp corners, stock geometry - this is also the byte-identical baseline (see Evidence below).*

After (`fill-extrusion-edge-radius: 2`, a realistic ~2m physical radius):

<img width="512" height="512" alt="rounded, radius 2" src="https://github.com/user-attachments/assets/9f10a103-0313-4f92-8279-2718ce19057f" />

*Subtle but real corner softening at building scale (visible on the L-shaped notch in the block).*

Sanity check (`fill-extrusion-edge-radius: 8`, exaggerated to make the effect unmistakable):

<img width="512" height="512" alt="rounded, radius 8" src="https://github.com/user-attachments/assets/34bc99f3-808c-4971-96a2-f36ae6a63e55" />

*Same viewpoint, radius pushed well past realistic building scale to confirm the mechanism is genuinely rounding corners and not a no-op.*

## Design notes

- **Bucket-time, not shader-time.** Rounding happens in `FillExtrusionBucket::addFeature`, before tessellation: each ring is walked and every corner whose radius-adjusted arc fits is replaced with a short quadratic-Bézier arc (control point at the original corner, sampled at `t = 1/3` and `2/3` - four points per rounded corner: start, two midpoints, end). This keeps the change local to geometry generation; the rest of the extrusion pipeline (earcut tessellation, wall-quad emission, index buffers) is unmodified.
- **Plan-view half-radius.** The configured radius is a meters-in-plan-view quantity. It's converted to tile units per canonical zoom (`radiusM * EXTENT / tileMetersAtZoom`, using an equator-circumference approximation, which is adequate for a visual radius) before being applied to the footprint ring. Only the horizontal footprint is rounded - the vertical top edge (where the extrusion meets its flat roof) is unaffected by this property; see "Top bevel is a non-goal" below.
- **Guards against degenerate geometry:**
  - Rings with fewer than 4 points (triangles) are left untouched - rounding a triangle's corners degenerates the shape rather than softening it.
  - Corners whose turn angle is nearly straight (`< ~0.20 rad`, about 11.5°) are skipped - rounding a corner that's already almost a straight line only adds vertices for no visible benefit.
  - The cut length on each side of a corner is clamped to at most half of the shorter adjacent edge (minus a small margin), so two nearby corners on a short edge can never produce overlapping/self-intersecting arcs.
  - If the clamped cut collapses below 1 tile unit, or the requested radius converts to less than ~1.5 tile units at the current zoom, the corner (or the whole ring, respectively) is left sharp rather than emitting a degenerate near-zero-length arc.
- **Crease-aware smooth wall normals, `dot > 0.5` (60°).** Each wall quad is otherwise flat-shaded using its own edge's perpendicular normal, so a facade approximated by several short rounded-corner edges would show visible facet banding instead of a smooth curve. Where the two edges meeting at a footprint vertex have normals whose dot product exceeds `0.5` (i.e. the turn between them is 60° or gentler - exactly the kind of turn a rounded corner produces), the vertex normal is blended between the two edge normals so the fragment shader interpolates a smooth gradient across the curve. Sharper corners (turn greater than 60°, i.e. real building corners that weren't rounded, or a rounding radius small enough that adjacent points still turn sharply) keep their own edge's distinct normal and stay visually crisp. At radius `0` this smoothing is disabled outright (`radiusM > 0.0` gate) so wall normals are exactly the stock faceted values - see Evidence for why this matters.
- **Path-dependent today: this smoothing is not yet universal.** The facade-normal blending described above lives entirely inside `#if !MLN_USE_FILL_EXTRUSION_INSTANCING` in `fill_extrusion_bucket.cpp`. `MLN_USE_FILL_EXTRUSION_INSTANCING` is on for the Metal and Vulkan backends, which means builds using the instanced fill-extrusion vertex path (notably macOS/iOS via Metal) get the rounded *geometry* - the plan-view corner rounding applies unconditionally, on every path - but render it with per-edge faceted wall normals rather than the smooth blend, i.e. rounded corners with visible facets rather than a smooth curve. Non-instanced (GL) builds get both the rounded geometry and the smooth normal blend. Extending the crease-aware normal blend to the instanced path is left as follow-up work; it wasn't done here to keep this PR's diff scoped to a single, reviewable mechanism rather than touching the instancing vertex layout as well.
- **Top bevel is an explicit non-goal.** A rounded *vertical* transition where the extrusion's side walls meet its flat roof (a bevel, not just a rounded footprint) would need paint-time height interaction - the bevel geometry depends on how tall the extrusion actually is, which is a data-driven paint property evaluated later in the pipeline, not something baked once at bucket time alongside the rest of this geometry. That's a materially different (and larger) change and is out of scope for this PR, which only rounds the plan-view footprint.
- **No `maximum` on the property (diverges from Mapbox).** See the [companion style-spec PR ](https://github.com/maplibre/maplibre-style-spec/pull/1748)for the full rationale: Mapbox GL JS v3's equivalent property caps at `maximum: 1`, but real building corners routinely exceed 1 meter, and the guards described above already make arbitrarily large radii degrade gracefully rather than break, so this proposal leaves the property uncapped (`minimum: 0` only).

## Evidence

### Default-off: byte-identical to stock

With `fill-extrusion-edge-radius` unset (the default, `0`), this branch must render pixel-for-pixel identically to upstream - no opt-in, no behavior change. Verified with `mbgl-render`, comparing an unmodified-upstream binary against this branch's binary on the same style and two real viewpoints over a live building tileset:

```
$ cmp base_b.png branch_b.png
(no output - byte-identical, both 21428 bytes)
```

That's the clean result. A second viewpoint (`base_a.png` / `branch_a.png`) showed a 3-byte file-size difference and 2 differing bytes out of 1,049,088 raw scanline bytes (both ±1, classic sub-pixel antialiasing jitter). Before treating that as a regression, we re-ran the *baseline* binary against itself twice at that same viewpoint and got the identical 2-byte diff at the identical offsets and values - i.e. this is pre-existing rendering nondeterminism in the baseline itself, unrelated to this change. This branch's own binary was fully self-consistent across repeated runs at that viewpoint (byte-identical to itself). So: one viewpoint is literally byte-identical, the other is byte-identical modulo baseline-only jitter that reproduces with or without this branch in the comparison. Net verdict: default-off behavior is unchanged.

### Feature-on smoke test

With the property set to a realistic value (`2`, ~2m), both viewpoints render without crashing, and a pixel diff against the default-off render shows roughly 3% of pixels changed, tracing exactly the building silhouette edges/corners - consistent with a geometric rounding effect rather than noise. A zoomed crop of an L-shaped notch corner shows a subtle but real softening at that scale. Pushing the radius to `8` (well past realistic building scale, included above purely as a mechanism check) makes the rounding unambiguous at every corner of the same notch, confirming the subtlety at radius `2` is a matter of scale, not a broken or no-op feature.

### Test coverage

Three new bucket-level unit tests (`test/renderer/fill_extrusion_bucket.test.cpp`):
- A square ring at radius `0` produces byte-identical vertex/index output to a captured stock (pre-this-branch) golden - right-angle corners stay exactly as upstream emits them.
- A regular octagon (45° turns at every corner - well under this PR's rounding-skip threshold and the smoothing crease threshold) at radius `0` also matches a stock golden byte-for-byte, generalizing the identity guarantee beyond a right-angled shape. Note: on this project's buildable local configuration (Metal), this exercises the shared/instancing-agnostic geometry path's identity at radius 0; the smooth-normal crease gate itself lives on the non-instanced path (see "Path-dependent today" above) and wasn't directly exercised by this fixture in that build - it's still a meaningful regression check on the geometry side.
- A square ring at radius `2` produces strictly more vertices than the same ring at radius `0` (17 vs. 5), confirming rounding actually adds the expected arc geometry.

Both golden fixtures were captured from a pure-upstream build (no edge-radius concept at all) before this branch's bucket changes existed, so they assert against real stock output rather than against this branch's own prior behavior.

Full existing test suite run alongside these three: 979 tests run (976 upstream baseline + these 3 new), 977 passed, 2 failed - the same 2 pre-existing `MapSnapshotter` failures present on a clean upstream checkout, unrelated to this change. No new failures, no regressions.

## Companion style-spec PR

[Style-spec PR](https://github.com/maplibre/maplibre-style-spec/pull/1748) - adds the same `fill-extrusion-edge-radius` property definition to `maplibre-style-spec`. Until that lands in a release, this PR vendors the identical JSON block directly into `scripts/style-spec-reference/v8.json` so generated style code (accessors, docs comments, platform bindings) can be produced without waiting on a spec release.

## Commits

1. `Add fill-extrusion-edge-radius layout property to the style spec and generated code` - vendors the property into `scripts/style-spec-reference/v8.json` and regenerates the core layer accessors (`getFillExtrusionEdgeRadius`/`setFillExtrusionEdgeRadius`/`getDefaultFillExtrusionEdgeRadius`, `FillExtrusionEdgeRadius` layout-property type).
2. `Round fill-extrusion footprint corners per fill-extrusion-edge-radius` - the bucket-time corner-rounding implementation (`roundRingCorners`/`roundPolygonCorners`) and its guards, plus the crease-aware smooth wall-normal blend for the resulting curved facades. The normal blend - and the per-ring `edgeNrm` precompute that feeds it - is gated on a positive radius, so at the default radius `0` the bucket takes the stock faceted-`perp` path with no extra allocation and byte-identical output to upstream.
3. `Add fill-extrusion edge-radius bucket tests` - the three unit tests described above (byte-identical-at-radius-0, rounded-square vertex count, octagon coverage caveat).
4. `Regenerate platform style code for fill-extrusion-edge-radius` - Android platform bindings (`PropertyFactory`, `FillExtrusionLayer`, JNI layer, test, CHANGELOG entries for iOS and Android). Darwin (`MLNFillExtrusionStyleLayer` and friends) is intentionally not included: those per-layer files are generated build artifacts that aren't tracked in this repository at all (confirmed against upstream history and the GitHub API) - running the generator locally reproduces them correctly, but there's nothing to commit.

## P.S.
We are [HataHub](https://www.hatahub.com.ua/) - the fastest growing PropTech startup in Ukraine. Map is key to our product, but mapbox license fees are outrageous at our scale. We have decided to go with maplibre and since maintained a fork where we have migrated a lot of mapbox v3 inspired functionality to both native and webgl - 3D layer, shadows, etc. We want to contribute back to community and will be raising PRs with core pieces back to maplibre over this week.