### PR TITLE
iOS: Handle GeoJSON with empty coordinates

### DIFF
--- a/platform/darwin/src/MLNShape.mm
+++ b/platform/darwin/src/MLNShape.mm
@@ -11,6 +11,72 @@ bool operator==(const CLLocationCoordinate2D lhs, const CLLocationCoordinate2D r
   return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude;
 }
 
+static BOOL MLNIsGeoJSONGeometryType(NSString *type) {
+  return [type isEqualToString:@"Point"] || [type isEqualToString:@"MultiPoint"] ||
+         [type isEqualToString:@"LineString"] || [type isEqualToString:@"MultiLineString"] ||
+         [type isEqualToString:@"Polygon"] || [type isEqualToString:@"MultiPolygon"];
+}
+
+static id MLNGeoJSONObjectByReplacingEmptyCoordinates(id object, BOOL *changed) {
+  if ([object isKindOfClass:[NSArray class]]) {
+    NSArray *array = object;
+    NSMutableArray *updatedArray = nil;
+    for (NSUInteger index = 0; index < array.count; index++) {
+      id updatedObject = MLNGeoJSONObjectByReplacingEmptyCoordinates(array[index], changed);
+      if (updatedObject != array[index]) {
+        if (!updatedArray) {
+          updatedArray = [array mutableCopy];
+        }
+        updatedArray[index] = updatedObject;
+      }
+    }
+    return updatedArray ?: object;
+  }
+
+  if (![object isKindOfClass:[NSDictionary class]]) {
+    return object;
+  }
+
+  NSDictionary *dictionary = object;
+  NSString *type = dictionary[@"type"];
+  if (![type isKindOfClass:[NSString class]]) {
+    return object;
+  }
+  id coordinates = dictionary[@"coordinates"];
+  if (MLNIsGeoJSONGeometryType(type) && [coordinates isKindOfClass:[NSArray class]] &&
+      [coordinates count] == 0) {
+    *changed = YES;
+    return [NSNull null];
+  }
+
+  NSString *childKey = nil;
+  if ([type isEqualToString:@"Feature"]) {
+    childKey = @"geometry";
+  } else if ([type isEqualToString:@"FeatureCollection"]) {
+    childKey = @"features";
+  } else if ([type isEqualToString:@"GeometryCollection"]) {
+    childKey = @"geometries";
+  }
+
+  if (!childKey) {
+    return object;
+  }
+
+  id child = dictionary[childKey];
+  if (!child) {
+    return object;
+  }
+
+  id updatedChild = MLNGeoJSONObjectByReplacingEmptyCoordinates(child, changed);
+  if (updatedChild == child) {
+    return object;
+  }
+
+  NSMutableDictionary *updatedDictionary = [dictionary mutableCopy];
+  updatedDictionary[childKey] = updatedChild;
+  return updatedDictionary;
+}
+
 @implementation MLNShape
 
 + (nullable MLNShape *)shapeWithData:(NSData *)data
