### PR TITLE
build: Make the emdawnwebgpu suspension mode configurable

### DIFF
--- a/vendor/dawn.cmake
+++ b/vendor/dawn.cmake
@@ -11,6 +11,8 @@ endif()
 if(MLN_WEBGPU_EMDAWN)
     set(MLN_WEBGPU_EMDAWN_PORT "emdawnwebgpu"
         CACHE STRING "Emscripten port name or path used for emdawnwebgpu")
+    set(MLN_WEBGPU_EMDAWN_SUSPEND "-sASYNCIFY=1"
+        CACHE STRING "Emscripten suspension link option for emdawnwebgpu (-sASYNCIFY=1 or -sJSPI)")
 
     message(STATUS "Configuring emdawnwebgpu port: ${MLN_WEBGPU_EMDAWN_PORT}")
     add_library(mbgl-vendor-dawn INTERFACE)
@@ -26,7 +28,7 @@ if(MLN_WEBGPU_EMDAWN)
         mbgl-vendor-dawn
         INTERFACE
             "--use-port=${MLN_WEBGPU_EMDAWN_PORT}"
-            "-sASYNCIFY=1"
+            "${MLN_WEBGPU_EMDAWN_SUSPEND}"
     )
 
     set_target_properties(


### PR DESCRIPTION
Emscripten calls async browser APIs by suspending the calling thread. Emscripten offers two mechanisms for this:

- ASYNCIFY=1 rewrites the calling code to replace the function call with an async state machine that parks the thread in a way that caused some trouble with pthreads.
- JSPI (formerly spelled ASYNCIFY=2) uses the wasm vm's native support for suspending calls. The downside is it's not as widely supported; in particular Safari is still missing support. Chrome 137 and Firefox 139 support this. 

Here I keep the existing setting but make it configurable, so mln-ffi can pick JSPI. 

AI disclosure, used opus 5 and sol 5.6 to root cause mln-ffi's browser build hangs and aborts. Opus created this branch and wrote a much more detailed word vomit commit message which you can inspect for some technical details of the crashes. 