### PR TITLE
core: remove unused Metal RendererBackend state-cache methods

### DIFF
--- a/include/mln/mtl/renderer_backend.hpp
+++ b/include/mln/mtl/renderer_backend.hpp
@@ -17,15 +17,11 @@ class ProgramParameters;
 namespace mtl {
 
 using ProcAddress = void (*)();
-using FramebufferID = uint32_t;
 
 class RendererBackend : public gfx::RendererBackend {
 public:
     RendererBackend(gfx::ContextMode);
     ~RendererBackend() override;
-
-    /// Called prior to rendering to update the internally assumed MetalMetal  state.
-    virtual void updateAssumedState() = 0;
 
     /// One-time shader initialization
     void initShaders(gfx::ShaderRegistry&, const ProgramParameters& programParameters) override;
@@ -40,26 +36,6 @@ protected:
     /// Reads the color pixel data from the currently bound framebuffer.
     PremultipliedImage readFramebuffer(const Size&);
 
-    /// A constant to signal that a framebuffer is bound, but with an unknown ID.
-    static constexpr const FramebufferID ImplicitFramebufferBinding = std::numeric_limits<FramebufferID>::max();
-
-    /// Tells the renderer that the Metal state has already been set by the windowing toolkit.
-    /// It sets the internal assumed state to the supplied values.
-    void assumeFramebufferBinding(FramebufferID fbo);
-    void assumeViewport(int32_t x, int32_t y, const Size&);
-    void assumeScissorTest(bool);
-
-    /// Returns true when assumed framebuffer binding hasn't changed from the implicit binding.
-    bool implicitFramebufferBound();
-
-public:
-    /// Triggers a Metal state update if the internal assumed state doesn't
-    /// match the supplied values.
-    void setFramebufferBinding(FramebufferID fbo);
-    void setViewport(int32_t x, int32_t y, const Size&);
-    void setScissorTest(bool);
-
-protected:
     MTLDevicePtr device;
     MTLCommandQueuePtr commandQueue;
     bool baseVertexInstanceDrawingSupported = false;

--- a/platform/default/include/mln/mtl/headless_backend.hpp
+++ b/platform/default/include/mln/mtl/headless_backend.hpp
@@ -15,7 +15,6 @@ public:
                     SwapBehaviour = SwapBehaviour::NoFlush,
                     gfx::ContextMode = gfx::ContextMode::Unique);
     ~HeadlessBackend() override;
-    void updateAssumedState() override;
     gfx::Renderable& getDefaultRenderable() override;
     PremultipliedImage readStillImage() override;
     MTL::Texture* getMetalTexture();

--- a/platform/default/src/mln/mtl/headless_backend.cpp
+++ b/platform/default/src/mln/mtl/headless_backend.cpp
@@ -87,10 +87,6 @@ void HeadlessBackend::ensureResource() {
     }
 }
 
-void HeadlessBackend::updateAssumedState() {
-    // no-op
-}
-
 PremultipliedImage HeadlessBackend::readStillImage() {
     return getResource<HeadlessRenderableResource>().readStillImage();
 }

--- a/platform/glfw/metal_backend.h
+++ b/platform/glfw/metal_backend.h
@@ -14,7 +14,6 @@ public:
     mln::gfx::Renderable &getDefaultRenderable() override;
     void activate() override;
     void deactivate() override;
-    void updateAssumedState() override;
     void setSize(mln::Size size_);
     mln::Size getSize() const;
 };

--- a/platform/glfw/metal_backend.mm
+++ b/platform/glfw/metal_backend.mm
@@ -127,7 +127,6 @@ mln::gfx::Renderable& MetalBackend::getDefaultRenderable() { return *this; }
 
 void MetalBackend::activate() {}
 void MetalBackend::deactivate() {}
-void MetalBackend::updateAssumedState() {}
 
 void MetalBackend::setSize(mln::Size size_) {
   size = size_;

--- a/platform/ios/src/MLNMapView+Metal.h
+++ b/platform/ios/src/MLNMapView+Metal.h
@@ -26,11 +26,6 @@ private:
   void deactivate() override;
   // End implementation of mln::gfx::RendererBackend
 
-  // Implementation of mln::gl::RendererBackend
-public:
-  void updateAssumedState() override;
-  // End implementation of mln::gl::Rendererbackend
-
   // Implementation of MLNMapViewImpl
 public:
   mln::gfx::RendererBackend& getRendererBackend() override { return *this; }

--- a/platform/ios/src/MLNMapView+Metal.mm
+++ b/platform/ios/src/MLNMapView+Metal.mm
@@ -208,15 +208,6 @@ void MLNMapViewMetalImpl::deactivate() {
   }
 }
 
