### PR TITLE
build(android): Use cacheable Gradle task for downloading Vulkan validation layers

### DIFF
--- a/platform/android/buildSrc/src/main/kotlin/maplibre.download-vulkan-validation.gradle.kts
+++ b/platform/android/buildSrc/src/main/kotlin/maplibre.download-vulkan-validation.gradle.kts
@@ -1,4 +1,4 @@
-import java.net.URL
+import java.net.URI
 
 
 /**
@@ -29,21 +29,30 @@ val vvlLibRoot = projectDir // Set project root or change to rootDir if needed
 val vvlJniLibDir = "$vvlLibRoot/src/vulkanDebug/jniLibs"
 val vvlSoName = "libVkLayer_khronos_validation.so"
 
-// Download the release zip file to ${vvlLibRoot}/
-val download = tasks.register("download") {
-    val vvlZipName = "releases/download/vulkan-sdk-$vvlVersion/android-binaries-$vvlVersion.zip"
-    val zipFile = file("$vvlLibRoot/android-binaries-$vvlVersion.zip")
+abstract class Download : DefaultTask() {
+    @get:Input
+    abstract val url: Property<String>
 
-    mkdir(vvlLibRoot)
+    @get:OutputFile
+    abstract val file: RegularFileProperty
 
-    doLast {
-        // Download the zip file from the Vulkan Validation Layers GitHub repo.
-        URL("$vvlSite/$vvlZipName").openStream().use { inputStream ->
-            zipFile.outputStream().use { outputStream ->
-                inputStream.copyTo(outputStream)
-            }
+    @TaskAction
+    fun download() {
+        URI.create(url.get()).toURL().openStream().use { inputStream ->
+            file.get().asFile
+                .outputStream()
+                .use { outputStream ->
+                    inputStream.copyTo(outputStream)
+                }
         }
     }
+}
+
+val download = tasks.register<Download>("download") {
+    // Download the zip file from the Vulkan Validation Layers GitHub repo.
+    url = "$vvlSite/releases/download/vulkan-sdk-$vvlVersion/android-binaries-$vvlVersion.zip"
+    // Download the release zip file to ${vvlLibRoot}/
+    file = file("$vvlLibRoot/android-binaries-$vvlVersion.zip")
 }
 
 val unzip = tasks.register<Copy>("unzip") {


### PR DESCRIPTION
Working on #4411 was really painful with a slow, unreliable connection as the build process downloads Vulkan validation layers for every build.

This PR creates a cacheable task for downloading the Vulkan validation layers. The task assumes that the URL content is static. If the input URL has not changed, Gradle can reuse results from previous builds. 


