### PR TITLE
docs: remove duplicate packages from macOS Homebrew
  install command

### DIFF
--- a/docs/mdbook/src/platforms/macos/README.md
+++ b/docs/mdbook/src/platforms/macos/README.md
@@ -25,7 +25,7 @@ git clone --recurse-submodules git@github.com:maplibre/maplibre-native.git
 Make sure the following Homebrew packages are installed:
 
 ```sh
-brew install bazelisk webp libuv webp icu4c jpeg-turbo glfw libuv
+brew install bazelisk webp libuv icu4c jpeg-turbo glfw
 brew link icu4c --force
 ```
 


### PR DESCRIPTION
Removes the duplicate `webp` and `libuv` entries from the `brew install` command in the macOS getting-started guide — each was listed twice.