### PR TITLE
macOS: report the drawable size to the renderer

### DIFF
--- a/platform/macos/src/MLNMapView+Metal.h
+++ b/platform/macos/src/MLNMapView+Metal.h
@@ -38,6 +38,8 @@ public:
   mbgl::PremultipliedImage readStillImage() override;
   MLNBackendResource* getObject() override;
 
+  void drawableSizeChanged(CGSize size);
+
 private:
   bool presentsWithTransaction = false;
 };

--- a/platform/macos/src/MLNMapView+Metal.mm
+++ b/platform/macos/src/MLNMapView+Metal.mm
@@ -25,6 +25,7 @@
 }
 
 - (void)mtkView:(MTKView*)view drawableSizeWillChange:(CGSize)size {
+  _impl->drawableSizeChanged(size);
 }
 
 - (void)drawInMTKView:(MTKView*)view {
@@ -127,6 +128,11 @@ MLNMapViewMetalImpl::MLNMapViewMetalImpl(MLNMapView* nativeView_)
   metalLayer.presentsWithTransaction = presentsWithTransaction;
 
   [mapView addSubview:resource.mtlView positioned:NSWindowBelow relativeTo:nil];
+  drawableSizeChanged(resource.mtlView.drawableSize);
+}
+
+void MLNMapViewMetalImpl::drawableSizeChanged(CGSize drawableSize) {
+  size = {static_cast<uint32_t>(drawableSize.width), static_cast<uint32_t>(drawableSize.height)};
 }
 
 MLNMapViewMetalImpl::~MLNMapViewMetalImpl() = default;


### PR DESCRIPTION
The renderable size stayed zero, so every frame computed a zero-sized scissor rectangle that could clip the whole map away.

This fixed a flickering issue I had on macOS where many frames would be rendered empty while panning/zooming

<img width="1624" height="1061" alt="Screenshot 2026-08-13 at 15 27 47" src="https://github.com/user-attachments/assets/08cc3dcb-418e-4757-83c0-7a33bd4af42f" />
<img width="1624" height="1061" alt="Screenshot 2026-08-13 at 15 27 49" src="https://github.com/user-attachments/assets/107f5af4-2784-4c65-992b-f61948d10500" />

Disclosure: this PR was authored using Claude Fable 5