### PR TITLE
core: Fix Vulkan snapshot timing for headless too

### DIFF
--- a/platform/default/include/mbgl/vulkan/headless_backend.hpp
+++ b/platform/default/include/mbgl/vulkan/headless_backend.hpp
@@ -38,8 +38,6 @@ private:
 private:
     std::unique_ptr<Impl> impl;
     bool active = false;
-
-    std::unique_ptr<Texture2D> texture;
 };
 
 } // namespace vulkan

--- a/platform/default/src/mbgl/vulkan/headless_backend.cpp
+++ b/platform/default/src/mbgl/vulkan/headless_backend.cpp
@@ -26,8 +26,8 @@ public:
     void bind() override {}
 
     void swap() override {
+        queueSurfaceRead();
         SurfaceRenderableResource::swap();
-        static_cast<Context&>(backend.getContext()).waitFrame();
     }
 };
 
@@ -41,8 +41,6 @@ HeadlessBackend::HeadlessBackend(const Size size_,
 
 HeadlessBackend::~HeadlessBackend() {
     gfx::BackendScope guard{*this, gfx::BackendScope::ScopeType::Implicit};
-
-    texture.reset();
 
     // Explicitly reset the renderable resource
     resource.reset();
@@ -79,21 +77,11 @@ PremultipliedImage HeadlessBackend::readStillImage() {
         resource = std::make_unique<HeadlessRenderableResource>(*this);
     }
 
-    auto& contextImpl = static_cast<Context&>(*context);
     auto& resourceImpl = static_cast<HeadlessRenderableResource&>(*resource);
 
-    if (!texture) {
-        texture = std::make_unique<Texture2D>(contextImpl);
-        texture->setFormat(gfx::TexturePixelType::RGBA, gfx::TextureChannelDataType::UnsignedByte);
-        texture->setUsage(Texture2DUsage::Read);
-    }
-
-    texture->setSize(size);
-
-    contextImpl.waitFrame();
-    texture->copyImage(resourceImpl.getAcquiredImage(), size);
-
-    return std::move(*texture->readImage());
+    auto image = resourceImpl.readImage();
+    assert(image);
+    return std::move(*image);
 }
 
 RendererBackend* HeadlessBackend::getRendererBackend() {

--- a/src/mbgl/vulkan/renderable_resource.cpp
+++ b/src/mbgl/vulkan/renderable_resource.cpp
@@ -511,18 +511,18 @@ void SurfaceRenderableResource::copySurfaceToReadTexture() {
                                               : vk::AccessFlags{vk::AccessFlagBits::eColorAttachmentWrite};
     const vk::AccessFlags dstAccess = surface ? vk::AccessFlagBits::eTransferWrite : vk::AccessFlagBits::eTransferRead;
 
-    const auto barrier = vk::ImageMemoryBarrier()
-                             .setImage(swapchainImage)
-                             .setOldLayout(oldLayout)
-                             .setNewLayout(vk::ImageLayout::eTransferSrcOptimal)
-                             .setSrcAccessMask(srcAccess)
-                             .setDstAccessMask(dstAccess)
-                             .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-                             .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-                             .setSubresourceRange({vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1});
+    const auto readBarrier = vk::ImageMemoryBarrier()
+                                 .setImage(swapchainImage)
+                                 .setOldLayout(oldLayout)
+                                 .setNewLayout(vk::ImageLayout::eTransferSrcOptimal)
+                                 .setSrcAccessMask(srcAccess)
+                                 .setDstAccessMask(dstAccess)
+                                 .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+                                 .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+                                 .setSubresourceRange({vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1});
 
     commandBuffer->pipelineBarrier(
-        srcStage, vk::PipelineStageFlagBits::eTransfer, {}, nullptr, nullptr, barrier, dispatcher);
+        srcStage, vk::PipelineStageFlagBits::eTransfer, {}, nullptr, nullptr, readBarrier, dispatcher);
 
     bool useBlit =
         surface &&
@@ -538,22 +538,22 @@ void SurfaceRenderableResource::copySurfaceToReadTexture() {
     }
 
     if (surface) {
-        const auto barrier = vk::ImageMemoryBarrier()
-                                 .setImage(swapchainImage)
-                                 .setOldLayout(vk::ImageLayout::eTransferSrcOptimal)
-                                 .setNewLayout(vk::ImageLayout::ePresentSrcKHR)
-                                 .setSrcAccessMask(vk::AccessFlagBits::eMemoryRead)
-                                 .setDstAccessMask(vk::AccessFlagBits::eTransferWrite)
-                                 .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-                                 .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-                                 .setSubresourceRange({vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1});
+        const auto presentBarrier = vk::ImageMemoryBarrier()
+                                        .setImage(swapchainImage)
+                                        .setOldLayout(vk::ImageLayout::eTransferSrcOptimal)
+                                        .setNewLayout(vk::ImageLayout::ePresentSrcKHR)
+                                        .setSrcAccessMask(vk::AccessFlagBits::eMemoryRead)
+                                        .setDstAccessMask(vk::AccessFlagBits::eTransferWrite)
+                                        .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+                                        .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+                                        .setSubresourceRange({vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1});
 
         commandBuffer->pipelineBarrier(vk::PipelineStageFlagBits::eTopOfPipe,
                                        vk::PipelineStageFlagBits::eTransfer,
                                        {},
                                        nullptr,
                                        nullptr,
-                                       barrier,
+                                       presentBarrier,
                                        dispatcher);
     }
 }

--- a/src/mbgl/vulkan/renderable_resource.cpp
+++ b/src/mbgl/vulkan/renderable_resource.cpp
@@ -483,7 +483,9 @@ void SurfaceRenderableResource::queueSurfaceRead() {
     }
 
     surfaceRead = true;
-    backend.getContext<Context>().requestSurfaceUpdate(false);
+    if (surface) {
+        backend.getContext<Context>().requestSurfaceUpdate(false);
+    }
 }
 
 void SurfaceRenderableResource::copySurfaceToReadTexture() {
@@ -502,25 +504,25 @@ void SurfaceRenderableResource::copySurfaceToReadTexture() {
     const auto swapchainImage = getAcquiredImage();
     auto& commandBuffer = contextImpl.getCommandBuffer();
 
-    if (surface) {
-        const auto barrier = vk::ImageMemoryBarrier()
-                                 .setImage(swapchainImage)
-                                 .setOldLayout(vk::ImageLayout::ePresentSrcKHR)
-                                 .setNewLayout(vk::ImageLayout::eTransferSrcOptimal)
-                                 .setSrcAccessMask({})
-                                 .setDstAccessMask(vk::AccessFlagBits::eTransferWrite)
-                                 .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-                                 .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-                                 .setSubresourceRange({vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1});
+    const auto oldLayout = surface ? vk::ImageLayout::ePresentSrcKHR : vk::ImageLayout::eTransferSrcOptimal;
+    const auto srcStage = surface ? vk::PipelineStageFlagBits::eTopOfPipe
+                                  : vk::PipelineStageFlagBits::eColorAttachmentOutput;
+    const vk::AccessFlags srcAccess = surface ? vk::AccessFlags{}
+                                              : vk::AccessFlags{vk::AccessFlagBits::eColorAttachmentWrite};
+    const vk::AccessFlags dstAccess = surface ? vk::AccessFlagBits::eTransferWrite : vk::AccessFlagBits::eTransferRead;
 
-        commandBuffer->pipelineBarrier(vk::PipelineStageFlagBits::eTopOfPipe,
-                                       vk::PipelineStageFlagBits::eTransfer,
-                                       {},
-                                       nullptr,
-                                       nullptr,
-                                       barrier,
-                                       dispatcher);
-    }
+    const auto barrier = vk::ImageMemoryBarrier()
+                             .setImage(swapchainImage)
+                             .setOldLayout(oldLayout)
+                             .setNewLayout(vk::ImageLayout::eTransferSrcOptimal)
+                             .setSrcAccessMask(srcAccess)
+                             .setDstAccessMask(dstAccess)
+                             .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+                             .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+                             .setSubresourceRange({vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1});
+
+    commandBuffer->pipelineBarrier(
+        srcStage, vk::PipelineStageFlagBits::eTransfer, {}, nullptr, nullptr, barrier, dispatcher);
 
     bool useBlit =
         surface &&

--- a/src/mbgl/vulkan/renderable_resource.cpp
+++ b/src/mbgl/vulkan/renderable_resource.cpp
@@ -505,11 +505,9 @@ void SurfaceRenderableResource::copySurfaceToReadTexture() {
     auto& commandBuffer = contextImpl.getCommandBuffer();
 
     const auto oldLayout = surface ? vk::ImageLayout::ePresentSrcKHR : vk::ImageLayout::eTransferSrcOptimal;
-    const auto srcStage = surface ? vk::PipelineStageFlagBits::eTopOfPipe
-                                  : vk::PipelineStageFlagBits::eColorAttachmentOutput;
-    const vk::AccessFlags srcAccess = surface ? vk::AccessFlags{}
-                                              : vk::AccessFlags{vk::AccessFlagBits::eColorAttachmentWrite};
-    const vk::AccessFlags dstAccess = surface ? vk::AccessFlagBits::eTransferWrite : vk::AccessFlagBits::eTransferRead;
+    const auto srcStage = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+    const vk::AccessFlags srcAccess = vk::AccessFlagBits::eColorAttachmentWrite;
+    const vk::AccessFlags dstAccess = vk::AccessFlagBits::eTransferRead;
 
     const auto readBarrier = vk::ImageMemoryBarrier()
                                  .setImage(swapchainImage)


### PR DESCRIPTION
Follow-up to #4339, which fixed the surface snapshot timing but not the headless backend.

The headless readback copied the color image without a barrier against rendering, so some (slower?) drivers (e.g. MoltenVK on macOS CI) could read back a stale frame.