### PR TITLE
metal: pass API validation with 3D terrain on and off

### DIFF
--- a/include/mln/gfx/context.hpp
+++ b/include/mln/gfx/context.hpp
@@ -155,6 +155,12 @@ public:
     /// Create a new vertex attribute array
     virtual gfx::VertexAttributeArrayPtr createVertexAttributeArray() const = 0;
 
+    /// A shared 1x1 zero texture to bind wherever a shader declares a sampler the current
+    /// frame has no real texture for (e.g. the DEM / terrain-depth slots of the symbol, circle
+    /// and fill-extrusion shaders when 3D terrain is off). Metal's API validation aborts on an
+    /// unbound sampler even when the shader never samples it; Vulkan already binds a dummy.
+    const Texture2DPtr& getPlaceholderTexture2D();
+
     /// Create a new drawable builder
     virtual UniqueDrawableBuilder createDrawableBuilder(std::string name) = 0;
 
@@ -231,6 +237,7 @@ protected:
     std::shared_mutex renderingStatsMutex;
     gfx::RenderingStats stats;
     ContextObserver* observer;
+    Texture2DPtr placeholderTexture2D;
 
     // Progressive new-tile build budget (see resetNewTileBuildBudget). Defaults to
     // effectively unlimited so any path that never resets it is unaffected.

--- a/src/mln/gfx/drawable.cpp
+++ b/src/mln/gfx/drawable.cpp
@@ -1,3 +1,7 @@
+#include <cstring>
+#include <mln/util/image.hpp>
+#include <mln/gfx/texture2d.hpp>
+#include <mln/gfx/context.hpp>
 #include <mln/gfx/drawable.hpp>
 
 #include <mln/gfx/color_mode.hpp>
@@ -88,6 +92,25 @@ const std::shared_ptr<Bucket>& Drawable::getBucket() const {
 void Drawable::setRenderTile(Immutable<std::vector<RenderTile>> renderTiles_, const RenderTile* tile_) {
     impl->renderTiles = std::move(renderTiles_);
     impl->renderTile = tile_;
+}
+
+} // namespace gfx
+} // namespace mln
+
+
+namespace mln {
+namespace gfx {
+
+const Texture2DPtr& Context::getPlaceholderTexture2D() {
+    if (!placeholderTexture2D) {
+        auto image = std::make_shared<PremultipliedImage>(Size{1, 1});
+        std::memset(image->data.get(), 0, image->bytes());
+        placeholderTexture2D = createTexture2D();
+        placeholderTexture2D->setImage(image);
+        placeholderTexture2D->setSamplerConfiguration(
+            {.filter = TextureFilterType::Nearest, .wrapU = TextureWrapType::Clamp, .wrapV = TextureWrapType::Clamp});
+    }
+    return placeholderTexture2D;
 }
 
 } // namespace gfx

--- a/src/mln/gfx/drawable.cpp
+++ b/src/mln/gfx/drawable.cpp
@@ -97,7 +97,6 @@ void Drawable::setRenderTile(Immutable<std::vector<RenderTile>> renderTiles_, co
 } // namespace gfx
 } // namespace mln
 
-
 namespace mln {
 namespace gfx {
 

--- a/src/mln/renderer/layers/circle_layer_tweaker.cpp
+++ b/src/mln/renderer/layers/circle_layer_tweaker.cpp
@@ -99,6 +99,9 @@ void CircleLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
             drawable.setTexture(
                 terrainData ? terrainData->demTexture : parameters.terrain->getPlaceholderDEMTexture(context),
                 idCircleDEMTexture);
+        } else {
+            // Keep the declared DEM sampler bound for Metal API validation (never sampled).
+            drawable.setTexture(context.getPlaceholderTexture2D(), idCircleDEMTexture);
         }
 
         // The terrain surface writes depth (so its skirts get occluded); circles

--- a/src/mln/renderer/layers/fill_extrusion_layer_tweaker.cpp
+++ b/src/mln/renderer/layers/fill_extrusion_layer_tweaker.cpp
@@ -131,6 +131,9 @@ void FillExtrusionLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintP
             drawable.setTexture(
                 terrainData ? terrainData->demTexture : parameters.terrain->getPlaceholderDEMTexture(context),
                 idFillExtrusionDEMTexture);
+        } else {
+            // Keep the declared DEM sampler bound for Metal API validation (never sampled).
+            drawable.setTexture(context.getPlaceholderTexture2D(), idFillExtrusionDEMTexture);
         }
 
 #if MLN_UBO_CONSOLIDATION

--- a/src/mln/renderer/layers/symbol_layer_tweaker.cpp
+++ b/src/mln/renderer/layers/symbol_layer_tweaker.cpp
@@ -180,6 +180,12 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
                 idSymbolDEMTexture);
             // Packed terrain depth for occlusion (calculate_visibility)
             drawable.setTexture(parameters.terrain->getDepthTexture(context), idSymbolDepthTexture);
+        } else {
+            // The shader declares both samplers regardless; leaving them unbound trips Metal's
+            // API validation (missing sampler binding) even though dem_enabled / depth_enabled
+            // are 0 and nothing is sampled.
+            drawable.setTexture(context.getPlaceholderTexture2D(), idSymbolDEMTexture);
+            drawable.setTexture(context.getPlaceholderTexture2D(), idSymbolDepthTexture);
         }
 
         // The terrain surface writes depth so its skirts get occluded; symbols

--- a/src/mln/shaders/mtl/shader_program.cpp
+++ b/src/mln/shaders/mtl/shader_program.cpp
@@ -1,4 +1,5 @@
 #include <mln/shaders/mtl/shader_program.hpp>
