### PR TITLE
accept libpng with different release/patch number

### DIFF
--- a/platform/default/src/mbgl/util/png_reader.cpp
+++ b/platform/default/src/mbgl/util/png_reader.cpp
@@ -21,7 +21,7 @@ std::string sprintf(const char* msg, Args... args) {
 
 const static bool png_version_check [[maybe_unused]] = []() {
     const png_uint_32 version = png_access_version_number();
-    if (version != PNG_LIBPNG_VER) {
+    if (version / 100 != PNG_LIBPNG_VER / 100) {
         throw std::runtime_error(
             sprintf<96>("libpng version mismatch: headers report %d.%d.%d, but library "
                         "reports %d.%d.%d",


### PR DESCRIPTION
I did not find a clear official statement but the definition of PNG_LIBPNG_VER_SHAREDLIB and the used soname at least imply that this versions should be abi compatible. We ran into this because an update of the stable opensuse leap increased the release/patch number and we do not automatically recompile on updates.

There is some relevant prior discussion in https://github.com/maplibre/maplibre-native/issues/3685.