### PR TITLE
macOS: render the Metal map on demand

### DIFF
--- a/platform/macos/src/MLNMapView+Impl.h
+++ b/platform/macos/src/MLNMapView+Impl.h
@@ -22,6 +22,8 @@ public:
 
   virtual CGLContextObj getCGLContextObj() { return nullptr; }
 
+  virtual void display();
+
 #if MLN_RENDER_BACKEND_METAL
   // Returns the backend resource for Metal rendering in custom layers
   virtual MLNBackendResource* getObject() { return nullptr; }

--- a/platform/macos/src/MLNMapView+Impl.mm
+++ b/platform/macos/src/MLNMapView+Impl.mm
@@ -23,6 +23,8 @@ MLNMapViewImpl::MLNMapViewImpl(MLNMapView* nativeView_) : mapView(nativeView_) {
 
 void MLNMapViewImpl::render() { [mapView renderSync]; }
 
+void MLNMapViewImpl::display() { [mapView.layer setNeedsDisplay]; }
+
 void MLNMapViewImpl::onCameraWillChange(mbgl::MapObserver::CameraChangeMode mode) {
   bool animated = mode == mbgl::MapObserver::CameraChangeMode::Animated;
   [mapView cameraWillChangeAnimated:animated];

--- a/platform/macos/src/MLNMapView+Metal.h
+++ b/platform/macos/src/MLNMapView+Metal.h
@@ -37,7 +37,8 @@ public:
 
   mbgl::PremultipliedImage readStillImage() override;
   MLNBackendResource* getObject() override;
+  void display() override;
 
 private:
-  bool presentsWithTransaction = false;
+  bool presentsWithTransaction = true;
 };

--- a/platform/macos/src/MLNMapView+Metal.mm
+++ b/platform/macos/src/MLNMapView+Metal.mm
@@ -70,12 +70,16 @@ public:
 
   void swap() override {
     id<CAMetalDrawable> currentDrawable = [mtlView currentDrawable];
-    [commandBuffer presentDrawable:currentDrawable];
-    [commandBuffer commit];
-
-    // Un-comment for synchronous, which can help troubleshoot rendering problems,
-    // particularly those related to resource tracking and multiple queued buffers.
-    //[commandBuffer waitUntilCompleted];
+    if (currentDrawable) {
+      if (presentsWithTransaction) {
+        [commandBuffer commit];
+        [commandBuffer waitUntilCompleted];
+        [currentDrawable present];
+      } else {
+        [commandBuffer presentDrawable:currentDrawable];
+        [commandBuffer commit];
+      }
+    }
 
     commandBuffer = nil;
     commandBufferPtr.reset();
@@ -99,6 +103,7 @@ public:
   MTKView* mtlView = nil;
   id<MTLCommandBuffer> commandBuffer;
   id<MTLCommandQueue> commandQueue;
+  bool presentsWithTransaction = false;
 
   // We count how often the context was activated/deactivated so that we can truly deactivate it
   // after the activation count drops to 0.
@@ -122,9 +127,11 @@ MLNMapViewMetalImpl::MLNMapViewMetalImpl(MLNMapView* nativeView_)
   resource.mtlView.colorPixelFormat = MTLPixelFormatBGRA8Unorm;
   resource.mtlView.depthStencilPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
   resource.mtlView.layer.opaque = mapView.opaque;
-  resource.mtlView.enableSetNeedsDisplay = NO;
+  resource.mtlView.paused = YES;
+  resource.mtlView.enableSetNeedsDisplay = YES;
   CAMetalLayer* metalLayer = MLN_OBJC_DYNAMIC_CAST(resource.mtlView.layer, CAMetalLayer);
   metalLayer.presentsWithTransaction = presentsWithTransaction;
+  resource.presentsWithTransaction = presentsWithTransaction;
 
   [mapView addSubview:resource.mtlView positioned:NSWindowBelow relativeTo:nil];
 }
@@ -157,6 +164,11 @@ void MLNMapViewMetalImpl::updateAssumedState() {
 mbgl::PremultipliedImage MLNMapViewMetalImpl::readStillImage() {
   // return readFramebuffer(mapView.framebufferSize); // TODO: RendererBackend::readFramebuffer
   return {};
+}
+
+void MLNMapViewMetalImpl::display() {
+  auto& resource = getResource<MLNMapViewMetalRenderableResource>();
+  resource.mtlView.needsDisplay = YES;
 }
 
 MLNBackendResource* MLNMapViewMetalImpl::getObject() {

--- a/platform/macos/src/MLNMapView.mm
+++ b/platform/macos/src/MLNMapView.mm
@@ -939,7 +939,10 @@ public:
 - (void)setNeedsRerender {
   MLNAssertIsMainThread();
 
-  [self.layer setNeedsDisplay];
+  if (!_mbglView) {
+    return;
+  }
+  _mbglView->display();
 }
 
 - (void)cameraWillChangeAnimated:(BOOL)animated {


### PR DESCRIPTION
The MTKView ran unpaused, re-rendering an unchanged map at the display refresh rate and burning CPU and GPU while the map sat idle. Pause the view and mark it through a display() hook, as iOS does, so an idle map doesn't use any resources.

Drawing now happens inside the display cycle, where an asynchronous present races the Core Animation commit and can flash a cleared, not yet drawn drawable. Commit, wait and present explicitly, as iOS does with presentsWithTransaction.

Disclosure: This PR was authored using Claude Fable 5