### PR TITLE
iOS: Clear transient edge padding for unchanged camera

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`M
 
 ## 6.29.0
 
+- iOS: Clear transient edge padding when setting an unchanged camera.
 - fix(core): accept alpha in hsl colors ([#4435](https://github.com/maplibre/maplibre-native/pull/4435)).
 - fix(core): repaint feature-state-driven symbol paint properties ([#4445](https://github.com/maplibre/maplibre-native/pull/4445)).
 - Make string expressions operate on unicode ([#4344](https://github.com/maplibre/maplibre-native/pull/4344)).

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -4317,7 +4317,7 @@ static void *windowScreenContext = &windowScreenContext;
   }
 
   if ([self.camera isEqualToMapCamera:camera] &&
-      UIEdgeInsetsEqualToEdgeInsets(_contentInset, edgePadding)) {
+      UIEdgeInsetsEqualToEdgeInsets(self.cameraEdgeInsets, edgePadding)) {
     if (pendingCompletion) {
       [self animateWithDelay:duration animations:pendingCompletion];
     }

--- a/platform/ios/test/MLNMapViewGestureRecognizerTests.mm
+++ b/platform/ios/test/MLNMapViewGestureRecognizerTests.mm
@@ -67,6 +67,39 @@
   [_styleLoadingExpectation fulfill];
 }
 
+- (void)testSetCameraClearsTransientEdgePaddingWhenCameraIsUnchanged {
+  UIEdgeInsets contentInset = UIEdgeInsetsMake(1, 2, 3, 4);
+  UIEdgeInsets transientPadding = UIEdgeInsetsMake(0, 0, 20, 0);
+  self.mapView.contentInset = contentInset;
+  MLNMapCamera *targetCamera = self.mapView.camera;
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Camera padding cleared"];
+  __weak __typeof__(self) weakSelf = self;
+
+  [self.mapView setCamera:targetCamera
+                 withDuration:0
+      animationTimingFunction:nil
+                  edgePadding:transientPadding
+            completionHandler:^{
+              MLNMapView *mapView = weakSelf.mapView;
+              auto cameraPadding = mapView.mbglMap.getCameraOptions().padding;
+              auto expectedPadding = MLNEdgeInsetsFromNSEdgeInsets(contentInset) +
+                                     MLNEdgeInsetsFromNSEdgeInsets(transientPadding);
+              XCTAssertEqual(cameraPadding, expectedPadding);
+
+              [mapView setCamera:targetCamera
+                             withDuration:0
+                  animationTimingFunction:nil
+                              edgePadding:UIEdgeInsetsZero
+                        completionHandler:^{
+                          [expectation fulfill];
+                        }];
+            }];
+  [self waitForExpectationsWithTimeout:2 handler:nil];
+
+  auto cameraPadding = self.mapView.mbglMap.getCameraOptions().padding;
+  XCTAssertEqual(cameraPadding, MLNEdgeInsetsFromNSEdgeInsets(contentInset));
+}
+
 - (void)testHandlePinchGestureContentInset {
   UIEdgeInsets contentInset = UIEdgeInsetsMake(1, 1, 1, 1);
   self.mapView.contentInset = contentInset;


### PR DESCRIPTION
Fixes #4449.

`setCamera` now compares the requested effective padding with the padding currently held by the core map before treating an unchanged camera as a no-op. This allows zero `edgePadding` to clear earlier transient padding.

The regression test applies bottom padding, sets the same camera again with zero padding, and verifies that only `contentInset` remains.

Tested with:

- `bazel test //platform/ios/test:ios_test --test_output=errors --//:renderer=metal --test_filter="MLNMapViewGestureRecognizerTests/testSetCameraClearsTransientEdgePaddingWhenCameraIsUnchanged"`

AI usage: OpenAI Codex (GPT-5) assisted with the implementation and tests under human supervision.