### PR TITLE
fix(core): accept alpha in hsl colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### 🐞 Bug fixes
 
 - *...Add new stuff here...*
+- [core] Accept alpha values in legacy comma-separated `hsl()` colors ([#4434](https://github.com/maplibre/maplibre-native/issues/4434)).
 - [core] Fix thread-unsafe headless OpenGL display singleton initialization [#4332](https://github.com/maplibre/maplibre-native/pull/4332)
 - [macos] Fix `mlt-cpp` and `mbgl-vendor-icu` not being included in the amalgamation
 - [core] Fix memory access violation exception in vector_tile_data.cpp [#632](https://github.com/maplibre/maplibre-native/pull/632)

--- a/test/util/color.test.cpp
+++ b/test/util/color.test.cpp
@@ -26,6 +26,8 @@ const std::map<std::string, std::optional<Color>> testCases = {
     {"rgb(-10, 0, 0)", Color(0.0f, 0.0f, 0.0f, 1.0f)},       // Clamped to 0
     {"rgba(300, 0, 0, 1.0)", Color(1.0f, 0.0f, 0.0f, 1.0f)}, // Clamped to 1
     {"rgba(100,100,100,0.2)", Color(20.0f / 255, 20.0f / 255, 20.0f / 255, 0.2f)},
+    {"hsl(120,100%,25%)", Color(0.0f, 0.5f, 0.0f, 1.0f)},
+    {"hsl(240,0%,55%,0.2)", Color(0.11f, 0.11f, 0.11f, 0.2f)},
     // 4-digit hex with alpha (#RGBA)
     {"#0F0F", Color(0.0f, 1.0f, 0.0f, 1.0f)},
     {"#F00C", Color(0.8f, 0.0f, 0.0f, 0.8f)},     // Red with ~80% alpha
@@ -38,6 +40,9 @@ const std::map<std::string, std::optional<Color>> testCases = {
     // Invalid inputs
     {"not-a-color", std::nullopt},
     {"", std::nullopt},
+    {"hsl(120,100%)", std::nullopt},
+    {"hsl(120,100%,50%,1,0)", std::nullopt},
+    {"hsla(120,100%,50%)", std::nullopt},
 };
 
 TEST(ColorParse, AllCases) {
@@ -60,4 +65,16 @@ TEST(ColorParse, AllCases) {
             EXPECT_FALSE(result.has_value());
         }
     }
+}
+
+TEST(ColorParse, HSLWithAlphaMatchesHSLA) {
+    const auto hsl = Color::parse("hsl(114,55%,73%,0.8)");
+    const auto hsla = Color::parse("hsla(114,55%,73%,0.8)");
+
+    ASSERT_TRUE(hsl.has_value());
+    ASSERT_TRUE(hsla.has_value());
+    EXPECT_FLOAT_EQ(hsl->r, hsla->r);
+    EXPECT_FLOAT_EQ(hsl->g, hsla->g);
+    EXPECT_FLOAT_EQ(hsl->b, hsla->b);
+    EXPECT_FLOAT_EQ(hsl->a, hsla->a);
 }

--- a/vendor/csscolorparser/csscolorparser.cpp
+++ b/vendor/csscolorparser/csscolorparser.cpp
@@ -282,6 +282,8 @@ std::optional<Color> parse(const std::string& css_str) {
                     return {};
                 }
                 alpha = parse_css_float(params.back());
+            } else if (params.size() == 4) {
+                alpha = parse_css_float(params.back());
             } else {
                 if (params.size() != 3) {
                     return {};


### PR DESCRIPTION
Fixes #4434.

## Motivation

MapLibre Style Spec and MapLibre GL JS accept legacy comma-separated `hsl()` colors with an alpha argument, such as `hsl(114,55%,73%,0.8)`. MapLibre Native rejected these values because its vendored parser required exactly three arguments for `hsl()`, causing style layers using them to be omitted.

## Change

- Accept a fourth alpha argument for comma-separated `hsl()`.
- Preserve existing three-argument `hsl()` and four-argument `hsla()` behavior.
- Keep three-argument `hsla()` and malformed arities invalid.
- Add regression coverage for the Style Spec example and the issue's reported color.

Modern space/slash CSS Color 4 syntax is intentionally outside this PR's scope.

## Verification

- `pre-commit run --files CHANGELOG.md test/util/color.test.cpp vendor/csscolorparser/csscolorparser.cpp`
- `cmake --preset macos-metal`
- `cmake --build build-macos-metal --target mbgl-test-runner`
- `build-macos-metal/mbgl-test-runner --gtest_filter='ColorParse.*'`

Both `ColorParse` tests pass.

## AI assistance

OpenAI Codex using GPT-5 assisted with repository research, the parser and test changes, and this PR description in response to a request to implement the narrowly scoped `hsl()` alpha fix described in issue #4434.
