### PR TITLE
Fix surface transform

### DIFF
--- a/src/mbgl/vulkan/renderable_resource.cpp
+++ b/src/mbgl/vulkan/renderable_resource.cpp
@@ -115,12 +115,12 @@ void SurfaceRenderableResource::initSwapchain(uint32_t w, uint32_t h) {
         // update values based on surface limits
         extent.width = std::min(std::max(w, capabilities.minImageExtent.width), capabilities.maxImageExtent.width);
         extent.height = std::min(std::max(h, capabilities.minImageExtent.height), capabilities.maxImageExtent.height);
+    }
 
-        if (hasSurfaceTransformSupport()) {
-            if (capabilities.currentTransform & vk::SurfaceTransformFlagBitsKHR::eRotate90 ||
-                capabilities.currentTransform & vk::SurfaceTransformFlagBitsKHR::eRotate270) {
-                std::swap(extent.width, extent.height);
-            }
+    if (hasSurfaceTransformSupport()) {
+        if (capabilities.currentTransform & vk::SurfaceTransformFlagBitsKHR::eRotate90 ||
+            capabilities.currentTransform & vk::SurfaceTransformFlagBitsKHR::eRotate270) {
+            std::swap(extent.width, extent.height);
         }
     }
 


### PR DESCRIPTION
Fixes #4494 

The 90/270 width/height swap for the swapchain extent sat in the else branch that only runs when currentExtent is 0xFFFFFFFF. On Android currentExtent is always concrete, so the swap never ran while preTransform still declared the rotation: images got the surface's aspect ratio, the vertex shader rotated the map into them anyway, and the presentation engine rescaled anisotropically. Horizontal resolution collapsed to the view's height (factor = width/height) while vertical was untouched.

If tested this on two devices: An Xiaomi Redmi Note 14 pro (android 16) and an rugged tablet with 8 inc screen (on android 14). On both devices the pixelation was gone.