### PR TITLE
core: Use compatible descriptor set layout for tile clipping

### DIFF
--- a/src/mbgl/shaders/vulkan/shader_program.cpp
+++ b/src/mbgl/shaders/vulkan/shader_program.cpp
@@ -88,8 +88,20 @@ ShaderProgram::ShaderProgram(shaders::BuiltIn shaderID,
 
         const auto intermediate = glslProgram.getIntermediate(language);
 
+        glslang::SpvOptions options;
+
+        options.disableOptimizer = false;
+        options.optimizeSize = true;
+
+#ifndef _NDEBUG
+        options.generateDebugInfo = true;
+        options.validate = true;
+#else
+        options.stripDebugInfo = true;
+#endif
+
         std::vector<uint32_t> spirv;
-        glslang::GlslangToSpv(*intermediate, spirv);
+        glslang::GlslangToSpv(*intermediate, spirv, &options);
 
         return spirv;
     };

--- a/src/mbgl/vulkan/context.cpp
+++ b/src/mbgl/vulkan/context.cpp
@@ -776,9 +776,6 @@ const vk::UniquePipelineLayout& Context::getPushConstantPipelineLayout() {
 
     auto layoutInfo = vk::PipelineLayoutCreateInfo().setPushConstantRanges(pushConstant);
 
-#ifdef ENABLE_VULKAN_GPU_ASSISTED_VALIDATION
-    // GPU assisted validation crashes when using a pipeline without descriptors.
-    // Use a compatible layout with the general pipeline when enabled
     const std::vector<vk::DescriptorSetLayout> layouts = {
         globalUniformDescriptorSetLayout.get(),
         layerUniformDescriptorSetLayout.get(),
@@ -787,7 +784,6 @@ const vk::UniquePipelineLayout& Context::getPushConstantPipelineLayout() {
     };
 
     layoutInfo.setSetLayouts(layouts);
-#endif
 
     pushConstantPipelineLayout = backend.getDevice()->createPipelineLayoutUnique(
         layoutInfo, nullptr, backend.getDispatcher());

--- a/src/mbgl/vulkan/context.cpp
+++ b/src/mbgl/vulkan/context.cpp
@@ -579,6 +579,7 @@ bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,
         clipping.pipelineInfo.stencilPass = vk::StencilOp::eReplace;
         clipping.pipelineInfo.dynamicValues.stencilWriteMask = 0b11111111;
         clipping.pipelineInfo.dynamicValues.stencilRef = 0b11111111;
+        clipping.pipelineInfo.dynamicValues.stencilCompareMask = 0xFF;
 
         clipping.pipelineInfo.inputBindings.push_back(
             vk::VertexInputBindingDescription()
@@ -591,6 +592,8 @@ bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,
                 .setBinding(0)
                 .setLocation(static_cast<uint32_t>(ShaderClass::attributes[0].index))
                 .setFormat(PipelineInfo::vulkanFormat(ShaderClass::attributes[0].dataType)));
+
+        clipping.pipelineInfo.updateVertexInputHash();
     }
 
     const auto& dispatcher = backend.getDispatcher();


### PR DESCRIPTION
Use the same descriptor set layout between the two pipelines. This triggered a crash in validation layers (GPU assisted validation was enabled) and from the nullptr offset it looks similar to https://github.com/maplibre/maplibre-native/issues/4464 (trying to index an empty layout array).