### PR TITLE
Make sure maplibre-tile-spec builds OK with Qt with all configurations

### DIFF
--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -153,6 +153,8 @@ target_link_libraries(
         $<BUILD_INTERFACE:mbgl-vendor-parsedate>
         $<BUILD_INTERFACE:mbgl-vendor-nunicode>
         $<BUILD_INTERFACE:mbgl-vendor-csscolorparser>
+        $<BUILD_INTERFACE:mlt-cpp>
+        $<BUILD_INTERFACE:fastpfor-lib>
         $<$<PLATFORM_ID:iOS>:$<BUILD_INTERFACE:mbgl-vendor-filesystem>>
         $<$<NOT:$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Emscripten>>>:z>
         $<IF:$<BOOL:${MLN_QT_WITH_INTERNAL_SQLITE}>,$<BUILD_INTERFACE:mbgl-vendor-sqlite>,Qt${QT_VERSION_MAJOR}::Sql>
@@ -179,6 +181,8 @@ if(MLN_QT_HAS_PARENT)
         mbgl-vendor-parsedate
         mbgl-vendor-nunicode
         mbgl-vendor-csscolorparser
+        mlt-cpp
+        fastpfor-lib
         $<$<PLATFORM_ID:iOS>:mbgl-vendor-filesystem>
         $<$<BOOL:${MLN_QT_WITH_INTERNAL_SQLITE}>:mbgl-vendor-sqlite>
         $<$<AND:$<PLATFORM_ID:Linux>,$<BOOL:${MLN_QT_WITH_INTERNAL_ICU}>>:mbgl-vendor-icu>

--- a/vendor/maplibre-tile-spec.cmake
+++ b/vendor/maplibre-tile-spec.cmake
@@ -2,9 +2,8 @@ set(MLT_WITH_JSON OFF CACHE BOOL "No JSON support" FORCE)
 set(MLT_WITH_PROTOZERO OFF CACHE BOOL "No protozero" FORCE)
 set(MLT_WITH_TESTS OFF CACHE BOOL "Google Test conflicts with Dawn")
 set(MLT_WITH_TOOLS OFF CACHE BOOL "Not used")
-
-# This is set by the platform CMakeLists.txt after vendor libraries.  If it was set earlier, we could just use it.
-set(CMAKE_OSX_DEPLOYMENT_TARGET 14.3)
-set(MLT_OSX_DEPLOYMENT_TARGET ${CMAKE_OSX_DEPLOYMENT_TARGET} CACHE STRING "Inherited MacOS/iOS target" FORCE)
+if(MLN_WITH_QT)
+    set(MLT_AS_OBJECT_LIBRARY ON CACHE BOOL "Build as object library" FORCE)
+endif()
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/vendor/maplibre-tile-spec/cpp SYSTEM)


### PR DESCRIPTION
Make sure `maplibre-tile-spec` builds OK with Qt with all configurations:
- remove unused and hardcoded `CMAKE_OSX_DEPLOYMENT_TARGET`
- build as object library (required upstream change)
- propagate the library

Unfortunately something seemed to have changed in CMake that may require another patch, but let's test in the CI first.