### PR TITLE
terrain: project annotations, labels and the collision index onto the draped surface; terrain pick (iOS + Android)

### DIFF
--- a/include/mln/map/map.hpp
+++ b/include/mln/map/map.hpp
@@ -122,6 +122,10 @@ public:
     /// so annotations and markers land on the draped surface rather than at sea level.
     ScreenCoordinate pixelForLatLng(const LatLng&, double elevationMeters) const;
     LatLng latLngForPixel(const ScreenCoordinate&) const;
+    /// Geographic position of the point where the screen pixel's view ray crosses the plane
+    /// `elevationMeters` above sea level (exaggerated terrain units, as pixelForLatLng). A
+    /// terrain-aware pick marches this along the ray - see MLNMapView convertPoint:toLatLngFromView:.
+    LatLng latLngForPixel(const ScreenCoordinate&, double elevationMeters) const;
     std::vector<ScreenCoordinate> pixelsForLatLngs(const std::vector<LatLng>&) const;
     std::vector<LatLng> latLngsForPixels(const std::vector<ScreenCoordinate>&) const;
 

--- a/include/mln/map/map.hpp
+++ b/include/mln/map/map.hpp
@@ -117,6 +117,10 @@ public:
 
     // Projection
     ScreenCoordinate pixelForLatLng(const LatLng&) const;
+    /// Screen position of a point `elevationMeters` above sea level. With 3D terrain, pass the
+    /// (exaggerated) terrain height at that location - see `Renderer::queryTerrainElevation` -
+    /// so annotations and markers land on the draped surface rather than at sea level.
+    ScreenCoordinate pixelForLatLng(const LatLng&, double elevationMeters) const;
     LatLng latLngForPixel(const ScreenCoordinate&) const;
     std::vector<ScreenCoordinate> pixelsForLatLngs(const std::vector<LatLng>&) const;
     std::vector<LatLng> latLngsForPixels(const std::vector<ScreenCoordinate>&) const;

--- a/include/mln/renderer/renderer.hpp
+++ b/include/mln/renderer/renderer.hpp
@@ -65,6 +65,10 @@ public:
     /// loaded, or nullopt without terrain. Feed it to `Map::pixelForLatLng(latLng, elevation)`
     /// to place markers on the draped surface. Must be called on the render thread.
     std::optional<double> queryTerrainElevation(const LatLng&) const;
+    /// Coordinate of the draped 3D-terrain surface under a screen pixel (view pixels, y-down),
+    /// or nullopt without terrain: the inverse of `pixelForLatLng(latLng, elevation)`, for taps
+    /// and picks. Must be called on the render thread.
+    std::optional<LatLng> queryTerrainPick(const ScreenCoordinate&) const;
     AnnotationIDs queryPointAnnotations(const ScreenBox& box) const;
     AnnotationIDs queryShapeAnnotations(const ScreenBox& box) const;
     AnnotationIDs getAnnotationIDs(const std::vector<Feature>&) const;

--- a/include/mln/renderer/renderer.hpp
+++ b/include/mln/renderer/renderer.hpp
@@ -7,6 +7,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -59,6 +60,11 @@ public:
                                                const RenderedQueryOptions& options = {}) const;
     std::vector<Feature> queryRenderedFeatures(const ScreenBox& box, const RenderedQueryOptions& options = {}) const;
     std::vector<Feature> querySourceFeatures(const std::string& sourceID, const SourceQueryOptions& options = {}) const;
+
+    /// Exaggerated 3D-terrain height (metres) at a coordinate, from the DEM tiles currently
+    /// loaded, or nullopt without terrain. Feed it to `Map::pixelForLatLng(latLng, elevation)`
+    /// to place markers on the draped surface. Must be called on the render thread.
+    std::optional<double> queryTerrainElevation(const LatLng&) const;
     AnnotationIDs queryPointAnnotations(const ScreenBox& box) const;
     AnnotationIDs queryShapeAnnotations(const ScreenBox& box) const;
     AnnotationIDs getAnnotationIDs(const std::vector<Feature>&) const;

--- a/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.cpp
@@ -1,5 +1,6 @@
 #include "android_renderer_frontend.hpp"
 
+#include <mln/renderer/update_parameters.hpp>
 #include <mln/tile/tile_operation.hpp>
 #include <mln/actor/scheduler.hpp>
 #include <mln/renderer/renderer.hpp>
@@ -148,6 +149,7 @@ void AndroidRendererFrontend::setObserver(RendererObserver& observer) {
 
 void AndroidRendererFrontend::update(std::shared_ptr<UpdateParameters> params) {
     MLN_TRACE_FUNC();
+    styleTerrain = params && params->terrain.has_value();
     updateParams = std::move(params);
     updateAsyncTask->send();
 }
@@ -224,6 +226,24 @@ AnnotationIDs AndroidRendererFrontend::queryPointAnnotations(const ScreenBox& bo
         return {};
     }
 
+    return future.get();
+}
+
+std::optional<double> AndroidRendererFrontend::queryTerrainElevation(const mln::LatLng& latLng,
+                                                                     const std::chrono::milliseconds& timeout) const {
+    auto future = mapRenderer.actor().ask(&Renderer::queryTerrainElevation, latLng);
+    if (future.wait_for(timeout) != std::future_status::ready) {
+        return std::nullopt;
+    }
+    return future.get();
+}
+
+std::optional<mln::LatLng> AndroidRendererFrontend::queryTerrainPick(const ScreenCoordinate& pixel,
+                                                                     const std::chrono::milliseconds& timeout) const {
+    auto future = mapRenderer.actor().ask(&Renderer::queryTerrainPick, pixel);
+    if (future.wait_for(timeout) != std::future_status::ready) {
+        return std::nullopt;
+    }
     return future.get();
 }
 

--- a/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/android_renderer_frontend.hpp
@@ -66,6 +66,14 @@ public:
     AnnotationIDs queryPointAnnotations(const ScreenBox& box, const std::chrono::milliseconds& timeout) const;
     AnnotationIDs queryShapeAnnotations(const ScreenBox& box, const std::chrono::milliseconds& timeout) const;
 
+    // 3D terrain (bounded render-thread round trips; nullopt without terrain or on timeout)
+    std::optional<double> queryTerrainElevation(const mln::LatLng&, const std::chrono::milliseconds& timeout) const;
+    std::optional<mln::LatLng> queryTerrainPick(const ScreenCoordinate&,
+                                                const std::chrono::milliseconds& timeout) const;
+    /// Whether the last update carried a style `terrain` (map thread only): lets projection
+    /// calls skip the render-thread round trip on a flat map.
+    bool hasStyleTerrain() const { return styleTerrain; }
+
     // Feature extension query
     FeatureExtensionValue queryFeatureExtensions(const std::string& sourceID,
                                                  const Feature& feature,
@@ -83,6 +91,7 @@ private:
     util::RunLoop* mapRunLoop;
     std::unique_ptr<util::AsyncTask> updateAsyncTask;
     std::shared_ptr<UpdateParameters> updateParams;
+    bool styleTerrain = false;
 };
 
 } // namespace android

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.cpp
@@ -768,7 +768,17 @@ jni::Local<jni::Object<LatLng>> NativeMapView::latLngForProjectedMeters(JNIEnv& 
 }
 
 jni::Local<jni::Object<PointF>> NativeMapView::pixelForLatLng(JNIEnv& env, jdouble latitude, jdouble longitude) {
-    mln::ScreenCoordinate pixel = map->pixelForLatLng(mln::LatLng(latitude, longitude));
+    const mln::LatLng latLng(latitude, longitude);
+    // With 3D terrain, project onto the draped surface so markers and view overlays sit on the
+    // ground they mark rather than at sea level. The elevation lives on the render thread: a
+    // bounded round trip, skipped entirely when the style has no terrain. The batch
+    // pixelsForLatLngs stays at sea level.
+    std::optional<double> elevation;
+    if (rendererFrontend->hasStyleTerrain()) {
+        elevation = rendererFrontend->queryTerrainElevation(latLng, terrainQueryTimeout);
+    }
+    const mln::ScreenCoordinate pixel = elevation ? map->pixelForLatLng(latLng, *elevation)
+                                                  : map->pixelForLatLng(latLng);
     return PointF::New(env, static_cast<float>(pixel.x), static_cast<float>(pixel.y));
 }
 
