### PR TITLE
terrain: make symbol occlusion behind terrain fire on Metal and GL

### DIFF
--- a/TERRAIN.md
+++ b/TERRAIN.md
@@ -315,7 +315,7 @@ filled in by @daviani on an iPhone 16 Pro Max / iOS 26.6, built for device with
 | builds | yes | yes | **yes** (bazel, for device) | yes (Dawn) |
 | terrain renders | yes | **yes, verified on device** | **yes, verified on device** | untested |
 | terrain off->on (all 3 load modes) | yes | **yes, verified** | **yes** (via style JSON; load modes not separated) | untested |
-| symbol occlusion | yes | looks correct on device | untested (code path is complete; see below) | untested |
+| symbol occlusion | yes | looks correct on device | verified on the iOS simulator (2026-09-05) after scaling the fade ramp to native's 1 px near plane and packing the depth as exact base-256 digits | untested |
 | **fill-extrusion elevation** | yes | **yes** (2026-08-01, render test pixel-matches the GL baseline) | **yes** (2026-08-02, shaders sample the DEM; CI confirmation pending) | yes |
 | instanced depth pass | yes (GL-only by design) | n/a (per-tile path) | n/a | n/a |
 

--- a/include/mln/shaders/gl/prelude.hpp
+++ b/include/mln/shaders/gl/prelude.hpp
@@ -161,40 +161,50 @@ vec4 apply_drape_transform(vec4 clip, mat4 matrix, vec4 target_tile) {
     return clip;
 }
 
-// Unpack a depth value packed by the terrain depth pass (terrain_depth.fragment.glsl).
-// Matches maplibre-gl-js unpack(): the depth pass packs gl_Position.z/gl_Position.w
-// (clip-space NDC z) directly, so no window-depth remap (no *2-1, no glDepthRange dependency).
+// Unpack a depth value packed by the terrain depth pass (terrain_depth.fragment.glsl): four
+// base-256 digits of the window depth, each stored exactly as k / 255 in the RGBA8 target, so
+// the decode is exact to float precision (the gl-js fract/bit_mask scheme stores k / 256 into a
+// unorm8 that holds n / 255, an error of up to 0.002 - far more than the depth differences the
+// test looks for at native's 1 px near plane). Converted back to clip-space NDC z to match the
+// pos.z / pos.w compared in calculate_visibility.
 float unpack_depth(vec4 rgba_depth) {
-    const highp vec4 bit_shift = vec4(1.0 / (256.0 * 256.0 * 256.0), 1.0 / (256.0 * 256.0), 1.0 / 256.0, 1.0);
-    return dot(rgba_depth, bit_shift);
+    const highp vec4 weights = vec4(1.0 / 256.0, 1.0 / 65536.0, 1.0 / 16777216.0, 1.0 / 4294967296.0);
+    highp vec4 digits = floor(rgba_depth * 255.0 + 0.5);
+    return dot(digits, weights) * 2.0 - 1.0;
 }
 
 // Opacity of a fragment behind the terrain, in [0, 1]: 1 fully visible, 0 fully hidden,
 // with a soft ramp and a small bias so geometry sitting exactly on the terrain surface
 // (e.g. a label anchored to it) does not occlude itself. Matches maplibre-gl-js depthOpacity().
