### PR TITLE
fix(darwin): accept a scalar for colorArray/numberArray style properties

### DIFF
--- a/platform/darwin/src/MLNStyleValue_Private.h
+++ b/platform/darwin/src/MLNStyleValue_Private.h
@@ -273,6 +273,22 @@ private:  // Private utilities for converting from mgl to mbgl values
 
   // Array
   void getMBGLValue(ObjCType rawValue, std::vector<MBGLElement> &mbglValue) {
+    if (![rawValue isKindOfClass:[NSArray class]]) {
+      // The style spec allows a scalar wherever a numberArray or colorArray is expected (it
+      // even keeps scalar defaults for those properties), and Converter<std::vector<T>> in
+      // mbgl::style::conversion turns a scalar into a one-element vector. Do the same here
+      // instead of sending -count to a color or a string, which raises
+      // doesNotRecognizeSelector and terminates the app.
+      id scalarValue = rawValue;
+      if ([scalarValue isKindOfClass:[NSExpression class]] &&
+          [scalarValue expressionType] == NSConstantValueExpressionType) {
+        scalarValue = [scalarValue constantValue];
+      }
+      MBGLElement mbglElement;
+      getMBGLValue(scalarValue, mbglElement);
+      mbglValue.push_back(mbglElement);
+      return;
+    }
     mbglValue.reserve(rawValue.count);
     for (id obj in rawValue) {
       id constantObject = obj;

--- a/platform/darwin/test/MLNColorArrayTests.mm
+++ b/platform/darwin/test/MLNColorArrayTests.mm
@@ -1,0 +1,64 @@
+#import <Mapbox.h>
+#import <XCTest/XCTest.h>
+
+#import "MLNStyleLayer_Private.h"
+
+#include <mbgl/style/layers/hillshade_layer.hpp>
+
+/// Regression tests for https://github.com/maplibre/maplibre-native/issues/4453.
+///
+/// `colorArray` and `numberArray` properties must accept a scalar, the same way the style spec
+/// (which keeps scalar defaults for them), `mbgl::style::conversion` and MapLibre GL JS do.
+@interface MLNColorArrayTests : XCTestCase
+@end
+
+@implementation MLNColorArrayTests
+
+- (MLNHillshadeStyleLayer *)hillshadeLayer {
+  MLNPointFeature *feature = [[MLNPointFeature alloc] init];
+  MLNShapeSource *source = [[MLNShapeSource alloc] initWithIdentifier:@"sourceID"
+                                                                shape:feature
+                                                              options:nil];
+  return [[MLNHillshadeStyleLayer alloc] initWithIdentifier:@"layerID" source:source];
+}
+
+- (void)testColorArrayPropertyAcceptsSingleColor {
+  MLNHillshadeStyleLayer *layer = [self hillshadeLayer];
+  auto rawLayer = static_cast<mbgl::style::HillshadeLayer *>(layer.rawLayer);
+
+  layer.hillshadeShadowColor = [NSExpression expressionForConstantValue:[MLNColor redColor]];
+
+  mbgl::style::PropertyValue<std::vector<mbgl::Color>> propertyValue =
+      std::vector<mbgl::Color>{mbgl::Color::red()};
+  XCTAssertEqual(rawLayer->getHillshadeShadowColor(), propertyValue,
+                 @"Setting hillshadeShadowColor to a single color should update "
+                 @"hillshade-shadow-color with a one-element color array.");
+}
+
+- (void)testColorArrayPropertyAcceptsColorArray {
+  MLNHillshadeStyleLayer *layer = [self hillshadeLayer];
+  auto rawLayer = static_cast<mbgl::style::HillshadeLayer *>(layer.rawLayer);
+
+  layer.hillshadeHighlightColor = [NSExpression
+      expressionForConstantValue:@[ [MLNColor redColor], [MLNColor blueColor] ]];
+
+  mbgl::style::PropertyValue<std::vector<mbgl::Color>> propertyValue =
+      std::vector<mbgl::Color>{mbgl::Color::red(), mbgl::Color::blue()};
+  XCTAssertEqual(rawLayer->getHillshadeHighlightColor(), propertyValue,
+                 @"Setting hillshadeHighlightColor to an array of colors should update "
+                 @"hillshade-highlight-color.");
+}
+
+- (void)testNumberArrayPropertyAcceptsSingleNumber {
+  MLNHillshadeStyleLayer *layer = [self hillshadeLayer];
+  auto rawLayer = static_cast<mbgl::style::HillshadeLayer *>(layer.rawLayer);
+
+  layer.hillshadeIlluminationDirection = [NSExpression expressionForConstantValue:@335];
+
+  mbgl::style::PropertyValue<std::vector<float>> propertyValue = std::vector<float>{335};
+  XCTAssertEqual(rawLayer->getHillshadeIlluminationDirection(), propertyValue,
+                 @"Setting hillshadeIlluminationDirection to a single number should update "
+                 @"hillshade-illumination-direction with a one-element number array.");
+}
+
+@end


### PR DESCRIPTION
Fixes #4453.

### Problem

Since the style-spec change in 6.24.0 (`hillshade-shadow-color` / `hillshade-highlight-color` → `colorArray`, `hillshade-illumination-direction` / `-altitude` → `numberArray`, #3396), the generated setters instantiate `MLNStyleValueTransformer<std::vector<mbgl::Color>, NSArray<MLNColor *> *, mbgl::Color>`. A constant-value expression takes the fast path in `toPropertyValue` straight into the array overload, which sends `-count` to the raw value with no type check:

```objc
  // Array
  void getMBGLValue(ObjCType rawValue, std::vector<MBGLElement> &mbglValue) {
    mbglValue.reserve(rawValue.count);   // rawValue is a UIColor / NSNumber here
```

So `layer.hillshadeShadowColor = [NSExpression expressionForConstantValue:UIColor.redColor]` — code that worked in 6.23.0 and still works on Android — dies with

```
NSInvalidArgumentException: -[UIDeviceRGBColor count]: unrecognized selector sent to instance
```

The `NSCAssert`s nearby are compiled out in the released framework, so shipping apps get an `NSException` from native code rather than an assertion. Through an FFI wrapper (Flutter, React Native) that is uncatchable and terminates the process.

### Fix

Treat a scalar as a one-element vector, which is what everything else already does:

* the spec keeps scalar defaults for these properties (`"type": "colorArray", "default": "#000000"`),
* `Converter<std::vector<Color>>` / `Converter<std::vector<float>>` in `src/mbgl/style/conversion/constant.cpp` explicitly accept a scalar (that is why the JSON and JNI paths never hit this),
* MapLibre GL JS accepts a scalar too.

Arrays keep the existing code path, so no behaviour changes for callers that already pass an `NSArray`.

### Tests

New `platform/darwin/test/MLNColorArrayTests.mm` (picked up by the existing `test/*.mm` glob in `platform/darwin/BUILD.bazel`):

* `colorArray` property set from a single `MLNColor` → one-element color array
* `colorArray` property set from an `NSArray` of two colors → unchanged behaviour
* `numberArray` property set from a single `NSNumber` → one-element float array

Disclosure: I develop on Windows and cannot build or run the darwin test suite locally, so these two changes have not been compiled here — they need your CI. The diagnosis behind them is verified against 6.19.0/6.23.0/6.24.0/6.25.0 sources and against 83 production crashes in our app.
