### PR TITLE
core: check if edge length is zero for rounded corners 

### DIFF
--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -316,12 +316,20 @@ GeometryCollectionFloat roundPolygonCorners(GeometryCollection& polygon, double 
             auto cornerPoint = convertPoint<double>(ring[i]);
             auto nextPoint = convertPoint<double>(ring[(i + 1) % nVertices]);
 
+            auto edge1Len = util::dist<double>(cornerPoint, prevPoint);
+            auto edge2Len = util::dist<double>(cornerPoint, nextPoint);
+            if (edge1Len == 0.0 || edge2Len == 0.0) {
+                // Duplicate vertex: no direction to round, keep it as-is.
+                roundedCornerRing.emplace_back(convertPoint<float>(ring[i]));
+                continue;
+            }
+
             // Compute the start and end points of the rounded corner
             auto edge1Vector = util::normal<double>(prevPoint, cornerPoint);
             auto edge2Vector = util::normal<double>(cornerPoint, nextPoint);
 
-            auto edge1MaxCornerDistance = util::dist<double>(cornerPoint, prevPoint) * maxEdgeLenPercent;
-            auto edge2MaxCornerDistance = util::dist<double>(cornerPoint, nextPoint) * maxEdgeLenPercent;
+            auto edge1MaxCornerDistance = edge1Len * maxEdgeLenPercent;
+            auto edge2MaxCornerDistance = edge2Len * maxEdgeLenPercent;
             auto cornerDistance = std::min({desiredCornerDistance, edge1MaxCornerDistance, edge2MaxCornerDistance});
 
             auto startPoint = cornerPoint - edge1Vector * cornerDistance;


### PR DESCRIPTION
This PR adds an additional check if nearby points are too close to be rounded.

Current implementation works well for 3D buildings without [buildings:parts](https://wiki.openstreetmap.org/wiki/Key:building:part) enriched geometry, but when the map style has building:part we can observe some artifacts on the map. 
For duplicate vertex - the edge vector length is zero, so `util::normal` computes 0.0 / 0.0 which leads to `NaN`. 

Prerequisites:
Use style with building:part geometry for extruded buildings.
Set any value greater than zero for `fill-extrusion-rounded-corner-distance`

**BEFORE:**
<img width="428" height="920" alt="image" src="https://github.com/user-attachments/assets/98703ebd-aae5-4aee-959c-d5b1f47cb06c" />

<img width="428" height="927" alt="image" src="https://github.com/user-attachments/assets/d1f918c7-4caa-4fe5-a85e-1ef1ecf06ae2" />


**AFTER:**
<img width="428" height="927" alt="Simulator Screenshot - BAZEL_TEST_iPhone 11 Pro_26 4 - 2026-07-22 at 13 20 25" src="https://github.com/user-attachments/assets/bd6711b3-7bc2-4193-9438-7102fcb06adf" />
<img width="428" height="927" alt="Simulator Screenshot - BAZEL_TEST_iPhone 11 Pro_26 4 - 2026-07-22 at 13 20 13" src="https://github.com/user-attachments/assets/2e00c5e4-e50f-4c85-a879-3f7d6afdf369" />