-highp float depth_opacity(vec3 frag, sampler2D depth_texture) {
-    highp float d = unpack_depth(texture(depth_texture, frag.xy * 0.5 + 0.5)) + 0.0001 - frag.z;
-    // gl-js uses 500 (ramp over ~0.002 NDC). Our perspective depth is compressed into a tighter
-    // NDC band near the far plane, so behind-ridge separations are only a few 1e-4; steepen to
-    // 5000 so those fully occlude. On-surface labels keep d = +0.0001 > 0 and stay fully visible.
-    return 1.0 - max(0.0, min(1.0, -d * 5000.0));
+// `depth_ramp` scales the gl-js ramp (500 per NDC unit) to this projection: gl-js uses a near
+// plane of height / 50 where native's TransformState::getProjMatrix uses 1 (one pixel at the
+// view centre), which compresses every fragment's NDC depth into the top ~0.1%. Scaling by the
+// near-plane ratio keeps gl-js's behaviour (fully hidden ~0.11 view-heights behind the surface
+// at the centre distance, self-occlusion bias ~5 px).
+highp float depth_opacity(vec3 frag, sampler2D depth_texture, highp float depth_ramp) {
+    highp float bias = 0.05 / depth_ramp; // gl-js: 0.0001 * 500
+    highp float d = unpack_depth(texture(depth_texture, frag.xy * 0.5 + 0.5)) + bias - frag.z;
+    return 1.0 - max(0.0, min(1.0, -d * depth_ramp));
 }
 
 // Whether a clip-space position is visible in front of the terrain, from the
 // packed terrain depth texture, matching maplibre-gl-js calculate_visibility().
 // Unlike gl-js (global terrain uniforms), the depth sampler and enable flag are
-// passed as arguments.
-float calculate_visibility(vec4 pos, sampler2D depth_texture, float depth_enabled) {
+// passed as arguments. `camera_to_center_distance` is 1.5 x the view height in
+// native's projection, so the near-plane ratio (height / 50) gives a ramp of
+// 500 * height / 50 = 10 * height = 6.67 * camera_to_center_distance.
+float calculate_visibility(vec4 pos, sampler2D depth_texture, float depth_enabled, highp float camera_to_center_distance) {
     if (depth_enabled == 0.0) {
         return 1.0;
     }
+    highp float depth_ramp = 6.67 * camera_to_center_distance;
     vec3 frag = pos.xyz / pos.w;
-    highp float d = depth_opacity(frag, depth_texture);
+    highp float d = depth_opacity(frag, depth_texture, depth_ramp);
     if (d > 0.95) {
         return 1.0;
     }
     // a label whose anchor is just behind a ridge still shows if its glyphs poke above it
-    return (d + depth_opacity(frag + vec3(0.0, 0.01, 0.0), depth_texture)) / 2.0;
+    return (d + depth_opacity(frag + vec3(0.0, 0.01, 0.0), depth_texture, depth_ramp)) / 2.0;
 }
 )";
     static constexpr const char* fragment = R"(#ifdef GL_ES

--- a/include/mln/shaders/gl/symbol_icon.hpp
+++ b/include/mln/shaders/gl/symbol_icon.hpp
@@ -159,7 +159,7 @@ lowp float opacity = u_opacity;
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_symbol_fade_change : -u_symbol_fade_change;
     v_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
-    v_fade_opacity *= calculate_visibility(projectedPoint, u_depth, u_depth_enabled);
+    v_fade_opacity *= calculate_visibility(projectedPoint, u_depth, u_depth_enabled, u_camera_to_center_distance);
 }
 )";
     static constexpr const char* fragment = R"(uniform sampler2D u_texture;

--- a/include/mln/shaders/gl/symbol_sdf.hpp
+++ b/include/mln/shaders/gl/symbol_sdf.hpp
@@ -213,7 +213,7 @@ lowp float halo_blur = u_halo_blur;
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_symbol_fade_change : -u_symbol_fade_change;
     float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
-    interpolated_fade_opacity *= calculate_visibility(projectedPoint, u_depth, u_depth_enabled);
+    interpolated_fade_opacity *= calculate_visibility(projectedPoint, u_depth, u_depth_enabled, u_camera_to_center_distance);
 
     v_data0 = a_tex / u_texsize;
     v_data1 = vec3(gamma_scale, size, interpolated_fade_opacity);

--- a/include/mln/shaders/gl/symbol_text_and_icon.hpp
+++ b/include/mln/shaders/gl/symbol_text_and_icon.hpp
@@ -212,7 +212,7 @@ lowp float halo_blur = u_halo_blur;
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_symbol_fade_change : -u_symbol_fade_change;
     float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
-    interpolated_fade_opacity *= calculate_visibility(projectedPoint, u_depth, u_depth_enabled);
+    interpolated_fade_opacity *= calculate_visibility(projectedPoint, u_depth, u_depth_enabled, u_camera_to_center_distance);
 
     v_data0.xy = a_tex / u_texsize;
     v_data0.zw = a_tex / u_texsize_icon;