@@ -799,7 +809,16 @@ void NativeMapView::pixelsForLatLngs(JNIEnv& env,
 }
 
 jni::Local<jni::Object<LatLng>> NativeMapView::latLngForPixel(JNIEnv& env, jfloat x, jfloat y) {
-    return LatLng::New(env, map->latLngForPixel(mln::ScreenCoordinate(x, y)));
+    const mln::ScreenCoordinate pixel(x, y);
+    // With 3D terrain, the pixel's view ray meets the draped surface before sea level; pick
+    // the surface (Renderer::queryTerrainPick) so taps land under the finger. The batch
+    // latLngsForPixels stays at sea level.
+    if (rendererFrontend->hasStyleTerrain()) {
+        if (const auto surface = rendererFrontend->queryTerrainPick(pixel, terrainQueryTimeout)) {
+            return LatLng::New(env, *surface);
+        }
+    }
+    return LatLng::New(env, map->latLngForPixel(pixel));
 }
 
 void NativeMapView::latLngsForPixels(JNIEnv& env,

--- a/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/native_map_view.hpp
@@ -402,6 +402,8 @@ private:
     int height = 64;
 
     static constexpr auto annotationRequestTimeout = std::chrono::milliseconds(200);
+    // Terrain-aware projection round trips (pixelForLatLng / latLngForPixel on 3D terrain)
+    static constexpr auto terrainQueryTimeout = std::chrono::milliseconds(200);
 
     // Ensure these are initialised last
     std::unique_ptr<mln::Map> map;

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -4583,7 +4583,17 @@ static void *windowScreenContext = &windowScreenContext;
 
 /// Converts a geographic coordinate to a point in the view’s coordinate system.
 - (CGPoint)convertLatLng:(mln::LatLng)latLng toPointToView:(nullable UIView *)view {
-  mln::ScreenCoordinate pixel = self.mbglMap.pixelForLatLng(latLng);
+  // With 3D terrain, project onto the draped surface so annotation views, the user location
+  // view and callouts sit on the ground they mark instead of at sea level. The renderer runs on
+  // the main thread on iOS, so the terrain query is safe here.
+  std::optional<double> elevation;
+  if (_rendererFrontend) {
+    if (mln::Renderer *renderer = _rendererFrontend->getRenderer()) {
+      elevation = renderer->queryTerrainElevation(latLng);
+    }
+  }
+  mln::ScreenCoordinate pixel = elevation ? self.mbglMap.pixelForLatLng(latLng, *elevation)
+                                          : self.mbglMap.pixelForLatLng(latLng);
   return [self convertPoint:CGPointMake(pixel.x, pixel.y) toView:view];
 }
 

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -4569,8 +4569,19 @@ static void *windowScreenContext = &windowScreenContext;
 /// Converts a point in the view’s coordinate system to a geographic coordinate.
 - (mln::LatLng)convertPoint:(CGPoint)point toLatLngFromView:(nullable UIView *)view {
   CGPoint convertedPoint = [self convertPoint:point fromView:view];
-  return self.mbglMap.latLngForPixel(mln::ScreenCoordinate(convertedPoint.x, convertedPoint.y))
-      .wrapped();
+  const mln::ScreenCoordinate pixel(convertedPoint.x, convertedPoint.y);
+  // With 3D terrain, the pixel's view ray meets the draped surface before sea level, so the
+  // sea-level unprojection would land well past the spot under the finger. Inverse of
+  // convertLatLng:toPointToView:. The renderer runs on the main thread on iOS, so the terrain
+  // pick is safe here; it returns nullopt without terrain.
+  if (_rendererFrontend) {
+    if (mln::Renderer *renderer = _rendererFrontend->getRenderer()) {
+      if (const auto surface = renderer->queryTerrainPick(pixel)) {
+        return surface->wrapped();
+      }
+    }
+  }
+  return self.mbglMap.latLngForPixel(pixel).wrapped();
 }
 
 - (CGPoint)convertCoordinate:(CLLocationCoordinate2D)coordinate

--- a/src/mln/layout/symbol_projection.cpp
+++ b/src/mln/layout/symbol_projection.cpp
@@ -152,8 +152,8 @@ mat4 getGlCoordMatrix(const mat4& posMatrix,
     return m;
 }
 
-PointAndCameraDistance project(const Point<float>& point, const mat4& matrix) {
-    vec4 pos = {{point.x, point.y, 0, 1}};
+PointAndCameraDistance project(const Point<float>& point, const mat4& matrix, const SymbolElevationFn* getElevation) {
+    vec4 pos = {{point.x, point.y, getElevation ? (*getElevation)(point) : 0.0f, 1}};
     matrix::transformMat4(pos, pos, matrix);
     return {{static_cast<float>(pos[0] / pos[3]), static_cast<float>(pos[1] / pos[3])}, static_cast<float>(pos[3])};
 }
@@ -216,14 +216,16 @@ Point<float> projectTruncatedLineSegment(const Point<float>& previousTilePoint,
                                          const Point<float>& currentTilePoint,
                                          const Point<float>& previousProjectedPoint,
                                          const float minimumLength,
-                                         const mat4& projectionMatrix) {
+                                         const mat4& projectionMatrix,
+                                         const SymbolElevationFn* getElevation) {
     // We are assuming "previousTilePoint" won't project to a point within one
     // unit of the camera plane If it did, that would mean our label extended
     // all the way out from within the viewport to a (very distant) point near
     // the plane of the camera. We wouldn't be able to render the label anyway
     // once it crossed the plane of the camera.
     const Point<float> projectedUnitVertex =
-        project(previousTilePoint + util::unit<float>(previousTilePoint - currentTilePoint), projectionMatrix).first;
+        project(previousTilePoint + util::unit<float>(previousTilePoint - currentTilePoint), projectionMatrix, getElevation)
+            .first;
     const Point<float> projectedUnitSegment = previousProjectedPoint - projectedUnitVertex;
 
     return previousProjectedPoint + (projectedUnitSegment * (minimumLength / util::mag<float>(projectedUnitSegment)));
@@ -239,7 +241,8 @@ std::optional<PlacedGlyph> placeGlyphAlongLine(const float offsetX,
                                                const GeometryCoordinates& line,
                                                const std::vector<float>& tileDistances,
                                                const mat4& labelPlaneMatrix,
-                                               const bool returnTileDistance) {
+                                               const bool returnTileDistance,
+                                               const SymbolElevationFn* getElevation) {
     const float combinedOffsetX = flip ? offsetX - lineOffsetX : offsetX + lineOffsetX;
 
     int16_t dir = combinedOffsetX > 0 ? 1 : -1;
@@ -272,7 +275,8 @@ std::optional<PlacedGlyph> placeGlyphAlongLine(const float offsetX,
         }
 
         prev = current;
-        PointAndCameraDistance projection = project(convertPoint<float>(line.at(currentIndex)), labelPlaneMatrix);
+        PointAndCameraDistance projection = project(
+            convertPoint<float>(line.at(currentIndex)), labelPlaneMatrix, getElevation);
         if (projection.second > 0) {
             current = projection.first;
         } else {
@@ -282,8 +286,12 @@ std::optional<PlacedGlyph> placeGlyphAlongLine(const float offsetX,
                                                        ? tileAnchorPoint
                                                        : convertPoint<float>(line.at(currentIndex - dir));
             const Point<float> currentTilePoint = convertPoint<float>(line.at(currentIndex));
-            current = projectTruncatedLineSegment(
-                previousTilePoint, currentTilePoint, prev, absOffsetX - distanceToPrev + 1, labelPlaneMatrix);
+            current = projectTruncatedLineSegment(previousTilePoint,
+                                                  currentTilePoint,
+                                                  prev,
+                                                  absOffsetX - distanceToPrev + 1,
+                                                  labelPlaneMatrix,
+                                                  getElevation);
         }
 
         distanceToPrev += currentSegmentDistance;
@@ -316,7 +324,8 @@ std::optional<std::pair<PlacedGlyph, PlacedGlyph>> placeFirstAndLastGlyph(const 
                                                                           const Point<float>& tileAnchorPoint,
                                                                           const PlacedSymbol& symbol,
                                                                           const mat4& labelPlaneMatrix,
-                                                                          const bool returnTileDistance) {
+                                                                          const bool returnTileDistance,
+                                                                          const SymbolElevationFn* getElevation) {
     if (symbol.glyphOffsets.empty()) {
         assert(false);
         return {};
@@ -335,7 +344,8 @@ std::optional<std::pair<PlacedGlyph, PlacedGlyph>> placeFirstAndLastGlyph(const 
                                                                       symbol.line,
                                                                       symbol.tileDistances,
                                                                       labelPlaneMatrix,
-                                                                      returnTileDistance);
+                                                                      returnTileDistance,
+                                                                      getElevation);
     if (!firstPlacedGlyph) return {};
 
     std::optional<PlacedGlyph> lastPlacedGlyph = placeGlyphAlongLine(fontScale * lastGlyphOffset,
@@ -348,7 +358,8 @@ std::optional<std::pair<PlacedGlyph, PlacedGlyph>> placeFirstAndLastGlyph(const 
                                                                      symbol.line,
                                                                      symbol.tileDistances,
                                                                      labelPlaneMatrix,
-                                                                     returnTileDistance);
+                                                                     returnTileDistance,
+                                                                     getElevation);
     if (!lastPlacedGlyph) return {};
 
     return std::make_pair(*firstPlacedGlyph, *lastPlacedGlyph);
@@ -387,7 +398,8 @@ PlacementResult placeGlyphsAlongLine(const PlacedSymbol& symbol,
                                      const mat4& glCoordMatrix,
                                      SymbolBucket::DynamicAttributeVector& dynamicVertexArray,
                                      const Point<float>& projectedAnchorPoint,
-                                     const float aspectRatio) {
+                                     const float aspectRatio,
+                                     const SymbolElevationFn* getElevation) {
     const float fontScale = fontSize / util::ONE_EM;
     const float lineOffsetX = symbol.lineOffset[0] * fontScale;
     const float lineOffsetY = symbol.lineOffset[1] * fontScale;
@@ -403,13 +415,14 @@ PlacementResult placeGlyphsAlongLine(const PlacedSymbol& symbol,
             symbol.anchorPoint,
             symbol,
             labelPlaneMatrix,
-            false);
+            false,
+            getElevation);
         if (!firstAndLastGlyph) {
             return PlacementResult::NotEnoughRoom;
         }
 
-        const Point<float> firstPoint = project(firstAndLastGlyph->first.point, glCoordMatrix).first;
-        const Point<float> lastPoint = project(firstAndLastGlyph->second.point, glCoordMatrix).first;
+        const Point<float> firstPoint = project(firstAndLastGlyph->first.point, glCoordMatrix, getElevation).first;
+        const Point<float> lastPoint = project(firstAndLastGlyph->second.point, glCoordMatrix, getElevation).first;
 
         if (keepUpright && !flip) {
             auto orientationChange = requiresOrientationChange(symbol.writingModes, firstPoint, lastPoint, aspectRatio);
@@ -434,7 +447,8 @@ PlacementResult placeGlyphsAlongLine(const PlacedSymbol& symbol,
                                                    symbol.line,
                                                    symbol.tileDistances,
                                                    labelPlaneMatrix,
-                                                   false);
+                                                   false,
+                                                   getElevation);
             if (placedGlyph) {
                 placedGlyphs.push_back(*placedGlyph);
             } else {
@@ -446,9 +460,9 @@ PlacementResult placeGlyphsAlongLine(const PlacedSymbol& symbol,
         // Only a single glyph to place
         // So, determine whether to flip based on projected angle of the line segment it's on
         if (keepUpright && !flip) {
-            const Point<float> a = project(symbol.anchorPoint, posMatrix).first;
+            const Point<float> a = project(symbol.anchorPoint, posMatrix, getElevation).first;
             const Point<float> tileSegmentEnd = convertPoint<float>(symbol.line.at(symbol.segment + 1));
-            const PointAndCameraDistance projectedVertex = project(tileSegmentEnd, posMatrix);
+            const PointAndCameraDistance projectedVertex = project(tileSegmentEnd, posMatrix, getElevation);
             // We know the anchor will be in the viewport, but the end of the
             // line segment may be behind the plane of the camera, in which case
             // we can use a point at any arbitrary (closer) point on the
@@ -456,7 +470,7 @@ PlacementResult placeGlyphsAlongLine(const PlacedSymbol& symbol,
             const Point<float> b = (projectedVertex.second > 0)
                                        ? projectedVertex.first
                                        : projectTruncatedLineSegment(
-                                             symbol.anchorPoint, tileSegmentEnd, a, 1, posMatrix);
+                                             symbol.anchorPoint, tileSegmentEnd, a, 1, posMatrix, getElevation);
 
             auto orientationChange = requiresOrientationChange(symbol.writingModes, a, b, aspectRatio);
             if (orientationChange) {
@@ -474,7 +488,8 @@ PlacementResult placeGlyphsAlongLine(const PlacedSymbol& symbol,
                                                                      symbol.line,
                                                                      symbol.tileDistances,
                                                                      labelPlaneMatrix,
-                                                                     false);
+                                                                     false,
+                                                                     getElevation);
         if (!singleGlyph) return PlacementResult::NotEnoughRoom;
 
         placedGlyphs.push_back(*singleGlyph);
@@ -501,7 +516,8 @@ void reprojectLineLabels(SymbolBucket::DynamicAttributeVector& dynamicVertexArra
                          bool keepUpright,
                          const RenderTile& tile,
                          const SymbolSizeBinder& sizeBinder,
-                         const TransformState& state) {
+                         const TransformState& state,
+                         const SymbolElevationFn* getElevation) {
     const ZoomEvaluatedSize partiallyEvaluatedSize = sizeBinder.evaluateForZoom(static_cast<float>(state.getZoom()));
 
     const std::array<double, 2> clippingBuffer = {
@@ -530,7 +546,10 @@ void reprojectLineLabels(SymbolBucket::DynamicAttributeVector& dynamicVertexArra
         // immediately after its horizontal counterpart
         useVertical = false;
 
-        vec4 anchorPos = {{placedSymbol.anchorPoint.x, placedSymbol.anchorPoint.y, 0, 1}};
+        vec4 anchorPos = {{placedSymbol.anchorPoint.x,
+                           placedSymbol.anchorPoint.y,
+                           getElevation ? (*getElevation)(placedSymbol.anchorPoint) : 0.0f,
+                           1}};
         matrix::transformMat4(anchorPos, anchorPos, posMatrix);
 
         // Don't bother calculating the correct point for invisible labels.
@@ -545,7 +564,7 @@ void reprojectLineLabels(SymbolBucket::DynamicAttributeVector& dynamicVertexArra
         const float fontSize = evaluateSizeForFeature(partiallyEvaluatedSize, placedSymbol);
         const float pitchScaledFontSize = pitchWithMap ? fontSize * perspectiveRatio : fontSize / perspectiveRatio;
 
-        const Point<float> anchorPoint = project(placedSymbol.anchorPoint, labelPlaneMatrix).first;
+        const Point<float> anchorPoint = project(placedSymbol.anchorPoint, labelPlaneMatrix, getElevation).first;
 
         PlacementResult placeUnflipped = placeGlyphsAlongLine(placedSymbol,
                                                               pitchScaledFontSize,
@@ -556,7 +575,8 @@ void reprojectLineLabels(SymbolBucket::DynamicAttributeVector& dynamicVertexArra
                                                               glCoordMatrix,
                                                               dynamicVertexArray,
                                                               anchorPoint,
-                                                              state.getSize().aspectRatio());
+                                                              state.getSize().aspectRatio(),
+                                                              getElevation);
 
         useVertical = placeUnflipped == PlacementResult::UseVertical;
 
@@ -571,7 +591,8 @@ void reprojectLineLabels(SymbolBucket::DynamicAttributeVector& dynamicVertexArra
                                   glCoordMatrix,
                                   dynamicVertexArray,
                                   anchorPoint,
-                                  state.getSize().aspectRatio()) == PlacementResult::NotEnoughRoom)) {
+                                  state.getSize().aspectRatio(),
+                                  getElevation) == PlacementResult::NotEnoughRoom)) {
             hideGlyphs(placedSymbol.glyphOffsets.size(), dynamicVertexArray);
         }
     }

--- a/src/mln/layout/symbol_projection.cpp
+++ b/src/mln/layout/symbol_projection.cpp
@@ -223,9 +223,11 @@ Point<float> projectTruncatedLineSegment(const Point<float>& previousTilePoint,
     // all the way out from within the viewport to a (very distant) point near
     // the plane of the camera. We wouldn't be able to render the label anyway
     // once it crossed the plane of the camera.
-    const Point<float> projectedUnitVertex =
-        project(previousTilePoint + util::unit<float>(previousTilePoint - currentTilePoint), projectionMatrix, getElevation)
-            .first;
+    const Point<float> projectedUnitVertex = project(previousTilePoint +
+                                                         util::unit<float>(previousTilePoint - currentTilePoint),
+                                                     projectionMatrix,
+                                                     getElevation)
+                                                 .first;
     const Point<float> projectedUnitSegment = previousProjectedPoint - projectedUnitVertex;
 
     return previousProjectedPoint + (projectedUnitSegment * (minimumLength / util::mag<float>(projectedUnitSegment)));

--- a/src/mln/layout/symbol_projection.hpp
+++ b/src/mln/layout/symbol_projection.hpp
@@ -67,16 +67,17 @@ void reprojectLineLabels(SymbolBucket::DynamicAttributeVector&,
                          const TransformState&,
                          const SymbolElevationFn* getElevation = nullptr);
 
-std::optional<std::pair<PlacedGlyph, PlacedGlyph>> placeFirstAndLastGlyph(float fontScale,
-                                                                          float lineOffsetX,
-                                                                          float lineOffsetY,
-                                                                          bool flip,
-                                                                          const Point<float>& anchorPoint,
-                                                                          const Point<float>& tileAnchorPoint,
-                                                                          const PlacedSymbol& symbol,
-                                                                          const mat4& labelPlaneMatrix,
-                                                                          bool returnTileDistance,
-                                                                          const SymbolElevationFn* getElevation = nullptr);
+std::optional<std::pair<PlacedGlyph, PlacedGlyph>> placeFirstAndLastGlyph(
+    float fontScale,
+    float lineOffsetX,
+    float lineOffsetY,
+    bool flip,
+    const Point<float>& anchorPoint,
+    const Point<float>& tileAnchorPoint,
+    const PlacedSymbol& symbol,
+    const mat4& labelPlaneMatrix,
+    bool returnTileDistance,
+    const SymbolElevationFn* getElevation = nullptr);
 
 void hideGlyphs(std::size_t numGlyphs, SymbolBucket::DynamicAttributeVector& dynamicVertexArray);
 void addDynamicAttributes(const Point<float>& anchorPoint,

--- a/src/mln/layout/symbol_projection.hpp
+++ b/src/mln/layout/symbol_projection.hpp
@@ -4,6 +4,8 @@
 #include <mln/gfx/vertex_buffer.hpp>
 #include <mln/renderer/buckets/symbol_bucket.hpp>
 
+#include <functional>
+
 namespace mln {
 
 class TransformState;
@@ -46,7 +48,13 @@ mat4 getGlCoordMatrix(
     const mat4& posMatrix, bool pitchWithMap, bool rotateWithMap, const TransformState& state, float pixelsToTileUnits);
 
 using PointAndCameraDistance = std::pair<Point<float>, float>;
-PointAndCameraDistance project(const Point<float>& point, const mat4& matrix);
+/// Tile-local point (0..EXTENT) -> terrain elevation in metres (exaggeration applied). With 3D
+/// terrain, line-placed labels are projected on the CPU, so their glyph anchors must be lifted
+/// here the way maplibre-gl-js's `getElevation` callback does; nullptr = flat.
+using SymbolElevationFn = std::function<float(const Point<float>&)>;
+PointAndCameraDistance project(const Point<float>& point,
+                               const mat4& matrix,
+                               const SymbolElevationFn* getElevation = nullptr);
 
 void reprojectLineLabels(SymbolBucket::DynamicAttributeVector&,
                          const std::vector<PlacedSymbol>&,
@@ -56,7 +64,8 @@ void reprojectLineLabels(SymbolBucket::DynamicAttributeVector&,
                          bool keepUpright,
                          const RenderTile&,
                          const SymbolSizeBinder& sizeBinder,
-                         const TransformState&);
+                         const TransformState&,
+                         const SymbolElevationFn* getElevation = nullptr);
 
 std::optional<std::pair<PlacedGlyph, PlacedGlyph>> placeFirstAndLastGlyph(float fontScale,
                                                                           float lineOffsetX,
@@ -66,7 +75,8 @@ std::optional<std::pair<PlacedGlyph, PlacedGlyph>> placeFirstAndLastGlyph(float 
                                                                           const Point<float>& tileAnchorPoint,
                                                                           const PlacedSymbol& symbol,
                                                                           const mat4& labelPlaneMatrix,
-                                                                          bool returnTileDistance);
+                                                                          bool returnTileDistance,
+                                                                          const SymbolElevationFn* getElevation = nullptr);
 
 void hideGlyphs(std::size_t numGlyphs, SymbolBucket::DynamicAttributeVector& dynamicVertexArray);
 void addDynamicAttributes(const Point<float>& anchorPoint,

--- a/src/mln/map/map.cpp
+++ b/src/mln/map/map.cpp
@@ -432,6 +432,12 @@ ScreenCoordinate Map::pixelForLatLng(const LatLng& latLng) const {
     return impl->transform.latLngToScreenCoordinate(unwrappedLatLng);
 }
 
+ScreenCoordinate Map::pixelForLatLng(const LatLng& latLng, double elevationMeters) const {
+    LatLng unwrappedLatLng = latLng.wrapped();
+    unwrappedLatLng.unwrapForShortestPath(impl->transform.getLatLng());
+    return impl->transform.latLngToScreenCoordinate(unwrappedLatLng, elevationMeters);
+}
+
 LatLng Map::latLngForPixel(const ScreenCoordinate& pixel) const {
     return impl->transform.screenCoordinateToLatLng(pixel);
 }

--- a/src/mln/map/map.cpp
+++ b/src/mln/map/map.cpp
@@ -442,6 +442,10 @@ LatLng Map::latLngForPixel(const ScreenCoordinate& pixel) const {
     return impl->transform.screenCoordinateToLatLng(pixel);
 }
 
+LatLng Map::latLngForPixel(const ScreenCoordinate& pixel, double elevationMeters) const {
+    return impl->transform.screenCoordinateToLatLng(pixel, elevationMeters);
+}
+
 std::vector<ScreenCoordinate> Map::pixelsForLatLngs(const std::vector<LatLng>& latLngs) const {
     std::vector<ScreenCoordinate> ret;
     ret.reserve(latLngs.size());

--- a/src/mln/map/transform.cpp
+++ b/src/mln/map/transform.cpp
@@ -735,6 +735,14 @@ LatLng Transform::screenCoordinateToLatLng(const ScreenCoordinate& point, LatLng
     return state.screenCoordinateToLatLng(flippedPoint, wrapMode);
 }
 
+LatLng Transform::screenCoordinateToLatLng(const ScreenCoordinate& point,
+                                           double elevationMeters,
+                                           LatLng::WrapMode wrapMode) const {
+    ScreenCoordinate flippedPoint = point;
+    flippedPoint.y = state.getSize().height - flippedPoint.y;
+    return state.screenCoordinateToLatLng(flippedPoint, elevationMeters, wrapMode);
+}
+
 double Transform::getMaxPitchForEdgeInsets(const EdgeInsets& insets) const {
     double centerOffsetY = 0.5 * (insets.top() - insets.bottom()); // See TransformState::getCenterOffset.
     if (centerOffsetY == 0.0) {

--- a/src/mln/map/transform.cpp
+++ b/src/mln/map/transform.cpp
@@ -722,6 +722,13 @@ ScreenCoordinate Transform::latLngToScreenCoordinate(const LatLng& latLng) const
     return point;
 }
 
+ScreenCoordinate Transform::latLngToScreenCoordinate(const LatLng& latLng, double elevationMeters) const {
+    vec4 p;
+    ScreenCoordinate point = state.latLngToScreenCoordinate(latLng, elevationMeters, p);
+    point.y = state.getSize().height - point.y;
+    return point;
+}
+
 LatLng Transform::screenCoordinateToLatLng(const ScreenCoordinate& point, LatLng::WrapMode wrapMode) const {
     ScreenCoordinate flippedPoint = point;
     flippedPoint.y = state.getSize().height - flippedPoint.y;

--- a/src/mln/map/transform.hpp
+++ b/src/mln/map/transform.hpp
@@ -129,6 +129,8 @@ public:
 
     // Conversion and projection
     ScreenCoordinate latLngToScreenCoordinate(const LatLng&) const;
+    /// As above, for a point `elevationMeters` above sea level (draped 3D terrain).
+    ScreenCoordinate latLngToScreenCoordinate(const LatLng&, double elevationMeters) const;
     LatLng screenCoordinateToLatLng(const ScreenCoordinate&, LatLng::WrapMode = LatLng::Wrapped) const;
 
     FreeCameraOptions getFreeCameraOptions() const;

--- a/src/mln/map/transform.hpp
+++ b/src/mln/map/transform.hpp
@@ -132,6 +132,10 @@ public:
     /// As above, for a point `elevationMeters` above sea level (draped 3D terrain).
     ScreenCoordinate latLngToScreenCoordinate(const LatLng&, double elevationMeters) const;
     LatLng screenCoordinateToLatLng(const ScreenCoordinate&, LatLng::WrapMode = LatLng::Wrapped) const;
+    /// As above, unprojecting onto the plane `elevationMeters` above sea level.
+    LatLng screenCoordinateToLatLng(const ScreenCoordinate&,
+                                    double elevationMeters,
+                                    LatLng::WrapMode = LatLng::Wrapped) const;
 
     FreeCameraOptions getFreeCameraOptions() const;
     void setFreeCameraOptions(const FreeCameraOptions& options);

--- a/src/mln/map/transform_state.cpp
+++ b/src/mln/map/transform_state.cpp
@@ -781,18 +781,18 @@ ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng,
     return {p[0] / p[3], size.height - p[1] / p[3]};
 }
 
-TileCoordinate TransformState::screenCoordinateToTileCoordinate(const ScreenCoordinate& point, uint8_t atZoom) const {
+TileCoordinate TransformState::screenCoordinateToTileCoordinate(const ScreenCoordinate& point,
+                                                                uint8_t atZoom,
+                                                                double targetZ) const {
     if (size.isEmpty()) {
         return {.p = {}, .z = 0};
     }
-
-    float targetZ = 0;
 
     double flippedY = size.height - point.y;
 
     // since we don't know the correct projected z value for the point,
     // unproject two points to get a line and then find the point on that
-    // line with z=0
+    // line with z=targetZ
 
     vec4 coord0;
     vec4 coord1;
@@ -817,6 +817,13 @@ TileCoordinate TransformState::screenCoordinateToTileCoordinate(const ScreenCoor
 
 LatLng TransformState::screenCoordinateToLatLng(const ScreenCoordinate& point, LatLng::WrapMode wrapMode) const {
     auto coord = screenCoordinateToTileCoordinate(point, 0);
+    return Projection::unproject(coord.p, 1. / util::tileSize_D, wrapMode);
+}
+
+LatLng TransformState::screenCoordinateToLatLng(const ScreenCoordinate& point,
+                                                double elevationMeters,
+                                                LatLng::WrapMode wrapMode) const {
+    auto coord = screenCoordinateToTileCoordinate(point, 0, elevationMeters);
     return Projection::unproject(coord.p, 1. / util::tileSize_D, wrapMode);
 }
 

--- a/src/mln/map/transform_state.cpp
+++ b/src/mln/map/transform_state.cpp
@@ -765,12 +765,18 @@ ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng) 
 }
 
 ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng, vec4& p) const {
+    return latLngToScreenCoordinate(latLng, 0.0, p);
+}
+
+ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng,
+                                                          double elevationMeters,
+                                                          vec4& p) const {
     if (size.isEmpty()) {
         return {};
     }
 
     Point<double> pt = Projection::project(latLng, scale) / util::tileSize_D;
-    vec4 c = {{pt.x, pt.y, 0, 1}};
+    vec4 c = {{pt.x, pt.y, elevationMeters, 1}};
     matrix::transformMat4(p, c, getCoordMatrix());
     return {p[0] / p[3], size.height - p[1] / p[3]};
 }

--- a/src/mln/map/transform_state.cpp
+++ b/src/mln/map/transform_state.cpp
@@ -768,9 +768,7 @@ ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng, 
     return latLngToScreenCoordinate(latLng, 0.0, p);
 }
 
-ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng,
-                                                          double elevationMeters,
-                                                          vec4& p) const {
+ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng, double elevationMeters, vec4& p) const {
     if (size.isEmpty()) {
         return {};
     }

--- a/src/mln/map/transform_state.hpp
+++ b/src/mln/map/transform_state.hpp
@@ -234,8 +234,17 @@ public:
     /// lands where the terrain mesh and elevated symbols draw that location.
     ScreenCoordinate latLngToScreenCoordinate(const LatLng&, double elevationMeters, vec4&) const;
     LatLng screenCoordinateToLatLng(const ScreenCoordinate&, LatLng::WrapMode = LatLng::Unwrapped) const;
+    /// Unprojects onto the plane `elevationMeters` above sea level (same units as
+    /// latLngToScreenCoordinate's elevation) instead of sea level.
+    LatLng screenCoordinateToLatLng(const ScreenCoordinate&,
+                                    double elevationMeters,
+                                    LatLng::WrapMode = LatLng::Unwrapped) const;
     // Implements mapbox-gl-js pointCoordinate() : MercatorCoordinate.
-    TileCoordinate screenCoordinateToTileCoordinate(const ScreenCoordinate&, uint8_t atZoom) const;
+    // `targetZ` is the world z (metres above sea level, see latLngToScreenCoordinate) of the
+    // plane the screen point is unprojected onto; 0 = sea level.
+    TileCoordinate screenCoordinateToTileCoordinate(const ScreenCoordinate&,
+                                                    uint8_t atZoom,
+                                                    double targetZ = 0.0) const;
 
     double zoomScale(double zoom) const;
     double scaleZoom(double scale) const;

--- a/src/mln/map/transform_state.hpp
+++ b/src/mln/map/transform_state.hpp
@@ -229,6 +229,10 @@ public:
     // Conversion
     ScreenCoordinate latLngToScreenCoordinate(const LatLng&) const;
     ScreenCoordinate latLngToScreenCoordinate(const LatLng&, vec4&) const;
+    /// Projects a point that sits `elevationMeters` above sea level (e.g. on draped 3D terrain,
+    /// exaggeration already applied). The camera matrix scales z from metres to pixels, so this
+    /// lands where the terrain mesh and elevated symbols draw that location.
+    ScreenCoordinate latLngToScreenCoordinate(const LatLng&, double elevationMeters, vec4&) const;
     LatLng screenCoordinateToLatLng(const ScreenCoordinate&, LatLng::WrapMode = LatLng::Unwrapped) const;
     // Implements mapbox-gl-js pointCoordinate() : MercatorCoordinate.
     TileCoordinate screenCoordinateToTileCoordinate(const ScreenCoordinate&, uint8_t atZoom) const;

--- a/src/mln/renderer/bucket.hpp
+++ b/src/mln/renderer/bucket.hpp
@@ -66,8 +66,11 @@ public:
     }
     // Places this bucket to the given placement.
     virtual void place(Placement&, const BucketPlacementData&, std::set<uint32_t>&) {}
-    virtual void updateVertices(
-        const Placement&, bool /*updateOpacities*/, const TransformState&, const RenderTile&, std::set<uint32_t>&,
+    virtual void updateVertices(const Placement&,
+                                bool /*updateOpacities*/,
+                                const TransformState&,
+                                const RenderTile&,
+                                std::set<uint32_t>&,
                                 const RenderTerrain* /*terrain*/ = nullptr) {}
 
     const util::SimpleIdentity& getID() const { return bucketID; }

--- a/src/mln/renderer/bucket.hpp
+++ b/src/mln/renderer/bucket.hpp
@@ -21,6 +21,7 @@ class OverscaledTileID;
 class PatternDependency;
 using PatternLayerMap = mln::unordered_map<std::string, PatternDependency>;
 class Placement;
+class RenderTerrain;
 class TransformState;
 class BucketPlacementData;
 class RenderTile;
@@ -66,7 +67,8 @@ public:
     // Places this bucket to the given placement.
     virtual void place(Placement&, const BucketPlacementData&, std::set<uint32_t>&) {}
     virtual void updateVertices(
-        const Placement&, bool /*updateOpacities*/, const TransformState&, const RenderTile&, std::set<uint32_t>&) {}
+        const Placement&, bool /*updateOpacities*/, const TransformState&, const RenderTile&, std::set<uint32_t>&,
+                                const RenderTerrain* /*terrain*/ = nullptr) {}
 
     const util::SimpleIdentity& getID() const { return bucketID; }
 

--- a/src/mln/renderer/buckets/symbol_bucket.cpp
+++ b/src/mln/renderer/buckets/symbol_bucket.cpp
@@ -347,14 +347,15 @@ void SymbolBucket::updateVertices(const Placement& placement,
                                   bool updateOpacities,
                                   const TransformState& state,
                                   const RenderTile& tile,
-                                  std::set<uint32_t>& seenIds) {
+                                  std::set<uint32_t>& seenIds,
+                                  const RenderTerrain* terrain) {
     if (updateOpacities) {
         placement.updateBucketOpacities(*this, state, seenIds);
         placementChangesUploaded = false;
         uploaded = false;
     }
 
-    if (placement.updateBucketDynamicAttributeData(*this, state, tile)) {
+    if (placement.updateBucketDynamicAttributeData(*this, state, tile, terrain)) {
         dynamicUploaded = false;
         uploaded = false;
     }

--- a/src/mln/renderer/buckets/symbol_bucket.hpp
+++ b/src/mln/renderer/buckets/symbol_bucket.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 namespace mln {
+class RenderTerrain;
 
 namespace style {
 
@@ -272,8 +273,12 @@ public:
     void update(const FeatureStates&, const GeometryTileLayer&, const std::string&, const ImagePositions&) override;
     std::pair<uint32_t, bool> registerAtCrossTileIndex(CrossTileSymbolLayerIndex&, const RenderTile&) override;
     void place(Placement&, const BucketPlacementData&, std::set<uint32_t>&) override;
-    void updateVertices(
-        const Placement&, bool updateOpacities, const TransformState&, const RenderTile&, std::set<uint32_t>&) override;
+    void updateVertices(const Placement&,
+                        bool updateOpacities,
+                        const TransformState&,
+                        const RenderTile&,
+                        std::set<uint32_t>&,
+                        const RenderTerrain* terrain = nullptr) override;
     bool hasTextData() const;
     bool hasIconData() const;
     bool hasSdfIconData() const;

--- a/src/mln/renderer/render_orchestrator.cpp
+++ b/src/mln/renderer/render_orchestrator.cpp
@@ -75,6 +75,7 @@ public:
                    RenderLayerReferences layersNeedPlacement_,
                    Immutable<Placement> placement_,
                    bool updateSymbolOpacities_,
+                   const RenderTerrain* terrain_,
                    double startTime_)
         : RenderTree(std::move(parameters_), startTime_),
           layerRenderItems(std::move(layerRenderItems_)),
@@ -83,13 +84,14 @@ public:
           patternAtlas(patternAtlas_),
           layersNeedPlacement(std::move(layersNeedPlacement_)),
           placement(std::move(placement_)),
-          updateSymbolOpacities(updateSymbolOpacities_) {}
+          updateSymbolOpacities(updateSymbolOpacities_),
+          terrain(terrain_) {}
 
     void prepare() override {
         MLN_TRACE_FUNC();
 
         for (auto it = layersNeedPlacement.rbegin(); it != layersNeedPlacement.rend(); ++it) {
-            placement->updateLayerBuckets(*it, parameters->transformParams.state, updateSymbolOpacities);
+            placement->updateLayerBuckets(*it, parameters->transformParams.state, updateSymbolOpacities, terrain);
         }
     }
 
@@ -111,6 +113,7 @@ public:
     RenderLayerReferences layersNeedPlacement;
     Immutable<Placement> placement;
     bool updateSymbolOpacities;
+    const RenderTerrain* terrain;
 };
 
 } // namespace
@@ -608,6 +611,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
                                             std::move(layersNeedPlacement),
                                             placementController.getPlacement(),
                                             symbolBucketsChanged,
+                                            renderTerrain.get(),
                                             startTime);
 }
 

--- a/src/mln/renderer/render_orchestrator.cpp
+++ b/src/mln/renderer/render_orchestrator.cpp
@@ -573,6 +573,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         symbolBucketsChanged |= renderTreeParameters->placementChanged;
         if (renderTreeParameters->placementChanged) {
             Mutable<Placement> placement = Placement::create(updateParameters, placementController.getPlacement());
+            placement->setTerrain(terrainEnabled ? renderTerrain.get() : nullptr);
             placement->placeLayers(layersNeedPlacement);
             placementController.setPlacement(std::move(placement));
             crossTileSymbolIndex.pruneUnusedLayers(usedSymbolLayers);
@@ -592,6 +593,7 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         if (renderTreeParameters->placementChanged) {
             Mutable<Placement> placement = Placement::create(updateParameters);
             placement->collectPlacedSymbolData(placedSymbolDataCollected);
+            placement->setTerrain(terrainEnabled ? renderTerrain.get() : nullptr);
             placement->placeLayers(layersNeedPlacement);
             placementController.setPlacement(std::move(placement));
         }
@@ -693,6 +695,13 @@ void RenderOrchestrator::queryRenderedSymbols(std::unordered_map<std::string, st
     }
 }
 
+std::optional<LatLng> RenderOrchestrator::pickTerrainLatLng(const ScreenCoordinate& pixel) const {
+    if (renderTerrain && renderTerrain->isEnabled()) {
+        return renderTerrain->pickLatLng(transformState, pixel);
+    }
+    return std::nullopt;
+}
+
 std::vector<Feature> RenderOrchestrator::queryRenderedFeatures(
     const ScreenLineString& geometry,
     const RenderedQueryOptions& options,
@@ -712,11 +721,27 @@ std::vector<Feature> RenderOrchestrator::queryRenderedFeatures(
     mat4 projMatrix;
     transformState.getProjMatrix(projMatrix);
 
+    // Tile-source and shape-annotation queries unproject the screen geometry at sea level. On
+    // 3D terrain a tapped pixel's ray meets the draped surface first, so substitute, for each
+    // point, the sea-level projection of the surface coordinate under it: the sea-level
+    // unprojection downstream then yields that surface coordinate. Symbols keep the original
+    // screen geometry - their collision boxes already sit at the terrain elevation.
+    ScreenLineString surfaceGeometry = geometry;
+    if (renderTerrain && renderTerrain->isEnabled()) {
+        for (auto& point : surfaceGeometry) {
+            if (const auto surface = renderTerrain->pickLatLng(transformState, point)) {
+                ScreenCoordinate projected = transformState.latLngToScreenCoordinate(*surface);
+                projected.y = transformState.getSize().height - projected.y; // back to y-down
+                point = projected;
+            }
+        }
+    }
+
     std::unordered_map<std::string, std::vector<Feature>> resultsByLayer;
     for (const auto& sourceID : sourceIDs) {
         if (RenderSource* renderSource = getRenderSource(sourceID)) {
             auto sourceResults = renderSource->queryRenderedFeatures(
-                geometry, transformState, filteredLayers, options, projMatrix);
+                surfaceGeometry, transformState, filteredLayers, options, projMatrix);
             std::ranges::move(sourceResults, std::inserter(resultsByLayer, resultsByLayer.begin()));
         }
     }
@@ -728,7 +753,7 @@ std::vector<Feature> RenderOrchestrator::queryRenderedFeatures(
         const RenderLayer* layer = pair.second;
         layer->populateDynamicRenderFeatureIndex(dynamicIndex);
     }
-    dynamicIndex.query(resultsByLayer, geometry, transformState);
+    dynamicIndex.query(resultsByLayer, surfaceGeometry, transformState);
     std::vector<Feature> result;
 
     if (resultsByLayer.empty()) {

--- a/src/mln/renderer/render_orchestrator.cpp
+++ b/src/mln/renderer/render_orchestrator.cpp
@@ -264,6 +264,12 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         terrainEnabled ? renderTerrain->getExaggeration() : 1.0};
     tileParameters.elevationProvider = terrainEnabled ? &elevationProvider : nullptr;
 
+    // The DEM source additionally keeps coarser ancestors of its cover loaded so that every
+    // tile another layer draws from - shallower far-field LOD tiles, overzoomed sources with
+    // a low maxzoom - has a DEM ancestor to bind for elevation (see TileParameters).
+    TileParameters demTileParameters = tileParameters;
+    demTileParameters.retainAncestorLevels = terrainEnabled ? RenderTerrain::demAncestorLevels : 0;
+
     const ImageDifference imageDiff = diffImages(imageImpls, updateParameters->images);
     imageImpls = updateParameters->images;
 
@@ -466,7 +472,12 @@ std::unique_ptr<RenderTree> RenderOrchestrator::createRenderTree(
         }
 
         tileParameters.isUpdateSynchronous = sourceImpl->isUpdateSynchronous();
-        source->update(sourceImpl, filteredLayersForSource, sourceNeedsRendering, sourceNeedsRelayout, tileParameters);
+        const bool isDEMSource = terrainEnabled && sourceImpl->id == renderTerrain->getSourceID();
+        source->update(sourceImpl,
+                       filteredLayersForSource,
+                       sourceNeedsRendering,
+                       sourceNeedsRelayout,
+                       isDEMSource ? demTileParameters : tileParameters);
         filteredLayersForSource.clear();
 
         // Update all layers with their new renderability status, if it changed.

--- a/src/mln/renderer/render_orchestrator.hpp
+++ b/src/mln/renderer/render_orchestrator.hpp
@@ -211,6 +211,12 @@ private:
     RendererObserver* observer;
 
     ZoomHistory zoomHistory;
+public:
+    /// Surface coordinate under a screen pixel on 3D terrain (RenderTerrain::pickLatLng), or
+    /// nullopt without terrain. Must be called on the render thread.
+    std::optional<LatLng> pickTerrainLatLng(const ScreenCoordinate& pixel) const;
+
+private:
     TransformState transformState;
 
     std::shared_ptr<GlyphManager> glyphManager;

--- a/src/mln/renderer/render_orchestrator.hpp
+++ b/src/mln/renderer/render_orchestrator.hpp
@@ -211,6 +211,7 @@ private:
     RendererObserver* observer;
 
     ZoomHistory zoomHistory;
+
 public:
     /// Surface coordinate under a screen pixel on 3D terrain (RenderTerrain::pickLatLng), or
     /// nullopt without terrain. Must be called on the render thread.

--- a/src/mln/renderer/render_terrain.cpp
+++ b/src/mln/renderer/render_terrain.cpp
@@ -1,4 +1,5 @@
 #include <mln/renderer/render_terrain.hpp>
+#include <mln/util/projection.hpp>
 #include <mln/renderer/update_parameters.hpp>
 #include <mln/renderer/render_source.hpp>
 #include <mln/renderer/render_tile.hpp>
@@ -639,6 +640,103 @@ float RenderTerrain::getElevation(const UnwrappedTileID& tileID, float x, float 
 
 float RenderTerrain::getElevationWithExaggeration(const UnwrappedTileID& tileID, float x, float y) const {
     return getElevation(tileID, x, y) * getExaggeration();
+}
+
+std::optional<std::function<float(const Point<float>&)>> RenderTerrain::elevationSampler(
+    const UnwrappedTileID& tileID) const {
+    if (!demSource || !isEnabled()) {
+        return std::nullopt;
+    }
+    const auto renderTiles = demSource->getRawRenderTiles();
+    const RenderTile* demRenderTile = nullptr;
+    int bestZoom = -1;
+    for (const auto& renderTile : *renderTiles) {
+        const UnwrappedTileID& candidate = renderTile.id;
+        if (!(candidate == tileID || tileID.isChildOf(candidate)) ||
+            static_cast<int>(candidate.canonical.z) <= bestZoom) {
+            continue;
+        }
+        const auto& tile = renderTile.getTile();
+        if (tile.kind != Tile::Kind::RasterDEM) {
+            continue;
+        }
+        auto* demTile = const_cast<RasterDEMTile*>(static_cast<const RasterDEMTile*>(&tile));
+        auto* bucket = demTile->getBucket();
+        if (!bucket || !bucket->getDEMData().getImagePtr() || bucket->getDEMData().dim <= 0) {
+            continue;
+        }
+        bestZoom = candidate.canonical.z;
+        demRenderTile = &renderTile;
+    }
+    if (!demRenderTile) {
+        return std::nullopt;
+    }
+    auto* demTile = const_cast<RasterDEMTile*>(static_cast<const RasterDEMTile*>(&demRenderTile->getTile()));
+    const DEMData* demData = &demTile->getBucket()->getDEMData();
+    const auto off = demSubTileOffset(tileID.canonical, demRenderTile->id.canonical);
+    const float exaggeration = getExaggeration();
+    const float dim = static_cast<float>(demData->dim);
+    return [demData, off, exaggeration, dim](const Point<float>& p) -> float {
+        const float xInDem = (off.dx * util::EXTENT + p.x) / off.scale;
+        const float yInDem = (off.dy * util::EXTENT + p.y) / off.scale;
+        const float px = util::clamp(xInDem / util::EXTENT * dim, 0.0f, dim - 1.0f);
+        const float py = util::clamp(yInDem / util::EXTENT * dim, 0.0f, dim - 1.0f);
+        const auto x0 = static_cast<int32_t>(std::floor(px));
+        const auto y0 = static_cast<int32_t>(std::floor(py));
+        const float fx = px - static_cast<float>(x0);
+        const float fy = py - static_cast<float>(y0);
+        const float tl = static_cast<float>(demData->get(x0, y0));
+        const float tr = static_cast<float>(demData->get(x0 + 1, y0));
+        const float bl = static_cast<float>(demData->get(x0, y0 + 1));
+        const float br = static_cast<float>(demData->get(x0 + 1, y0 + 1));
+        const float top = tl + (tr - tl) * fx;
+        const float bottom = bl + (br - bl) * fx;
+        return (top + (bottom - top) * fy) * exaggeration;
+    };
+}
+
+std::optional<double> RenderTerrain::getElevationAtLatLng(const LatLng& latLng) const {
+    if (!demSource || !isEnabled()) {
+        return std::nullopt;
+    }
+    const auto renderTiles = demSource->getRawRenderTiles();
+    // Deepest loaded DEM tile *with data* that contains the point. Tiles past the archive's
+    // stored zoom come back empty (noContent) yet still sit in the render set, so skip them
+    // or the deepest match samples nothing and reads as sea level.
+    const RenderTile* best = nullptr;
+    double bestX = 0;
+    double bestY = 0;
+    for (const auto& renderTile : *renderTiles) {
+        const UnwrappedTileID& id = renderTile.id;
+        const auto z = static_cast<int32_t>(id.canonical.z);
+        if (best && z <= static_cast<int32_t>(best->id.canonical.z)) {
+            continue;
+        }
+        const auto& tile = renderTile.getTile();
+        if (tile.kind != Tile::Kind::RasterDEM) {
+            continue;
+        }
+        auto* demTile = const_cast<RasterDEMTile*>(static_cast<const RasterDEMTile*>(&tile));
+        auto* bucket = demTile->getBucket();
+        if (!bucket || !bucket->getDEMData().getImagePtr() || bucket->getDEMData().dim <= 0) {
+            continue;
+        }
+        // The integer-zoom overload projects into tile units (world size 2^z), not pixels.
+        const Point<double> world = Projection::project(latLng, z);
+        const double tilesAcross = std::pow(2.0, z);
+        const double tx = world.x - (static_cast<double>(id.canonical.x) + static_cast<double>(id.wrap) * tilesAcross);
+        const double ty = world.y - static_cast<double>(id.canonical.y);
+        if (tx < 0.0 || tx >= 1.0 || ty < 0.0 || ty >= 1.0) {
+            continue;
+        }
+        best = &renderTile;
+        bestX = tx * util::EXTENT;
+        bestY = ty * util::EXTENT;
+    }
+    if (!best) {
+        return std::nullopt;
+    }
+    return static_cast<double>(getElevationWithExaggeration(best->id, static_cast<float>(bestX), static_cast<float>(bestY)));
 }
 
 std::optional<RenderTerrain::TerrainData> RenderTerrain::getTerrainData(const UnwrappedTileID& tileID) const {

--- a/src/mln/renderer/render_terrain.cpp
+++ b/src/mln/renderer/render_terrain.cpp
@@ -783,7 +783,8 @@ std::optional<double> RenderTerrain::getElevationAtLatLng(const LatLng& latLng) 
     if (!best) {
         return std::nullopt;
     }
-    return static_cast<double>(getElevationWithExaggeration(best->id, static_cast<float>(bestX), static_cast<float>(bestY)));
+    return static_cast<double>(
+        getElevationWithExaggeration(best->id, static_cast<float>(bestX), static_cast<float>(bestY)));
 }
 
 std::optional<RenderTerrain::TerrainData> RenderTerrain::getTerrainData(const UnwrappedTileID& tileID) const {

--- a/src/mln/renderer/render_terrain.cpp
+++ b/src/mln/renderer/render_terrain.cpp
@@ -704,6 +704,55 @@ std::optional<std::function<float(const Point<float>&)>> RenderTerrain::elevatio
     };
 }
 
+std::optional<LatLng> RenderTerrain::pickLatLng(const TransformState& state, const ScreenCoordinate& pixel) const {
+    if (!isEnabled()) {
+        return std::nullopt;
+    }
+    // TransformState unprojects y-up screen points; queries and the platform views hand us y-down
+    ScreenCoordinate flipped = pixel;
+    flipped.y = state.getSize().height - pixel.y;
+    const LatLng seaLevel = state.screenCoordinateToLatLng(flipped);
+    if (!getElevationAtLatLng(seaLevel)) {
+        return std::nullopt; // no DEM under the ray: nothing to pick against
+    }
+    const auto camera = state.getFreeCameraOptions().getLocation();
+    if (!camera || camera->altitude <= 0.0) {
+        return std::nullopt;
+    }
+    // Terrain height (exaggerated metres, the projection's z unit) where the ray crosses the
+    // horizontal plane at `planeHeight`
+    const auto surfaceHeightAt = [&](double planeHeight, LatLng& out) {
+        out = state.screenCoordinateToLatLng(flipped, planeHeight);
+        return getElevationAtLatLng(out).value_or(0.0);
+    };
+    constexpr int steps = 64;
+    const double top = camera->altitude * 0.999;
+    double above = top; // last plane height known to be above the surface
+    LatLng probe;
+    if (surfaceHeightAt(above, probe) >= above) {
+        return std::nullopt; // camera inside the terrain
+    }
+    for (int i = 1; i <= steps; ++i) {
+        const double h = top * (1.0 - static_cast<double>(i) / steps);
+        if (surfaceHeightAt(h, probe) < h) {
+            above = h;
+            continue;
+        }
+        // Crossed between `above` and `h`: bisect onto the surface
+        double below = h;
+        for (int j = 0; j < 8; ++j) {
+            const double mid = 0.5 * (above + below);
+            if (surfaceHeightAt(mid, probe) < mid) {
+                above = mid;
+            } else {
+                below = mid;
+            }
+        }
+        return state.screenCoordinateToLatLng(flipped, 0.5 * (above + below), LatLng::Wrapped);
+    }
+    return std::nullopt;
+}
+
 std::optional<double> RenderTerrain::getElevationAtLatLng(const LatLng& latLng) const {
     if (!demSource || !isEnabled()) {
         return std::nullopt;

--- a/src/mln/renderer/render_terrain.cpp
+++ b/src/mln/renderer/render_terrain.cpp
@@ -1,4 +1,6 @@
 #include <mln/renderer/render_terrain.hpp>
+#include <mln/renderer/sources/render_tile_source.hpp>
+#include <mln/renderer/tile_pyramid.hpp>
 #include <mln/util/projection.hpp>
 #include <mln/renderer/update_parameters.hpp>
 #include <mln/renderer/render_source.hpp>
@@ -75,6 +77,49 @@ DEMSubTileOffset demSubTileOffset(const CanonicalTileID& child, const CanonicalT
     return {static_cast<float>(1u << dz),
             static_cast<float>(child.x - (ancestor.x << dz)),
             static_cast<float>(child.y - (ancestor.y << dz))};
+}
+
+/// Every DEM tile the source currently holds with decoded data - rendered ones and the
+/// ancestors retained for elevation lookups - keyed by unwrapped tile.
+struct LoadedDEMTile {
+    UnwrappedTileID id;
+    const DEMData* data;
+};
+
+std::vector<LoadedDEMTile> loadedDEMTiles(const RenderSource* demSource) {
+    std::vector<LoadedDEMTile> out;
+    // Core builds without RTTI; a raster-dem render source is always a RenderTileSource.
+    if (!demSource || demSource->baseImpl->type != style::SourceType::RasterDEM) {
+        return out;
+    }
+    const auto* tileSource = static_cast<const RenderTileSource*>(demSource);
+    for (const auto& [id, tile] : tileSource->getTilePyramid().getTiles()) {
+        if (!tile || tile->kind != Tile::Kind::RasterDEM) {
+            continue;
+        }
+        auto* demTile = static_cast<RasterDEMTile*>(tile.get());
+        auto* bucket = demTile->getBucket();
+        if (!bucket) {
+            continue;
+        }
+        const auto& demData = bucket->getDEMData();
+        if (!demData.getImagePtr() || demData.getImagePtr()->size.isEmpty() || demData.dim <= 0) {
+            continue;
+        }
+        const UnwrappedTileID unwrapped = id.toUnwrapped();
+        bool duplicate = false;
+        for (const auto& existing : out) {
+            if (existing.id == unwrapped) {
+                duplicate = true;
+                break;
+            }
+        }
+        if (duplicate) {
+            continue;
+        }
+        out.push_back({unwrapped, &demData});
+    }
+    return out;
 }
 
 } // namespace
@@ -227,30 +272,25 @@ void RenderTerrain::update(RenderOrchestrator& orchestrator,
         return;
     }
 
-    // Decode and cache the DEM textures of loaded DEM tiles
+    // Decode and cache the DEM textures of loaded DEM tiles - rendered ones and the
+    // retained ancestors alike, so shallower layer tiles can bind an ancestor DEM.
     ++demUpdateCounter;
-    for (const auto& renderTile : *renderTiles) {
-        const auto& tile = renderTile.getTile();
-        if (tile.kind != Tile::Kind::RasterDEM) {
-            continue;
-        }
-        auto* demTile = const_cast<RasterDEMTile*>(static_cast<const RasterDEMTile*>(&tile));
-        auto* hillshadeBucket = demTile->getBucket();
-        const auto* demData = hillshadeBucket ? &hillshadeBucket->getDEMData() : nullptr;
-        if (demData && demData->getImagePtr() && !demData->getImagePtr()->size.isEmpty()) {
+    for (const auto& loaded : loadedDEMTiles(demSource)) {
+        const DEMData* demData = loaded.data;
+        {
             // All tiles come from the same raster-dem source, so they share one
             // encoding and DEM dimension
             demUnpackVector = demData->getUnpackVector();
             demDim = demData->dim;
-            if (auto existing = demTextures.find(renderTile.id); existing != demTextures.end()) {
+            if (auto existing = demTextures.find(loaded.id); existing != demTextures.end()) {
                 existing->second.lastUsed = demUpdateCounter;
             } else if (auto texture = createDEMTexture(context, *demData)) {
                 // Keep the texture available for elevation sampling by non-draped layers
-                demTextures[renderTile.id] = {texture, demData->dim, demUpdateCounter};
+                demTextures[loaded.id] = {texture, demData->dim, demUpdateCounter};
 #if MLN_RENDER_BACKEND_OPENGL
                 // Also pack this tile's DEM into the array for the (upcoming) instanced
                 // depth pass. Additive: the per-tile texture above is still the fallback.
-                packDEMArrayLayer(context, renderTile.id, *demData);
+                packDEMArrayLayer(context, loaded.id, *demData);
 #endif
             }
         }
@@ -585,39 +625,22 @@ float RenderTerrain::getElevation(const UnwrappedTileID& tileID, float x, float 
         return 0.0f;
     }
 
-    // Find the DEM tile matching the requested tile, or its closest available ancestor
-    const auto renderTiles = demSource->getRawRenderTiles();
-    const RenderTile* demRenderTile = nullptr;
-    int bestZoom = -1;
-    for (const auto& renderTile : *renderTiles) {
-        const UnwrappedTileID& candidate = renderTile.id;
-        if ((candidate == tileID || tileID.isChildOf(candidate)) &&
-            static_cast<int>(candidate.canonical.z) > bestZoom) {
-            bestZoom = candidate.canonical.z;
-            demRenderTile = &renderTile;
+    // Deepest loaded DEM tile (with data) matching the requested tile or an ancestor of it
+    const LoadedDEMTile* best = nullptr;
+    const auto loaded = loadedDEMTiles(demSource);
+    for (const auto& candidate : loaded) {
+        if ((candidate.id == tileID || tileID.isChildOf(candidate.id)) &&
+            (!best || candidate.id.canonical.z > best->id.canonical.z)) {
+            best = &candidate;
         }
     }
-    if (!demRenderTile) {
+    if (!best) {
         return 0.0f;
     }
-
-    const auto& tile = demRenderTile->getTile();
-    if (tile.kind != Tile::Kind::RasterDEM) {
-        return 0.0f;
-    }
-    auto* demTile = const_cast<RasterDEMTile*>(static_cast<const RasterDEMTile*>(&tile));
-    auto* bucket = demTile->getBucket();
-    if (!bucket) {
-        return 0.0f;
-    }
-    const auto& demData = bucket->getDEMData();
-    if (!demData.getImagePtr() || demData.dim <= 0) {
-        return 0.0f;
-    }
+    const DEMData& demData = *best->data;
 
     // Map the tile-local coordinate into the (possibly ancestor) DEM tile
-    const UnwrappedTileID& demTileID = demRenderTile->id;
-    const auto off = demSubTileOffset(tileID.canonical, demTileID.canonical);
+    const auto off = demSubTileOffset(tileID.canonical, best->id.canonical);
     const float xInDem = (off.dx * util::EXTENT + x) / off.scale;
     const float yInDem = (off.dy * util::EXTENT + y) / off.scale;
 
@@ -647,33 +670,19 @@ std::optional<std::function<float(const Point<float>&)>> RenderTerrain::elevatio
     if (!demSource || !isEnabled()) {
         return std::nullopt;
     }
-    const auto renderTiles = demSource->getRawRenderTiles();
-    const RenderTile* demRenderTile = nullptr;
-    int bestZoom = -1;
-    for (const auto& renderTile : *renderTiles) {
-        const UnwrappedTileID& candidate = renderTile.id;
-        if (!(candidate == tileID || tileID.isChildOf(candidate)) ||
-            static_cast<int>(candidate.canonical.z) <= bestZoom) {
-            continue;
+    const LoadedDEMTile* best = nullptr;
+    const auto loaded = loadedDEMTiles(demSource);
+    for (const auto& candidate : loaded) {
+        if ((candidate.id == tileID || tileID.isChildOf(candidate.id)) &&
+            (!best || candidate.id.canonical.z > best->id.canonical.z)) {
+            best = &candidate;
         }
-        const auto& tile = renderTile.getTile();
-        if (tile.kind != Tile::Kind::RasterDEM) {
-            continue;
-        }
-        auto* demTile = const_cast<RasterDEMTile*>(static_cast<const RasterDEMTile*>(&tile));
-        auto* bucket = demTile->getBucket();
-        if (!bucket || !bucket->getDEMData().getImagePtr() || bucket->getDEMData().dim <= 0) {
-            continue;
-        }
-        bestZoom = candidate.canonical.z;
-        demRenderTile = &renderTile;
     }
-    if (!demRenderTile) {
+    if (!best) {
         return std::nullopt;
     }
-    auto* demTile = const_cast<RasterDEMTile*>(static_cast<const RasterDEMTile*>(&demRenderTile->getTile()));
-    const DEMData* demData = &demTile->getBucket()->getDEMData();
-    const auto off = demSubTileOffset(tileID.canonical, demRenderTile->id.canonical);
+    const DEMData* demData = best->data;
+    const auto off = demSubTileOffset(tileID.canonical, best->id.canonical);
     const float exaggeration = getExaggeration();
     const float dim = static_cast<float>(demData->dim);
     return [demData, off, exaggeration, dim](const Point<float>& p) -> float {
@@ -699,26 +708,15 @@ std::optional<double> RenderTerrain::getElevationAtLatLng(const LatLng& latLng) 
     if (!demSource || !isEnabled()) {
         return std::nullopt;
     }
-    const auto renderTiles = demSource->getRawRenderTiles();
-    // Deepest loaded DEM tile *with data* that contains the point. Tiles past the archive's
-    // stored zoom come back empty (noContent) yet still sit in the render set, so skip them
-    // or the deepest match samples nothing and reads as sea level.
-    const RenderTile* best = nullptr;
+    // Deepest loaded DEM tile with data that contains the point
+    const LoadedDEMTile* best = nullptr;
     double bestX = 0;
     double bestY = 0;
-    for (const auto& renderTile : *renderTiles) {
-        const UnwrappedTileID& id = renderTile.id;
+    const auto loaded = loadedDEMTiles(demSource);
+    for (const auto& candidate : loaded) {
+        const UnwrappedTileID& id = candidate.id;
         const auto z = static_cast<int32_t>(id.canonical.z);
         if (best && z <= static_cast<int32_t>(best->id.canonical.z)) {
-            continue;
-        }
-        const auto& tile = renderTile.getTile();
-        if (tile.kind != Tile::Kind::RasterDEM) {
-            continue;
-        }
-        auto* demTile = const_cast<RasterDEMTile*>(static_cast<const RasterDEMTile*>(&tile));
-        auto* bucket = demTile->getBucket();
-        if (!bucket || !bucket->getDEMData().getImagePtr() || bucket->getDEMData().dim <= 0) {
             continue;
         }
         // The integer-zoom overload projects into tile units (world size 2^z), not pixels.
@@ -729,7 +727,7 @@ std::optional<double> RenderTerrain::getElevationAtLatLng(const LatLng& latLng) 
         if (tx < 0.0 || tx >= 1.0 || ty < 0.0 || ty >= 1.0) {
             continue;
         }
-        best = &renderTile;
+        best = &candidate;
         bestX = tx * util::EXTENT;
         bestY = ty * util::EXTENT;
     }

--- a/src/mln/renderer/render_terrain.hpp
+++ b/src/mln/renderer/render_terrain.hpp
@@ -140,6 +140,12 @@ public:
      */
     std::optional<double> getElevationAtLatLng(const LatLng& latLng) const;
 
+    /// Zoom levels of DEM ancestors kept loaded above the cover (TileParameters::retainAncestorLevels).
+    /// The cover follows the declared maxzoom (16 with overzoom), while layers can draw from tiles
+    /// as shallow as ~z9 (far-field distance LOD, low-maxzoom sources), so reach eight levels up;
+    /// the tile count shrinks by 4x per level, so this is a handful of tiles.
+    static constexpr uint8_t demAncestorLevels = 8;
+
     /**
      * @brief Per-tile elevation sampler for CPU-side symbol projection (line-placed labels):
      * tile-local point -> exaggerated metres, from the DEM tile covering `tileID` or its

--- a/src/mln/renderer/render_terrain.hpp
+++ b/src/mln/renderer/render_terrain.hpp
@@ -8,6 +8,8 @@
 #include <mln/gfx/index_buffer.hpp>
 #include <mln/renderer/texture_pool.hpp>
 #include <mln/util/mat4.hpp>
+#include <mln/util/geo.hpp>
+#include <mln/util/geometry.hpp>
 
 #include <array>
 #include <memory>
@@ -15,6 +17,7 @@
 #include <set>
 #include <string>
 #include <optional>
+#include <functional>
 #include <vector>
 #include <cstdint>
 #include <unordered_map>
@@ -129,6 +132,20 @@ public:
      * @return Elevation in meters with exaggeration multiplier applied
      */
     float getElevationWithExaggeration(const UnwrappedTileID& tileID, float x, float y) const;
+
+    /**
+     * @brief Exaggerated terrain height (metres) at a geographic coordinate, sampled from the
+     * deepest loaded DEM tile covering it. Render-thread only. nullopt when terrain is off or
+     * no DEM tile covers the point yet.
+     */
+    std::optional<double> getElevationAtLatLng(const LatLng& latLng) const;
+
+    /**
+     * @brief Per-tile elevation sampler for CPU-side symbol projection (line-placed labels):
+     * tile-local point -> exaggerated metres, from the DEM tile covering `tileID` or its
+     * closest loaded ancestor. Valid for the current frame only. nullopt without DEM data.
+     */
+    std::optional<std::function<float(const Point<float>&)>> elevationSampler(const UnwrappedTileID& tileID) const;
 
     /**
      * @brief Get the terrain exaggeration multiplier

--- a/src/mln/renderer/render_terrain.hpp
+++ b/src/mln/renderer/render_terrain.hpp
@@ -140,6 +140,16 @@ public:
      */
     std::optional<double> getElevationAtLatLng(const LatLng& latLng) const;
 
+    /**
+     * @brief Coordinate of the draped surface under a screen pixel (y-down view pixels, as
+     * rendered-feature queries use). The pixel's view ray is marched from just below the camera
+     * down to sea level, sampling the terrain height at each candidate plane, and the first
+     * crossing (the nearest surface, so a ridge in front wins) is bisected. Inverse of
+     * Map::pixelForLatLng(latLng, elevation). nullopt without terrain, without a camera
+     * altitude, when the camera is inside the terrain, or when the ray never meets the surface.
+     */
+    std::optional<LatLng> pickLatLng(const TransformState& state, const ScreenCoordinate& pixel) const;
+
     /// Zoom levels of DEM ancestors kept loaded above the cover (TileParameters::retainAncestorLevels).
     /// The cover follows the declared maxzoom (16 with overzoom), while layers can draw from tiles
     /// as shallow as ~z9 (far-field distance LOD, low-maxzoom sources), so reach eight levels up;

--- a/src/mln/renderer/renderer.cpp
+++ b/src/mln/renderer/renderer.cpp
@@ -109,6 +109,10 @@ std::vector<Feature> Renderer::querySourceFeatures(const std::string& sourceID,
     return impl->orchestrator.querySourceFeatures(sourceID, options);
 }
 
+std::optional<LatLng> Renderer::queryTerrainPick(const ScreenCoordinate& pixel) const {
+    return impl->orchestrator.pickTerrainLatLng(pixel);
+}
+
 std::optional<double> Renderer::queryTerrainElevation(const LatLng& latLng) const {
     if (const RenderTerrain* terrain = impl->orchestrator.getRenderTerrain()) {
         return terrain->getElevationAtLatLng(latLng);

--- a/src/mln/renderer/renderer.cpp
+++ b/src/mln/renderer/renderer.cpp
@@ -6,6 +6,7 @@
 #include <mln/gfx/renderer_backend.hpp>
 #include <mln/layermanager/layer_manager.hpp>
 #include <mln/renderer/renderer_impl.hpp>
+#include <mln/renderer/render_terrain.hpp>
 #include <mln/renderer/render_static_data.hpp>
 #include <mln/renderer/render_tree.hpp>
 #include <mln/renderer/update_parameters.hpp>
@@ -106,6 +107,13 @@ AnnotationIDs Renderer::getAnnotationIDs(const std::vector<Feature>& features) c
 std::vector<Feature> Renderer::querySourceFeatures(const std::string& sourceID,
                                                    const SourceQueryOptions& options) const {
     return impl->orchestrator.querySourceFeatures(sourceID, options);
+}
+
+std::optional<double> Renderer::queryTerrainElevation(const LatLng& latLng) const {
+    if (const RenderTerrain* terrain = impl->orchestrator.getRenderTerrain()) {
+        return terrain->getElevationAtLatLng(latLng);
+    }
+    return std::nullopt;
 }
 
 FeatureExtensionValue Renderer::queryFeatureExtensions(const std::string& sourceID,

--- a/src/mln/renderer/sources/render_tile_source.hpp
+++ b/src/mln/renderer/sources/render_tile_source.hpp
@@ -28,6 +28,8 @@ public:
     RenderTiles getRenderTilesSortedByYPosition() const override;
     const Tile* getRenderedTile(const UnwrappedTileID&) const override;
     Immutable<std::vector<RenderTile>> getRawRenderTiles() const override { return renderTiles; }
+    /// Every tile the pyramid currently holds, rendered or merely retained (e.g. DEM ancestors).
+    const TilePyramid& getTilePyramid() const { return tilePyramid; }
 
     std::unordered_map<std::string, std::vector<Feature>> queryRenderedFeatures(
         const ScreenLineString& geometry,

--- a/src/mln/renderer/tile_parameters.hpp
+++ b/src/mln/renderer/tile_parameters.hpp
@@ -47,6 +47,11 @@ public:
     /// Terrain elevation for the tile cover; null when there is no terrain, which
     /// leaves the cover flat. See util::TileElevationProvider.
     const util::TileElevationProvider* elevationProvider = nullptr;
+    /// Keep this many zoom levels of ancestors of the ideal cover loaded (Required, never
+    /// rendered). Used for the 3D-terrain DEM source so layers drawn from shallower tiles
+    /// (overzoomed low-maxzoom sources, far-field distance LOD) still find a DEM tile that
+    /// covers them; without it those symbols and circles fall back to sea level.
+    uint8_t retainAncestorLevels = 0;
 };
 
 } // namespace mln

--- a/src/mln/renderer/tile_pyramid.cpp
+++ b/src/mln/renderer/tile_pyramid.cpp
@@ -197,6 +197,31 @@ void TilePyramid::update(const std::vector<Immutable<style::LayerProperties>>& l
         return tiles.emplace(tileID, std::move(tile)).first->second.get();
     };
 
+    // Keep ancestors of the ideal cover loaded (but not rendered) when asked to - see
+    // TileParameters::retainAncestorLevels.
+    if (parameters.retainAncestorLevels > 0) {
+        std::set<OverscaledTileID> ancestors;
+        for (const auto& id : idealTiles) {
+            const auto& c = id.canonical;
+            for (uint8_t level = 1; level <= parameters.retainAncestorLevels && level <= c.z; ++level) {
+                const auto az = static_cast<uint8_t>(c.z - level);
+                if (az < zoomRange.min) {
+                    break;
+                }
+                ancestors.emplace(az, id.wrap, CanonicalTileID(az, c.x >> level, c.y >> level));
+            }
+        }
+        for (const auto& id : ancestors) {
+            Tile* tile = getTileFn(id);
+            if (!tile) {
+                tile = createTileFn(id);
+            }
+            if (tile) {
+                retainTileFn(*tile, TileNecessity::Required);
+            }
+        }
+    }
+
     auto previouslyRenderedTiles = std::move(renderedTiles);
 
     auto renderTileFn = [&](const UnwrappedTileID& tileID, Tile& tile) {

--- a/src/mln/text/collision_index.cpp
+++ b/src/mln/text/collision_index.cpp
@@ -166,8 +166,7 @@ std::pair<bool, bool> CollisionIndex::placeFeature(
     assert(projectedBoxes.empty());
     if (!feature.alongLine) {
         const CollisionBox& box = feature.boxes.front();
-        auto collisionBoundaries = getProjectedCollisionBoundaries(
-            posMatrix, shift, textPixelRatio, box, getElevation);
+        auto collisionBoundaries = getProjectedCollisionBoundaries(posMatrix, shift, textPixelRatio, box, getElevation);
         projectedBoxes.emplace_back(
             collisionBoundaries[0], collisionBoundaries[1], collisionBoundaries[2], collisionBoundaries[3]);
         if ((avoidEdges && !isInsideTile(collisionBoundaries, *avoidEdges)) || !isInsideGrid(collisionBoundaries) ||

--- a/src/mln/text/collision_index.cpp
+++ b/src/mln/text/collision_index.cpp
@@ -112,8 +112,9 @@ IntersectStatus CollisionIndex::intersectsTileEdges(const CollisionBox& box,
                                                     Point<float> shift,
                                                     const mat4& posMatrix,
                                                     const float textPixelRatio,
-                                                    const CollisionBoundaries& tileEdges) const {
-    auto boundaries = getProjectedCollisionBoundaries(posMatrix, shift, textPixelRatio, box);
+                                                    const CollisionBoundaries& tileEdges,
+                                                    const SymbolElevationFn* getElevation) const {
+    auto boundaries = getProjectedCollisionBoundaries(posMatrix, shift, textPixelRatio, box, getElevation);
     IntersectStatus result;
     const float x1 = boundaries[0];
     const float y1 = boundaries[1];
@@ -160,11 +161,13 @@ std::pair<bool, bool> CollisionIndex::placeFeature(
     const bool collisionDebug,
     const std::optional<CollisionBoundaries>& avoidEdges,
     const std::optional<std::function<bool(const RefIndexedSubfeature&)>>& collisionGroupPredicate,
-    std::vector<ProjectedCollisionBox>& projectedBoxes) {
+    std::vector<ProjectedCollisionBox>& projectedBoxes,
+    const SymbolElevationFn* getElevation) {
     assert(projectedBoxes.empty());
     if (!feature.alongLine) {
         const CollisionBox& box = feature.boxes.front();
-        auto collisionBoundaries = getProjectedCollisionBoundaries(posMatrix, shift, textPixelRatio, box);
+        auto collisionBoundaries = getProjectedCollisionBoundaries(
+            posMatrix, shift, textPixelRatio, box, getElevation);
         projectedBoxes.emplace_back(
             collisionBoundaries[0], collisionBoundaries[1], collisionBoundaries[2], collisionBoundaries[3]);
         if ((avoidEdges && !isInsideTile(collisionBoundaries, *avoidEdges)) || !isInsideGrid(collisionBoundaries) ||
@@ -186,7 +189,8 @@ std::pair<bool, bool> CollisionIndex::placeFeature(
                                 collisionDebug,
                                 avoidEdges,
                                 collisionGroupPredicate,
-                                projectedBoxes);
+                                projectedBoxes,
+                                getElevation);
     }
 }
 
@@ -203,17 +207,18 @@ std::pair<bool, bool> CollisionIndex::placeLineFeature(
     const bool collisionDebug,
     const std::optional<CollisionBoundaries>& avoidEdges,
     const std::optional<std::function<bool(const RefIndexedSubfeature&)>>& collisionGroupPredicate,
-    std::vector<ProjectedCollisionBox>& projectedBoxes) {
+    std::vector<ProjectedCollisionBox>& projectedBoxes,
+    const SymbolElevationFn* getElevation) {
     assert(feature.alongLine);
     assert(projectedBoxes.empty());
     const auto tileUnitAnchorPoint = symbol.anchorPoint;
-    const auto projectedAnchor = projectAnchor(posMatrix, tileUnitAnchorPoint);
+    const auto projectedAnchor = projectAnchor(posMatrix, tileUnitAnchorPoint, getElevation);
 
     const float fontScale = fontSize / 24;
     const float lineOffsetX = symbol.lineOffset[0] * fontSize;
     const float lineOffsetY = symbol.lineOffset[1] * fontSize;
 
-    const auto labelPlaneAnchorPoint = project(tileUnitAnchorPoint, labelPlaneMatrix).first;
+    const auto labelPlaneAnchorPoint = project(tileUnitAnchorPoint, labelPlaneMatrix, getElevation).first;
 
     const auto firstAndLastGlyph = placeFirstAndLastGlyph(fontScale,
                                                           lineOffsetX,
@@ -223,7 +228,8 @@ std::pair<bool, bool> CollisionIndex::placeLineFeature(
                                                           tileUnitAnchorPoint,
                                                           symbol,
                                                           labelPlaneMatrix,
-                                                          /*return tile distance*/ true);
+                                                          /*return tile distance*/ true,
+                                                          getElevation);
 
     bool collisionDetected = false;
     bool inGrid = false;
@@ -264,7 +270,7 @@ std::pair<bool, bool> CollisionIndex::placeLineFeature(
             continue;
         }
 
-        const auto projectedPoint = projectPoint(posMatrix, circle.anchor);
+        const auto projectedPoint = projectPoint(posMatrix, circle.anchor, getElevation);
         const float tileUnitRadius = (circle.x2 - circle.x1) / 2;
         const float radius = tileUnitRadius * tileToViewport;
 
@@ -422,16 +428,28 @@ std::unordered_map<uint32_t, std::vector<IndexedSubfeature>> CollisionIndex::que
     return result;
 }
 
-std::pair<float, float> CollisionIndex::projectAnchor(const mat4& posMatrix, const Point<float>& point) const {
-    vec4 p = {{point.x, point.y, 0, 1}};
+// The z of the projected point is the terrain elevation (exaggerated metres; the
+// projection matrix bakes pixelsPerMeter, as for the elevated symbol vertices), or
+// 0 without terrain. Without this, boxes are laid out where the label would sit at
+// sea level and the elevated label overlaps its neighbours on pitched terrain.
+namespace {
+vec4 elevatedPoint(const Point<float>& point, const SymbolElevationFn* getElevation) {
+    return {{point.x, point.y, getElevation ? (*getElevation)(point) : 0.0, 1}};
+}
+} // namespace
+
+std::pair<float, float> CollisionIndex::projectAnchor(const mat4& posMatrix,
+                                                      const Point<float>& point,
+                                                      const SymbolElevationFn* getElevation) const {
+    vec4 p = elevatedPoint(point, getElevation);
     matrix::transformMat4(p, p, posMatrix);
     return std::make_pair(0.5f + 0.5f * (transformState.getCameraToCenterDistance() / static_cast<float>(p[3])),
                           static_cast<float>(p[3]));
 }
 
-std::pair<Point<float>, float> CollisionIndex::projectAndGetPerspectiveRatio(const mat4& posMatrix,
-                                                                             const Point<float>& point) const {
-    vec4 p = {{point.x, point.y, 0, 1}};
+std::pair<Point<float>, float> CollisionIndex::projectAndGetPerspectiveRatio(
+    const mat4& posMatrix, const Point<float>& point, const SymbolElevationFn* getElevation) const {
+    vec4 p = elevatedPoint(point, getElevation);
     matrix::transformMat4(p, p, posMatrix);
     auto size = transformState.getSize();
     return std::make_pair(Point<float>(static_cast<float>(((p[0] / p[3] + 1) / 2) * size.width + viewportPadding),
@@ -442,8 +460,10 @@ std::pair<Point<float>, float> CollisionIndex::projectAndGetPerspectiveRatio(con
                           0.5f + 0.5f * transformState.getCameraToCenterDistance() / static_cast<float>(p[3]));
 }
 
-Point<float> CollisionIndex::projectPoint(const mat4& posMatrix, const Point<float>& point) const {
-    vec4 p = {{point.x, point.y, 0, 1}};
+Point<float> CollisionIndex::projectPoint(const mat4& posMatrix,
+                                          const Point<float>& point,
+                                          const SymbolElevationFn* getElevation) const {
+    vec4 p = elevatedPoint(point, getElevation);
     matrix::transformMat4(p, p, posMatrix);
     auto size = transformState.getSize();
     return Point<float>{static_cast<float>((((p[0] / p[3] + 1) / 2) * size.width) + viewportPadding),
@@ -453,8 +473,9 @@ Point<float> CollisionIndex::projectPoint(const mat4& posMatrix, const Point<flo
 CollisionBoundaries CollisionIndex::getProjectedCollisionBoundaries(const mat4& posMatrix,
                                                                     Point<float> shift,
                                                                     float textPixelRatio,
-                                                                    const CollisionBox& box) const {
-    const auto projectedPoint = projectAndGetPerspectiveRatio(posMatrix, box.anchor);
+                                                                    const CollisionBox& box,
+                                                                    const SymbolElevationFn* getElevation) const {
+    const auto projectedPoint = projectAndGetPerspectiveRatio(posMatrix, box.anchor, getElevation);
     const float tileToViewport = textPixelRatio * projectedPoint.second;
     return CollisionBoundaries{{
         (box.x1 + shift.x) * tileToViewport + projectedPoint.first.x,

--- a/src/mln/text/collision_index.hpp
+++ b/src/mln/text/collision_index.hpp
@@ -5,10 +5,17 @@
 #include <mln/text/collision_feature.hpp>
 #include <mln/util/grid_index.hpp>
 #include <mln/map/transform_state.hpp>
+#include <mln/util/geometry.hpp>
+
+#include <functional>
 
 #include <array>
 
 namespace mln {
+
+/// Same alias as in layout/symbol_projection.hpp (not included here: its `project`
+/// overloads would hide unrelated `project` calls in translation units using this header).
+using SymbolElevationFn = std::function<float(const Point<float>&)>;
 
 class PlacedSymbol;
 
@@ -34,7 +41,8 @@ public:
                                         Point<float> shift,
                                         const mat4& posMatrix,
                                         float textPixelRatio,
-                                        const CollisionBoundaries& tileEdges) const;
+                                        const CollisionBoundaries& tileEdges,
+                                        const SymbolElevationFn* getElevation = nullptr) const;
     std::pair<bool, bool> placeFeature(
         const CollisionFeature& feature,
         Point<float> shift,
@@ -49,8 +57,10 @@ public:
         bool collisionDebug,
         const std::optional<CollisionBoundaries>& avoidEdges,
         const std::optional<std::function<bool(const RefIndexedSubfeature&)>>& collisionGroupPredicate,
-        std::vector<ProjectedCollisionBox>& /*out*/
-    );
+        std::vector<ProjectedCollisionBox>& /*out*/,
+        /// On 3D terrain: tile-local point -> exaggerated metres, so the boxes are
+        /// projected where the elevated symbol actually renders (gl-js getElevation)
+        const SymbolElevationFn* getElevation = nullptr);
 
     void insertFeature(const CollisionFeature& feature,
                        const std::vector<ProjectedCollisionBox>&,
@@ -85,8 +95,8 @@ private:
         bool collisionDebug,
         const std::optional<CollisionBoundaries>& avoidEdges,
         const std::optional<std::function<bool(const RefIndexedSubfeature&)>>& collisionGroupPredicate,
-        std::vector<ProjectedCollisionBox>& /*out*/
-    );
+        std::vector<ProjectedCollisionBox>& /*out*/,
+        const SymbolElevationFn* getElevation);
 
     float approximateTileDistance(const TileDistance& tileDistance,
                                   float lastSegmentAngle,
@@ -94,14 +104,20 @@ private:
                                   float cameraToAnchorDistance,
                                   bool pitchWithMap);
 
-    std::pair<float, float> projectAnchor(const mat4& posMatrix, const Point<float>& point) const;
+    std::pair<float, float> projectAnchor(const mat4& posMatrix,
+                                          const Point<float>& point,
+                                          const SymbolElevationFn* getElevation) const;
     std::pair<Point<float>, float> projectAndGetPerspectiveRatio(const mat4& posMatrix,
-                                                                 const Point<float>& point) const;
-    Point<float> projectPoint(const mat4& posMatrix, const Point<float>& point) const;
+                                                                 const Point<float>& point,
+                                                                 const SymbolElevationFn* getElevation) const;
+    Point<float> projectPoint(const mat4& posMatrix,
+                              const Point<float>& point,
+                              const SymbolElevationFn* getElevation = nullptr) const;
     CollisionBoundaries getProjectedCollisionBoundaries(const mat4& posMatrix,
                                                         Point<float> shift,
                                                         float textPixelRatio,
-                                                        const CollisionBox& box) const;
+                                                        const CollisionBox& box,
+                                                        const SymbolElevationFn* getElevation) const;
 
     const TransformState transformState;
 

--- a/src/mln/text/placement.cpp
+++ b/src/mln/text/placement.cpp
@@ -877,7 +877,10 @@ bool Placement::updateBucketDynamicAttributeData(SymbolBucket& bucket,
                 hideGlyphs(symbol.glyphOffsets.size(), bucket.text.dynamicAttributeData());
             } else {
                 const Point<float> tileAnchor = symbol.anchorPoint;
-                const auto projectedAnchor = project(tileAnchor, pitchWithMap ? tile.matrix : labelPlaneMatrix);
+                // On 3D terrain the anchor sits on the surface, so project it with its elevation
+                // (as maplibre-gl-js does for variable anchors); the shader treats the result as final.
+                const auto projectedAnchor = project(
+                    tileAnchor, pitchWithMap ? tile.matrix : labelPlaneMatrix, getElevation);
                 const float perspectiveRatio = 0.5f +
                                                0.5f * (state.getCameraToCenterDistance() / projectedAnchor.second);
                 float renderTextSize = evaluateSizeForFeature(partiallyEvaluatedSize, symbol) * perspectiveRatio /
@@ -901,8 +904,10 @@ bool Placement::updateBucketDynamicAttributeData(SymbolBucket& bucket,
                 // plane.
                 Point<float> shiftedAnchor;
                 if (pitchWithMap) {
-                    shiftedAnchor =
-                        project(Point<float>(tileAnchor.x + shift.x, tileAnchor.y + shift.y), labelPlaneMatrix).first;
+                    shiftedAnchor = project(Point<float>(tileAnchor.x + shift.x, tileAnchor.y + shift.y),
+                                            labelPlaneMatrix,
+                                            getElevation)
+                                        .first;
                 } else if (rotateWithMap) {
                     auto rotated = util::rotate(shift, -state.getPitch());
                     shiftedAnchor = Point<float>(projectedAnchor.first.x + rotated.x,

--- a/src/mln/text/placement.cpp
+++ b/src/mln/text/placement.cpp
@@ -1,4 +1,5 @@
 #include <mln/text/placement.hpp>
+#include <mln/renderer/render_terrain.hpp>
 
 #include <mln/layout/symbol_layout.hpp>
 #include <mln/renderer/bucket.hpp>
@@ -749,11 +750,14 @@ void Placement::commit() {
                                      : (getPrevPlacement() ? getPrevPlacement()->fadeStartTime : TimePoint{});
 }
 
-void Placement::updateLayerBuckets(const RenderLayer& layer, const TransformState& state, bool updateOpacities) const {
+void Placement::updateLayerBuckets(const RenderLayer& layer,
+                                   const TransformState& state,
+                                   bool updateOpacities,
+                                   const RenderTerrain* terrain) const {
     std::set<uint32_t> seenCrossTileIDs;
     for (const auto& item : layer.getPlacementData()) {
         if (!item.sortKeyRange || item.sortKeyRange->isFirstRange()) {
-            item.bucket.get().updateVertices(*this, updateOpacities, state, item.tile, seenCrossTileIDs);
+            item.bucket.get().updateVertices(*this, updateOpacities, state, item.tile, seenCrossTileIDs, terrain);
         }
     }
 }
@@ -775,8 +779,16 @@ Point<float> calculateVariableRenderShift(style::SymbolAnchorType anchor,
 
 bool Placement::updateBucketDynamicAttributeData(SymbolBucket& bucket,
                                                  const TransformState& state,
-                                                 const RenderTile& tile) const {
+                                                 const RenderTile& tile,
+                                                 const RenderTerrain* terrain) const {
     using namespace style;
+    // With 3D terrain, line-placed labels are projected here on the CPU and must be lifted
+    // onto the surface (the vertex shader elevates point symbols only).
+    std::optional<SymbolElevationFn> elevation;
+    if (terrain) {
+        elevation = terrain->elevationSampler(tile.id);
+    }
+    const SymbolElevationFn* getElevation = elevation ? &*elevation : nullptr;
     const auto& layout = *bucket.layout;
     const bool alongLine = layout.get<SymbolPlacement>() != SymbolPlacementType::Point;
     const bool hasVariableAnchors = bucket.hasVariableTextAnchors() && bucket.hasTextData();
@@ -798,7 +810,8 @@ bool Placement::updateBucketDynamicAttributeData(SymbolBucket& bucket,
                                     keepUpright,
                                     tile,
                                     *bucket.iconSizeBinder,
-                                    state);
+                                    state,
+                                    getElevation);
                 result = true;
             }
             if (bucket.hasIconData()) {
@@ -810,7 +823,8 @@ bool Placement::updateBucketDynamicAttributeData(SymbolBucket& bucket,
                                     keepUpright,
                                     tile,
                                     *bucket.iconSizeBinder,
-                                    state);
+                                    state,
+                                    getElevation);
                 result = true;
             }
         }
@@ -826,7 +840,8 @@ bool Placement::updateBucketDynamicAttributeData(SymbolBucket& bucket,
                                 keepUpright,
                                 tile,
                                 *bucket.textSizeBinder,
-                                state);
+                                state,
+                                getElevation);
             result = true;
         }
     } else if (hasVariableAnchors) {

--- a/src/mln/text/placement.cpp
+++ b/src/mln/text/placement.cpp
@@ -78,7 +78,8 @@ public:
                      const TransformState& state_,
                      float placementZoom,
                      CollisionGroups::CollisionGroup collisionGroup_,
-                     std::optional<CollisionBoundaries> avoidEdges_ = std::nullopt)
+                     std::optional<CollisionBoundaries> avoidEdges_ = std::nullopt,
+                     const RenderTerrain* terrain = nullptr)
         : bucket(bucket_),
           renderTile(renderTile_),
           state(state_),
@@ -88,9 +89,12 @@ public:
           collisionGroup(std::move(collisionGroup_)),
           partiallyEvaluatedTextSize(bucket_.textSizeBinder->evaluateForZoom(placementZoom)),
           partiallyEvaluatedIconSize(bucket_.iconSizeBinder->evaluateForZoom(placementZoom)),
-          avoidEdges(std::move(avoidEdges_)) {}
+          avoidEdges(std::move(avoidEdges_)),
+          elevation(terrain ? terrain->elevationSampler(renderTile_.id) : std::nullopt) {}
 
     const SymbolBucket& getBucket() const { return bucket.get(); }
+    /// Tile-local point -> terrain elevation for collision projection; null off terrain
+    const SymbolElevationFn* getElevation() const { return elevation ? &*elevation : nullptr; }
     const style::SymbolLayoutProperties::PossiblyEvaluated& getLayout() const { return *getBucket().layout; }
     const RenderTile& getRenderTile() const { return renderTile.get(); }
 
@@ -146,6 +150,7 @@ public:
     bool hasIconTextFit = getLayout().get<IconTextFit>() != IconTextFitType::None;
 
     std::optional<CollisionBoundaries> avoidEdges;
+    std::optional<SymbolElevationFn> elevation;
 };
 
 // PlacementController implementation
@@ -243,7 +248,8 @@ void Placement::placeSymbolBucket(const BucketPlacementData& params, std::set<ui
                          collisionIndex.getTransformState(),
                          placementZoom,
                          collisionGroups.get(params.sourceId),
-                         getAvoidEdges(symbolBucket, renderTile.matrix)};
+                         getAvoidEdges(symbolBucket, renderTile.matrix),
+                         placementTerrain};
     for (const SymbolInstance& symbol : getSortedSymbols(params, ctx.pixelRatio)) {
         if (!symbol.check(SYM_GUARD_LOC)) continue;
         if (seenCrossTileIDs.contains(symbol.getCrossTileID())) continue;
@@ -342,7 +348,8 @@ JointPlacement Placement::placeSymbol(const SymbolInstance& symbolInstance, cons
                                                                  showCollisionBoxes,
                                                                  ctx.avoidEdges,
                                                                  collisionGroup.second,
-                                                                 textBoxes);
+                                                                 textBoxes,
+                                                                 ctx.getElevation());
                 if (placedFeature.first) {
                     placedOrientations.emplace(symbolInstance.getCrossTileID(), orientation);
                 }
@@ -418,8 +425,13 @@ JointPlacement Placement::placeSymbol(const SymbolInstance& symbolInstance, cons
                                                           ctx.pitchTextWithMap,
                                                           static_cast<float>(ctx.getTransformState().getBearing()));
                     textBoxes.clear();
-                    if (!canPlaceAtVariableAnchor(
-                            textBox, anchor, shift, variableTextAnchors, posMatrix, ctx.pixelRatio)) {
+                    if (!canPlaceAtVariableAnchor(textBox,
+                                                  anchor,
+                                                  shift,
+                                                  variableTextAnchors,
+                                                  posMatrix,
+                                                  ctx.pixelRatio,
+                                                  ctx.getElevation())) {
                         continue;
                     }
 
@@ -436,7 +448,8 @@ JointPlacement Placement::placeSymbol(const SymbolInstance& symbolInstance, cons
                                                                 showCollisionBoxes,
                                                                 ctx.avoidEdges,
                                                                 collisionGroup.second,
-                                                                textBoxes);
+                                                                textBoxes,
+                                                                ctx.getElevation());
 
                     if (doVariableIconPlacement) {
                         auto placedIconFeature = collisionIndex.placeFeature(
@@ -453,7 +466,8 @@ JointPlacement Placement::placeSymbol(const SymbolInstance& symbolInstance, cons
                             showCollisionBoxes,
                             ctx.avoidEdges,
                             collisionGroup.second,
-                            iconBoxes);
+                            iconBoxes,
+                            ctx.getElevation());
                         iconBoxes.clear();
                         if (!placedIconFeature.first) continue;
                     }
@@ -551,7 +565,8 @@ JointPlacement Placement::placeSymbol(const SymbolInstance& symbolInstance, cons
                                                showCollisionBoxes,
                                                ctx.avoidEdges,
                                                collisionGroup.second,
-                                               iconBoxes);
+                                               iconBoxes,
+                                               ctx.getElevation());
         };
 
         std::pair<bool, bool> placedIcon;
@@ -1412,7 +1427,8 @@ private:
                                   Point<float> shift,
                                   std::vector<style::TextVariableAnchorType>& anchors,
                                   const mat4& posMatrix,
-                                  float textPixelRatio) override;
+                                  float textPixelRatio,
+                                  const SymbolElevationFn* getElevation) override;
     void newSymbolPlaced(const SymbolInstance&,
                          const PlacementContext&,
                          const JointPlacement&,
@@ -1511,7 +1527,8 @@ void TilePlacement::placeSymbolBucket(const BucketPlacementData& params, std::se
                          collisionIndex.getTransformState(),
                          placementZoom,
                          collisionGroups.get(params.sourceId),
-                         getAvoidEdges(bucket, renderTile.matrix)};
+                         getAvoidEdges(bucket, renderTile.matrix),
+                         placementTerrain};
 
     // In this case we first try to place symbols, which intersects the tile
     // borders, so that those symbols will remain even if each tile is handled
@@ -1549,13 +1566,17 @@ void TilePlacement::placeSymbolBucket(const BucketPlacementData& params, std::se
     auto collisionBoxIntersectsTileEdges = [&](const CollisionBox& collisionBox,
                                                Point<float> shift) noexcept -> IntersectStatus {
         IntersectStatus intersects = collisionIndex.intersectsTileEdges(
-            collisionBox, shift, renderTile.matrix, ctx.pixelRatio, *tileBorders);
+            collisionBox, shift, renderTile.matrix, ctx.pixelRatio, *tileBorders, ctx.getElevation());
         // Check if this symbol intersects the neighbor tile borders. If so, it
         // also shall be placed with priority.
         for (const auto& neighbor : neighbours) {
             if (intersects.flags != IntersectStatus::None) break;
-            intersects = collisionIndex.intersectsTileEdges(
-                collisionBox, shift + neighbor.shift, neighbor.matrix, ctx.pixelRatio, neighbor.borders);
+            intersects = collisionIndex.intersectsTileEdges(collisionBox,
+                                                            shift + neighbor.shift,
+                                                            neighbor.matrix,
+                                                            ctx.pixelRatio,
+                                                            neighbor.borders,
+                                                            ctx.getElevation());
         }
         return intersects;
     };
@@ -1640,7 +1661,8 @@ bool TilePlacement::canPlaceAtVariableAnchor(const CollisionBox& box,
                                              Point<float> shift,
                                              std::vector<style::TextVariableAnchorType>& anchors,
                                              const mat4& posMatrix,
-                                             float textPixelRatio) {
+                                             float textPixelRatio,
+                                             const SymbolElevationFn* getElevation) {
     assert(tileBorders);
     if (populateIntersections) {
         // A variable label is only allowed to intersect tile border with the first anchor.
@@ -1648,7 +1670,8 @@ bool TilePlacement::canPlaceAtVariableAnchor(const CollisionBox& box,
             // Check, that the label would intersect the tile borders even
             // without shift, otherwise intersection is not allowed (preventing
             // cut-offs in case the shift is lager than the buffer size).
-            auto status = collisionIndex.intersectsTileEdges(box, {}, posMatrix, textPixelRatio, *tileBorders);
+            auto status = collisionIndex.intersectsTileEdges(
+                box, {}, posMatrix, textPixelRatio, *tileBorders, getElevation);
             if (status.flags != IntersectStatus::None) return true;
         }
         // The most important labels shall be placed first anyway, so we continue trying
@@ -1657,7 +1680,7 @@ bool TilePlacement::canPlaceAtVariableAnchor(const CollisionBox& box,
         if (currentIntersectionPriority > 0u) return false;
     }
     // Can be placed, if it does not intersect tile borders.
-    auto status = collisionIndex.intersectsTileEdges(box, shift, posMatrix, textPixelRatio, *tileBorders);
+    auto status = collisionIndex.intersectsTileEdges(box, shift, posMatrix, textPixelRatio, *tileBorders, getElevation);
     return (status.flags == IntersectStatus::None);
 }
 

--- a/src/mln/text/placement.hpp
+++ b/src/mln/text/placement.hpp
@@ -123,6 +123,9 @@ public:
 
     virtual ~Placement();
     virtual void placeLayers(const RenderLayerReferences&);
+    /// 3D terrain for this placement round (or null): collision boxes are then projected
+    /// at the terrain elevation, where the elevated symbols render. Set before placeLayers.
+    void setTerrain(const RenderTerrain* terrain) { placementTerrain = terrain; }
     /// `terrain` (optional) lifts CPU-projected line labels onto draped 3D terrain.
     void updateLayerBuckets(const RenderLayer&,
                             const TransformState&,
@@ -170,8 +173,8 @@ protected:
                                           Point<float> /*shift*/,
                                           std::vector<style::TextVariableAnchorType>&,
                                           const mat4& /*posMatrix*/,
-                                          float /*textPixelRatio*/
-    ) {
+                                          float /*textPixelRatio*/,
+                                          const SymbolElevationFn* /*getElevation*/) {
         return true;
     }
 
@@ -190,6 +193,7 @@ protected:
     bool isTiltedView() const;
 
     std::shared_ptr<const UpdateParameters> updateParameters;
+    const RenderTerrain* placementTerrain = nullptr;
     CollisionIndex collisionIndex;
 
     style::TransitionOptions transitionOptions;

--- a/src/mln/text/placement.hpp
+++ b/src/mln/text/placement.hpp
@@ -12,6 +12,7 @@
 namespace mln {
 
 class SymbolBucket;
+class RenderTerrain;
 class SymbolInstance;
 using SymbolInstanceReferences = std::vector<std::reference_wrapper<const SymbolInstance>>;
 class UpdateParameters;
@@ -122,7 +123,11 @@ public:
 
     virtual ~Placement();
     virtual void placeLayers(const RenderLayerReferences&);
-    void updateLayerBuckets(const RenderLayer&, const TransformState&, bool updateOpacities) const;
+    /// `terrain` (optional) lifts CPU-projected line labels onto draped 3D terrain.
+    void updateLayerBuckets(const RenderLayer&,
+                            const TransformState&,
+                            bool updateOpacities,
+                            const RenderTerrain* terrain = nullptr) const;
     virtual float symbolFadeChange(TimePoint now) const;
     virtual bool hasTransitions(TimePoint now) const;
     virtual bool transitionsEnabled() const;
@@ -171,7 +176,10 @@ protected:
     }
 
     // Returns `true` if bucket vertices were updated; returns `false` otherwise.
-    bool updateBucketDynamicAttributeData(SymbolBucket&, const TransformState&, const RenderTile& tile) const;
+    bool updateBucketDynamicAttributeData(SymbolBucket&,
+                                          const TransformState&,
+                                          const RenderTile& tile,
+                                          const RenderTerrain* terrain = nullptr) const;
     void updateBucketOpacities(SymbolBucket&, const TransformState&, std::set<uint32_t>&) const;
     void markUsedJustification(SymbolBucket&,
                                style::TextVariableAnchorType,


### PR DESCRIPTION
## What

With 3D terrain on, everything projected on the CPU still assumed sea level, so it drifted away from the draped surface as the map tilted or panned. Four related fixes, in dependency order:

1. **Annotations and line-placed labels** (`Map::pixelForLatLng(latLng, elevation)`, `Renderer::queryTerrainElevation`, `RenderTerrain::getElevationAtLatLng`; a `SymbolElevationFn` threaded through `symbol_projection` and `Placement::updateBucketDynamicAttributeData`, mirroring gl-js's `getElevation` callback). Annotation views, the user location view and road names now sit on the ground they mark. iOS `convertLatLng:toPointToView:` uses the terrain-aware projection.
2. **DEM ancestors kept loaded; variable-anchor symbols elevated.** Layers draw from tiles shallower than the DEM mesh cover (far-field distance LOD, overzoomed low-maxzoom sources) and found no DEM to sample, falling to sea level. `TileParameters::retainAncestorLevels` keeps ancestors of the ideal cover loaded (Required, never rendered) for the terrain's DEM source only, and `RenderTerrain` samples every loaded DEM tile. Separately, `text-variable-anchor` symbols are projected on the CPU in placement and were projected without elevation; they now use the tile elevation sampler.
3. **Collision index elevated; terrain pick.** Every collision projection (point boxes, line-label circles, tile-edge tests) ran at sea level while the symbols rendered on the surface, so show/hide and overlap decisions were made for the wrong screen position, and since annotation hit-testing uses the same grid, pins on hillsides could not be selected. Placement hands the per-tile elevation sampler to `CollisionIndex`. `RenderTerrain::pickLatLng` ray-marches a screen pixel against the DEM (nearest surface first), exposed as `Renderer::queryTerrainPick`; rendered-feature queries and iOS `convertPoint:toCoordinateFromView:` use it, with `TransformState` / `Transform` / `Map` overloads that unproject onto a plane at a given elevation.
4. **Android** `Projection.toScreenLocation` / `fromScreenLocation` use the same queries through a bounded render-thread round trip, skipped when the style has no terrain.

## How it was verified

- Exaggeration-3 test scenes on the iOS simulator (Mt Buller, Mansfield): pins, the puck, road names and locality labels ride the surface and stay put while panning.
- Tap round trip: a tapped pixel -> terrain pick -> `convertCoordinate:toPointToView:` returns the exact tapped pixel at pitch 68.
- POI pins on slopes select in 3D (previously missed).
- Android: builds and runs on a Galaxy S10e (OpenGL) and the emulator; the projection path is exercised by the app's tap-to-coordinate flows.
- Not covered: Android `MapSnapshotter`, batch `pixelsForLatLngs` / `latLngsForPixels` (left at sea level, documented).

## Notes

Written with AI assistance (Claude), reviewed and tested by me before opening this PR, per MapLibre's AI policy.
