### PR TITLE
fix(ios): reuse annotation container across updates

### DIFF
--- a/platform/ios/src/MLNAnnotationContainerView.h
+++ b/platform/ios/src/MLNAnnotationContainerView.h
@@ -8,9 +8,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MLNAnnotationContainerView : UIView
 
-+ (instancetype)annotationContainerViewWithAnnotationContainerView:
-    (MLNAnnotationContainerView *)annotationContainerView;
-
 - (void)addSubviews:(NSArray<MLNAnnotationView *> *)subviews;
 
 @end

--- a/platform/ios/src/MLNAnnotationContainerView.m
+++ b/platform/ios/src/MLNAnnotationContainerView.m
@@ -19,13 +19,6 @@
     return self;
 }
 
-+ (instancetype)annotationContainerViewWithAnnotationContainerView:(nonnull MLNAnnotationContainerView *)annotationContainerView
-{
-    MLNAnnotationContainerView *newAnnotationContainerView = [[MLNAnnotationContainerView alloc] initWithFrame:annotationContainerView.frame];
-    [newAnnotationContainerView addSubviews:annotationContainerView.subviews];
-    return newAnnotationContainerView;
-}
-
 - (void)addSubviews:(NSArray<MLNAnnotationView *> *)subviews
 {
     for (MLNAnnotationView *view in subviews)

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -4908,21 +4908,17 @@ static void *windowScreenContext = &windowScreenContext;
     (NSArray<MLNAnnotationView *> *)annotationViews {
   if (annotationViews.count == 0) return;
 
-  MLNAnnotationContainerView *newAnnotationContainerView;
-  if (self.annotationContainerView) {
-    // reload any previously added views
-    newAnnotationContainerView = [MLNAnnotationContainerView
-        annotationContainerViewWithAnnotationContainerView:self.annotationContainerView];
-    [self.annotationContainerView removeFromSuperview];
-  } else {
-    newAnnotationContainerView = [[MLNAnnotationContainerView alloc] initWithFrame:self.bounds];
+  MLNAnnotationContainerView *annotationContainerView = self.annotationContainerView;
+  if (!annotationContainerView) {
+    annotationContainerView = [[MLNAnnotationContainerView alloc] initWithFrame:self.bounds];
+    annotationContainerView.autoresizingMask =
+        UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    annotationContainerView.contentMode = UIViewContentModeCenter;
+    [_mbglView->getView() insertSubview:annotationContainerView atIndex:0];
+    self.annotationContainerView = annotationContainerView;
   }
-  newAnnotationContainerView.autoresizingMask =
-      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  newAnnotationContainerView.contentMode = UIViewContentModeCenter;
-  [newAnnotationContainerView addSubviews:annotationViews];
-  [_mbglView->getView() insertSubview:newAnnotationContainerView atIndex:0];
-  self.annotationContainerView = newAnnotationContainerView;
+
+  [annotationContainerView addSubviews:annotationViews];
 
   [self updatePresentsWithTransaction];
 }
@@ -5082,7 +5078,7 @@ static void *windowScreenContext = &windowScreenContext;
     if (annotationContext.viewReuseIdentifier) {
       NSMutableArray *annotationViewReuseQueue =
           [self annotationViewReuseQueueForIdentifier:annotationContext.viewReuseIdentifier];
-      if (![annotationViewReuseQueue containsObject:annotationView]) {
+      if ([annotationViewReuseQueue containsObject:annotationView]) {
         [annotationViewReuseQueue removeObject:annotationView];
       }
     }
@@ -5115,6 +5111,25 @@ static void *windowScreenContext = &windowScreenContext;
     if (_mbglMap) {
       self.mbglMap.removeAnnotation(annotationTag);
     }
+  }
+
+  BOOL hasAnnotationViewContexts = NO;
+  for (const auto &annotationContextPair : _annotationContextsByAnnotationTag) {
+    if (annotationContextPair.second.viewReuseIdentifier) {
+      hasAnnotationViewContexts = YES;
+      break;
+    }
+  }
+
+  if (!hasAnnotationViewContexts) {
+    for (NSArray<MLNAnnotationView *>
+             *annotationViewReuseQueue in _annotationViewReuseQueueByIdentifier.allValues) {
+      for (MLNAnnotationView *annotationView in annotationViewReuseQueue) {
+        [annotationView removeFromSuperview];
+        [self.annotationContainerView.annotationViews removeObject:annotationView];
+      }
+    }
+    [_annotationViewReuseQueueByIdentifier removeAllObjects];
   }
 
   [self updatePresentsWithTransaction];

--- a/platform/ios/test/MLNAnnotationViewTests.m
+++ b/platform/ios/test/MLNAnnotationViewTests.m
@@ -1,5 +1,6 @@
 #import <Mapbox.h>
 #import <XCTest/XCTest.h>
+#import "MLNAnnotationContainerView_Private.h"
 #import "MLNTestUtility.h"
 
 static NSString * const MLNTestAnnotationReuseIdentifer = @"MLNTestAnnotationReuseIdentifer";
@@ -7,6 +8,10 @@ static NSString * const MLNTestAnnotationReuseIdentifer = @"MLNTestAnnotationReu
 
 @interface MLNMapView (Tests)
 @property (nonatomic) MLNCameraChangeReason cameraChangeReasonBitmask;
+@property (nonatomic) MLNAnnotationContainerView *annotationContainerView;
+@property (nonatomic) NSMutableDictionary<NSString *, NSMutableArray<MLNAnnotationView *> *>
+    *annotationViewReuseQueueByIdentifier;
+- (void)updateAnnotationViews;
 @end
 
 
@@ -100,6 +105,47 @@ static NSString * const MLNTestAnnotationReuseIdentifer = @"MLNTestAnnotationReu
 
     XCTAssert(_mapView.annotations.count == 0, @"number of annotations should be 0");
     XCTAssertNil(_annotationView.annotation, @"annotation property should be nil");
+}
+
+- (void)testRemovingAnnotationsRemovesOffscreenReusableViews {
+  self.mapView.centerCoordinate = CLLocationCoordinate2DMake(0, 0);
+  self.mapView.zoomLevel = 14;
+
+  MLNTestAnnotation *visibleAnnotation = [[MLNTestAnnotation alloc] init];
+  visibleAnnotation.coordinate = CLLocationCoordinate2DMake(0, 0);
+
+  MLNTestAnnotation *offscreenAnnotation = [[MLNTestAnnotation alloc] init];
+  offscreenAnnotation.coordinate = CLLocationCoordinate2DMake(45, 45);
+
+  NSArray<MLNTestAnnotation *> *annotations = @[ visibleAnnotation, offscreenAnnotation ];
+  [self.mapView addAnnotations:annotations];
+  [self.mapView updateAnnotationViews];
+
+  NSArray<MLNAnnotationView *> *reusableViews =
+      self.mapView.annotationViewReuseQueueByIdentifier[MLNTestAnnotationReuseIdentifer];
+  XCTAssertGreaterThan(reusableViews.count, 0UL,
+                       @"The test must enqueue at least one offscreen annotation view");
+
+  [self.mapView removeAnnotations:annotations];
+  [self.mapView updateAnnotationViews];
+
+  XCTAssertEqual(self.mapView.annotationContainerView.annotationViews.count, 0UL);
+  XCTAssertNil(self.mapView.annotationViewReuseQueueByIdentifier[MLNTestAnnotationReuseIdentifer]);
+}
+
+- (void)testAddingAnnotationsReusesAnnotationContainerView {
+  MLNTestAnnotation *firstAnnotation = [[MLNTestAnnotation alloc] init];
+  firstAnnotation.coordinate = CLLocationCoordinate2DMake(0, 0);
+  [self.mapView addAnnotation:firstAnnotation];
+
+  MLNAnnotationContainerView *annotationContainerView = self.mapView.annotationContainerView;
+
+  MLNTestAnnotation *secondAnnotation = [[MLNTestAnnotation alloc] init];
+  secondAnnotation.coordinate = CLLocationCoordinate2DMake(1, 1);
+  [self.mapView addAnnotation:secondAnnotation];
+
+  XCTAssertEqual(self.mapView.annotationContainerView, annotationContainerView);
+  XCTAssertEqual(self.mapView.annotationContainerView.annotationViews.count, 2UL);
 }
 
 - (void)testCustomAnnotationView


### PR DESCRIPTION
## Summary

Closes #3960. Adding view-backed annotations in batches caused `MLNMapView` to replace the annotation container each time and reparent all existing views.

This change keeps the existing container. It also removes deleted annotation views from the reuse queue and clears reusable views once no view-backed annotations remain. Regression tests cover offscreen view removal and container reuse across batches.

## Verification

- `bazel test //platform/ios/test:ios_test --test_filter=MLNAnnotationViewTests --test_output=errors --//:renderer=metal`
- iOS 26.5 Simulator with 3,000 annotation views added in 30 batches
- Annotation-container replacements: 29 before, 0 after

**AI disclosure:** OpenAI Codex (GPT-5) assisted with implementation and tests under human supervision.
