### PR TITLE
macOS: render the map at the window backing scale

### DIFF
--- a/platform/macos/src/MLNMapView+Impl.h
+++ b/platform/macos/src/MLNMapView+Impl.h
@@ -22,6 +22,8 @@ public:
 
   virtual CGLContextObj getCGLContextObj() { return nullptr; }
 
+  virtual void backingPropertiesChanged() {}
+
 #if MLN_RENDER_BACKEND_METAL
   // Returns the backend resource for Metal rendering in custom layers
   virtual MLNBackendResource* getObject() { return nullptr; }

--- a/platform/macos/src/MLNMapView+Metal.h
+++ b/platform/macos/src/MLNMapView+Metal.h
@@ -38,6 +38,8 @@ public:
   mbgl::PremultipliedImage readStillImage() override;
   MLNBackendResource* getObject() override;
 
+  void backingPropertiesChanged() override;
+
 private:
   bool presentsWithTransaction = false;
 };

--- a/platform/macos/src/MLNMapView+Metal.mm
+++ b/platform/macos/src/MLNMapView+Metal.mm
@@ -129,6 +129,18 @@ MLNMapViewMetalImpl::MLNMapViewMetalImpl(MLNMapView* nativeView_)
   [mapView addSubview:resource.mtlView positioned:NSWindowBelow relativeTo:nil];
 }
 
+void MLNMapViewMetalImpl::backingPropertiesChanged() {
+  auto& resource = getResource<MLNMapViewMetalRenderableResource>();
+  const CGFloat scale = mapView.window.backingScaleFactor;
+  if (!resource.mtlView || scale <= 0) {
+    return;
+  }
+  resource.mtlView.layer.contentsScale = scale;
+  const CGSize bounds = resource.mtlView.bounds.size;
+  resource.mtlView.drawableSize =
+      CGSizeMake(std::round(bounds.width * scale), std::round(bounds.height * scale));
+}
+
 MLNMapViewMetalImpl::~MLNMapViewMetalImpl() = default;
 
 void MLNMapViewMetalImpl::activate() {

--- a/platform/macos/src/MLNMapView.mm
+++ b/platform/macos/src/MLNMapView.mm
@@ -807,6 +807,10 @@ public:
     self.dormant = NO;
   }
 
+  if (window && _mbglView) {
+    _mbglView->backingPropertiesChanged();
+  }
+
   if (window && _mbglMap->getMapOptions().constrainMode() == mbgl::ConstrainMode::None) {
     _mbglMap->setConstrainMode(mbgl::ConstrainMode::HeightOnly);
   }
@@ -819,6 +823,13 @@ public:
            forKeyPath:@"titlebarAppearsTransparent"
               options:NSKeyValueObservingOptionInitial
               context:NULL];
+}
+
+- (void)viewDidChangeBackingProperties {
+  [super viewDidChangeBackingProperties];
+  if (_mbglView) {
+    _mbglView->backingPropertiesChanged();
+  }
 }
 
 - (BOOL)wantsLayer {


### PR DESCRIPTION
The MTKView keeps the contents scale of 1 it got before the view had a window, so a Retina display gets a half-resolution map. After this PR maps are drawn at full display resolution.

Disclosure: this PR was authored using Claude Fable 5