### PR TITLE
feat(android): Create default OkHttpClient only when needed

### DIFF
--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/module/http/HttpRequestImpl.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/module/http/HttpRequestImpl.java
@@ -1,5 +1,7 @@
 package org.maplibre.android.module.http;
 
+import static org.maplibre.android.module.http.HttpRequestUtil.toHumanReadableAscii;
+
 import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
@@ -22,7 +24,6 @@ import java.net.NoRouteToHostException;
 import java.net.ProtocolException;
 import java.net.SocketException;
 import java.net.UnknownHostException;
-import java.util.Objects;
 
 import javax.net.ssl.SSLException;
 
@@ -34,8 +35,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-
-import static org.maplibre.android.module.http.HttpRequestUtil.toHumanReadableAscii;
 
 public class HttpRequestImpl implements HttpRequest {
 
@@ -49,10 +48,10 @@ public class HttpRequestImpl implements HttpRequest {
   );
 
   @VisibleForTesting
-  static final OkHttpClient DEFAULT_CLIENT = new OkHttpClient.Builder().dispatcher(getDispatcher()).build();
+  static volatile OkHttpClient defaultClient = null;
 
   @VisibleForTesting
-  static Call.Factory client = DEFAULT_CLIENT;
+  static volatile Call.Factory client = null;
 
   private Call call;
 
@@ -87,7 +86,7 @@ public class HttpRequestImpl implements HttpRequest {
       }
 
       final Request request = builder.build();
-      call = client.newCall(request);
+      call = getHttpClient().newCall(request);
       call.enqueue(callback);
     } catch (Exception exception) {
       callback.handleFailure(call, exception);
@@ -113,7 +112,7 @@ public class HttpRequestImpl implements HttpRequest {
   }
 
   public static void setOkHttpClient(@Nullable Call.Factory client) {
-    HttpRequestImpl.client = Objects.requireNonNullElse(client, DEFAULT_CLIENT);
+    HttpRequestImpl.client = client != null ? client : getOrCreateDefaultClient();
   }
 
   private static class OkHttpCallback implements Callback {
@@ -186,6 +185,27 @@ public class HttpRequestImpl implements HttpRequest {
       }
       return PERMANENT_ERROR;
     }
+  }
+
+  private static Call.Factory getHttpClient() {
+    if (client == null) {
+      synchronized (HttpRequestImpl.class) {
+        if (client == null) {
+          client = getOrCreateDefaultClient();
+        }
+      }
+    }
+
+    return client;
+  }
+
+  @NonNull
+  private static synchronized OkHttpClient getOrCreateDefaultClient() {
+    if (defaultClient == null) {
+      defaultClient = new OkHttpClient.Builder().dispatcher(getDispatcher()).build();
+    }
+
+    return defaultClient;
   }
 
   @NonNull

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/module/http/HttpRequestUtilTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/module/http/HttpRequestUtilTest.kt
@@ -5,6 +5,8 @@ import org.maplibre.android.utils.ConfigUtils
 import io.mockk.mockk
 import okhttp3.Call
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.maplibre.android.BaseTest
@@ -17,10 +19,10 @@ class HttpRequestUtilTest : BaseTest() {
     fun replaceHttpClient() {
         MapLibreInjector.inject(mockk(relaxed = true), "", ConfigUtils.getMockedOptions())
 
-        assertEquals(HttpRequestImpl.DEFAULT_CLIENT, HttpRequestImpl.client)
-
         val httpMock = mockk<Call.Factory>()
         HttpRequestUtil.setOkHttpClient(httpMock)
+
+        assertNull("Default HTTP client should not be initialized", HttpRequestImpl.defaultClient)
         assertEquals(
             "Http client should have set to the mocked client",
             httpMock,
@@ -28,9 +30,10 @@ class HttpRequestUtilTest : BaseTest() {
         )
 
         HttpRequestUtil.setOkHttpClient(null)
+        assertNotNull("Default HTTP client should be initialized", HttpRequestImpl.defaultClient)
         assertEquals(
             "Http client should have been reset to the default client",
-            HttpRequestImpl.DEFAULT_CLIENT,
+            HttpRequestImpl.defaultClient,
             HttpRequestImpl.client
         )
 


### PR DESCRIPTION
Currently, the default OkHttpClient is always created even when a custom HTTP client is provided and the default client is never used.

In my use case, I want all HTTP traffic to be done with a custom OkHttpClient. I'm using `HttpRequestUtil.setOkHttpClient(httpClient)` to set the HTTP client just before initializing the map. This caused the default client to be created even when not needed. Doing this from the UI thread causes a StrictMode violation:
```
StrictMode policy violation; ~duration=18 ms: android.os.strictmode.CustomViolation: newSSLContext
  at android.os.StrictMode$AndroidBlockGuardPolicy.onCustomSlowCall(StrictMode.java:1650)
  at android.os.StrictMode.noteSlowCall(StrictMode.java:2785)
  at okhttp3.internal.platform.Android10Platform.newSSLContext(Android10Platform.kt:63)
  at okhttp3.internal.platform.Platform.newSslSocketFactory(Platform.kt:195)
  at okhttp3.OkHttpClient.<init>(OkHttpClient.kt:293)
  at okhttp3.OkHttpClient$Builder.build(OkHttpClient.kt:1382)
  at org.maplibre.android.module.http.HttpRequestImpl.<clinit>(HttpRequestImpl.java:52)
  at org.maplibre.android.module.http.HttpRequestUtil.setOkHttpClient(HttpRequestUtil.java:51)
```

Existing behavior should be preserved. The default client gets created lazily if no custom client is provided and setting the client to `null` restores the default client.