### PR TITLE
Configure shared sccache S3 setup

### DIFF
--- a/.github/actions/configure-sccache-s3/action.yml
+++ b/.github/actions/configure-sccache-s3/action.yml
@@ -1,0 +1,46 @@
+name: configure-sccache-s3
+description: "Configure AWS credentials and sccache S3 cache"
+inputs:
+  role-to-assume:
+    description: "AWS role to assume with GitHub OIDC. Leave empty to use sccache without S3 writes."
+    required: false
+  aws-region:
+    description: "AWS region used to assume the role"
+    required: false
+    default: us-west-2
+  role-session-name:
+    description: "AWS role session name"
+    required: false
+    default: GitHubActions
+  sccache-bucket:
+    description: "S3 bucket used by sccache"
+    required: false
+    default: maplibre-native-sccache
+  sccache-region:
+    description: "S3 bucket region used by sccache"
+    required: false
+    default: eu-central-1
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS Credentials
+      if: ${{ inputs.role-to-assume != '' }}
+      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+      with:
+        aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ inputs.role-to-assume }}
+        role-session-name: ${{ inputs.role-session-name }}
+
+    - name: Configure sccache
+      shell: bash
+      env:
+        SCCACHE_BUCKET: ${{ inputs.sccache-bucket }}
+        SCCACHE_REGION: ${{ inputs.sccache-region }}
+      run: |
+        echo "SCCACHE_BUCKET=${SCCACHE_BUCKET}" >> "$GITHUB_ENV"
+        echo "SCCACHE_REGION=${SCCACHE_REGION}" >> "$GITHUB_ENV"
+
+        if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+          echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
+          echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
+        fi

--- a/.github/actions/configure-sccache-s3/action.yml
+++ b/.github/actions/configure-sccache-s3/action.yml
@@ -1,6 +1,10 @@
 name: configure-sccache-s3
 description: "Install sccache and configure AWS credentials and S3 cache"
 inputs:
+  vars:
+    description: "JSON-encoded GitHub Actions vars context"
+    required: false
+    default: "{}"
   sccache-bucket:
     description: "S3 bucket used by sccache"
     required: false
@@ -17,11 +21,11 @@ runs:
       run: "$GITHUB_ACTION_PATH/../install-sccache/install-sccache"
 
     - name: Configure AWS Credentials
-      if: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME != '' }}
+      if: fromJSON(inputs.vars).OIDC_AWS_ROLE_TO_ASSUME
       uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
       with:
         aws-region: us-west-2
-        role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+        role-to-assume: ${{ fromJSON(inputs.vars).OIDC_AWS_ROLE_TO_ASSUME }}
         role-session-name: ${{ github.run_id }}
 
     - name: Configure sccache

--- a/.github/actions/configure-sccache-s3/action.yml
+++ b/.github/actions/configure-sccache-s3/action.yml
@@ -1,5 +1,5 @@
 name: configure-sccache-s3
-description: "Configure AWS credentials and sccache S3 cache"
+description: "Install sccache and configure AWS credentials and S3 cache"
 inputs:
   role-to-assume:
     description: "AWS role to assume with GitHub OIDC. Leave empty to use sccache without S3 writes."
@@ -23,6 +23,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Install sccache
+      shell: bash
+      run: "$GITHUB_ACTION_PATH/../install-sccache/install-sccache"
+
     - name: Configure AWS Credentials
       if: ${{ inputs.role-to-assume != '' }}
       uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4

--- a/.github/actions/configure-sccache-s3/action.yml
+++ b/.github/actions/configure-sccache-s3/action.yml
@@ -1,17 +1,6 @@
 name: configure-sccache-s3
 description: "Install sccache and configure AWS credentials and S3 cache"
 inputs:
