### PR TITLE
ci: cancel superseded rust-ci runs on pull requests

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 defaults:
   run:
     working-directory: rustutils/


### PR DESCRIPTION
rust-ci is the one CI workflow here without a concurrency group, so a push to an open pull request starts another macOS, Windows and two Linux jobs while the previous run keeps going. This is the block the other maplibre repos are standardising on (tile-spec, martin, gl-js in maplibre/maplibre-gl-js#8317): pull request runs are keyed by number and cancelled when superseded; runs on main queue behind each other and are never cancelled. The org shares one pool of 60 concurrent jobs and five macOS slots, and this repo is its largest macOS consumer.

Checked with actionlint; not run on the fork.