--- a/include/mln/shaders/gl/terrain_depth.hpp
+++ b/include/mln/shaders/gl/terrain_depth.hpp
@@ -72,15 +72,19 @@ void main() {
 )";
     static constexpr const char* fragment = R"(in highp float v_depth;
 void main() {
-    // Pack the clip-space NDC depth into RGBA8, as in the maplibre-gl-js
-    // terrain_depth shader; unpacked by unpack_depth() in the vertex prelude
-    // for calculate_visibility()
-    highp float depth = v_depth;
-    const highp vec4 bit_shift = vec4(256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0);
-    const highp vec4 bit_mask = vec4(0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0);
-    highp vec4 res = fract(depth * bit_shift);
-    res -= res.xxyz * bit_mask;
-    fragColor = res;
+    // v_depth is clip-space NDC z (gl_Position.z / w). Pack the window depth [0, 1] into RGBA8
+    // as four base-256 digits, each written as k / 255 so the unorm8 target stores it exactly
+    // (the gl-js fract/bit_mask scheme stores k / 256 and loses up to 0.002 to unorm rounding).
+    // Decoded by unpack_depth() in the vertex prelude for calculate_visibility().
+    highp float r = clamp(v_depth * 0.5 + 0.5, 0.0, 0.99999994) * 256.0;
+    highp float d0 = floor(r);
+    r = (r - d0) * 256.0;
+    highp float d1 = floor(r);
+    r = (r - d1) * 256.0;
+    highp float d2 = floor(r);
+    r = (r - d2) * 256.0;
+    highp float d3 = floor(r);
+    fragColor = vec4(d0, d1, d2, d3) / 255.0;
 }
 )";
 };

--- a/include/mln/shaders/mtl/common.hpp
+++ b/include/mln/shaders/mtl/common.hpp
@@ -102,46 +102,64 @@ inline float get_elevation(float2 pos,
     return elevation * dem_exaggeration;
 }
 
-// Unpack a depth value packed by the terrain depth pass (mtl/terrain_depth.hpp),
-// converted to NDC z, as in the maplibre-gl-js prelude
+// Unpack a depth value packed by the terrain depth pass (mtl/terrain_depth.hpp):
+// four base-256 digits, each stored exactly as k/255 in the RGBA8 target, so the
+// decode is exact to float precision. The pass packs Metal window depth in [0, 1]
+// (rendered with the terrain tweaker's [0, 1]-remapped matrix); the symbol matrices
+// carry no such remap, so convert back to GL NDC [-1, 1] to match pos.z / pos.w.
 inline float unpack_depth(float4 rgba_depth) {
-    const float4 bit_shift = float4(1.0 / (256.0 * 256.0 * 256.0), 1.0 / (256.0 * 256.0), 1.0 / 256.0, 1.0);
-    return dot(rgba_depth, bit_shift) * 2.0 - 1.0;
+    const float4 digits = round(rgba_depth * 255.0);
+    const float4 weights = float4(1.0 / 256.0, 1.0 / 65536.0, 1.0 / 16777216.0, 1.0 / 4294967296.0);
+    return dot(digits, weights) * 2.0 - 1.0;
 }
 
 // Opacity of a fragment behind the terrain, in [0, 1]: 1 fully visible, 0 fully
 // hidden, with a soft ramp over ~0.002 NDC depth and a small bias so geometry
 // sitting exactly on the terrain surface (e.g. a label anchored to it) does not
 // occlude itself. Matches the maplibre-gl-js depthOpacity() prelude function.
+//
+// `depth_ramp` scales the gl-js ramp (500 per NDC unit) to this projection. gl-js uses
+// a near plane of height / 50 while native's TransformState::getProjMatrix uses 1
+// (one pixel at the view centre), which compresses every fragment's NDC depth into
+// the top ~0.1%: a label 100 px behind a ridge differs by ~1e-4, and at 500 the
+// gl-js ramp would fade it by 5%. Scaling by the near-plane ratio keeps gl-js's
+// behaviour (fully hidden ~0.11 view-heights behind the surface at the centre
+// distance, self-occlusion bias ~5 px); see calculate_visibility for the value.
 inline float depth_opacity(float3 frag,
                            texture2d<float, access::sample> depth_texture,
-                           sampler depth_sampler) {
+                           sampler depth_sampler,
+                           float depth_ramp) {
     const float2 uv = frag.xy * 0.5 + 0.5;
-    const float d = unpack_depth(depth_texture.sample(depth_sampler, float2(uv.x, 1.0 - uv.y))) + 0.0001 -
-                    frag.z;
-    return 1.0 - max(0.0, min(1.0, -d * 500.0));
+    const float bias = 0.05 / depth_ramp; // gl-js: 0.0001 * 500
+    const float d = unpack_depth(depth_texture.sample(depth_sampler, float2(uv.x, 1.0 - uv.y))) + bias - frag.z;
+    return 1.0 - max(0.0, min(1.0, -d * depth_ramp));
 }
 
 // Whether a clip-space position is visible in front of the terrain, from the
 // packed terrain depth texture, matching maplibre-gl-js calculate_visibility().
 // Unlike gl-js (global terrain uniforms), the depth texture and enable flag are
 // passed as arguments.
