### PR TITLE
metal: compile shader libraries off the render thread (opt-in); drawables wait instead of blocking

### DIFF
--- a/include/mln/gfx/context.hpp
+++ b/include/mln/gfx/context.hpp
@@ -135,6 +135,16 @@ public:
     /// Get the generic shader with the specified name
     virtual gfx::ShaderProgramBasePtr getGenericShader(gfx::ShaderRegistry&, const std::string& name) = 0;
 
+    /// Compile shader programs off the render thread where the backend supports it (Metal).
+    /// A program's drawables are skipped for the frames its library is still compiling and the
+    /// renderer keeps requesting frames until every pending compile has landed, so first use of
+    /// a shader (a new symbol permutation, the terrain pass) no longer stalls the render thread
+    /// - on iOS that thread is the main thread, and a terrain style's first draped frame stalled
+    /// it for over a second. Off by default so single-frame renders (render tests, snapshots)
+    /// stay deterministic.
+    virtual void setAsyncShaderCompilation(bool) {}
+    virtual bool hasPendingShaderCompiles() const { return false; }
+
     /// Create a tile layer group implementation
     virtual TileLayerGroupPtr createTileLayerGroup(int32_t layerIndex,
                                                    std::size_t initialCapacity,

--- a/include/mln/mtl/context.hpp
+++ b/include/mln/mtl/context.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+#include <memory>
 #include <mln/gfx/draw_mode.hpp>
 #include <mln/gfx/depth_mode.hpp>
 #include <mln/gfx/stencil_mode.hpp>
@@ -92,6 +94,9 @@ public:
 
     gfx::ShaderProgramBasePtr getGenericShader(gfx::ShaderRegistry&, const std::string& name) override;
 
+    void setAsyncShaderCompilation(bool enabled) override { asyncShaderCompilation = enabled; }
+    bool hasPendingShaderCompiles() const override { return pendingShaderCompiles->load() > 0; }
+
     TileLayerGroupPtr createTileLayerGroup(int32_t layerIndex, std::size_t initialCapacity, std::string name) override;
 
     LayerGroupPtr createLayerGroup(int32_t layerIndex, std::size_t initialCapacity, std::string name) override;
@@ -173,6 +178,10 @@ private:
     MTLRenderPipelineStatePtr clipMaskPipelineState;
     std::optional<BufferResource> clipMaskUniformsBuffer;
     bool clipMaskUniformsBufferUsed = false;
+    bool asyncShaderCompilation = false;
+    // Shared with the compile completion handlers so a handler landing after the context is
+    // gone has nothing dangling to decrement.
+    std::shared_ptr<std::atomic<int>> pendingShaderCompiles = std::make_shared<std::atomic<int>>(0);
     const gfx::Renderable* stencilStateRenderable = nullptr;
 
     UniformBufferArray globalUniformBuffers;

--- a/include/mln/renderer/renderer.hpp
+++ b/include/mln/renderer/renderer.hpp
@@ -112,6 +112,9 @@ public:
     const std::vector<PlacedSymbolData>& getPlacedSymbolsData() const;
 
     // Memory
+    /// Compile shaders off the render thread (Metal); see gfx::Context::setAsyncShaderCompilation.
+    /// Platforms whose render thread is the UI thread (iOS) turn this on.
+    void setAsyncShaderCompilation(bool);
     void setTileCacheEnabled(bool);
     bool getTileCacheEnabled() const;
     void reduceMemoryUse();

--- a/include/mln/shaders/mtl/shader_program.hpp
+++ b/include/mln/shaders/mtl/shader_program.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <atomic>
+#include <memory>
+#include <mutex>
 #include <mln/shaders/shader_program_base.hpp>
 #include <mln/mtl/mtl_fwd.hpp>
 #include <mln/mtl/vertex_attribute.hpp>
@@ -45,14 +48,32 @@ using UniqueShaderProgram = std::unique_ptr<ShaderProgram>;
 
 class ShaderProgram final : public gfx::ShaderProgramBase {
 public:
+    /// Functions of a program whose Metal library is compiling off the render thread
+    /// (gfx::Context::setAsyncShaderCompilation). Filled in by the compile completion handler;
+    /// the program adopts them on the render thread once `ready` is set.
+    struct PendingFunctions {
+        std::mutex mutex;
+        MTLFunctionPtr vertex;
+        MTLFunctionPtr fragment;
+        std::atomic<bool> ready{false};
+        std::atomic<bool> failed{false};
+    };
+
     ShaderProgram(std::string name,
                   RendererBackend& backend,
                   MTLFunctionPtr vertexFunction,
                   MTLFunctionPtr fragmentFunction);
+    /// A program still compiling: `getRenderPipelineState` returns null until the functions land.
+    ShaderProgram(std::string name, RendererBackend& backend, std::shared_ptr<PendingFunctions> pending);
     ~ShaderProgram() noexcept override;
 
     static constexpr std::string_view Name{"GenericMTLShader"};
     const std::string_view typeName() const noexcept override { return Name; }
+
+    /// Whether the compiled functions are available (always true for synchronously compiled
+    /// programs). Drawables skip their draw while this is false; the renderer keeps requesting
+    /// frames until it turns true.
+    bool isReady() const;
 
     MTLRenderPipelineStatePtr getRenderPipelineState(const gfx::Renderable&,
                                                      const MTLVertexDescriptorPtr&,
@@ -72,8 +93,9 @@ public:
 protected:
     std::string shaderName;
     RendererBackend& backend;
-    MTLFunctionPtr vertexFunction;
-    MTLFunctionPtr fragmentFunction;
+    mutable MTLFunctionPtr vertexFunction;
+    mutable MTLFunctionPtr fragmentFunction;
+    mutable std::shared_ptr<PendingFunctions> pending;
     VertexAttributeArray vertexAttributes;
     VertexAttributeArray instanceAttributes;
     std::array<std::optional<size_t>, shaders::maxTextureCountPerShader> textureBindings;

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -700,6 +700,10 @@ public:
           : std::nullopt;
   auto renderer = std::make_unique<mln::Renderer>(_mbglView->getRendererBackend(),
                                                   config.scaleFactor, localFontFamilyName);
+  // MapLibre renders on the main thread here, and compiling a Metal shader from source on first
+  // use took the main thread for up to ~1.2 s per program (3D terrain's first draped frame, new
+  // symbol permutations). Compile off-thread; drawables wait a frame or two instead.
+  renderer->setAsyncShaderCompilation(true);
   BOOL enableCrossSourceCollisions = !config.perSourceCollisions;
   _rendererFrontend = std::make_unique<MLNRenderFrontend>(std::move(renderer), self,
                                                           _mbglView->getRendererBackend());

--- a/src/mln/mtl/context.cpp
+++ b/src/mln/mtl/context.cpp
@@ -1,5 +1,7 @@
 #include <mln/mtl/context.hpp>
 
+#include <chrono>
+
 #include <mln/gfx/shader_registry.hpp>
 #include <mln/mtl/command_encoder.hpp>
 #include <mln/mtl/drawable_builder.hpp>
@@ -144,7 +146,64 @@ UniqueShaderProgram Context::createProgram(shaders::BuiltIn shaderID,
         source.data(), NS::UTF8StringEncoding); // NOLINT(bugprone-suspicious-stringview-data-usage)
 
     const auto& device = backend.getDevice();
+    const auto compileStart = std::chrono::steady_clock::now();
+
+    // Asynchronous path: hand back a program whose functions arrive later, and let Metal compile
+    // the library on its own queue. The clipping mask program stays synchronous - it is drawn
+    // through Context::renderTileClippingMasks rather than a drawable, so it has no "skip this
+    // frame" path. Observer post-compile / failure callbacks belong to the render thread and are
+    // not raised from the completion handler.
+    if (asyncShaderCompilation && shaderID != shaders::BuiltIn::ClippingMaskProgram) {
+        auto pending = std::make_shared<ShaderProgram::PendingFunctions>();
+        auto shader = std::make_unique<ShaderProgram>(name, backend, pending);
+        pendingShaderCompiles->fetch_add(1);
+        device->newLibrary(
+            nsSource,
+            options.get(),
+            [pending,
+             counter = pendingShaderCompiles,
+             shaderName = name,
+             vertName = std::string(vertexName),
+             fragName = std::string(fragmentName),
+             compileStart](MTL::Library* library, NS::Error* compileError) {
+                auto pool = NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
+                MTLFunctionPtr vert;
+                MTLFunctionPtr frag;
+                if (library && !compileError) {
+                    vert = NS::TransferPtr(
+                        library->newFunction(NS::String::string(vertName.c_str(), NS::UTF8StringEncoding)));
+                    if (!fragName.empty()) {
+                        frag = NS::TransferPtr(
+                            library->newFunction(NS::String::string(fragName.c_str(), NS::UTF8StringEncoding)));
+                    }
+                }
+                const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                                                      compileStart)
+                                    .count();
+                if (!vert || (!fragName.empty() && !frag)) {
+                    const auto errPtr = compileError ? compileError->localizedDescription()->utf8String() : nullptr;
+                    const auto errStr = (errPtr && errPtr[0]) ? ": " + std::string(errPtr) : std::string();
+                    Log::Error(Event::Shader, shaderName + " async compile failed" + errStr);
+                    pending->failed.store(true);
+                } else {
+                    std::scoped_lock lock(pending->mutex);
+                    pending->vertex = std::move(vert);
+                    pending->fragment = std::move(frag);
+                    Log::Info(Event::Shader, shaderName + " compiled asynchronously in " + std::to_string(ms) + " ms");
+                }
+                pending->ready.store(true, std::memory_order_release);
+                counter->fetch_sub(1);
+            });
+        return shader;
+    }
+
     auto library = NS::TransferPtr(device->newLibrary(nsSource, options.get(), &error));
+    Log::Info(Event::Shader,
+              name + " compiled in " +
+                  std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                     std::chrono::steady_clock::now() - compileStart)
+                                     .count()) +
+                  " ms");
     if (!library || error) {
         const auto errPtr = error ? error->localizedDescription()->utf8String() : nullptr;
         const auto errStr = (errPtr && errPtr[0]) ? ": " + std::string(errPtr) : std::string();

--- a/src/mln/mtl/drawable.cpp
+++ b/src/mln/mtl/drawable.cpp
@@ -227,6 +227,12 @@ void Drawable::draw(PaintParameters& parameters) const {
     renderPass.setScissorRect(getMetalScissorRect(parameters.scissorRect));
 
     if (!impl->pipelineState) {
+        if (!shaderMTL.isReady()) {
+            // The program's library is still compiling off the render thread
+            // (gfx::Context::setAsyncShaderCompilation); skip this drawable for the frame. The
+            // renderer keeps requesting frames while any compile is pending.
+            return;
+        }
         impl->pipelineState = shaderMTL.getRenderPipelineState(
             renderable, impl->vertexDesc, getColorMode(), mln::util::hash(getColorMode().hash(), impl->vertexDescHash));
     }

--- a/src/mln/renderer/renderer.cpp
+++ b/src/mln/renderer/renderer.cpp
@@ -157,6 +157,10 @@ const std::vector<PlacedSymbolData>& Renderer::getPlacedSymbolsData() const {
     return impl->orchestrator.getPlacedSymbolsData();
 }
 
+void Renderer::setAsyncShaderCompilation(bool enable) {
+    impl->asyncShaderCompilation = enable;
+}
+
 void Renderer::setTileCacheEnabled(bool enable) {
     impl->orchestrator.setTileCacheEnabled(enable);
 }

--- a/src/mln/renderer/renderer_impl.cpp
+++ b/src/mln/renderer/renderer_impl.cpp
@@ -92,6 +92,7 @@ void Renderer::Impl::setObserver(RendererObserver* observer_) {
 void Renderer::Impl::render(const RenderTree& renderTree, const std::shared_ptr<UpdateParameters>& updateParameters) {
     MLN_TRACE_FUNC();
     auto& context = backend.getContext();
+    context.setAsyncShaderCompilation(asyncShaderCompilation);
     context.setObserver(this);
 
     assert(updateParameters);
@@ -481,7 +482,9 @@ void Renderer::Impl::render(const RenderTree& renderTree, const std::shared_ptr<
 
     observer->onDidFinishRenderingFrame(
         renderTreeParameters.loaded ? RendererObserver::RenderMode::Full : RendererObserver::RenderMode::Partial,
-        renderTreeParameters.needsRepaint,
+        // Keep repainting while shader libraries are still compiling off-thread so the
+        // drawables that skipped this frame get drawn as soon as their program is ready.
+        renderTreeParameters.needsRepaint || context.hasPendingShaderCompiles(),
         renderTreeParameters.placementChanged,
         context.threadSafeCopyRenderingStats());
 

--- a/src/mln/renderer/renderer_impl.hpp
+++ b/src/mln/renderer/renderer_impl.hpp
@@ -48,6 +48,8 @@ private:
     RenderOrchestrator orchestrator;
 
     gfx::RendererBackend& backend;
+    /// Applied to the context every frame; see gfx::Context::setAsyncShaderCompilation.
+    bool asyncShaderCompilation = false;
 
     RendererObserver* observer;
 

--- a/src/mln/shaders/mtl/shader_program.cpp
+++ b/src/mln/shaders/mtl/shader_program.cpp
@@ -78,12 +78,42 @@ ShaderProgram::ShaderProgram(std::string name, RendererBackend& backend_, MTLFun
       vertexFunction(std::move(vert)),
       fragmentFunction(std::move(frag)) {}
 
+ShaderProgram::ShaderProgram(std::string name, RendererBackend& backend_, std::shared_ptr<PendingFunctions> pending_)
+    : ShaderProgramBase(),
+      shaderName(std::move(name)),
+      backend(backend_),
+      pending(std::move(pending_)) {}
+
 ShaderProgram::~ShaderProgram() noexcept = default;
+
+bool ShaderProgram::isReady() const {
+    if (!pending) {
+        return true;
+    }
+    if (!pending->ready.load(std::memory_order_acquire)) {
+        return false;
+    }
+    if (pending->failed.load()) {
+        // Keep reporting "not ready": nothing can be drawn with a program that did not compile
+        // (the failure was logged by the compile completion handler).
+        return false;
+    }
+    {
+        std::scoped_lock lock(pending->mutex);
+        vertexFunction = pending->vertex;
+        fragmentFunction = pending->fragment;
+    }
+    pending.reset();
+    return true;
+}
 
 MTLRenderPipelineStatePtr ShaderProgram::getRenderPipelineState(const gfx::Renderable& renderable,
                                                                 const MTLVertexDescriptorPtr& vertexDescriptor,
                                                                 const gfx::ColorMode& colorMode,
                                                                 const std::optional<std::size_t> reuseHash) const {
+    if (!isReady()) {
+        return nullptr; // still compiling asynchronously
+    }
     if (reuseHash.has_value()) {
         // we'd like to reuse a previous value
         if (auto it = renderPipelineStateCache.find(reuseHash.value()); it != renderPipelineStateCache.end())


### PR DESCRIPTION
Re-targeted at `main`, replacing #4560 (which was opened against `feature/terrain-3d` by mistake; this change is independent of terrain).

## What

Every Metal program is compiled from source on first use with a synchronous `newLibrary`, on the render thread, which on iOS is the main thread. With a cold shader cache that is roughly 0.4 to 0.6 s per program, one after another: a first launch stalls the UI for seconds, and any style whose first frame needs several new programs (for example a pitched view introducing new symbol permutations) stalls it for over a second (Xcode reports "Hang detected" for each).

- `gfx::Context::setAsyncShaderCompilation(bool)`, implemented by the Metal context. When on, `createProgram` returns a `ShaderProgram` whose functions arrive from Metal's asynchronous `newLibrary` completion handler (`ShaderProgram::PendingFunctions`, adopted on the render thread by `isReady()`).
- A drawable whose program is not ready skips its draw for that frame, and `Renderer` keeps requesting frames while `Context::hasPendingShaderCompiles()`, so everything appears a frame or two later instead of blocking.
- The clipping mask program stays synchronous (it is drawn by `Context::renderTileClippingMasks`, not through a drawable).
- Off by default, so single-frame renders (render tests, snapshots) are unchanged. `MLNMapView` turns it on through `Renderer::setAsyncShaderCompilation(true)`. Compile durations are logged at Info on both paths.

## How it was verified

- iOS simulator with the app's Metal shader cache deleted: 13 programs compiled concurrently off-thread (400 to 560 ms each), the map renders identically; no hangs. With a warm cache compiles report 0 to 25 ms.
- Running in a shipped iOS app since 2026-09-05.
- Rebased onto `main` and compiled with the macOS Metal CMake configuration.

## Notes

Written with AI assistance (Claude), reviewed and tested by me before opening this PR, per MapLibre's AI policy.
