### PR TITLE
fix(android): Add option to move symbol location indicator bearing down the image stack

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentOptions.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentOptions.java
@@ -133,6 +133,7 @@ public class LocationComponentOptions implements Parcelable {
   private RectF trackingMultiFingerProtectedMoveArea;
   private String layerAbove;
   private String layerBelow;
+  private Boolean bearingOnTop;
   private float trackingAnimationDurationMultiplier;
   private boolean compassAnimationEnabled;
   private boolean accuracyAnimationEnabled;
@@ -177,6 +178,7 @@ public class LocationComponentOptions implements Parcelable {
     RectF trackingMultiFingerProtectedMoveArea,
     String layerAbove,
     String layerBelow,
+    Boolean bearingOnTop,
     float trackingAnimationDurationMultiplier,
     boolean compassAnimationEnabled,
     boolean accuracyAnimationEnabled,
@@ -221,6 +223,7 @@ public class LocationComponentOptions implements Parcelable {
     this.trackingMultiFingerProtectedMoveArea = trackingMultiFingerProtectedMoveArea;
     this.layerAbove = layerAbove;
     this.layerBelow = layerBelow;
+    this.bearingOnTop = bearingOnTop;
     this.trackingAnimationDurationMultiplier = trackingAnimationDurationMultiplier;
     this.compassAnimationEnabled = compassAnimationEnabled;
     this.accuracyAnimationEnabled = accuracyAnimationEnabled;
@@ -326,6 +329,9 @@ public class LocationComponentOptions implements Parcelable {
 
     builder.layerBelow(
       typedArray.getString(R.styleable.maplibre_LocationComponent_maplibre_layer_below));
+
+    builder.bearingOnTop(
+      typedArray.getBoolean(R.styleable.maplibre_LocationComponent_maplibre_bearing_on_top, false));
 
     float minScale = typedArray.getFloat(
       R.styleable.maplibre_LocationComponent_maplibre_minZoomIconScale, MIN_ZOOM_ICON_SCALE_DEFAULT);
@@ -798,6 +804,10 @@ public class LocationComponentOptions implements Parcelable {
     return layerBelow;
   }
 
+  public Boolean bearingOnTop() {
+    return bearingOnTop;
+  }
+
   /**
    * Get the tracking animation duration multiplier.
    *
@@ -927,6 +937,7 @@ public class LocationComponentOptions implements Parcelable {
       + "trackingMultiFingerProtectedMoveArea=" + trackingMultiFingerProtectedMoveArea + ", "
       + "layerAbove=" + layerAbove
       + "layerBelow=" + layerBelow
+      + "bearingOnTop=" + bearingOnTop
       + "trackingAnimationDurationMultiplier=" + trackingAnimationDurationMultiplier
       + "pulseEnabled=" + pulseEnabled
       + "pulseFadeEnabled=" + pulseFadeEnabled
@@ -1057,6 +1068,10 @@ public class LocationComponentOptions implements Parcelable {
       return false;
     }
 
+    if (bearingOnTop != options.bearingOnTop) {
+      return false;
+    }
+
     if (pulseEnabled != options.pulseEnabled) {
       return false;
     }
@@ -1120,6 +1135,7 @@ public class LocationComponentOptions implements Parcelable {
       ? trackingMultiFingerProtectedMoveArea.hashCode() : 0);
     result = 31 * result + (layerAbove != null ? layerAbove.hashCode() : 0);
     result = 31 * result + (layerBelow != null ? layerBelow.hashCode() : 0);
+    result = 31 * result + (bearingOnTop ? 1 : 0);
     result = 31 * result + (trackingAnimationDurationMultiplier != +0.0f
       ? Float.floatToIntBits(trackingAnimationDurationMultiplier) : 0);
     result = 31 * result + (compassAnimationEnabled ? 1 : 0);
@@ -1171,6 +1187,7 @@ public class LocationComponentOptions implements Parcelable {
     dest.writeParcelable(this.trackingMultiFingerProtectedMoveArea, flags);
     dest.writeString(this.layerAbove);
     dest.writeString(this.layerBelow);
+    dest.writeBoolean(this.bearingOnTop);
     dest.writeFloat(this.trackingAnimationDurationMultiplier);
     dest.writeByte(this.compassAnimationEnabled ? (byte) 1 : (byte) 0);
     dest.writeByte(this.accuracyAnimationEnabled ? (byte) 1 : (byte) 0);
@@ -1214,6 +1231,7 @@ public class LocationComponentOptions implements Parcelable {
     this.trackingMultiFingerProtectedMoveArea = in.readParcelable(RectF.class.getClassLoader());
     this.layerAbove = in.readString();
     this.layerBelow = in.readString();
+    this.bearingOnTop = in.readByte() != 0;
     this.trackingAnimationDurationMultiplier = in.readFloat();
     this.compassAnimationEnabled = in.readByte() != 0;
     this.accuracyAnimationEnabled = in.readByte() != 0;
@@ -1338,6 +1356,7 @@ public class LocationComponentOptions implements Parcelable {
     private RectF trackingMultiFingerProtectedMoveArea;
     private String layerAbove;
     private String layerBelow;
+    private Boolean bearingOnTop;
     private Float trackingAnimationDurationMultiplier;
     private Boolean compassAnimationEnabled;
     private Boolean accuracyAnimationEnabled;
@@ -1385,6 +1404,7 @@ public class LocationComponentOptions implements Parcelable {
       this.trackingMultiFingerProtectedMoveArea = source.trackingMultiFingerProtectedMoveArea();
       this.layerAbove = source.layerAbove();
       this.layerBelow = source.layerBelow();
+      this.bearingOnTop = source.bearingOnTop();
       this.trackingAnimationDurationMultiplier = source.trackingAnimationDurationMultiplier();
       this.compassAnimationEnabled = source.compassAnimationEnabled();
       this.accuracyAnimationEnabled = source.accuracyAnimationEnabled();
@@ -1866,6 +1886,11 @@ public class LocationComponentOptions implements Parcelable {
       return this;
     }
 
+    public LocationComponentOptions.Builder bearingOnTop(Boolean bearingOnTop) {
+      this.bearingOnTop = bearingOnTop;
+      return this;
+    }
+
     /**
      * Sets the tracking animation duration multiplier.
      *
@@ -2065,6 +2090,7 @@ public class LocationComponentOptions implements Parcelable {
         this.trackingMultiFingerProtectedMoveArea,
         this.layerAbove,
         this.layerBelow,
+        this.bearingOnTop,
         this.trackingAnimationDurationMultiplier,
         this.compassAnimationEnabled,
         this.accuracyAnimationEnabled,

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentOptions.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentOptions.java
@@ -804,6 +804,11 @@ public class LocationComponentOptions implements Parcelable {
     return layerBelow;
   }
 
+  /**
+   * Whether the bearing icon is rendered on top of the foreground icon in the location layer stack.
+   *
+   * @return true if the bearing icon is rendered above the foreground icon, false otherwise.
+   */
   public Boolean bearingOnTop() {
     return bearingOnTop;
   }
@@ -1886,6 +1891,14 @@ public class LocationComponentOptions implements Parcelable {
       return this;
     }
 
+    /**
+     * Sets whether the bearing icon is rendered on top of the foreground icon in the location
+     * layer stack. When true, the bearing layer is placed above the foreground layer; when false,
+     * it is rendered below.
+     *
+     * @param bearingOnTop true to render the bearing icon above the foreground icon, false for below.
+     */
+    @NonNull
     public LocationComponentOptions.Builder bearingOnTop(Boolean bearingOnTop) {
       this.bearingOnTop = bearingOnTop;
       return this;

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentOptions.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentOptions.java
@@ -331,7 +331,7 @@ public class LocationComponentOptions implements Parcelable {
       typedArray.getString(R.styleable.maplibre_LocationComponent_maplibre_layer_below));
 
     builder.bearingOnTop(
-      typedArray.getBoolean(R.styleable.maplibre_LocationComponent_maplibre_bearing_on_top, false));
+      typedArray.getBoolean(R.styleable.maplibre_LocationComponent_maplibre_bearing_on_top, true));
 
     float minScale = typedArray.getFloat(
       R.styleable.maplibre_LocationComponent_maplibre_minZoomIconScale, MIN_ZOOM_ICON_SCALE_DEFAULT);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentOptions.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentOptions.java
@@ -1192,7 +1192,7 @@ public class LocationComponentOptions implements Parcelable {
     dest.writeParcelable(this.trackingMultiFingerProtectedMoveArea, flags);
     dest.writeString(this.layerAbove);
     dest.writeString(this.layerBelow);
-    dest.writeBoolean(this.bearingOnTop);
+    dest.writeByte(this.bearingOnTop ? (byte) 1 : (byte) 0);
     dest.writeFloat(this.trackingAnimationDurationMultiplier);
     dest.writeByte(this.compassAnimationEnabled ? (byte) 1 : (byte) 0);
     dest.writeByte(this.accuracyAnimationEnabled ? (byte) 1 : (byte) 0);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentOptions.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentOptions.java
@@ -133,7 +133,7 @@ public class LocationComponentOptions implements Parcelable {
   private RectF trackingMultiFingerProtectedMoveArea;
   private String layerAbove;
   private String layerBelow;
-  private Boolean bearingOnTop;
+  private boolean bearingOnTop;
   private float trackingAnimationDurationMultiplier;
   private boolean compassAnimationEnabled;
   private boolean accuracyAnimationEnabled;
@@ -178,7 +178,7 @@ public class LocationComponentOptions implements Parcelable {
     RectF trackingMultiFingerProtectedMoveArea,
     String layerAbove,
     String layerBelow,
-    Boolean bearingOnTop,
+    boolean bearingOnTop,
     float trackingAnimationDurationMultiplier,
     boolean compassAnimationEnabled,
     boolean accuracyAnimationEnabled,
@@ -809,7 +809,7 @@ public class LocationComponentOptions implements Parcelable {
    *
    * @return true if the bearing icon is rendered above the foreground icon, false otherwise.
    */
-  public Boolean bearingOnTop() {
+  public boolean bearingOnTop() {
     return bearingOnTop;
   }
 
@@ -1361,7 +1361,7 @@ public class LocationComponentOptions implements Parcelable {
     private RectF trackingMultiFingerProtectedMoveArea;
     private String layerAbove;
     private String layerBelow;
-    private Boolean bearingOnTop;
+    private boolean bearingOnTop;
     private Float trackingAnimationDurationMultiplier;
     private Boolean compassAnimationEnabled;
     private Boolean accuracyAnimationEnabled;
@@ -1899,7 +1899,7 @@ public class LocationComponentOptions implements Parcelable {
      * @param bearingOnTop true to render the bearing icon above the foreground icon, false for below.
      */
     @NonNull
-    public LocationComponentOptions.Builder bearingOnTop(Boolean bearingOnTop) {
+    public LocationComponentOptions.Builder bearingOnTop(boolean bearingOnTop) {
       this.bearingOnTop = bearingOnTop;
       return this;
     }

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentPositionManager.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentPositionManager.java
@@ -17,22 +17,28 @@ class LocationComponentPositionManager {
   @Nullable
   private String layerBelow;
 
-  LocationComponentPositionManager(@NonNull Style style, @Nullable String layerAbove, @Nullable String layerBelow) {
+  public Boolean bearingOnTop;
+
+  LocationComponentPositionManager(@NonNull Style style, @Nullable String layerAbove,
+                                   @Nullable String layerBelow, Boolean bearingOnTop) {
     this.style = style;
     this.layerAbove = layerAbove;
     this.layerBelow = layerBelow;
+    this.bearingOnTop = bearingOnTop;
   }
 
   /**
    * Returns true whenever layer above/below configuration has changed and requires re-layout.
    */
-  boolean update(@Nullable String layerAbove, @Nullable String layerBelow) {
+  boolean update(@Nullable String layerAbove, @Nullable String layerBelow, Boolean bearingOnTop) {
     boolean requiresUpdate =
       !(this.layerAbove == layerAbove || (this.layerAbove != null && this.layerAbove.equals(layerAbove)))
-        || !(this.layerBelow == layerBelow || (this.layerBelow != null && this.layerBelow.equals(layerBelow)));
+        || !(this.layerBelow == layerBelow || (this.layerBelow != null && this.layerBelow.equals(layerBelow)))
+        || (this.bearingOnTop != bearingOnTop);
 
     this.layerAbove = layerAbove;
     this.layerBelow = layerBelow;
+    this.bearingOnTop = bearingOnTop;
     return requiresUpdate;
   }
 

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentPositionManager.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationComponentPositionManager.java
@@ -17,7 +17,7 @@ class LocationComponentPositionManager {
   @Nullable
   private String layerBelow;
 
-  public Boolean bearingOnTop;
+  public boolean bearingOnTop;
 
   LocationComponentPositionManager(@NonNull Style style, @Nullable String layerAbove,
                                    @Nullable String layerBelow, Boolean bearingOnTop) {
@@ -30,7 +30,7 @@ class LocationComponentPositionManager {
   /**
    * Returns true whenever layer above/below configuration has changed and requires re-layout.
    */
-  boolean update(@Nullable String layerAbove, @Nullable String layerBelow, Boolean bearingOnTop) {
+  boolean update(@Nullable String layerAbove, @Nullable String layerBelow, boolean bearingOnTop) {
     boolean requiresUpdate =
       !(this.layerAbove == layerAbove || (this.layerAbove != null && this.layerAbove.equals(layerAbove)))
         || !(this.layerBelow == layerBelow || (this.layerBelow != null && this.layerBelow.equals(layerBelow)))

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationLayerController.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/LocationLayerController.java
@@ -74,7 +74,8 @@ final class LocationLayerController {
   }
 
   void initializeComponents(Style style, LocationComponentOptions options) {
-    this.positionManager = new LocationComponentPositionManager(style, options.layerAbove(), options.layerBelow());
+    this.positionManager = new LocationComponentPositionManager(style, options.layerAbove(),
+            options.layerBelow(), options.bearingOnTop());
     locationLayerRenderer.initializeComponents(style);
     locationLayerRenderer.addLayers(positionManager);
     applyStyle(options);
@@ -87,7 +88,7 @@ final class LocationLayerController {
   }
 
   void applyStyle(@NonNull LocationComponentOptions options) {
-    if (positionManager.update(options.layerAbove(), options.layerBelow())) {
+    if (positionManager.update(options.layerAbove(), options.layerBelow(), options.bearingOnTop())) {
       locationLayerRenderer.removeLayers();
       locationLayerRenderer.addLayers(positionManager);
       if (isHidden) {

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/SymbolLocationLayerRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/SymbolLocationLayerRenderer.java
@@ -83,14 +83,18 @@ final class SymbolLocationLayerRenderer implements LocationLayerRenderer {
 
   @Override
   public void addLayers(LocationComponentPositionManager positionManager) {
+
+    String firstLayer = positionManager.bearingOnTop ? BEARING_LAYER : FOREGROUND_LAYER;
+    String secondLayer = positionManager.bearingOnTop ? FOREGROUND_LAYER : BEARING_LAYER;
+
     // positions the top-most reference layer
-    Layer layer = layerSourceProvider.generateLayer(BEARING_LAYER);
+    Layer layer = layerSourceProvider.generateLayer(firstLayer);
     positionManager.addLayerToMap(layer);
     layerSet.add(layer.getId());
 
     // adds remaining layers while keeping the order
-    addSymbolLayer(FOREGROUND_LAYER, BEARING_LAYER);
-    addSymbolLayer(BACKGROUND_LAYER, FOREGROUND_LAYER);
+    addSymbolLayer(secondLayer, firstLayer);
+    addSymbolLayer(BACKGROUND_LAYER, secondLayer);
     addSymbolLayer(SHADOW_LAYER, BACKGROUND_LAYER);
     addAccuracyLayer();
     addPulsingCircleLayerToMap();

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/SymbolLocationLayerRenderer.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/location/SymbolLocationLayerRenderer.java
@@ -84,18 +84,28 @@ final class SymbolLocationLayerRenderer implements LocationLayerRenderer {
   @Override
   public void addLayers(LocationComponentPositionManager positionManager) {
 
-    String firstLayer = positionManager.bearingOnTop ? BEARING_LAYER : FOREGROUND_LAYER;
-    String secondLayer = positionManager.bearingOnTop ? FOREGROUND_LAYER : BEARING_LAYER;
+    if (positionManager.bearingOnTop) {
+      // positions the top-most reference layer
+      Layer layer = layerSourceProvider.generateLayer(BEARING_LAYER);
+      positionManager.addLayerToMap(layer);
+      layerSet.add(layer.getId());
 
-    // positions the top-most reference layer
-    Layer layer = layerSourceProvider.generateLayer(firstLayer);
-    positionManager.addLayerToMap(layer);
-    layerSet.add(layer.getId());
+      // adds remaining layers while keeping the order
+      addSymbolLayer(FOREGROUND_LAYER, BEARING_LAYER);
+      addSymbolLayer(BACKGROUND_LAYER, FOREGROUND_LAYER);
+      addSymbolLayer(SHADOW_LAYER, BACKGROUND_LAYER);
+    } else {
+      // positions the top-most reference layer
+      Layer layer = layerSourceProvider.generateLayer(FOREGROUND_LAYER);
+      positionManager.addLayerToMap(layer);
+      layerSet.add(layer.getId());
 
-    // adds remaining layers while keeping the order
-    addSymbolLayer(secondLayer, firstLayer);
-    addSymbolLayer(BACKGROUND_LAYER, secondLayer);
-    addSymbolLayer(SHADOW_LAYER, BACKGROUND_LAYER);
+      // adds remaining layers while keeping the order
+      addSymbolLayer(BACKGROUND_LAYER, FOREGROUND_LAYER);
+      addSymbolLayer(BEARING_LAYER, BACKGROUND_LAYER);
+      addSymbolLayer(SHADOW_LAYER, BEARING_LAYER);
+    }
+
     addAccuracyLayer();
     addPulsingCircleLayerToMap();
   }

--- a/platform/android/MapLibreAndroid/src/main/res/values/attrs.xml
+++ b/platform/android/MapLibreAndroid/src/main/res/values/attrs.xml
@@ -181,6 +181,7 @@
         <!-- Map layer configuration -->
         <attr name="maplibre_layer_above" format="string"/>
         <attr name="maplibre_layer_below" format="string"/>
+        <attr name="maplibre_bearing_on_top" format="boolean"/>
 
         <!-- Icon scale based on map zoom levels -->
         <attr name="maplibre_maxZoomIconScale" format="float"/>

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/location/LocationComponentPositionManagerTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/location/LocationComponentPositionManagerTest.kt
@@ -26,70 +26,91 @@ class LocationComponentPositionManagerTest : BaseTest() {
 
     @Test
     fun update_noChange_null() {
-        val positionManager = LocationComponentPositionManager(style, null, null)
-        val requiresUpdate = positionManager.update(null, null)
+        val positionManager = LocationComponentPositionManager(style, null, null, false)
+        val requiresUpdate = positionManager.update(null, null, false)
         assertFalse(requiresUpdate)
     }
 
     @Test
     fun update_noChange_above() {
-        val positionManager = LocationComponentPositionManager(style, "above", null)
-        val requiresUpdate = positionManager.update("above", null)
+        val positionManager = LocationComponentPositionManager(style, "above", null, false)
+        val requiresUpdate = positionManager.update("above", null, false)
         assertFalse(requiresUpdate)
     }
 
     @Test
     fun update_noChange_below() {
-        val positionManager = LocationComponentPositionManager(style, null, "below")
-        val requiresUpdate = positionManager.update(null, "below")
+        val positionManager = LocationComponentPositionManager(style, null, "below", false)
+        val requiresUpdate = positionManager.update(null, "below", false)
+        assertFalse(requiresUpdate)
+    }
+
+    @Test
+    fun update_noChange_bearingOnTop() {
+        val positionManager = LocationComponentPositionManager(style, null, null, true)
+        val requiresUpdate = positionManager.update(null, null, true)
         assertFalse(requiresUpdate)
     }
 
     @Test
     fun update_fromNull_above() {
-        val positionManager = LocationComponentPositionManager(style, null, null)
-        val requiresUpdate = positionManager.update("above", null)
+        val positionManager = LocationComponentPositionManager(style, null, null, false)
+        val requiresUpdate = positionManager.update("above", null, false)
         assertTrue(requiresUpdate)
     }
 
     @Test
     fun update_fromNull_below() {
-        val positionManager = LocationComponentPositionManager(style, null, null)
-        val requiresUpdate = positionManager.update(null, "below")
+        val positionManager = LocationComponentPositionManager(style, null, null, false)
+        val requiresUpdate = positionManager.update(null, "below", false)
         assertTrue(requiresUpdate)
     }
 
     @Test
     fun update_toNull_above() {
-        val positionManager = LocationComponentPositionManager(style, "above", null)
-        val requiresUpdate = positionManager.update(null, null)
+        val positionManager = LocationComponentPositionManager(style, "above", null, false)
+        val requiresUpdate = positionManager.update(null, null, false)
         assertTrue(requiresUpdate)
     }
 
     @Test
     fun update_toNull_below() {
-        val positionManager = LocationComponentPositionManager(style, null, "below")
-        val requiresUpdate = positionManager.update(null, null)
+        val positionManager = LocationComponentPositionManager(style, null, "below", false)
+        val requiresUpdate = positionManager.update(null, null, false)
         assertTrue(requiresUpdate)
     }
 
     @Test
     fun update_fromValue_above() {
-        val positionManager = LocationComponentPositionManager(style, "above1", null)
-        val requiresUpdate = positionManager.update("above2", null)
+        val positionManager = LocationComponentPositionManager(style, "above1", null, false)
+        val requiresUpdate = positionManager.update("above2", null, false)
         assertTrue(requiresUpdate)
     }
 
     @Test
     fun update_fromValue_below() {
-        val positionManager = LocationComponentPositionManager(style, null, "below1")
-        val requiresUpdate = positionManager.update(null, "below2")
+        val positionManager = LocationComponentPositionManager(style, null, "below1", false)
+        val requiresUpdate = positionManager.update(null, "below2", false)
+        assertTrue(requiresUpdate)
+    }
+
+    @Test
+    fun update_bearingOnTop_changed() {
+        val positionManager = LocationComponentPositionManager(style, null, null, false)
+        val requiresUpdate = positionManager.update(null, null, true)
+        assertTrue(requiresUpdate)
+    }
+
+    @Test
+    fun update_bearingOnTop_changedToFalse() {
+        val positionManager = LocationComponentPositionManager(style, null, null, true)
+        val requiresUpdate = positionManager.update(null, null, false)
         assertTrue(requiresUpdate)
     }
 
     @Test
     fun addLayer_noModifier() {
-        val positionManager = LocationComponentPositionManager(style, null, null)
+        val positionManager = LocationComponentPositionManager(style, null, null, false)
         positionManager.addLayerToMap(layer)
 
         verify { style.addLayer(layer) }
@@ -97,7 +118,7 @@ class LocationComponentPositionManagerTest : BaseTest() {
 
     @Test
     fun addLayer_above() {
-        val positionManager = LocationComponentPositionManager(style, "above", null)
+        val positionManager = LocationComponentPositionManager(style, "above", null, false)
         positionManager.addLayerToMap(layer)
 
         verify { style.addLayerAbove(layer, "above") }
@@ -105,7 +126,7 @@ class LocationComponentPositionManagerTest : BaseTest() {
 
     @Test
     fun addLayer_below() {
-        val positionManager = LocationComponentPositionManager(style, null, "below")
+        val positionManager = LocationComponentPositionManager(style, null, "below", false)
         positionManager.addLayerToMap(layer)
 
         verify { style.addLayerBelow(layer, "below") }
@@ -113,8 +134,8 @@ class LocationComponentPositionManagerTest : BaseTest() {
 
     @Test
     fun addLayer_afterUpdate_above() {
-        val positionManager = LocationComponentPositionManager(style, null, null)
-        positionManager.update("above", null)
+        val positionManager = LocationComponentPositionManager(style, null, null, false)
+        positionManager.update("above", null, false)
         positionManager.addLayerToMap(layer)
 
         verify { style.addLayerAbove(layer, "above") }
@@ -122,8 +143,8 @@ class LocationComponentPositionManagerTest : BaseTest() {
 
     @Test
     fun addLayer_afterUpdate_below() {
-        val positionManager = LocationComponentPositionManager(style, null, null)
-        positionManager.update(null, "below")
+        val positionManager = LocationComponentPositionManager(style, null, null, false)
+        positionManager.update(null, "below", false)
         positionManager.addLayerToMap(layer)
 
         verify { style.addLayerBelow(layer, "below") }

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/location/LocationLayerControllerTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/location/LocationLayerControllerTest.kt
@@ -142,7 +142,7 @@ class LocationLayerControllerTest : BaseTest() {
             false
         )
         Mockito.verify(style)
-            .addLayerBelow(backgroundLayer, LocationComponentConstants.FOREGROUND_LAYER)
+            .addLayerBelow(backgroundLayer, LocationComponentConstants.BEARING_LAYER)
     }
 
     @Test
@@ -181,8 +181,7 @@ class LocationLayerControllerTest : BaseTest() {
             internalRenderModeChangedListener,
             false
         )
-        Mockito.verify(style)
-            .addLayerBelow(foregroundLayer, LocationComponentConstants.BEARING_LAYER)
+        Mockito.verify(style).addLayer(foregroundLayer)
     }
 
     @Test
@@ -223,7 +222,8 @@ class LocationLayerControllerTest : BaseTest() {
             internalRenderModeChangedListener,
             false
         )
-        Mockito.verify(style).addLayerBelow(bearingLayer, layerBelow)
+        Mockito.verify(style)
+            .addLayerBelow(bearingLayer, LocationComponentConstants.FOREGROUND_LAYER)
     }
 
     @Test
@@ -757,11 +757,11 @@ class LocationLayerControllerTest : BaseTest() {
         Mockito.verify(style).removeLayer(LocationComponentConstants.BACKGROUND_LAYER)
         Mockito.verify(style).removeLayer(LocationComponentConstants.SHADOW_LAYER)
         Mockito.verify(style).removeLayer(LocationComponentConstants.ACCURACY_LAYER)
-        Mockito.verify(style).addLayerBelow(bearingLayer2, layerBelow)
+        Mockito.verify(style).addLayerBelow(foregroundLayer2, layerBelow)
         Mockito.verify(style)
-            .addLayerBelow(foregroundLayer2, LocationComponentConstants.BEARING_LAYER)
+            .addLayerBelow(bearingLayer2, LocationComponentConstants.FOREGROUND_LAYER)
         Mockito.verify(style)
-            .addLayerBelow(backgroundLayer2, LocationComponentConstants.FOREGROUND_LAYER)
+            .addLayerBelow(backgroundLayer2, LocationComponentConstants.BEARING_LAYER)
         Mockito.verify(style)
             .addLayerBelow(shadowLayer2, LocationComponentConstants.BACKGROUND_LAYER)
         Mockito.verify(style)

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/location/LocationLayerControllerTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/location/LocationLayerControllerTest.kt
@@ -102,7 +102,7 @@ class LocationLayerControllerTest : BaseTest() {
             false
         )
         Mockito.verify(style)
-            .addLayerBelow(shadowLayer, LocationComponentConstants.BACKGROUND_LAYER)
+            .addLayerBelow(shadowLayer, LocationComponentConstants.BEARING_LAYER)
     }
 
     @Test
@@ -142,7 +142,7 @@ class LocationLayerControllerTest : BaseTest() {
             false
         )
         Mockito.verify(style)
-            .addLayerBelow(backgroundLayer, LocationComponentConstants.BEARING_LAYER)
+            .addLayerBelow(backgroundLayer, LocationComponentConstants.FOREGROUND_LAYER)
     }
 
     @Test
@@ -223,7 +223,7 @@ class LocationLayerControllerTest : BaseTest() {
             false
         )
         Mockito.verify(style)
-            .addLayerBelow(bearingLayer, LocationComponentConstants.FOREGROUND_LAYER)
+            .addLayerBelow(bearingLayer, LocationComponentConstants.BACKGROUND_LAYER)
     }
 
     @Test
@@ -759,11 +759,11 @@ class LocationLayerControllerTest : BaseTest() {
         Mockito.verify(style).removeLayer(LocationComponentConstants.ACCURACY_LAYER)
         Mockito.verify(style).addLayerBelow(foregroundLayer2, layerBelow)
         Mockito.verify(style)
-            .addLayerBelow(bearingLayer2, LocationComponentConstants.FOREGROUND_LAYER)
+            .addLayerBelow(backgroundLayer2, LocationComponentConstants.FOREGROUND_LAYER)
         Mockito.verify(style)
-            .addLayerBelow(backgroundLayer2, LocationComponentConstants.BEARING_LAYER)
+            .addLayerBelow(bearingLayer2, LocationComponentConstants.BACKGROUND_LAYER)
         Mockito.verify(style)
-            .addLayerBelow(shadowLayer2, LocationComponentConstants.BACKGROUND_LAYER)
+            .addLayerBelow(shadowLayer2, LocationComponentConstants.BEARING_LAYER)
         Mockito.verify(style)
             .addLayerBelow(accuracyLayer2, LocationComponentConstants.BACKGROUND_LAYER)
     }


### PR DESCRIPTION
Currently the symbol location indicator uses a background/foreground/bearing image stack, while the specialized implementation and overall documentation use the bearing under foreground and background images. 
This PR adds the `bearingOnTop` option to move the bearing image to make both implementation consistent.

Bearing image is visible only when using `RenderMode.Compass` (all other modes are unaffected) and maplibre default values don't overlap making the draw order irrelevant for this scenario.
<p align="center">
<img width="128" alt="default bearing" title="default bearing image" src="https://github.com/user-attachments/assets/11040b15-504d-458b-8770-238623d75490" /> </br>
<sub>Default bearing drawable</sub>
</p>

<p align="center">Custom bearing drawable:</p>

<table align="center">
    <tr>
        <td align="center">
            <img align="center" width="140" height="142" src="https://github.com/user-attachments/assets/2e0e0f0d-51b4-46d0-b223-873bb8d96917" />
            </br><sub>bearingOnTop(true) - main</sub>
        </td>
        <td align="center">
            <img width="140" height="142" title="bearingOnTop(true) - current implementation" alt="bearingOnTop(true) - current implementation" src="https://github.com/user-attachments/assets/bfa453a8-ff68-46cb-885f-65f5203d1a8f" />
            </br><sub>bearingOnTop(false) -  PR</sub>
        </td>
    </tr>
</table>
