### PR TITLE
Add WGPU default platform includes to mbgl-core

### DIFF
--- a/cmake/webgpu.cmake
+++ b/cmake/webgpu.cmake
@@ -9,6 +9,12 @@ target_compile_definitions(
         MLN_RENDER_BACKEND_WEBGPU=1
 )
 
+target_include_directories(
+        mbgl-core
+        PUBLIC
+        ${PROJECT_SOURCE_DIR}/platform/default/include
+)
+
 list(APPEND
         SRC_FILES
         ${PROJECT_SOURCE_DIR}/src/mbgl/webgpu/buffer_resource.cpp


### PR DESCRIPTION
Adds platform/default/include to mbgl-core when WGPU is enabled, so core-only source builds can compile the WebGPU headless backend header from the default platform include tree.