### PR TITLE
Fix intermittent iOS CppUnitTests build race

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,6 +14,16 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "rules_swift_package_manager", version = "1.3.0")
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 
+# rules_xcodeproj accidentally includes a trailing comma in the generated
+# Testing.framework rsync exclusion, causing intermittent test-host build races.
+# https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3211
+single_version_override(
+    module_name = "rules_xcodeproj",
+    patch_strip = 1,
+    patches = ["//bazel/patches/rules_xcodeproj:testing-framework.patch"],
+    version = "3.3.0",
+)
+
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 node.toolchain(node_version = "20.14.0")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,8 @@ bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 
 # rules_xcodeproj accidentally includes a trailing comma in the generated
 # Testing.framework rsync exclusion, causing intermittent test-host build races.
-# https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3211
+# TODO: Remove this override once the upstream fix is released:
+# https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3321
 single_version_override(
     module_name = "rules_xcodeproj",
     patch_strip = 1,

--- a/bazel/patches/rules_xcodeproj/BUILD.bazel
+++ b/bazel/patches/rules_xcodeproj/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["testing-framework.patch"])

--- a/bazel/patches/rules_xcodeproj/testing-framework.patch
+++ b/bazel/patches/rules_xcodeproj/testing-framework.patch
@@ -1,0 +1,12 @@
+diff --git a/xcodeproj/internal/bazel_integration_files/BUILD b/xcodeproj/internal/bazel_integration_files/BUILD
+--- a/xcodeproj/internal/bazel_integration_files/BUILD
++++ b/xcodeproj/internal/bazel_integration_files/BUILD
+@@ -52,7 +52,7 @@ frameworks=(
+   'libclang_rt.ubsan*.dylib'
+   'libXCTestBundleInject.dylib'
+   'libXCTestSwiftSupport.dylib'
+-  'Testing.framework',
++  'Testing.framework'
+   'XCTAutomationSupport.framework'
+   'XCTest.framework'
+   'XCTestCore.framework'


### PR DESCRIPTION
GPT 5.6 wrote the text below and the code in this PR.

tl;dr there's an extra comma in the `rules_xcodeproj` Bazel dependency. This patches it until https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3321 is merged.

> ## What does this change?
> 
> Patch `rules_xcodeproj` 3.3.0 so its generated rsync exclusion correctly names `Testing.framework` without a trailing comma.
> 
> ## Why?
> 
> The malformed `Testing.framework,` pattern does not exclude the real framework. During `xcodebuild build-for-testing`, the generated Bazel output-copy script runs rsync with `--delete` while Xcode copies `Testing.framework` into the same test host. Depending on timing, either operation can remove files or directories underneath the other.
> 
> This caused the intermittent `CppUnitTestsApp` failures seen in:
> 
> - https://github.com/maplibre/maplibre-native/actions/runs/29261436369/job/86881585165?pr=4146
> - attempt 1: Xcode reported a missing `Testing.framework/Info.plist`
> - attempt 2: rsync reported `Testing.framework: unlinkat: Directory not empty`
> 
> The typo originated in https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3211 and is still present upstream.
> 
> ## Validation
> 
> - `bazel mod graph`
> - `bazel build @rules_xcodeproj//xcodeproj/internal/bazel_integration_files:rsync_excludes`
> - `bazel run //platform/ios:xcodeproj --@rules_xcodeproj//xcodeproj:extra_common_flags=--//:renderer=metal`
> - Confirmed both generated app exclusion entries end in `Testing.framework`, with no trailing comma
> 