### PR TITLE
android, core: reduce Android AAR size with header-only Prefab

### DIFF
--- a/include/mbgl/style/layers/custom_layer_host.hpp
+++ b/include/mbgl/style/layers/custom_layer_host.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
-#include <mbgl/gfx/context.hpp>
 #include <mbgl/style/layers/custom_layer_init_parameters.hpp>
 #include <mbgl/style/layers/custom_layer_render_parameters.hpp>
 
 namespace mbgl {
+
+namespace gfx {
+class Context;
+} // namespace gfx
+
 namespace style {
 
 class CustomLayerHost {

--- a/platform/android/MapLibreAndroid/build.gradle.kts
+++ b/platform/android/MapLibreAndroid/build.gradle.kts
@@ -204,7 +204,7 @@ android {
     prefab {
         create("maplibre") {
             headers = "../prefab-headers"
-            libraryName = "libmaplibre"
+            headerOnly = true
         }
     }
 
@@ -237,6 +237,16 @@ tasks.configureEach {
     if (name == "syncPrefabHeaders") return@configureEach
     if (name.contains("Prefab", ignoreCase = true) || name.contains("bundleLibRuntimeTo", ignoreCase = true)) {
         dependsOn(syncPrefabHeaders)
+    }
+}
+
+// AGP 9.1.1 still adds the native build output to the AAR even when the Prefab module is
+// declared header-only. Keep the header-only metadata and omit that redundant unstripped copy.
+tasks.withType<org.gradle.api.tasks.bundling.Zip>().configureEach {
+    if (name.startsWith("bundle") && name.endsWith("Aar")) {
+        // The Prefab artifact is added under a `prefab/` destination by a nested copy spec,
+        // so its paths are still relative to the Prefab root when exclusions are evaluated.
+        exclude("modules/maplibre/libs/**")
     }
 }
 


### PR DESCRIPTION
#4348 caused some prefab libraries with debug symbols to be included.

Switch to header only so the .aar releases are not bloated anymore by this.

GPT 5.6 used.