-/// This function is called before we start rendering, when iOS invokes our rendering method.
-/// iOS already sets the correct framebuffer and viewport for us, so we need to update the
-/// context state with the anticipated values.
-void MLNMapViewMetalImpl::updateAssumedState() {
-  auto& resource = getResource<MLNMapViewMetalRenderableResource>();
-  assumeFramebufferBinding(ImplicitFramebufferBinding);
-  assumeViewport(0, 0, resource.framebufferSize());
-}
-
 UIImage* MLNMapViewMetalImpl::snapshot() {
   auto& resource = getResource<MLNMapViewMetalRenderableResource>();
   return nil;  // TODO: resource.mtlView.snapshot;

--- a/platform/macos/src/MLNMapView+Metal.h
+++ b/platform/macos/src/MLNMapView+Metal.h
@@ -26,11 +26,6 @@ private:
   void deactivate() override;
   // End implementation of mln::gfx::RendererBackend
 
-  // Implementation of mln::gl::RendererBackend
-public:
-  void updateAssumedState() override;
-  // End implementation of mln::gl::Rendererbackend
-
   // Implementation of MLNMapViewImpl
 public:
   mln::gfx::RendererBackend& getRendererBackend() override { return *this; }

--- a/platform/macos/src/MLNMapView+Metal.mm
+++ b/platform/macos/src/MLNMapView+Metal.mm
@@ -158,15 +158,6 @@ void MLNMapViewMetalImpl::deactivate() {
   }
 }
 
-/// This function is called before we start rendering, when iOS invokes our rendering method.
-/// iOS already sets the correct framebuffer and viewport for us, so we need to update the
-/// context state with the anticipated values.
-void MLNMapViewMetalImpl::updateAssumedState() {
-  auto& resource = getResource<MLNMapViewMetalRenderableResource>();
-  assumeFramebufferBinding(ImplicitFramebufferBinding);
-  assumeViewport(0, 0, resource.framebufferSize());
-}
-
 mln::PremultipliedImage MLNMapViewMetalImpl::readStillImage() {
   // return readFramebuffer(mapView.framebufferSize); // TODO: RendererBackend::readFramebuffer
   return {};

--- a/src/mln/mtl/renderer_backend.cpp
+++ b/src/mln/mtl/renderer_backend.cpp
@@ -60,22 +60,6 @@ PremultipliedImage RendererBackend::readFramebuffer(const Size& size) {
     return PremultipliedImage(size);
 }
 
-void RendererBackend::assumeFramebufferBinding(const mtl::FramebufferID) {}
-
-void RendererBackend::assumeViewport(int32_t, int32_t, const Size&) {}
-
-void RendererBackend::assumeScissorTest(bool) {}
-
-bool RendererBackend::implicitFramebufferBound() {
-    return false;
-}
-
-void RendererBackend::setFramebufferBinding(const mtl::FramebufferID) {}
-
-void RendererBackend::setViewport(int32_t, int32_t, const Size&) {}
-
-void RendererBackend::setScissorTest(bool) {}
-
 /// @brief Register a list of types with a shader registry instance
 /// @tparam ...ShaderID Pack of BuiltIn:: shader IDs
 /// @param registry A shader registry instance


### PR DESCRIPTION
Removes unused state-cache methods from the Metal renderer backend. Refs #2213.

Metal isn't a state machine, so the `assume*` / `set*` state-caching pattern the GL backend relies on has no equivalent here. The seven methods linked in the issue have no callers and no overrides.

This also removes `updateAssumedState()` (pure virtual in `include/mln/mtl/renderer_backend.hpp`, so it isn't in the issue's permalink) along with its four overrides. The headless and glfw overrides are empty; the macOS and iOS ones only call `assumeFramebufferBinding()` and `assumeViewport()` — and are their only callers. Since nothing calls `updateAssumedState()` on the Metal side, that whole chain is unreachable. On the GL side it is genuinely live (`src/mln/gl/context.cpp:722`), which is presumably where it was copied from.

With those gone, `ImplicitFramebufferBinding` and `FramebufferID` have no remaining users and are removed too. `mtl::ProcAddress` is also unused, but was already unused before this change, so it is left alone.

## Verification

Built clean before and after with the same command — `//:mbgl-core`, `//platform/glfw:glfw_app`, `//platform/macos/app:macos_app` and `//platform/ios:App` under `--//:renderer=metal` — plus the device `arm64` slice. The iOS app also builds and runs on a physical device.

Not verified locally: the CMake configurations, including `platform/qt/qt.cmake`'s `MLN_WITH_METAL` path, which compiles `platform/default/src/mln/mtl/headless_backend.cpp`. Left to CI.

## Notes

Not a public API change: these aren't part of `gfx::RendererBackend`, and the header isn't in the podspec or `platform/darwin/bazel/files.bzl` public header lists. One caveat — removing a pure virtual is a source break for any out-of-tree Metal backend declaring `void updateAssumedState() override;`; all four in-tree overrides are removed here. No `CHANGELOG.md` entry since nothing platform-facing changed, though happy to add one.

Happy to trim back to just the seven methods in the issue's permalink if you'd rather keep the original scope.

**AI disclosure:** Developed with AI assistance (Claude Opus 5 via Claude Code), used to help trace call sites and set up the before/after builds. I made the code changes and verified all findings and build results.
