### PR TITLE
Fix MLNNetworkConfiguration not forwarding 'didReceiveResponse' to its delegate.

### DIFF
--- a/platform/darwin/src/MLNNetworkConfiguration.mm
+++ b/platform/darwin/src/MLNNetworkConfiguration.mm
@@ -101,6 +101,7 @@ NSString *const kMLNDownloadPerformanceEvent = @"mobile.performance_trace";
     MLNNetworkResponse *tempResponse = [MLNNetworkResponse responseWithData:response.data
                                                                 urlResponse:response.response
                                                                       error:response.error];
+    tempResponse = [self.delegate didReceiveResponse:tempResponse];
     if (tempResponse) {
       MLNInternalNetworkResponse *internalResponse =
           [MLNInternalNetworkResponse responseWithData:tempResponse.data

--- a/platform/ios/test/MLNNetworkConfigurationTests.m
+++ b/platform/ios/test/MLNNetworkConfigurationTests.m
@@ -2,6 +2,23 @@
 #import <XCTest/XCTest.h>
 #import "MLNNetworkConfiguration_Private.h"
 
+@interface MLNTestNetworkConfigurationDelegate : NSObject <MLNNetworkConfigurationDelegate>
+@property (nonatomic) NSUInteger receivedResponseCount;
+@property (nonatomic, nullable) NSURLResponse *replacementResponse;
+@end
+
+@implementation MLNTestNetworkConfigurationDelegate
+
+- (MLNNetworkResponse *)didReceiveResponse:(MLNNetworkResponse *)response {
+    self.receivedResponseCount += 1;
+    if (self.replacementResponse) {
+        response.response = self.replacementResponse;
+    }
+    return response;
+}
+
+@end
+
 @interface MLNNetworkConfigurationTests : XCTestCase
 @end
 
@@ -39,5 +56,45 @@
     }
 
     [self waitForExpectations:@[expectation] timeout:10.0];
+}
+
+// Regression test: received responses were converted for the delegate but the delegate was
+// never actually called, so `didReceiveResponse:` implementations had no effect.
+- (void)testDidReceiveResponseIsForwardedToTheDelegate {
+    MLNNetworkConfiguration *configuration = [[MLNNetworkConfiguration alloc] init];
+    MLNTestNetworkConfigurationDelegate *delegate = [[MLNTestNetworkConfigurationDelegate alloc] init];
+    configuration.delegate = delegate;
+
+    NSURL *url = [NSURL URLWithString:@"test://tile"];
+    delegate.replacementResponse = [[NSHTTPURLResponse alloc] initWithURL:url
+                                                               statusCode:404
+                                                              HTTPVersion:@"HTTP/1.1"
+                                                             headerFields:nil];
+
+    MLNInternalNetworkResponse *internalResponse = [[MLNInternalNetworkResponse alloc] init];
+    internalResponse.response = [[NSHTTPURLResponse alloc] initWithURL:url
+                                                            statusCode:403
+                                                           HTTPVersion:@"HTTP/1.1"
+                                                          headerFields:nil];
+    internalResponse.data = [@"forbidden" dataUsingEncoding:NSUTF8StringEncoding];
+
+    MLNInternalNetworkResponse *processedResponse =
+        [(id<MLNNativeNetworkDelegate>)configuration didReceiveResponse:internalResponse];
+
+    XCTAssertEqual(delegate.receivedResponseCount, 1);
+    XCTAssertEqual(((NSHTTPURLResponse *)processedResponse.response).statusCode, 404);
+    XCTAssertEqualObjects(processedResponse.data, internalResponse.data);
+}
+
+- (void)testDidReceiveResponseWithoutDelegateReturnsResponseUnchanged {
+    MLNNetworkConfiguration *configuration = [[MLNNetworkConfiguration alloc] init];
+
+    MLNInternalNetworkResponse *internalResponse = [[MLNInternalNetworkResponse alloc] init];
+    internalResponse.data = [@"payload" dataUsingEncoding:NSUTF8StringEncoding];
+
+    MLNInternalNetworkResponse *processedResponse =
+        [(id<MLNNativeNetworkDelegate>)configuration didReceiveResponse:internalResponse];
+
+    XCTAssertEqual(processedResponse, internalResponse);
 }
 @end


### PR DESCRIPTION
I found that the MLNNetworkConfiguration isn't calling all of the protocol functions of the MLNNetworkConfigurationDelegate. More specifically the `didReceiveResponse` is never being called, resulting in any implementation of MLNNetworkConfigurationDelegate not being able to listen to network responses or modify the response. 

AI usage: I have used Claude Fable 5 to help me find the problem and come up with a fix for it.

Description written by Claude:

## Root cause

The forwarding method in `MLNNetworkConfiguration.mm` checks `respondsToSelector:` and converts the internal response into an `MLNNetworkResponse` for the delegate — but never actually invokes the delegate. It just converts the unchanged response back and returns it:

```objc
if ([self.delegate respondsToSelector:@selector(didReceiveResponse:)]) {
  MLNNetworkResponse *tempResponse = [MLNNetworkResponse responseWithData:response.data
                                                              urlResponse:response.response
                                                                    error:response.error];
  // the delegate call was missing here
  if (tempResponse) {
    ...
```

The dead `if (tempResponse)` nil-check suggests the delegate call was intended but accidentally left out. This has been the case since the API was introduced in #3917, so it appears the delegate method has never worked.

## Fix

Invoke the delegate and use the response it returns, so delegates can observe or modify responses. One behavioral note: a delegate returning `nil` now suppresses the response (the method returns `nil`), which the pre-existing nil-check clearly anticipated but which could not previously happen — flagging it in case reviewers see that differently.

## Testing

Added two unit tests to `MLNNetworkConfigurationTests`:

- The delegate receives the response exactly once, and modifications the delegate makes (replacing the `NSURLResponse`) are reflected in the returned internal response.
- Without a delegate, the response is returned unchanged.
