### PR TITLE
android: load APK assets from file:///android_asset/ URIs

### DIFF
--- a/platform/android/MapLibreAndroid/src/cpp/asset_manager_file_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/asset_manager_file_source.cpp
@@ -5,6 +5,7 @@
 #include <mln/storage/resource.hpp>
 #include <mln/storage/resource_options.hpp>
 #include <mln/storage/response.hpp>
+#include <mln/util/constants.hpp>
 #include <mln/util/thread.hpp>
 #include <mln/util/url.hpp>
 #include <mln/util/util.hpp>
@@ -12,7 +13,39 @@
 #include <android/asset_manager.h>
 #include <android/asset_manager_jni.h>
 
+#include <optional>
+#include <string_view>
+
 namespace mln {
+namespace {
+
+constexpr std::string_view androidAssetPathPrefix = "/android_asset/";
+
+void stripLeadingSlashes(std::string& path) {
+    path.erase(0, path.find_first_not_of('/'));
+}
+
+std::optional<std::string> androidAssetPathFromUrl(const std::string& url) {
+    if (url.starts_with(util::ASSET_PROTOCOL)) {
+        std::string path = util::percentDecode(url.substr(std::char_traits<char>::length(util::ASSET_PROTOCOL)));
+        stripLeadingSlashes(path);
+        return path;
+    }
+
+    if (url.starts_with(util::FILE_PROTOCOL)) {
+        std::string path = util::percentDecode(url.substr(std::char_traits<char>::length(util::FILE_PROTOCOL)));
+        if (!path.starts_with(androidAssetPathPrefix)) {
+            return std::nullopt;
+        }
+        path.erase(0, androidAssetPathPrefix.size());
+        stripLeadingSlashes(path);
+        return path;
+    }
+
+    return std::nullopt;
+}
+
+} // namespace
 
 class AssetManagerFileSource::Impl {
 public:
@@ -25,12 +58,12 @@ public:
           assetManager(assetManager_) {}
 
     void request(const std::string& url, ActorRef<FileSourceRequest> req) {
-        // Note: AssetManager already prepends "assets" to the filename.
-        const std::string path = mln::util::percentDecode(url.substr(8));
-
         Response response;
 
-        if (AAsset* asset = AAssetManager_open(assetManager, path.c_str(), AASSET_MODE_BUFFER)) {
+        // Note: AssetManager already prepends "assets" to the filename.
+        const auto path = androidAssetPathFromUrl(url);
+        AAsset* asset = path ? AAssetManager_open(assetManager, path->c_str(), AASSET_MODE_BUFFER) : nullptr;
+        if (asset) {
             response.data = std::make_shared<std::string>(reinterpret_cast<const char*>(AAsset_getBuffer(asset)),
                                                           AAsset_getLength64(asset));
             AAsset_close(asset);
@@ -79,7 +112,7 @@ std::unique_ptr<AsyncRequest> AssetManagerFileSource::request(const Resource& re
 }
 
 bool AssetManagerFileSource::canRequest(const Resource& resource) const {
-    return 0 == resource.url.rfind(mln::util::ASSET_PROTOCOL, 0);
+    return androidAssetPathFromUrl(resource.url).has_value();
 }
 
 void AssetManagerFileSource::setResourceOptions(ResourceOptions options) {

--- a/platform/android/MapLibreAndroid/src/cpp/asset_manager_file_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/asset_manager_file_source.cpp
@@ -62,8 +62,7 @@ public:
 
         // Note: AssetManager already prepends "assets" to the filename.
         const auto path = androidAssetPathFromUrl(url);
-        AAsset* asset = path ? AAssetManager_open(assetManager, path->c_str(), AASSET_MODE_BUFFER) : nullptr;
-        if (asset) {
+        if (AAsset* asset = path ? AAssetManager_open(assetManager, path->c_str(), AASSET_MODE_BUFFER) : nullptr) {
             response.data = std::make_shared<std::string>(reinterpret_cast<const char*>(AAsset_getBuffer(asset)),
                                                           AAsset_getLength64(asset));
             AAsset_close(asset);

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/Style.java
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/maps/Style.java
@@ -824,6 +824,9 @@ public class Style {
      * <li>{@code asset://...}:
      * loads the style from the APK {@code assets/} directory.
      * This is used to load a style bundled with your app.</li>
+     * <li>{@code file:///android_asset/...}:
+     * same as {@code asset://}, using the Android WebView-style asset URI
+     * (also produced by Compose Multiplatform {@code Res.getUri()}).</li>
      * <li>{@code file://...}:
      * loads the style from a file path. This is used to load a style from disk.
      * </li>
@@ -861,6 +864,9 @@ public class Style {
      * <li>{@code asset://...}:
      * loads the style from the APK {@code assets/} directory.
      * This is used to load a style bundled with your app.</li>
+     * <li>{@code file:///android_asset/...}:
+     * same as {@code asset://}, using the Android WebView-style asset URI
+     * (also produced by Compose Multiplatform {@code Res.getUri()}).</li>
      * <li>{@code file://...}:
      * loads the style from a file path. This is used to load a style from disk.
      * </li>

--- a/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/testapp/style/StyleLoaderTest.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/testapp/style/StyleLoaderTest.kt
@@ -9,6 +9,7 @@ import org.maplibre.android.testapp.R
 import org.maplibre.android.testapp.action.MapLibreMapAction
 import org.maplibre.android.testapp.activity.EspressoTest
 import org.maplibre.android.testapp.utils.ResourceUtils.readRawResource
+import org.maplibre.android.testapp.utils.TestingAsyncUtils
 import org.junit.Assert
 import org.junit.Test
 import java.io.IOException
@@ -69,6 +70,21 @@ class StyleLoaderTest : EspressoTest() {
             } catch (exception: IOException) {
                 exception.printStackTrace()
             }
+        }
+    }
+
+    @Test
+    fun testLoadStyleFromAndroidAssetFileUri() {
+        validateTestSetup()
+        MapLibreMapAction.invoke(
+            maplibreMap
+        ) { uiController: UiController, maplibreMap: MapLibreMap ->
+            val expected = rule.activity.assets.open("fill_color_style.json").bufferedReader().use { it.readText() }
+            val uri = "file:///android_asset/fill_color_style.json"
+            maplibreMap.setStyle(Style.Builder().fromUri(uri))
+            TestingAsyncUtils.waitForLayer(uiController, mapView)
+            Assert.assertEquals("Style URI should match", uri, maplibreMap.style!!.uri)
+            Assert.assertEquals("Style json should match", expected, maplibreMap.style!!.json)
         }
     }
 }

--- a/platform/android/docs/data/PMTiles.md
+++ b/platform/android/docs/data/PMTiles.md
@@ -41,4 +41,4 @@ For files on device storage, use `file://` with an absolute path. The example be
 --8<-- "MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/sources/PMTilesActivity.kt:loadFromFile"
 ```
 
-> Note: `pmtiles://asset://` (files in `src/main/assets/`) is not currently supported. `AssetManagerFileSource` does not implement byte-range reads, which PMTiles requires to read its header and metadata. Use `file://` from device storage instead. See the [open issue](https://github.com/maplibre/maplibre-native/issues/4360) for status.
+> Note: `pmtiles://asset://` and `pmtiles://file:///android_asset/` (files in `src/main/assets/`) are not currently supported. `AssetManagerFileSource` does not implement byte-range reads, which PMTiles requires to read its header and metadata. Use `file://` from device storage instead. See the [open issue](https://github.com/maplibre/maplibre-native/issues/4360) for status.


### PR DESCRIPTION
## Why

MapLibre Android reads APK assets only through `asset://` URLs. Other Android components use `file:///android_asset/` for the same thing:

- Android WebView [always allows it](https://developer.android.com/reference/android/webkit/WebSettings#setAllowFileAccess(boolean)), even with file access disabled.
- Compose Multiplatform's [`Res.getUri()`](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-resources-usage.html) returns `file:///android_asset/composeResources/...` for bundled resources.
- [Coil](https://github.com/coil-kt/coil/blob/9ccce7a05f60bddd7e183d155d1899a8c8e72125/coil-core/src/androidMain/kotlin/coil3/util/utils.android.kt#L102-L106) treats a `file` URI whose first path segment is `android_asset` as an asset.
- [Glide](https://github.com/bumptech/glide/blob/83f3b6712884a29d3a0d6af55d115f1803eaa275/library/src/main/java/com/bumptech/glide/load/model/AssetUriLoader.java#L21-L24) matches the `file:///android_asset/` prefix.

A style, glyph, or sprite URL taken from `Res.getUri()` therefore fails in MapLibre Android with "Failed to load glyph range" or a style load error, while the same URI works everywhere else. #4498.

## Change

`AssetManagerFileSource` accepts `file:///android_asset/<path>` as well as `asset://<path>` and resolves both to `<path>` for `AAssetManager_open`. Leading slashes are stripped for both forms, so `asset:///foo` now resolves to `foo` too; before, it was passed through with the slash and failed. Other `file://` URLs still go to the local file source. The `Style.Builder` docs list the new form.

## Test

`StyleLoaderTest.testLoadStyleFromAndroidAssetFileUri` (MapLibre Android instrumentation tests) loads `file:///android_asset/fill_color_style.json` and checks the loaded style URI and JSON against the asset's contents.

Resolves #4498.

AI disclosure: prepared with Claude Code (Claude Fable 5.1). Draft until I have reviewed the generated changes.