+#include <mln/util/hash.hpp>
 
 #include <mln/gfx/render_pass.hpp>
 #include <mln/mtl/context.hpp>
@@ -84,12 +85,6 @@ MTLRenderPipelineStatePtr ShaderProgram::getRenderPipelineState(const gfx::Rende
                                                                 const MTLVertexDescriptorPtr& vertexDescriptor,
                                                                 const gfx::ColorMode& colorMode,
                                                                 const std::optional<std::size_t> reuseHash) const {
-    if (reuseHash.has_value()) {
-        // we'd like to reuse a previous value
-        if (auto it = renderPipelineStateCache.find(reuseHash.value()); it != renderPipelineStateCache.end())
-            return it->second;
-    }
-
     auto pool = NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
 
     const auto& renderableResource = renderable.getResource<RenderableResource>();
@@ -112,6 +107,22 @@ MTLRenderPipelineStatePtr ShaderProgram::getRenderPipelineState(const gfx::Rende
             if (auto* tex = stencilTarget->texture()) {
                 stencilFormat = tex->pixelFormat();
             }
+        }
+    }
+
+    // A pipeline state is only valid for the attachment formats it was built with. The caller's
+    // reuse hash covers the colour mode and vertex layout; fold the renderable's colour, depth
+    // and stencil formats in too, or a state built for the BGRA8 + stencil screen gets reused for
+    // an RGBA8 offscreen target (terrain drape targets, hillshade prepare targets) and Metal's
+    // API validation aborts on the mismatch.
+    std::optional<std::size_t> cacheKey;
+    if (reuseHash.has_value()) {
+        cacheKey = mln::util::hash(reuseHash.value(),
+                                   static_cast<std::size_t>(colorFormat),
+                                   static_cast<std::size_t>(depthFormat.value_or(MTL::PixelFormat::PixelFormatInvalid)),
+                                   static_cast<std::size_t>(stencilFormat.value_or(MTL::PixelFormat::PixelFormatInvalid)));
+        if (auto it = renderPipelineStateCache.find(*cacheKey); it != renderPipelineStateCache.end()) {
+            return it->second;
         }
     }
 
@@ -173,7 +184,7 @@ MTLRenderPipelineStatePtr ShaderProgram::getRenderPipelineState(const gfx::Rende
 
     if (reuseHash.has_value()) {
         // store the value for future reuse
-        renderPipelineStateCache[reuseHash.value()] = rps;
+        renderPipelineStateCache[*cacheKey] = rps;
     }
 
     return rps;

--- a/src/mln/shaders/mtl/shader_program.cpp
+++ b/src/mln/shaders/mtl/shader_program.cpp
@@ -117,10 +117,11 @@ MTLRenderPipelineStatePtr ShaderProgram::getRenderPipelineState(const gfx::Rende
     // API validation aborts on the mismatch.
     std::optional<std::size_t> cacheKey;
     if (reuseHash.has_value()) {
-        cacheKey = mln::util::hash(reuseHash.value(),
-                                   static_cast<std::size_t>(colorFormat),
-                                   static_cast<std::size_t>(depthFormat.value_or(MTL::PixelFormat::PixelFormatInvalid)),
-                                   static_cast<std::size_t>(stencilFormat.value_or(MTL::PixelFormat::PixelFormatInvalid)));
+        cacheKey = mln::util::hash(
+            reuseHash.value(),
+            static_cast<std::size_t>(colorFormat),
+            static_cast<std::size_t>(depthFormat.value_or(MTL::PixelFormat::PixelFormatInvalid)),
+            static_cast<std::size_t>(stencilFormat.value_or(MTL::PixelFormat::PixelFormatInvalid)));
         if (auto it = renderPipelineStateCache.find(*cacheKey); it != renderPipelineStateCache.end()) {
             return it->second;
         }


### PR DESCRIPTION
## What

Two Metal API validation failures with the terrain-3d branch, one with terrain off and one with it on. Xcode's Run scheme enables Metal API Validation by default, so with this branch any app hits one of them on launch (terrain off) or on the first draped frame (terrain on).

1. **Missing sampler bindings with terrain off.** The symbol, circle and fill-extrusion shaders declare the DEM and depth samplers unconditionally, but their tweakers only bind textures when a terrain is present, so validation aborts with `missing sampler binding at index N for demSampler/depthSampler`. `gfx::Context::getPlaceholderTexture2D()` now provides a 1x1 texture that the tweakers bind when `parameters.terrain` is null (the shaders never sample it, `dem_enabled` / `depth_enabled` are 0).
2. **Pipeline state reuse across attachment formats with terrain on.** `mtl::ShaderProgram::getRenderPipelineState` cached states keyed only on the colour mode and vertex layout, so a state created for the BGRA8 screen was reused for the RGBA8 drape and hillshade render targets (`Set Render Pipeline State Validation ... BGRA8Unorm vs RGBA8Unorm`, and a stencil format mismatch). The cache key now folds in the colour, depth and stencil attachment formats.

## How it was verified

- Reproduced both aborts on the iOS simulator with `SIMCTL_CHILD_MTL_DEBUG_LAYER=1 xcrun simctl launch <udid> <bundle>`; both are gone with this change, with terrain on and off.
- Running in a shipped iOS app (Metal, iPhone 16 Pro and simulator) since 2026-09-05.

## Notes

Written with AI assistance (Claude), reviewed and tested by me before opening this PR, per MapLibre's AI policy.