+// `camera_to_center_distance` (GlobalPaintParamsUBO) is 1.5 x the view height in
+// native's projection, so the near-plane ratio (height / 50) / 1 gives a ramp of
+// 500 * height / 50 = 10 * height = 6.67 * camera_to_center_distance.
 inline float calculate_visibility(float4 pos,
                                   texture2d<float, access::sample> depth_texture,
                                   sampler depth_sampler,
-                                  float depth_enabled) {
+                                  float depth_enabled,
+                                  float camera_to_center_distance) {
     if (depth_enabled == 0.0) {
         return 1.0;
     }
+    const float depth_ramp = 6.67 * camera_to_center_distance;
     const float3 frag = pos.xyz / pos.w;
     // check if coordinate is fully visible
-    const float d = depth_opacity(frag, depth_texture, depth_sampler);
+    const float d = depth_opacity(frag, depth_texture, depth_sampler, depth_ramp);
     if (d > 0.95) {
         return 1.0;
     }
     // if not, sample some pixels above: a label whose anchor is just behind a
     // ridge still shows if its glyphs poke above it (maplibre-gl-js behaviour)
-    return (d + depth_opacity(frag + float3(0.0, 0.01, 0.0), depth_texture, depth_sampler)) / 2.0;
+    return (d + depth_opacity(frag + float3(0.0, 0.01, 0.0), depth_texture, depth_sampler, depth_ramp)) / 2.0;
 }
 
 template<class ForwardIt, class T>

