### PR TITLE
fix(core): bundle fastpfor-lib into the Linux/macOS amalgams

### DIFF
--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -227,6 +227,7 @@ if(MLN_CREATE_AMALGAMATION)
             $<TARGET_FILE:mbgl-vendor-sqlite>
             $<TARGET_FILE:mbgl-vendor-parsedate>
             $<TARGET_FILE:mlt-cpp>
+            $<TARGET_FILE:fastpfor-lib>
             ${ICUUC_LIBRARY_DIRS}/libicuuc.a
             ${ICUUC_LIBRARY_DIRS}/libicudata.a
             ${ICUI18N_LIBRARY_DIRS}/libicui18n.a

--- a/platform/macos/macos.cmake
+++ b/platform/macos/macos.cmake
@@ -180,6 +180,7 @@ if(MLN_CREATE_AMALGAMATION)
             $<TARGET_FILE:mbgl-vendor-parsedate>
             $<TARGET_FILE:mbgl-vendor-icu>
             $<TARGET_FILE:mlt-cpp>
+            $<TARGET_FILE:fastpfor-lib>
             ${STATIC_LIBS}
         # In Mach-O/Itanium ABI names, ZTI/ZTS/ZTV identify typeinfo,
         # type names, and vtables, while St denotes std::.


### PR DESCRIPTION
MapLibre Native now enables FastPFor (#4146), so the Linux and macOS amalgams must bundle it alongside `mlt-cpp`. Without it, downstream builds fail.

- #4146