### PR TITLE
Fix Android feature state instrumentation tests

### DIFF
--- a/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/testapp/style/GeoJsonSourceTests.java
+++ b/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/testapp/style/GeoJsonSourceTests.java
@@ -23,6 +23,7 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import android.graphics.PointF;
 import android.view.View;
 
 import java.util.ArrayList;
@@ -34,6 +35,8 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
 
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link GeoJsonSource}
@@ -134,10 +137,11 @@ public class GeoJsonSourceTests extends EspressoTest {
 
       JsonObject state = new JsonObject();
       state.addProperty("selected", true);
-      source.setFeatureState("feature-1", state);
+      assertTrue(source.setFeatureState("feature-1", state));
+      assertEquals(state, source.getFeatureState("feature-1"));
 
       // The feature-state update is applied on a subsequent render pass, so
-      // poll until the filter re-evaluates rather than relying on a single
+      // poll until the paint property re-evaluates rather than relying on a single
       // didBecomeIdle callback (which can be missed if the repaint completes
       // before the listener is attached).
       assertEquals(1, pollFeatureCount(uiController, maplibreMap, 1));
@@ -161,17 +165,20 @@ public class GeoJsonSourceTests extends EspressoTest {
       GeoJsonSource source = maplibreMap.getStyle().getSourceAs("style-source");
       JsonObject state = new JsonObject();
       state.addProperty("selected", true);
-      source.setFeatureState("feature-1", state);
+      assertTrue(source.setFeatureState("feature-1", state));
       assertEquals(1, pollFeatureCount(uiController, maplibreMap, 1));
 
-      source.removeFeatureState(null, "selected");
+      assertTrue(source.removeFeatureState(null, "selected"));
       assertEquals(0, pollFeatureCount(uiController, maplibreMap, 0));
+      assertNull(source.getFeatureState("feature-1"));
     });
   }
 
   private int queryFeatureCount(org.maplibre.android.maps.MapLibreMap maplibreMap) {
+    PointF queryPoint = maplibreMap.getProjection().toScreenLocation(new LatLng(0.0, 0.0));
+    queryPoint.offset(12, 0);
     return maplibreMap.queryRenderedFeatures(
-            maplibreMap.getProjection().toScreenLocation(new LatLng(0.0, 0.0)), "selected-layer").size();
+            queryPoint, "selected-layer").size();
   }
 
   private int pollFeatureCount(androidx.test.espresso.UiController uiController,

--- a/platform/android/MapLibreAndroidTestApp/src/main/res/raw/test_feature_state_style.json
+++ b/platform/android/MapLibreAndroidTestApp/src/main/res/raw/test_feature_state_style.json
@@ -33,9 +33,13 @@
       "id": "selected-layer",
       "type": "circle",
       "source": "style-source",
-      "filter": ["==", ["feature-state", "selected"], true],
       "paint": {
-        "circle-radius": 12,
+        "circle-radius": [
+          "case",
+          ["boolean", ["feature-state", "selected"], false],
+          24,
+          0
+        ],
         "circle-color": "#ff0000"
       }
     }


### PR DESCRIPTION
Fixes the Android feature state instrumentation tests. As per the [spec](https://maplibre.org/maplibre-style-spec/expressions/#feature-state):

> Note that ["feature-state"] can only be used with paint properties that support data-driven styling.

And this is ~probably~ true in the MapLibre Native implementation too...

For reference here is what GPT 5.6 spat out.

> ## Summary
> 
> - replace the unsupported `feature-state` layer filter in the Android test fixture with a feature-state-driven `circle-radius` paint expression
> - query away from the feature center so the rendered hit area still proves that state changes are applied
> - assert state update dispatch, direct state retrieval, source-wide key removal, and final state removal
> 
> ## Root cause
> 
> Feature state is supported in data-driven paint properties, but not in layer filter expressions. The previous fixture used it in a filter, which is evaluated while building the circle bucket without feature state. The feature was therefore excluded permanently, and `queryRenderedFeatures` continued to return zero after setting state.
> 
> ## Testing
> 
> - focused `connectedOpenglDebugAndroidTest` run on a local Android 17 emulator: 2/2 passed
> - three additional focused instrumentation runs using the installed test package: 6/6 passed
> 
> The failure reproduced locally before this change, so no additional AWS Device Farm run was submitted.
> 