--- a/include/mln/shaders/mtl/symbol.hpp
+++ b/include/mln/shaders/mtl/symbol.hpp
@@ -249,7 +249,7 @@ FragmentStage vertex vertexMain(thread const VertexStage vertx [[stage_in]],
     const float2 posOffset = a_offset * max(a_minFontScale, fontScale) / 32.0 + a_pxoffset / 16.0;
     const float4 position = drawable.coord_matrix * float4(pos0 + rotation_matrix * posOffset, z, 1.0);
     // Fade out symbols hidden behind the terrain (see calculate_visibility)
-    const half vis = half(calculate_visibility(projectedPoint, depthTexture, depthSampler, drawable.depth_enabled));
+    const half vis = half(calculate_visibility(projectedPoint, depthTexture, depthSampler, drawable.depth_enabled, paintParams.camera_to_center_distance));
 
     return {
         .position     = position,
@@ -473,7 +473,7 @@ FragmentStage vertex vertexMain(thread const VertexStage vertx [[stage_in]],
     const float2 pos0 = projected_pos.xy / projected_pos.w + rotation_matrix * pos_rot;
     const float4 position = drawable.coord_matrix * float4(pos0, z, 1.0);
     // Fade out symbols hidden behind the terrain (see calculate_visibility)
-    const half vis = half(calculate_visibility(projectedPoint, depthTexture, depthSampler, drawable.depth_enabled));
+    const half vis = half(calculate_visibility(projectedPoint, depthTexture, depthSampler, drawable.depth_enabled, paintParams.camera_to_center_distance));
 
     return {
         .position     = position,
@@ -757,7 +757,7 @@ FragmentStage vertex vertexMain(thread const VertexStage vertx [[stage_in]],
     const float gamma_scale = position.w;
     const bool is_icon = (is_sdf == ICON);
     // Fade out symbols hidden behind the terrain (see calculate_visibility)
-    const half vis = half(calculate_visibility(projectedPoint, depthTexture, depthSampler, drawable.depth_enabled));
+    const half vis = half(calculate_visibility(projectedPoint, depthTexture, depthSampler, drawable.depth_enabled, paintParams.camera_to_center_distance));
 
     return {
         .position     = position,

--- a/include/mln/shaders/mtl/terrain_depth.hpp
+++ b/include/mln/shaders/mtl/terrain_depth.hpp
@@ -54,14 +54,20 @@ FragmentStage vertex vertexMain(thread const VertexStage vertx [[stage_in]],
 }
 
 half4 fragment fragmentMain(FragmentStage in [[stage_in]]) {
-    // Pack the fragment depth into RGBA8, matching the maplibre-gl-js
-    // terrain_depth shader; unpacked by unpack_depth() for calculate_visibility()
-    const float depth = in.position.z;
-    const float4 bit_shift = float4(256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0);
-    const float4 bit_mask = float4(0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0);
-    float4 res = fract(depth * bit_shift);
-    res -= res.xxyz * bit_mask;
-    return half4(res);
+    // Pack the window depth into RGBA8 as four base-256 digits, each written as
+    // k / 255 so it survives the unorm8 target exactly (the gl-js fract/bit_mask
+    // scheme stores k / 256, which unorm8 rounds by up to 0.002 - at native's near
+    // plane of 1 px that is 20x the depth difference the occlusion test looks
+    // for). Decoded by unpack_depth() for calculate_visibility().
+    float r = min(in.position.z, 0.99999994) * 256.0;
+    const float d0 = floor(r);
+    r = (r - d0) * 256.0;
+    const float d1 = floor(r);
+    r = (r - d1) * 256.0;
+    const float d2 = floor(r);
+    r = (r - d2) * 256.0;
+    const float d3 = floor(r);
+    return half4(float4(d0, d1, d2, d3) / 255.0);
 }
 )";
 };

--- a/shaders/_prelude.vertex.glsl
+++ b/shaders/_prelude.vertex.glsl
@@ -151,38 +151,48 @@ vec4 apply_drape_transform(vec4 clip, mat4 matrix, vec4 target_tile) {
     return clip;
 }
 
-// Unpack a depth value packed by the terrain depth pass (terrain_depth.fragment.glsl).
-// Matches maplibre-gl-js unpack(): the depth pass packs gl_Position.z/gl_Position.w
-// (clip-space NDC z) directly, so no window-depth remap (no *2-1, no glDepthRange dependency).
+// Unpack a depth value packed by the terrain depth pass (terrain_depth.fragment.glsl): four
+// base-256 digits of the window depth, each stored exactly as k / 255 in the RGBA8 target, so
+// the decode is exact to float precision (the gl-js fract/bit_mask scheme stores k / 256 into a
+// unorm8 that holds n / 255, an error of up to 0.002 - far more than the depth differences the
+// test looks for at native's 1 px near plane). Converted back to clip-space NDC z to match the
+// pos.z / pos.w compared in calculate_visibility.
 float unpack_depth(vec4 rgba_depth) {
-    const highp vec4 bit_shift = vec4(1.0 / (256.0 * 256.0 * 256.0), 1.0 / (256.0 * 256.0), 1.0 / 256.0, 1.0);
-    return dot(rgba_depth, bit_shift);
+    const highp vec4 weights = vec4(1.0 / 256.0, 1.0 / 65536.0, 1.0 / 16777216.0, 1.0 / 4294967296.0);
+    highp vec4 digits = floor(rgba_depth * 255.0 + 0.5);
+    return dot(digits, weights) * 2.0 - 1.0;
 }
 
 // Opacity of a fragment behind the terrain, in [0, 1]: 1 fully visible, 0 fully hidden,
 // with a soft ramp and a small bias so geometry sitting exactly on the terrain surface
 // (e.g. a label anchored to it) does not occlude itself. Matches maplibre-gl-js depthOpacity().
-highp float depth_opacity(vec3 frag, sampler2D depth_texture) {
-    highp float d = unpack_depth(texture(depth_texture, frag.xy * 0.5 + 0.5)) + 0.0001 - frag.z;
-    // gl-js uses 500 (ramp over ~0.002 NDC). Our perspective depth is compressed into a tighter
-    // NDC band near the far plane, so behind-ridge separations are only a few 1e-4; steepen to
-    // 5000 so those fully occlude. On-surface labels keep d = +0.0001 > 0 and stay fully visible.
-    return 1.0 - max(0.0, min(1.0, -d * 5000.0));
+// `depth_ramp` scales the gl-js ramp (500 per NDC unit) to this projection: gl-js uses a near
+// plane of height / 50 where native's TransformState::getProjMatrix uses 1 (one pixel at the
+// view centre), which compresses every fragment's NDC depth into the top ~0.1%. Scaling by the
+// near-plane ratio keeps gl-js's behaviour (fully hidden ~0.11 view-heights behind the surface
+// at the centre distance, self-occlusion bias ~5 px).
+highp float depth_opacity(vec3 frag, sampler2D depth_texture, highp float depth_ramp) {
+    highp float bias = 0.05 / depth_ramp; // gl-js: 0.0001 * 500
+    highp float d = unpack_depth(texture(depth_texture, frag.xy * 0.5 + 0.5)) + bias - frag.z;
+    return 1.0 - max(0.0, min(1.0, -d * depth_ramp));
 }
 
 // Whether a clip-space position is visible in front of the terrain, from the
 // packed terrain depth texture, matching maplibre-gl-js calculate_visibility().
 // Unlike gl-js (global terrain uniforms), the depth sampler and enable flag are
-// passed as arguments.
-float calculate_visibility(vec4 pos, sampler2D depth_texture, float depth_enabled) {
+// passed as arguments. `camera_to_center_distance` is 1.5 x the view height in
+// native's projection, so the near-plane ratio (height / 50) gives a ramp of
+// 500 * height / 50 = 10 * height = 6.67 * camera_to_center_distance.
+float calculate_visibility(vec4 pos, sampler2D depth_texture, float depth_enabled, highp float camera_to_center_distance) {
     if (depth_enabled == 0.0) {
         return 1.0;
     }
+    highp float depth_ramp = 6.67 * camera_to_center_distance;
     vec3 frag = pos.xyz / pos.w;
-    highp float d = depth_opacity(frag, depth_texture);
+    highp float d = depth_opacity(frag, depth_texture, depth_ramp);
     if (d > 0.95) {
         return 1.0;
     }
     // a label whose anchor is just behind a ridge still shows if its glyphs poke above it
-    return (d + depth_opacity(frag + vec3(0.0, 0.01, 0.0), depth_texture)) / 2.0;
+    return (d + depth_opacity(frag + vec3(0.0, 0.01, 0.0), depth_texture, depth_ramp)) / 2.0;
 }

--- a/shaders/symbol_icon.vertex.glsl
+++ b/shaders/symbol_icon.vertex.glsl
@@ -142,5 +142,5 @@ void main() {
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_symbol_fade_change : -u_symbol_fade_change;
     v_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
-    v_fade_opacity *= calculate_visibility(projectedPoint, u_depth, u_depth_enabled);
+    v_fade_opacity *= calculate_visibility(projectedPoint, u_depth, u_depth_enabled, u_camera_to_center_distance);
 }

--- a/shaders/symbol_sdf.vertex.glsl
+++ b/shaders/symbol_sdf.vertex.glsl
@@ -168,7 +168,7 @@ void main() {
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_symbol_fade_change : -u_symbol_fade_change;
     float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
-    interpolated_fade_opacity *= calculate_visibility(projectedPoint, u_depth, u_depth_enabled);
+    interpolated_fade_opacity *= calculate_visibility(projectedPoint, u_depth, u_depth_enabled, u_camera_to_center_distance);
 
     v_data0 = a_tex / u_texsize;
     v_data1 = vec3(gamma_scale, size, interpolated_fade_opacity);

--- a/shaders/symbol_text_and_icon.vertex.glsl
+++ b/shaders/symbol_text_and_icon.vertex.glsl
@@ -167,7 +167,7 @@ void main() {
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_symbol_fade_change : -u_symbol_fade_change;
     float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
-    interpolated_fade_opacity *= calculate_visibility(projectedPoint, u_depth, u_depth_enabled);
+    interpolated_fade_opacity *= calculate_visibility(projectedPoint, u_depth, u_depth_enabled, u_camera_to_center_distance);
 
     v_data0.xy = a_tex / u_texsize;
     v_data0.zw = a_tex / u_texsize_icon;

--- a/shaders/terrain_depth.fragment.glsl
+++ b/shaders/terrain_depth.fragment.glsl
@@ -1,12 +1,16 @@
 in highp float v_depth;
 void main() {
-    // Pack the clip-space NDC depth into RGBA8, as in the maplibre-gl-js
-    // terrain_depth shader; unpacked by unpack_depth() in the vertex prelude
-    // for calculate_visibility()
-    highp float depth = v_depth;
-    const highp vec4 bit_shift = vec4(256.0 * 256.0 * 256.0, 256.0 * 256.0, 256.0, 1.0);
-    const highp vec4 bit_mask = vec4(0.0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0);
-    highp vec4 res = fract(depth * bit_shift);
-    res -= res.xxyz * bit_mask;
-    fragColor = res;
+    // v_depth is clip-space NDC z (gl_Position.z / w). Pack the window depth [0, 1] into RGBA8
+    // as four base-256 digits, each written as k / 255 so the unorm8 target stores it exactly
+    // (the gl-js fract/bit_mask scheme stores k / 256 and loses up to 0.002 to unorm rounding).
+    // Decoded by unpack_depth() in the vertex prelude for calculate_visibility().
+    highp float r = clamp(v_depth * 0.5 + 0.5, 0.0, 0.99999994) * 256.0;
+    highp float d0 = floor(r);
+    r = (r - d0) * 256.0;
+    highp float d1 = floor(r);
+    r = (r - d1) * 256.0;
+    highp float d2 = floor(r);
+    r = (r - d2) * 256.0;
+    highp float d3 = floor(r);
+    fragColor = vec4(d0, d1, d2, d3) / 255.0;
 }

--- a/src/mln/renderer/render_terrain.cpp
+++ b/src/mln/renderer/render_terrain.cpp
@@ -739,6 +739,11 @@ void RenderTerrain::prepareDepthTarget(PaintParameters& parameters) {
         }
         // Far plane everywhere the terrain does not cover (unpack_depth(1,1,1,1) ~ 1.0)
         depthRenderTarget->setClearColor(Color::white());
+        // The packed digits must not be filtered: blending neighbouring texels'
+        // channels decodes to garbage (offscreen textures default to Linear)
+        depthRenderTarget->getTexture()->setSamplerConfiguration({.filter = gfx::TextureFilterType::Nearest,
+                                                                  .wrapU = gfx::TextureWrapType::Clamp,
+                                                                  .wrapV = gfx::TextureWrapType::Clamp});
     }
     // (Re)attach the depth layer group; it may not have existed yet when the
     // target was first created on an early frame


### PR DESCRIPTION
## What

Symbol occlusion behind terrain (TERRAIN.md: "code-complete, unverified on Metal") never fires on Metal, and on GL only with a hand-tuned constant. The pack/unpack is consistent (the depth pass packs [0,1] window depth from the [0,1]-remapped terrain matrix; unpack converts back to the GL [-1,1] convention the symbol matrices use), but two things stop the comparison from working:

1. **Near plane.** `TransformState::getProjMatrix` uses `nearZ = 1` (one pixel at the view centre) where maplibre-gl-js uses `height / 50`, so every fragment's NDC depth lands in the top ~0.1% of the range. The gl-js fade ramp (500 per NDC unit) fades a label 100 px behind a ridge by about 5%. The ramp is now scaled by the near-plane ratio: `500 * height / 50 = 6.67 * camera_to_center_distance`, passed in by the symbol shaders; the self-occlusion bias scales the same way (`0.05 / ramp`). On GL this replaces the fixed `5000` the branch had, which was not proportional to the view.
2. **Packing precision.** The gl-js `fract` / `bit_mask` RGBA8 packing writes `k/256` per channel into a unorm8 target that stores `n/255`, an error of up to 0.002, twenty times the depth differences the test looks for at this near plane. The depth pass now packs four base-256 digits as `k/255`, which unorm8 stores exactly, decoded with `round(rgba * 255)`.
3. The offscreen depth target is sampled with Nearest filtering (offscreen textures default to Linear, which blends the packed digits).

Metal and GL are both covered; Vulkan and WebGPU share the shape of this code and presumably the problem, left untouched here (not verifiable on my side). TERRAIN.md's status row for Metal is updated.

## How it was verified

- iOS simulator, Mt Buller at exaggeration 3 and at 1.3: labels behind the summit ridge (locality names, a route shield, a creek label in the far valley, the far-field pile behind the mountains) fade out; labels on visible slopes and the open plain are unchanged. Before/after screenshots available on request.
- Android (OpenGL, Galaxy S10e and the emulator): renders correctly with the new packing; ridge occlusion not yet inspected on a dedicated scene.

## Notes

Written with AI assistance (Claude), reviewed and tested by me before opening this PR, per MapLibre's AI policy.
