### PR TITLE
fix(ios): use window scene interface orientation for heading compensation

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -16,6 +16,7 @@ MapLibre welcomes participation and contributions from everyone. Please read [`M
 - core: rename `mbgl` directories to `mln` ([#4511]((https://github.com/maplibre/maplibre-native/pull/4511))).
 - Fix surface transform ([#4495](https://github.com/maplibre/maplibre-native/pull/4495)).
 - fix(core): Fix nullptr access during custom layer pre-render ([#4496](https://github.com/maplibre/maplibre-native/pull/4496)).
+- fix(ios): use the window scene's interface orientation for heading compensation, replacing the deprecated `-[UIApplication statusBarOrientation]`.
 
 ## 6.28.0
 

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -6573,7 +6573,17 @@ static void *windowScreenContext = &windowScreenContext;
     // note that right/left device and interface orientations are opposites (see UIApplication.h)
     //
     CLDeviceOrientation orientation;
-    switch ([[UIApplication sharedApplication] statusBarOrientation]) {
+    // -[UIApplication statusBarOrientation] is deprecated and is a no-op as of
+    // iOS 27, so it can no longer be used to compensate the heading. It is also
+    // called on every heading update, which makes UIKit log a deprecation notice
+    // several times per second.
+    UIInterfaceOrientation interfaceOrientation;
+    if (@available(iOS 13.0, *)) {
+      interfaceOrientation = self.window.windowScene.interfaceOrientation;
+    } else {
+      interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
+    }
+    switch (interfaceOrientation) {
       case (UIInterfaceOrientationLandscapeLeft): {
         orientation = CLDeviceOrientationLandscapeRight;
         break;


### PR DESCRIPTION
`MLNMapView.updateHeadingForDeviceOrientation` reads the interface orientation with `-[UIApplication statusBarOrientation]`. That API is deprecated and is a no-op as of iOS 27, which has two consequences.

First, the heading is no longer compensated for the interface orientation: the switch always falls through to the portrait default. Second, the method runs on every heading update, so UIKit emits its deprecation notice several times per second. In a navigation app that is hundreds of lines per minute.

This reads the orientation from the view's window scene instead, keeping the old call behind an availability check because the deployment target is still iOS 12.

One behavioural note: when the map view is not yet in a window, `windowScene` is nil and the orientation resolves to `UIInterfaceOrientationUnknown`, which lands on the existing portrait default. Previously the application-wide orientation was used. No heading is rendered in that state, so this should not be observable.