### PR TITLE
raster-dem: let inline minzoom/maxzoom override the TileJSON

### DIFF
--- a/include/mln/style/sources/raster_dem_source.hpp
+++ b/include/mln/style/sources/raster_dem_source.hpp
@@ -10,6 +10,12 @@ namespace style {
 struct SourceOptions {
     std::optional<Tileset::RasterEncoding> rasterEncoding = std::nullopt;
     std::optional<Tileset::VectorEncoding> vectorEncoding = std::nullopt;
+    // Inline style overrides applied on top of a fetched TileJSON, matching maplibre-gl-js
+    // (`extend(tileJSON, options)` in load_tilejson.ts). A raster-dem source served from an
+    // archive whose TileJSON stops at its deepest stored zoom can declare a higher `maxzoom`
+    // so terrain meshes and drapes at the display zoom while the DEM overzooms.
+    std::optional<uint8_t> minzoom = std::nullopt;
+    std::optional<uint8_t> maxzoom = std::nullopt;
 };
 
 // NOTE: Any derived class must invalidate `weakFactory` in the destructor

--- a/include/mln/style/sources/raster_dem_source.hpp
+++ b/include/mln/style/sources/raster_dem_source.hpp
@@ -10,10 +10,11 @@ namespace style {
 struct SourceOptions {
     std::optional<Tileset::RasterEncoding> rasterEncoding = std::nullopt;
     std::optional<Tileset::VectorEncoding> vectorEncoding = std::nullopt;
-    // Inline style overrides applied on top of a fetched TileJSON, matching maplibre-gl-js
-    // (`extend(tileJSON, options)` in load_tilejson.ts). A raster-dem source served from an
-    // archive whose TileJSON stops at its deepest stored zoom can declare a higher `maxzoom`
-    // so terrain meshes and drapes at the display zoom while the DEM overzooms.
+    // Inline style overrides applied on top of a fetched TileJSON, matching maplibre-gl-js:
+    // https://github.com/maplibre/maplibre-gl-js/blob/32e555b2c114d6b60da4acd824d272182c656bbe/src/source/load_tilejson.ts#L39
+    // A raster-dem source served from an archive whose TileJSON stops at its deepest stored zoom
+    // can declare a higher `maxzoom` so terrain meshes and drapes at the display zoom while the
+    // DEM overzooms.
     std::optional<uint8_t> minzoom = std::nullopt;
     std::optional<uint8_t> maxzoom = std::nullopt;
 };

--- a/src/mln/style/conversion/source_options.cpp
+++ b/src/mln/style/conversion/source_options.cpp
@@ -1,4 +1,7 @@
 #include <mln/style/conversion/source_options.hpp>
+
+#include <limits>
+#include <string>
 #include <mln/style/conversion_impl.hpp>
 #include <mln/style/expression/dsl.hpp>
 
@@ -6,26 +9,63 @@ namespace mln {
 namespace style {
 namespace conversion {
 
+namespace {
+
+std::optional<uint8_t> zoomMember(const Convertible& value, const char* name, Error& error, bool& invalid) {
+    const auto member = objectMember(value, name);
+    if (!member) {
+        return std::nullopt;
+    }
+    const auto number = toNumber(*member);
+    if (!number || *number < 0 || *number > std::numeric_limits<uint8_t>::max()) {
+        error.message = std::string("invalid ") + name;
+        invalid = true;
+        return std::nullopt;
+    }
+    return static_cast<uint8_t>(*number);
+}
+
+} // namespace
+
 std::optional<SourceOptions> Converter<SourceOptions>::operator()(const Convertible& value, Error& error) const {
+    SourceOptions options;
+    bool any = false;
+
     const auto encodingValue = objectMember(value, "encoding");
     if (encodingValue) {
         const auto encoding = toString(*encodingValue);
         if (encoding && *encoding == "terrarium") {
-            return {{.rasterEncoding = Tileset::RasterEncoding::Terrarium}};
+            options.rasterEncoding = Tileset::RasterEncoding::Terrarium;
         } else if (encoding && *encoding == "mapbox") {
-            return {{.rasterEncoding = Tileset::RasterEncoding::Mapbox}};
+            options.rasterEncoding = Tileset::RasterEncoding::Mapbox;
         } else if (encoding && *encoding == "mvt") {
-            return {{.vectorEncoding = Tileset::VectorEncoding::Mapbox}};
+            options.vectorEncoding = Tileset::VectorEncoding::Mapbox;
         } else if (encoding && *encoding == "mlt") {
-            return {{.vectorEncoding = Tileset::VectorEncoding::MLT}};
+            options.vectorEncoding = Tileset::VectorEncoding::MLT;
         } else {
             error.message =
                 "invalid encoding - valid types are 'mapbox' and 'terrarium' for raster sources, 'mvt' and 'mlt' for "
                 "vector sources";
             return std::nullopt;
         }
+        any = true;
     }
-    return {};
+
+    bool invalid = false;
+    options.minzoom = zoomMember(value, "minzoom", error, invalid);
+    if (invalid) {
+        return std::nullopt;
+    }
+    options.maxzoom = zoomMember(value, "maxzoom", error, invalid);
+    if (invalid) {
+        return std::nullopt;
+    }
+    any = any || options.minzoom || options.maxzoom;
+
+    if (!any) {
+        return {};
+    }
+    return options;
 }
 
 } // namespace conversion

--- a/src/mln/style/sources/raster_dem_source.cpp
+++ b/src/mln/style/sources/raster_dem_source.cpp
@@ -33,6 +33,13 @@ void RasterDEMSource::setTilesetOverrides(Tileset& tileset) {
         if (const auto encoding = options->rasterEncoding) {
             tileset.rasterEncoding = encoding;
         }
+        // Inline zoom range wins over the TileJSON's, as in maplibre-gl-js.
+        if (const auto minzoom = options->minzoom) {
+            tileset.zoomRange.min = *minzoom;
+        }
+        if (const auto maxzoom = options->maxzoom) {
+            tileset.zoomRange.max = *maxzoom;
+        }
     }
 }
 

--- a/test/style/conversion/source_options.test.cpp
+++ b/test/style/conversion/source_options.test.cpp
@@ -70,3 +70,51 @@ TEST(SourceOptions, MLTEncodingParsed) {
     ASSERT_EQ(converted.value().vectorEncoding, Tileset::VectorEncoding::MLT);
     ASSERT_FALSE(converted.value().rasterEncoding);
 }
+
+TEST(SourceOptions, ZoomRangeParsed) {
+    Error error;
+    auto converted = convertJSON<SourceOptions>(
+        R"JSON({
+        "minzoom": 5,
+        "maxzoom": 14
+    })JSON",
+        error);
+    ASSERT_TRUE(converted);
+    ASSERT_EQ(converted->minzoom, 5);
+    ASSERT_EQ(converted->maxzoom, 14);
+    ASSERT_FALSE(converted->rasterEncoding);
+    ASSERT_FALSE(converted->vectorEncoding);
+}
+
+TEST(SourceOptions, ZoomRangeAlongsideEncoding) {
+    Error error;
+    auto converted = convertJSON<SourceOptions>(
+        R"JSON({
+        "encoding": "terrarium",
+        "maxzoom": 15
+    })JSON",
+        error);
+    ASSERT_TRUE(converted);
+    ASSERT_EQ(converted->rasterEncoding, Tileset::RasterEncoding::Terrarium);
+    ASSERT_FALSE(converted->minzoom);
+    ASSERT_EQ(converted->maxzoom, 15);
+}
+
+TEST(SourceOptions, InvalidMaxzoomType) {
+    Error error;
+    auto converted = convertJSON<SourceOptions>(
+        R"JSON({
+        "maxzoom": "high"
+    })JSON",
+        error);
+    ASSERT_FALSE(converted);
+    ASSERT_EQ(0, error.message.find("invalid maxzoom"));
+}
+
+TEST(SourceOptions, ZoomOutOfRange) {
+    Error error;
+    ASSERT_FALSE(convertJSON<SourceOptions>(R"JSON({ "minzoom": -1 })JSON", error));
+    ASSERT_EQ(0, error.message.find("invalid minzoom"));
+    ASSERT_FALSE(convertJSON<SourceOptions>(R"JSON({ "maxzoom": 300 })JSON", error));
+    ASSERT_EQ(0, error.message.find("invalid maxzoom"));
+}

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -13,6 +13,7 @@
 #include <mln/style/layers/raster_layer.hpp>
 #include <mln/style/layers/raster_layer_impl.hpp>
 #include <mln/style/source_impl.hpp>
