### PR TITLE
Enable heatmap-translucent opaque combination render tests

### DIFF
--- a/metrics/ignores/platform-all.json
+++ b/metrics/ignores/platform-all.json
@@ -124,7 +124,5 @@
     "render-tests/feature-state/promote-id-fill-extrusion": "https://github.com/mapbox/mapbox-gl-js/pull/9202",
     "render-tests/line-pattern/with-dasharray":"https://github.com/mapbox/mapbox-gl-js/pull/9189",
     "render-tests/symbol-sort-key/placement-tile-boundary-right-then-left": "https://github.com/mapbox/mapbox-gl-js/pull/9054",
-    "render-tests/tile-mode/streets-v11": "ignored due to flaky metrics results",
-    "render-tests/combinations/heatmap-translucent--fill-opaque": "Temporarily disabled until the renderer switch",
-    "render-tests/combinations/heatmap-translucent--background-opaque": "Temporarily disabled until the renderer switch"
+    "render-tests/tile-mode/streets-v11": "ignored due to flaky metrics results"
 }


### PR DESCRIPTION
## Why

`render-tests/combinations/heatmap-translucent--fill-opaque` and `render-tests/combinations/heatmap-translucent--background-opaque` were added to `metrics/ignores/platform-all.json` in #1633 with the reason "Temporarily disabled until the renderer switch". The renderer switch (legacy → Drawable architecture) has since been completed, and the underlying issues from that period (#1511, #1543) are both closed — so the ignore reason no longer applies.

## What

Remove the two entries from `metrics/ignores/platform-all.json` (no other changes).

## Verification

Both tests pass against the **default expected images** (no platform-specific expectations needed) on:

- macOS Metal (Apple Silicon, local build) — `2 passed (100.0%)`
- Linux OpenGL (Docker + xvfb, same setup as CI) — `2 passed (100.0%)`
- Linux Vulkan (Docker + xvfb, same setup as CI) — `2 passed (100.0%)`

Windows is the one render-test CI platform I could not verify locally.

## AI disclosure

Per the [MapLibre AI Policy](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md): I used Claude Code (Claude Fable 5) to assist with the investigation and verification. The change itself and the test results were reviewed and confirmed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)