-  role-to-assume:
-    description: "AWS role to assume with GitHub OIDC. Leave empty to use sccache without S3 writes."
-    required: false
-  aws-region:
-    description: "AWS region used to assume the role"
-    required: false
-    default: us-west-2
-  role-session-name:
-    description: "AWS role session name"
-    required: false
-    default: GitHubActions
   sccache-bucket:
     description: "S3 bucket used by sccache"
     required: false
@@ -28,12 +17,12 @@ runs:
       run: "$GITHUB_ACTION_PATH/../install-sccache/install-sccache"
 
     - name: Configure AWS Credentials
-      if: ${{ inputs.role-to-assume != '' }}
+      if: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME != '' }}
       uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
       with:
-        aws-region: ${{ inputs.aws-region }}
-        role-to-assume: ${{ inputs.role-to-assume }}
-        role-session-name: ${{ inputs.role-session-name }}
+        aws-region: us-west-2
+        role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+        role-session-name: ${{ github.run_id }}
 
     - name: Configure sccache
       shell: bash

--- a/.github/actions/install-sccache/install-sccache
+++ b/.github/actions/install-sccache/install-sccache
@@ -1,7 +1,31 @@
 #!/bin/bash
 
-curl -LO https://github.com/mozilla/sccache/releases/download/v0.10.0/sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz
-tar -xzf sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz
-sudo mv sccache-v0.10.0-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
-sudo chmod +x /usr/bin/sccache
-rm -rf sccache-v0.10.0-x86_64-unknown-linux-musl*
+set -euo pipefail
+
+if command -v sccache >/dev/null 2>&1; then
+    sccache --version
+    exit 0
+fi
+
+case "$(uname -s)" in
+    Darwin)
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install sccache
+        ;;
+    Linux)
+        tmpdir="$(mktemp -d)"
+        trap 'rm -rf "${tmpdir}"' EXIT
+
+        curl --fail --location --retry 3 \
+            --output "${tmpdir}/sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz" \
+            https://github.com/mozilla/sccache/releases/download/v0.10.0/sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz
+        tar -xzf "${tmpdir}/sccache-v0.10.0-x86_64-unknown-linux-musl.tar.gz" -C "${tmpdir}"
+        sudo mv "${tmpdir}/sccache-v0.10.0-x86_64-unknown-linux-musl/sccache" /usr/local/bin/sccache
+        sudo chmod +x /usr/local/bin/sccache
+        ;;
+    *)
+        echo "Unsupported runner OS: $(uname -s)"
+        exit 1
+        ;;
+esac
+
+sccache --version

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -107,6 +107,8 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
+        with:
+          vars: ${{ toJSON(vars) }}
 
       - name: Check code style
         if: matrix.renderer == 'opengl'
@@ -221,6 +223,8 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
+        with:
+          vars: ${{ toJSON(vars) }}
 
       - name: Build C++ Unit Tests App
         run: |
@@ -260,6 +264,8 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
+        with:
+          vars: ${{ toJSON(vars) }}
 
       - name: Build and Upload Render Test APKs (${{ matrix.flavor }})
         uses: ./.github/actions/android-build-and-upload-render-test
@@ -286,6 +292,8 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
+        with:
+          vars: ${{ toJSON(vars) }}
 
       - name: Build WebGPU Dawn library for arm64-v8a
         run: ./gradlew :MapLibreAndroid:assembleWebgpuDawnDebug -Pmaplibre.abis=arm64-v8a
@@ -349,6 +357,8 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
+        with:
+          vars: ${{ toJSON(vars) }}
 
       - name: Build WebGPU wgpu-native library for Android
         run: ./gradlew :MapLibreAndroid:assembleWebgpuWgpuDebug -Pmaplibre.abis=${{ env.ANDROID_ARCH }}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -105,23 +105,11 @@ jobs:
         with:
           check_untracked: true
 
-      - name: Configure AWS Credentials
-        if: vars.OIDC_AWS_ROLE_TO_ASSUME
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+      - name: Configure sccache
+        uses: ./.github/actions/configure-sccache-s3
         with:
