### PR TITLE
fix(glfw): synchronize Metal renderable size

### DIFF
--- a/platform/glfw/metal_backend.mm
+++ b/platform/glfw/metal_backend.mm
@@ -130,6 +130,7 @@ void MetalBackend::deactivate() {}
 void MetalBackend::updateAssumedState() {}
 
 void MetalBackend::setSize(mln::Size size_) {
+  size = size_;
   getResource<mln::MetalRenderableResource>().setBackendSize(size_);
 }
 


### PR DESCRIPTION
The description below and the code in this PR was written by GPT 5.6.

Thanks @adrian-cojocaru for helping me debug this.

---

## What does this change?

Synchronize the GLFW Metal backend inherited `gfx::Renderable` size with the framebuffer size supplied by GLFW.

Since #4147, the renderer uses `getDefaultRenderable().getSize()` to calculate the scissor rectangle. The GLFW Metal backend only forwarded resize events to its private `MetalRenderableResource`, leaving the inherited renderable size at its initial `0x0`. On a Retina display, LLDB showed the split directly:

- GLFW framebuffer event: `2048x1536`
- Metal resource size: `2048x1536`
- Default renderable size: `0x0`
- Logical map size: `1024x768`

Updating the inherited size matches the behavior added for the Cocoa Metal view in #4479 and keeps the renderer-facing default renderable in sync with the actual drawable.

## Testing

- Built `mbgl-glfw` with the `macos-metal` CMake configuration and ccache.
- Launched the Metal GLFW app with the OpenFreeMap Liberty style.
- Reproduced the stutter before this change and verified smooth interaction after it using the same camera position and warmed cache.