### PR TITLE
android: allow configurable Maven publication repository

### DIFF
--- a/platform/android/buildSrc/src/main/kotlin/maplibre.gradle-publish.gradle.kts
+++ b/platform/android/buildSrc/src/main/kotlin/maplibre.gradle-publish.gradle.kts
@@ -1,7 +1,9 @@
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import org.gradle.api.Task
+import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.authentication.http.BasicAuthentication
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import org.gradle.kotlin.dsl.get
 import java.util.Locale
@@ -16,6 +18,12 @@ plugins {
 
 val androidComponents = extensions.getByType<LibraryAndroidComponentsExtension>()
 val androidLibrary = extensions.getByType<LibraryExtension>()
+val publicationRepositoryUrl = providers.gradleProperty("publicationRepositoryUrl")
+    .orElse(providers.environmentVariable("MAVEN_REPOSITORY_URL"))
+val publicationRepositoryUsername = providers.gradleProperty("publicationRepositoryUsername")
+    .orElse(providers.environmentVariable("MAVEN_REPOSITORY_USERNAME"))
+val publicationRepositoryPassword = providers.gradleProperty("publicationRepositoryPassword")
+    .orElse(providers.environmentVariable("MAVEN_REPOSITORY_PASSWORD"))
 
 androidLibrary.publishing {
     singleVariant("vulkanRelease")
@@ -27,9 +35,37 @@ androidLibrary.publishing {
 }
 
 afterEvaluate {
-    mavenPublishing {
-        publishToMavenCentral(true)
-        signAllPublications()
+    val configuredRepositoryUrl = publicationRepositoryUrl.orNull
+    if (configuredRepositoryUrl == null) {
+        mavenPublishing {
+            publishToMavenCentral(true)
+        }
+    } else {
+        publishing.repositories.maven {
+            name = "Configured"
+            url = uri(configuredRepositoryUrl)
+
+            val configuredUsername = publicationRepositoryUsername.orNull
+            val configuredPassword = publicationRepositoryPassword.orNull
+            require(configuredUsername.isNullOrBlank() == configuredPassword.isNullOrBlank()) {
+                "Both publicationRepositoryUsername and publicationRepositoryPassword must be configured together"
+            }
+            if (!configuredUsername.isNullOrBlank()) {
+                credentials(PasswordCredentials::class) {
+                    username = configuredUsername
+                    password = configuredPassword
+                }
+                authentication {
+                    create<BasicAuthentication>("basic")
+                }
+            }
+        }
+    }
+
+    if (configuredRepositoryUrl == null || providers.gradleProperty("signingInMemoryKey").isPresent) {
+        mavenPublishing {
+            signAllPublications()
+        }
     }
 }
 
@@ -39,7 +75,9 @@ gradle.projectsEvaluated {
     // This fixes Gradle's implicit dependency validation warnings
     // Since some publications may share components (e.g., defaultdebug and opengldebug both use openglDebug),
     // we ensure all signing tasks complete before any publish task
-    tasks.filter { it.name.startsWith("publish") && it.name.endsWith("PublicationToMavenCentralRepository") }.forEach { publishTask ->
+    tasks.filter {
+        it.name.startsWith("publish") && it.name.contains("PublicationTo") && it.name.endsWith("Repository")
+    }.forEach { publishTask ->
         tasks.filter { it.name.startsWith("sign") && it.name.endsWith("Publication") }.forEach { signingTask ->
             publishTask.dependsOn(signingTask)
         }


### PR DESCRIPTION
This PR allows publishing MapLibre Android to a custom Maven repository.

I'm experimenting a lot with custom publications of MapLibre Android for the Plugin API. I set up a custom [Reposilite](https://reposilite.com/) instance where I can publish versions of MapLibre Android to.

Implemented using GPT 5.6.