-          aws-region: us-west-2
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
-
-      - name: Configure sccache
-        run: |
-          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
-          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
-
-          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
-            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
-          fi
 
       - name: Check code style
         if: matrix.renderer == 'opengl'
@@ -234,23 +222,11 @@ jobs:
         run: zip -r test/android/app/src/main/assets/data.zip -@ < test/android/app/src/main/assets/to_zip.txt
         working-directory: .
 
-      - name: Configure AWS Credentials
-        if: vars.OIDC_AWS_ROLE_TO_ASSUME
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+      - name: Configure sccache
+        uses: ./.github/actions/configure-sccache-s3
         with:
-          aws-region: us-west-2
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
-
-      - name: Configure sccache
-        run: |
-          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
-          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
-
-          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
-            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
-          fi
 
       - name: Build C++ Unit Tests App
         run: |
@@ -288,23 +264,11 @@ jobs:
 
       - uses: ./.github/actions/setup-android-ci
 
-      - name: Configure AWS Credentials
-        if: vars.OIDC_AWS_ROLE_TO_ASSUME
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+      - name: Configure sccache
+        uses: ./.github/actions/configure-sccache-s3
         with:
-          aws-region: us-west-2
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
-
-      - name: Configure sccache
-        run: |
-          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
-          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
-
-          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
-            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
-          fi
 
       - name: Build and Upload Render Test APKs (${{ matrix.flavor }})
         uses: ./.github/actions/android-build-and-upload-render-test
@@ -329,23 +293,11 @@ jobs:
 
       - uses: ./.github/actions/setup-android-ci
 
-      - name: Configure AWS Credentials
-        if: vars.OIDC_AWS_ROLE_TO_ASSUME
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+      - name: Configure sccache
+        uses: ./.github/actions/configure-sccache-s3
         with:
-          aws-region: us-west-2
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
-
-      - name: Configure sccache
-        run: |
-          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
-          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
-
-          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
-            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
-          fi
 
       - name: Build WebGPU Dawn library for arm64-v8a
         run: ./gradlew :MapLibreAndroid:assembleWebgpuDawnDebug -Pmaplibre.abis=arm64-v8a
@@ -407,23 +359,11 @@ jobs:
           export "${ENV_VAR}=--sysroot=$NDK_PREBUILT/sysroot --target=${{ env.BINDGEN_TARGET }} -isystem $RESOURCE_DIR/include"
           cargo build --release --target ${{ env.RUST_TARGET }} --no-default-features --features vulkan,wgsl,spirv,glsl
 
-      - name: Configure AWS Credentials
-        if: vars.OIDC_AWS_ROLE_TO_ASSUME
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+      - name: Configure sccache
+        uses: ./.github/actions/configure-sccache-s3
         with:
-          aws-region: us-west-2
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
-
-      - name: Configure sccache
-        run: |
-          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
-          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
-
-          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
-            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
-          fi
 
       - name: Build WebGPU wgpu-native library for Android
         run: ./gradlew :MapLibreAndroid:assembleWebgpuWgpuDebug -Pmaplibre.abis=${{ env.ANDROID_ARCH }}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -107,9 +107,6 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
-        with:
-          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ github.run_id }}
 
       - name: Check code style
         if: matrix.renderer == 'opengl'
@@ -224,9 +221,6 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
-        with:
-          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ github.run_id }}
 
       - name: Build C++ Unit Tests App
         run: |
@@ -266,9 +260,6 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
-        with:
-          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ github.run_id }}
 
       - name: Build and Upload Render Test APKs (${{ matrix.flavor }})
         uses: ./.github/actions/android-build-and-upload-render-test
@@ -295,9 +286,6 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
-        with:
-          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ github.run_id }}
 
       - name: Build WebGPU Dawn library for arm64-v8a
         run: ./gradlew :MapLibreAndroid:assembleWebgpuDawnDebug -Pmaplibre.abis=arm64-v8a
