### PR TITLE
fix(core): canonicalize default MapLibre glyph URLs

### DIFF
--- a/src/mbgl/util/tile_server_options.cpp
+++ b/src/mbgl/util/tile_server_options.cpp
@@ -225,7 +225,7 @@ TileServerOptions TileServerOptions::MapLibreConfiguration() {
                                     .withSourceTemplate("/tiles/{domain}.json", "", {})
                                     .withStyleTemplate("{path}.json", "maps", {})
                                     .withSpritesTemplate("/{path}/sprite{scale}.{format}", "", {})
-                                    .withGlyphsTemplate("/font/{fontstack}/{start}-{end}.pbf", "fonts", {})
+                                    .withGlyphsTemplate("/font{path}", "fonts", {})
                                     .withTileTemplate("/{path}", "tiles", {})
                                     .withDefaultStyles(styles)
                                     .withDefaultStyle("Basic")

--- a/test/util/mapbox.test.cpp
+++ b/test/util/mapbox.test.cpp
@@ -313,6 +313,9 @@ TEST(MapLibre, CanonicalURL) {
     EXPECT_EQ("https://demotiles.maplibre.org/font/{fontstack}/{start}-{end}.pbf",
               mln::util::mapbox::normalizeGlyphsURL(
                   mapboxFixture::mapLibreTileServerOptions, "maplibre://fonts/{fontstack}/{start}-{end}.pbf", ""));
+    EXPECT_EQ("maplibre://fonts/{fontstack}/{range}.pbf",
+              mln::util::mapbox::canonicalizeGlyphURL(mapboxFixture::mapLibreTileServerOptions,
+                                                      "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf"));
 
     EXPECT_EQ("maplibre://tiles/tiles/{z}/{x}/{y}.pbf",
               mln::util::mapbox::canonicalizeTileURL(mapboxFixture::mapLibreTileServerOptions,


### PR DESCRIPTION
## Summary

- change the default MapLibre glyph template to the existing `{path}` grammar used by URL canonicalization
- preserve `{fontstack}/{range}` in the canonical `maplibre://fonts/...` URL
- add a regression for the demotiles glyph URL reported in #4403

## Root cause

`createTokenMap` expands only its generic URL placeholders. The default MapLibre glyph template contained `{fontstack}`, `{start}`, and `{end}`, so those braces reached `std::regex` and could raise `std::regex_error` while an offline pack was being prepared.

This change is intentionally scoped to the default MapLibre/demotiles configuration. It does not broaden the generic template parser for arbitrary custom glyph templates.

Fixes #4403.

## Validation

- confirmed the new `MapLibre.CanonicalURL` regression throws `std::regex_error` before the source change
- passed the focused regression 100 consecutive times after the change
- passed 22 adjacent Mapbox, MapLibre, MapTiler, and `TileServerOptions` URL tests
- passed ClangFormat 20.1.8, targeted pre-commit whitespace/line-ending hooks, and `git diff --check`

The full project suite was not completed locally; remote CI is pending.

## AI assistance disclosure

OpenAI Codex (GPT-5) assisted with investigation, test drafting, implementation, validation, and this draft description. The contributor must personally review every changed line and approve or rewrite this description before marking the PR ready for review.