+#include <mln/style/sources/tile_source_impl.hpp>
 #include <mln/style/sources/custom_geometry_source.hpp>
 #include <mln/style/sources/geojson_source.hpp>
 #include <mln/style/sources/image_source.hpp>
@@ -661,6 +662,61 @@ TEST(Source, RasterDEMTileAttribution) {
 
     auto renderSource = RenderSource::create(source.baseImpl, test.threadPool);
     renderSource->update(source.baseImpl, layers, true, true, test.tileParameters());
+
+    test.run();
+}
+
+TEST(Source, RasterDEMInlineZoomOverridesTileJSON) {
+    SourceTest test;
+
+    test.fileSource->sourceResponse = [&](const Resource& resource) {
+        EXPECT_EQ("url", resource.url);
+        Response response;
+        response.data = std::make_unique<std::string>(
+            R"TILEJSON({ "tilejson": "2.1.0", "tiles": [ "tiles" ], "minzoom": 4, "maxzoom": 12 })TILEJSON");
+        return response;
+    };
+
+    test.styleObserver.sourceLoaded = [&](Source& source) {
+        const auto& tileset = static_cast<const TileSource::Impl&>(*source.baseImpl).tileset;
+        ASSERT_TRUE(tileset);
+        // The inline maxzoom wins over the TileJSON's; minzoom was not given inline, so the
+        // TileJSON value is kept.
+        EXPECT_EQ(4, tileset->zoomRange.min);
+        EXPECT_EQ(15, tileset->zoomRange.max);
+        EXPECT_EQ(Tileset::RasterEncoding::Terrarium, tileset->rasterEncoding);
+        test.end();
+    };
+
+    RasterDEMSource source(
+        "source", "url", 512, SourceOptions{.rasterEncoding = Tileset::RasterEncoding::Terrarium, .maxzoom = 15});
+    source.setObserver(&test.styleObserver);
+    source.loadDescription(*test.fileSource);
+
+    test.run();
+}
+
+TEST(Source, RasterDEMTileJSONZoomKeptWithoutInlineOverride) {
+    SourceTest test;
+
+    test.fileSource->sourceResponse = [&](const Resource&) {
+        Response response;
+        response.data = std::make_unique<std::string>(
+            R"TILEJSON({ "tilejson": "2.1.0", "tiles": [ "tiles" ], "minzoom": 4, "maxzoom": 12 })TILEJSON");
+        return response;
+    };
+
+    test.styleObserver.sourceLoaded = [&](Source& source) {
+        const auto& tileset = static_cast<const TileSource::Impl&>(*source.baseImpl).tileset;
+        ASSERT_TRUE(tileset);
+        EXPECT_EQ(4, tileset->zoomRange.min);
+        EXPECT_EQ(12, tileset->zoomRange.max);
+        test.end();
+    };
+
+    RasterDEMSource source("source", "url", 512);
+    source.setObserver(&test.styleObserver);
+    source.loadDescription(*test.fileSource);
 
     test.run();
 }


### PR DESCRIPTION
## What

A `raster-dem` source's inline `minzoom` / `maxzoom` are ignored on native when the source also has a TileJSON (`url`, or a PMTiles archive header): the TileJSON's zoom range replaces them. maplibre-gl-js lets the inline values win. The practical effect on this branch: a Terrarium PMTiles archive with a z12 header pins the terrain mesh and the drape cover at z12, so every road and building goes soft as soon as the map is tilted at z14+, even though the style asked for `maxzoom: 16` (overzoom).

`RasterDEMSource` now records inline `minzoom` / `maxzoom` from the style (`SourceOptions`) and reapplies them over the loaded tileset's zoom range, matching gl-js precedence.

## How it was verified

- Simulator A/B at z14.3, pitched: with the style's inline `maxzoom: 16` honoured, the drape is rendered from z14 tiles and roads stay crisp; before, identical output for `maxzoom` 14 and 16 (both ignored, cover stuck at the archive's z12).
- Shipped in an iOS app since 2026-09-05.

## Notes

Written with AI assistance (Claude), reviewed and tested by me before opening this PR, per MapLibre's AI policy.