@@ -361,9 +349,6 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
-        with:
-          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ github.run_id }}
 
       - name: Build WebGPU wgpu-native library for Android
         run: ./gradlew :MapLibreAndroid:assembleWebgpuWgpuDebug -Pmaplibre.abis=${{ env.ANDROID_ARCH }}

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -248,9 +248,6 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
-        with:
-          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ github.run_id }}
 
       - name: Initialize sccache
         run: |
@@ -283,9 +280,6 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
-        with:
-          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ github.run_id }}
 
       - name: Initialize sccache
         run: |
@@ -332,9 +326,6 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
-        with:
-          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ github.run_id }}
 
       - name: Initialize sccache
         run: |

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -248,6 +248,8 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
+        with:
+          vars: ${{ toJSON(vars) }}
 
       - name: Initialize sccache
         run: |
@@ -280,6 +282,8 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
+        with:
+          vars: ${{ toJSON(vars) }}
 
       - name: Initialize sccache
         run: |
@@ -326,6 +330,8 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
+        with:
+          vars: ${{ toJSON(vars) }}
 
       - name: Initialize sccache
         run: |

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -246,11 +246,42 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Configure AWS Credentials
+        if: vars.OIDC_AWS_ROLE_TO_ASSUME
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
+      - name: Configure sccache
+        run: |
+          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
+          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
+
+          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
+            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
+          fi
+
+      - name: Initialize sccache
+        run: |
+          sccache --start-server
+          sccache --zero-stats
+
       - name: Configure build with CMake
-        run: cmake --preset ios-metal
+        run: |
+          cmake --preset ios-metal \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build mbgl-core
         run: cmake --build build-ios --target mbgl-core ios-sdk-static app
+
+      - name: Show sccache stats
+        if: always()
+        run: |
+          sccache --show-stats
 
   ios-build-webgpu-dawn:
     needs: pre_job
@@ -262,12 +293,43 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
+      - name: Configure AWS Credentials
+        if: vars.OIDC_AWS_ROLE_TO_ASSUME
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
+      - name: Configure sccache
+        run: |
+          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
+          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
+
+          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
+            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
+          fi
+
+      - name: Initialize sccache
+        run: |
+          sccache --start-server
+          sccache --zero-stats
+
       - name: Configure build with CMake
-        run: cmake --preset ios-webgpu-dawn
+        run: |
+          cmake --preset ios-webgpu-dawn \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build mbgl-core and iOS SDK
         continue-on-error: true
         run: cmake --build build-ios-webgpu-dawn --target mbgl-core ios-sdk-static
+
+      - name: Show sccache stats
+        if: always()
+        run: |
+          sccache --show-stats
 
   ios-build-webgpu-wgpu:
     needs: pre_job
@@ -292,12 +354,43 @@ jobs:
           rustup target add aarch64-apple-ios --toolchain "$ACTIVE_TOOLCHAIN"
           rustup target list --toolchain "$ACTIVE_TOOLCHAIN" --installed | grep -x 'aarch64-apple-ios'
 
+      - name: Configure AWS Credentials
+        if: vars.OIDC_AWS_ROLE_TO_ASSUME
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
+      - name: Configure sccache
+        run: |
+          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
+          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
+
+          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
+            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
+          fi
+
+      - name: Initialize sccache
+        run: |
+          sccache --start-server
+          sccache --zero-stats
+
       - name: Configure build with CMake
-        run: cmake --preset ios-webgpu-wgpu
+        run: |
+          RUSTC_WRAPPER=sccache cmake --preset ios-webgpu-wgpu \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build mbgl-core and iOS SDK
         continue-on-error: true
