### PR TITLE
fix(android): Use header only prefab

### DIFF
--- a/platform/android/MapLibreAndroid/build.gradle.kts
+++ b/platform/android/MapLibreAndroid/build.gradle.kts
@@ -204,7 +204,7 @@ android {
     prefab {
         create("maplibre") {
             headers = "../prefab-headers"
-            libraryName = "libmaplibre"
+            headerOnly = true
         }
     }
 


### PR DESCRIPTION
Distribute only headers in prefab modules (avoid bundling duplicated libs) to reduce aar size.
Follow-up to https://github.com/maplibre/maplibre-native/pull/4348.