@@ -28,11 +94,32 @@ bool operator==(const CLLocationCoordinate2D lhs, const CLLocationCoordinate2D r
     const auto geojson = mapbox::geojson::parse(string.UTF8String);
     return MLNShapeFromGeoJSON(geojson);
   } catch (std::runtime_error &err) {
+    NSString *failureReason = @(err.what());
+    NSData *utf8Data = [string dataUsingEncoding:NSUTF8StringEncoding];
+    id jsonObject = [NSJSONSerialization JSONObjectWithData:utf8Data options:0 error:nil];
+    BOOL changed = NO;
+    id updatedJSONObject = MLNGeoJSONObjectByReplacingEmptyCoordinates(jsonObject, &changed);
+    if (changed) {
+      if ([updatedJSONObject isKindOfClass:[NSNull class]]) {
+        updatedJSONObject = @{@"type" : @"GeometryCollection", @"geometries" : @[]};
+      }
+      NSData *updatedData = [NSJSONSerialization dataWithJSONObject:updatedJSONObject
+                                                            options:NSJSONWritingFragmentsAllowed
+                                                              error:nil];
+      NSString *updatedString = [[NSString alloc] initWithData:updatedData
+                                                      encoding:NSUTF8StringEncoding];
+      try {
+        const auto geojson = mapbox::geojson::parse(updatedString.UTF8String);
+        return MLNShapeFromGeoJSON(geojson);
+      } catch (std::runtime_error &updatedError) {
+        failureReason = @(updatedError.what());
+      }
+    }
     if (outError) {
       *outError = [NSError errorWithDomain:MLNErrorDomain
                                       code:MLNErrorCodeUnknown
                                   userInfo:@{
-                                    NSLocalizedFailureReasonErrorKey : @(err.what()),
+                                    NSLocalizedFailureReasonErrorKey : failureReason,
                                   }];
     }
     return nil;

--- a/platform/darwin/src/MLNShape.mm
+++ b/platform/darwin/src/MLNShape.mm
@@ -17,64 +17,78 @@ static BOOL MLNIsGeoJSONGeometryType(NSString *type) {
          [type isEqualToString:@"Polygon"] || [type isEqualToString:@"MultiPolygon"];
 }
 
-static id MLNGeoJSONObjectByReplacingEmptyCoordinates(id object, BOOL *changed) {
-  if ([object isKindOfClass:[NSArray class]]) {
-    NSArray *array = object;
-    NSMutableArray *updatedArray = nil;
-    for (NSUInteger index = 0; index < array.count; index++) {
-      id updatedObject = MLNGeoJSONObjectByReplacingEmptyCoordinates(array[index], changed);
-      if (updatedObject != array[index]) {
-        if (!updatedArray) {
-          updatedArray = [array mutableCopy];
-        }
-        updatedArray[index] = updatedObject;
-      }
-    }
-    return updatedArray ?: object;
+static NSRegularExpression *MLNEmptyArrayRegularExpression(void) {
+  static NSRegularExpression *regularExpression;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    regularExpression = [NSRegularExpression regularExpressionWithPattern:@"\\[\\s*\\]"
+                                                                  options:0
+                                                                    error:nil];
+  });
+  return regularExpression;
+}
+
+static BOOL MLNReplaceEmptyFeatureCoordinates(id object) {
+  if (![object isKindOfClass:[NSMutableDictionary class]]) {
+    return NO;
   }
 
-  if (![object isKindOfClass:[NSDictionary class]]) {
-    return object;
-  }
-
-  NSDictionary *dictionary = object;
+  NSMutableDictionary *dictionary = object;
   NSString *type = dictionary[@"type"];
   if (![type isKindOfClass:[NSString class]]) {
-    return object;
+    return NO;
   }
-  id coordinates = dictionary[@"coordinates"];
-  if (MLNIsGeoJSONGeometryType(type) && [coordinates isKindOfClass:[NSArray class]] &&
-      [coordinates count] == 0) {
-    *changed = YES;
-    return [NSNull null];
-  }
-
-  NSString *childKey = nil;
   if ([type isEqualToString:@"Feature"]) {
-    childKey = @"geometry";
-  } else if ([type isEqualToString:@"FeatureCollection"]) {
-    childKey = @"features";
-  } else if ([type isEqualToString:@"GeometryCollection"]) {
-    childKey = @"geometries";
+    id geometry = dictionary[@"geometry"];
+    if (![geometry isKindOfClass:[NSDictionary class]]) {
+      return NO;
+    }
+
+    NSString *geometryType = geometry[@"type"];
+    id coordinates = geometry[@"coordinates"];
+    if (![geometryType isKindOfClass:[NSString class]] || !MLNIsGeoJSONGeometryType(geometryType) ||
+        ![coordinates isKindOfClass:[NSArray class]] || [coordinates count] != 0) {
+      return NO;
+    }
+
+    dictionary[@"geometry"] = [NSNull null];
+    return YES;
   }
 
-  if (!childKey) {
-    return object;
+  if (![type isEqualToString:@"FeatureCollection"]) {
+    return NO;
   }
 
-  id child = dictionary[childKey];
-  if (!child) {
-    return object;
+  NSArray *features = dictionary[@"features"];
+  if (![features isKindOfClass:[NSArray class]]) {
+    return NO;
   }
 
-  id updatedChild = MLNGeoJSONObjectByReplacingEmptyCoordinates(child, changed);
-  if (updatedChild == child) {
-    return object;
+  BOOL changed = NO;
+  for (id feature in features) {
+    changed |= MLNReplaceEmptyFeatureCoordinates(feature);
+  }
+  return changed;
+}
+
+static NSString *MLNGeoJSONStringByReplacingEmptyFeatureCoordinates(NSString *string) {
+  NSRange range = NSMakeRange(0, string.length);
+  if (![MLNEmptyArrayRegularExpression() firstMatchInString:string options:0 range:range]) {
+    return string;
   }
 
-  NSMutableDictionary *updatedDictionary = [dictionary mutableCopy];
-  updatedDictionary[childKey] = updatedChild;
-  return updatedDictionary;
+  NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
+  id jsonObject = [NSJSONSerialization JSONObjectWithData:data
+                                                  options:NSJSONReadingMutableContainers
+                                                    error:nil];
+  if (!MLNReplaceEmptyFeatureCoordinates(jsonObject)) {
+    return string;
+  }
+
+  NSData *updatedData = [NSJSONSerialization dataWithJSONObject:jsonObject options:0 error:nil];
+  NSString *updatedString = [[NSString alloc] initWithData:updatedData
+                                                  encoding:NSUTF8StringEncoding];
+  return updatedString ?: string;
 }
 
 @implementation MLNShape
@@ -90,36 +104,16 @@ static id MLNGeoJSONObjectByReplacingEmptyCoordinates(id object, BOOL *changed) 
     return nil;
   }
 
+  NSString *normalizedString = MLNGeoJSONStringByReplacingEmptyFeatureCoordinates(string);
   try {
-    const auto geojson = mapbox::geojson::parse(string.UTF8String);
+    const auto geojson = mapbox::geojson::parse(normalizedString.UTF8String);
     return MLNShapeFromGeoJSON(geojson);
   } catch (std::runtime_error &err) {
-    NSString *failureReason = @(err.what());
-    NSData *utf8Data = [string dataUsingEncoding:NSUTF8StringEncoding];
-    id jsonObject = [NSJSONSerialization JSONObjectWithData:utf8Data options:0 error:nil];
-    BOOL changed = NO;
-    id updatedJSONObject = MLNGeoJSONObjectByReplacingEmptyCoordinates(jsonObject, &changed);
-    if (changed) {
-      if ([updatedJSONObject isKindOfClass:[NSNull class]]) {
-        updatedJSONObject = @{@"type" : @"GeometryCollection", @"geometries" : @[]};
-      }
-      NSData *updatedData = [NSJSONSerialization dataWithJSONObject:updatedJSONObject
-                                                            options:NSJSONWritingFragmentsAllowed
-                                                              error:nil];
-      NSString *updatedString = [[NSString alloc] initWithData:updatedData
-                                                      encoding:NSUTF8StringEncoding];
-      try {
-        const auto geojson = mapbox::geojson::parse(updatedString.UTF8String);
-        return MLNShapeFromGeoJSON(geojson);
-      } catch (std::runtime_error &updatedError) {
-        failureReason = @(updatedError.what());
-      }
-    }
     if (outError) {
       *outError = [NSError errorWithDomain:MLNErrorDomain
                                       code:MLNErrorCodeUnknown
                                   userInfo:@{
-                                    NSLocalizedFailureReasonErrorKey : failureReason,
+                                    NSLocalizedFailureReasonErrorKey : @(err.what()),
                                   }];
     }
     return nil;

--- a/platform/darwin/test/MLNShapeSourceTests.mm
+++ b/platform/darwin/test/MLNShapeSourceTests.mm
@@ -91,9 +91,47 @@
   XCTAssertTrue([collection.shapes.firstObject isMemberOfClass:[MLNPolylineFeature class]]);
 }
 
-- (void)testMLNShapeSourceWithEmptyGeometries {
+- (void)testMLNShapeSourceWithNullGeometry {
+  NSData *data = [@"{\"type\":\"Feature\",\"properties\":{},\"geometry\":null}"
+      dataUsingEncoding:NSUTF8StringEncoding];
+  NSError *error = nil;
+  MLNShape *shape = [MLNShape shapeWithData:data encoding:NSUTF8StringEncoding error:&error];
+
+  XCTAssertNil(error);
+  XCTAssertTrue([shape isKindOfClass:[MLNEmptyFeature class]]);
+
+  MLNShapeSource *source;
+  XCTAssertNoThrow(source = [[MLNShapeSource alloc] initWithIdentifier:@"source-id"
+                                                                 shape:shape
+                                                               options:nil]);
+  XCTAssertNotNil(source.shape);
+}
+
+- (void)testMLNShapeSourceWithEmptyFeatureCoordinates {
+  NSArray<NSString *> *geometryTypes =
+      @[ @"Point", @"MultiPoint", @"LineString", @"MultiLineString", @"Polygon", @"MultiPolygon" ];
+  for (NSString *geometryType in geometryTypes) {
+    NSString *geoJSON =
+        [NSString stringWithFormat:@"{\"type\":\"Feature\",\"properties\":{},\"geometry\":{"
+                                   @"\"type\":\"%@\",\"coordinates\":[ ]}}",
+                                   geometryType];
+    NSData *data = [geoJSON dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *error = nil;
+    MLNShape *shape = [MLNShape shapeWithData:data encoding:NSUTF8StringEncoding error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertTrue([shape isKindOfClass:[MLNEmptyFeature class]]);
+
+    MLNShapeSource *source;
+    XCTAssertNoThrow(source = [[MLNShapeSource alloc] initWithIdentifier:@"source-id"
+                                                                   shape:shape
+                                                                 options:nil]);
+    XCTAssertNotNil(source.shape);
+  }
+}
+
+- (void)testMLNShapeSourceWithEmptyFeatureAndValidSibling {
   NSString *geoJSON = @"{\"type\":\"FeatureCollection\",\"features\":["
-                       "{\"type\":\"Feature\",\"properties\":{},\"geometry\":null},"
                        "{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Point\","
                        "\"coordinates\":[]}},"
                        "{\"type\":\"Feature\",\"properties\":{\"name\":\"Café\"},"
@@ -107,32 +145,14 @@
                                                      error:&error];
 
   XCTAssertNil(error);
-  XCTAssertEqual(collection.shapes.count, 3UL);
+  XCTAssertEqual(collection.shapes.count, 2UL);
   XCTAssertTrue([collection.shapes[0] isKindOfClass:[MLNEmptyFeature class]]);
-  XCTAssertTrue([collection.shapes[1] isKindOfClass:[MLNEmptyFeature class]]);
-  XCTAssertTrue([collection.shapes[2] isKindOfClass:[MLNPointFeature class]]);
-  XCTAssertEqualObjects([collection.shapes[2] attributeForKey:@"name"], @"Café");
+  XCTAssertTrue([collection.shapes[1] isKindOfClass:[MLNPointFeature class]]);
+  XCTAssertEqualObjects([collection.shapes[1] attributeForKey:@"name"], @"Café");
 
   MLNShapeSource *source;
   XCTAssertNoThrow(source = [[MLNShapeSource alloc] initWithIdentifier:@"source-id"
                                                                  shape:collection
-                                                               options:nil]);
-  XCTAssertNotNil(source.shape);
-}
-
-- (void)testMLNShapeSourceWithEmptyTopLevelGeometry {
-  NSData *data =
-      [@"{\"type\":\"Point\",\"coordinates\":[]}" dataUsingEncoding:NSUTF8StringEncoding];
-  NSError *error = nil;
-  MLNShape *shape = [MLNShape shapeWithData:data encoding:NSUTF8StringEncoding error:&error];
-
-  XCTAssertNil(error);
-  XCTAssertTrue([shape isKindOfClass:[MLNShapeCollection class]]);
-  XCTAssertEqual(((MLNShapeCollection *)shape).shapes.count, 0UL);
-
-  MLNShapeSource *source;
-  XCTAssertNoThrow(source = [[MLNShapeSource alloc] initWithIdentifier:@"source-id"
-                                                                 shape:shape
                                                                options:nil]);
   XCTAssertNotNil(source.shape);
 }

--- a/platform/darwin/test/MLNShapeSourceTests.mm
+++ b/platform/darwin/test/MLNShapeSourceTests.mm
@@ -91,6 +91,52 @@
   XCTAssertTrue([collection.shapes.firstObject isMemberOfClass:[MLNPolylineFeature class]]);
 }
 
+- (void)testMLNShapeSourceWithEmptyGeometries {
+  NSString *geoJSON = @"{\"type\":\"FeatureCollection\",\"features\":["
+                       "{\"type\":\"Feature\",\"properties\":{},\"geometry\":null},"
+                       "{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Point\","
+                       "\"coordinates\":[]}},"
+                       "{\"type\":\"Feature\",\"properties\":{\"name\":\"Café\"},"
+                       "\"geometry\":{\"type\":\"Point\","
+                       "\"coordinates\":[0,0]}}]}";
+  NSData *data = [geoJSON dataUsingEncoding:NSISOLatin1StringEncoding];
+  NSError *error = nil;
+  MLNShapeCollectionFeature *collection =
+      (MLNShapeCollectionFeature *)[MLNShape shapeWithData:data
+                                                  encoding:NSISOLatin1StringEncoding
+                                                     error:&error];
+
+  XCTAssertNil(error);
+  XCTAssertEqual(collection.shapes.count, 3UL);
+  XCTAssertTrue([collection.shapes[0] isKindOfClass:[MLNEmptyFeature class]]);
+  XCTAssertTrue([collection.shapes[1] isKindOfClass:[MLNEmptyFeature class]]);
+  XCTAssertTrue([collection.shapes[2] isKindOfClass:[MLNPointFeature class]]);
+  XCTAssertEqualObjects([collection.shapes[2] attributeForKey:@"name"], @"Café");
+
+  MLNShapeSource *source;
+  XCTAssertNoThrow(source = [[MLNShapeSource alloc] initWithIdentifier:@"source-id"
+                                                                 shape:collection
+                                                               options:nil]);
+  XCTAssertNotNil(source.shape);
+}
+
+- (void)testMLNShapeSourceWithEmptyTopLevelGeometry {
+  NSData *data =
+      [@"{\"type\":\"Point\",\"coordinates\":[]}" dataUsingEncoding:NSUTF8StringEncoding];
+  NSError *error = nil;
+  MLNShape *shape = [MLNShape shapeWithData:data encoding:NSUTF8StringEncoding error:&error];
+
+  XCTAssertNil(error);
+  XCTAssertTrue([shape isKindOfClass:[MLNShapeCollection class]]);
+  XCTAssertEqual(((MLNShapeCollection *)shape).shapes.count, 0UL);
+
+  MLNShapeSource *source;
+  XCTAssertNoThrow(source = [[MLNShapeSource alloc] initWithIdentifier:@"source-id"
+                                                                 shape:shape
+                                                               options:nil]);
+  XCTAssertNotNil(source.shape);
+}
+
 - (void)testMLNShapeSourceWithSingleGeometry {
   NSData *data =
       [@"{\"type\": \"Point\", \"coordinates\": [0, 0]}" dataUsingEncoding:NSUTF8StringEncoding];

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`M
 
 ## 6.29.0
 
+- iOS: Accept GeoJSON features with empty coordinates.
 - fix(core): accept alpha in hsl colors ([#4435](https://github.com/maplibre/maplibre-native/pull/4435)).
 - fix(core): repaint feature-state-driven symbol paint properties ([#4445](https://github.com/maplibre/maplibre-native/pull/4445)).
 - Make string expressions operate on unicode ([#4344](https://github.com/maplibre/maplibre-native/pull/4344)).

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,7 +4,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`M
 
 ## 6.29.0
 
-- iOS: Accept GeoJSON features with empty coordinates.
+- iOS: Accept GeoJSON features with empty coordinate arrays.
 - fix(core): accept alpha in hsl colors ([#4435](https://github.com/maplibre/maplibre-native/pull/4435)).
 - fix(core): repaint feature-state-driven symbol paint properties ([#4445](https://github.com/maplibre/maplibre-native/pull/4445)).
 - Make string expressions operate on unicode ([#4344](https://github.com/maplibre/maplibre-native/pull/4344)).

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -4,6 +4,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`C
 
 ## 6.27.0
 
+- Accept GeoJSON features with empty coordinate arrays.
 - First automated native macOS XCFramework release ([#4088](https://github.com/maplibre/maplibre-native/issues/4088)).
 - Add Bazel `MapLibre.dynamic` and `MapLibre.static` xcframework targets for macOS ([#4113](https://github.com/maplibre/maplibre-native/pull/4113)).
 - Fix Xcode 26 build compatibility ([#4226](https://github.com/maplibre/maplibre-native/pull/4226)).


### PR DESCRIPTION
Fixes #1452.

GeoJSON features with empty coordinate arrays now deserialize as empty features. Valid sibling features remain intact.

The regression tests cover `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, and `MultiPolygon`, plus null geometry and non-UTF-8 input.

Tested with:

- `bazel test //platform/ios/test:ios_test --test_output=errors --//:renderer=metal --test_filter='MLNShapeSourceTests'` (19 tests passed on an iPhone 15 simulator, iOS 26.5, Xcode 26.6)

AI usage: OpenAI Codex assisted under human supervision.