-        run: cmake --build build-ios-webgpu-wgpu --target mbgl-core ios-sdk-static
+        run: RUSTC_WRAPPER=sccache cmake --build build-ios-webgpu-wgpu --target mbgl-core ios-sdk-static
+
+      - name: Show sccache stats
+        if: always()
+        run: |
+          sccache --show-stats
 
   ios-ci-result:
     runs-on: ubuntu-latest

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -246,23 +246,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Configure AWS Credentials
-        if: vars.OIDC_AWS_ROLE_TO_ASSUME
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+      - name: Configure sccache
+        uses: ./.github/actions/configure-sccache-s3
         with:
-          aws-region: us-west-2
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
-
-      - name: Configure sccache
-        run: |
-          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
-          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
-
-          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
-            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
-          fi
 
       - name: Initialize sccache
         run: |
@@ -293,23 +281,11 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - name: Configure AWS Credentials
-        if: vars.OIDC_AWS_ROLE_TO_ASSUME
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+      - name: Configure sccache
+        uses: ./.github/actions/configure-sccache-s3
         with:
-          aws-region: us-west-2
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
-
-      - name: Configure sccache
-        run: |
-          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
-          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
-
-          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
-            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
-          fi
 
       - name: Initialize sccache
         run: |
@@ -354,23 +330,11 @@ jobs:
           rustup target add aarch64-apple-ios --toolchain "$ACTIVE_TOOLCHAIN"
           rustup target list --toolchain "$ACTIVE_TOOLCHAIN" --installed | grep -x 'aarch64-apple-ios'
 
-      - name: Configure AWS Credentials
-        if: vars.OIDC_AWS_ROLE_TO_ASSUME
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+      - name: Configure sccache
+        uses: ./.github/actions/configure-sccache-s3
         with:
-          aws-region: us-west-2
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
-
-      - name: Configure sccache
-        run: |
-          echo SCCACHE_BUCKET=maplibre-native-sccache >> "$GITHUB_ENV"
-          echo SCCACHE_REGION=eu-central-1 >> "$GITHUB_ENV"
-
-          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
-            echo SCCACHE_S3_NO_CREDENTIALS=1 >> "$GITHUB_ENV"
-          fi
 
       - name: Initialize sccache
         run: |

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -96,11 +96,9 @@ jobs:
           cd ..
           mv ctcache /usr/local/bin
 
-      - name: Configure AWS Credentials
-        if: vars.OIDC_AWS_ROLE_TO_ASSUME
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v4
+      - name: Configure sccache
+        uses: ./.github/actions/configure-sccache-s3
         with:
-          aws-region: us-west-2
           role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}
 
@@ -109,15 +107,6 @@ jobs:
           CI: 1
         run: |
           cmake --version
-
-          # sccache configuration
-          export SCCACHE_BUCKET=maplibre-native-sccache
-          export SCCACHE_REGION=eu-central-1
-
-          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
-            export SCCACHE_S3_NO_CREDENTIALS=1
-          fi
 
           # ctcache configuration
           export CTCACHE_HOST=34.229.50.221

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -86,8 +86,6 @@ jobs:
       - if: matrix.variant.rust
         run: cargo install cxxbridge-cmd --version 1.0.157 --locked
 
-      - uses: ./.github/actions/install-sccache
-
       - name: Install ctcache
         run: |
           # pending open PR https://github.com/matus-chochlik/ctcache/pull/94

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -96,9 +96,6 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
-        with:
-          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ github.run_id }}
 
       - name: Build MapLibre Native
         env:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -96,6 +96,8 @@ jobs:
 
       - name: Configure sccache
         uses: ./.github/actions/configure-sccache-s3
+        with:
+          vars: ${{ toJSON(vars) }}
 
       - name: Build MapLibre Native
         env:


### PR DESCRIPTION
This PR simplifies setting up sccache by extracting the logic to a reusable workflows, so it's not duplicated across different workflows.

It also modifies the script to install sccache to be platform-aware.

Lastly, it modifies the CMake actions in `ios-ci` to use sccache. This ~should~ offers a nice speedup. We're now using GitHub macOS runners for all workflows, so speeding up macOS workflows is useful so that we don't run out of concurrent runners.