### PR TITLE
Core: share Metal shader groups using reflection

### DIFF
--- a/bazel/core.bzl
+++ b/bazel/core.bzl
@@ -1086,6 +1086,7 @@ MLN_DRAWABLES_MTL_SOURCE = [
     "src/mln/mtl/vertex_attribute.cpp",
     "src/mln/mtl/vertex_buffer_resource.cpp",
     "src/mln/shaders/mtl/shader_program.cpp",
+    "src/mln/shaders/mtl/shader_group.cpp",
     "src/mln/shaders/mtl/background.cpp",
     "src/mln/shaders/mtl/circle.cpp",
     "src/mln/shaders/mtl/collision.cpp",

--- a/cmake/metal.cmake
+++ b/cmake/metal.cmake
@@ -90,6 +90,7 @@ list(APPEND
         ${PROJECT_SOURCE_DIR}/src/mln/mtl/vertex_attribute.cpp
         ${PROJECT_SOURCE_DIR}/src/mln/mtl/vertex_buffer_resource.cpp
         ${PROJECT_SOURCE_DIR}/src/mln/shaders/mtl/shader_program.cpp
+        ${PROJECT_SOURCE_DIR}/src/mln/shaders/mtl/shader_group.cpp
         ${PROJECT_SOURCE_DIR}/src/mln/shaders/mtl/background.cpp
         ${PROJECT_SOURCE_DIR}/src/mln/shaders/mtl/circle.cpp
         ${PROJECT_SOURCE_DIR}/src/mln/shaders/mtl/collision.cpp

--- a/include/mln/shaders/mtl/shader_group.hpp
+++ b/include/mln/shaders/mtl/shader_group.hpp
@@ -9,6 +9,7 @@
 #include <mln/util/containers.hpp>
 
 #include <numeric>
+#include <span>
 #include <string>
 #include <type_traits>
 
@@ -36,61 +37,33 @@ private:
     static constexpr auto uniformPrefix = "HAS_UNIFORM_u_";
 };
 
-template <shaders::BuiltIn ShaderID>
+// Views refer to static reflection arrays; accessors lazily load source. Each shader uses
+// the same group implementation; only this metadata varies between built-ins.
+struct ShaderInfo {
+    shaders::BuiltIn id;
+    const char* name;
+    std::string_view (*prelude)();
+    std::string_view (*source)();
+    const char* vertexMain;
+    const char* fragmentMain;
+    std::span<const shaders::AttributeInfo> attributes;
+    std::span<const shaders::AttributeInfo> instanceAttributes;
+    std::span<const shaders::TextureInfo> textures;
+};
+
 class ShaderGroup final : public ShaderGroupBase {
 public:
-    ShaderGroup(const ProgramParameters& programParameters_)
-        : ShaderGroupBase(programParameters_) {}
+    ShaderGroup(const ProgramParameters& programParameters_, const ShaderInfo& info_)
+        : ShaderGroupBase(programParameters_),
+          info(info_) {}
     ~ShaderGroup() noexcept override = default;
 
-    gfx::ShaderPtr getOrCreateShader(gfx::Context& gfxContext,
+    gfx::ShaderPtr getOrCreateShader(gfx::Context&,
                                      const StringIDSetsPair& propertiesAsUniforms,
-                                     std::string_view /*firstAttribName*/) override {
-        using ShaderSource = shaders::ShaderSource<ShaderID, gfx::Backend::Type::Metal>;
-        constexpr auto& name = ShaderSource::name;
-        constexpr auto& vertMain = ShaderSource::vertexMainFunction;
-        constexpr auto& fragMain = ShaderSource::fragmentMainFunction;
+                                     std::string_view firstAttribName) override;
 
-        std::size_t seed = 0;
-        mln::util::hash_combine(seed, propertyHash(propertiesAsUniforms));
-        mln::util::hash_combine(seed, programParameters.getDefinesHash());
-        const std::string shaderName = getShaderName(name, seed);
-
-        auto shader = get<mtl::ShaderProgram>(shaderName);
-        if (!shader) {
-            DefinesMap additionalDefines;
-            addAdditionalDefines(propertiesAsUniforms, additionalDefines);
-
-            auto& context = static_cast<Context&>(gfxContext);
-            std::string shaderSource(shaders::prelude());
-            shaderSource.append(ShaderSource::prelude());
-            shaderSource.append(ShaderSource::source());
-            shader = context.createProgram(
-                ShaderID, shaderName, shaderSource, vertMain, fragMain, programParameters, additionalDefines);
-            assert(shader);
-            if (!shader || !registerShader(shader, shaderName)) {
-                assert(false);
-                Log::Error(Event::Shader, "Failed to register " + shaderName + " with shader group!");
-                return nullptr;
-            }
-
-            using ShaderClass = shaders::ShaderSource<ShaderID, gfx::Backend::Type::Metal>;
-            for (const auto& attrib : ShaderClass::attributes) {
-                if (!propertiesAsUniforms.second.count(attrib.id)) {
-                    shader->initVertexAttribute(attrib);
-                }
-            }
-            for (const auto& attrib : ShaderClass::instanceAttributes) {
-                if (!propertiesAsUniforms.second.count(attrib.id)) {
-                    shader->initInstanceAttribute(attrib);
-                }
-            }
-            for (const auto& texture : ShaderClass::textures) {
-                shader->initTexture(texture);
-            }
-        }
-        return shader;
-    }
+private:
+    const ShaderInfo info;
 };
 
 } // namespace mtl

--- a/src/mln/mtl/renderer_backend.cpp
+++ b/src/mln/mtl/renderer_backend.cpp
@@ -76,7 +76,16 @@ void registerTypes(gfx::ShaderRegistry& registry, const ProgramParameters& progr
         [&]() {
             using namespace std::string_literals;
             using ShaderClass = shaders::ShaderSource<ShaderID, gfx::Backend::Type::Metal>;
-            auto group = std::make_shared<ShaderGroup<ShaderID>>(programParameters);
+            auto group = std::make_shared<ShaderGroup>(programParameters,
+                                                       ShaderInfo{ShaderID,
+                                                                  ShaderClass::name,
+                                                                  ShaderClass::prelude,
+                                                                  ShaderClass::source,
+                                                                  ShaderClass::vertexMainFunction,
+                                                                  ShaderClass::fragmentMainFunction,
+                                                                  ShaderClass::attributes,
+                                                                  ShaderClass::instanceAttributes,
+                                                                  ShaderClass::textures});
             if (!registry.registerShaderGroup(std::move(group), ShaderClass::name)) {
                 assert(!"duplicate shader group");
                 throw std::runtime_error("Failed to register "s + ShaderClass::name + " with shader registry!");

--- a/src/mln/shaders/mtl/shader_group.cpp
+++ b/src/mln/shaders/mtl/shader_group.cpp
@@ -1,0 +1,54 @@
+#include <mln/shaders/mtl/shader_group.hpp>
+#include <mln/mtl/context.hpp>
+
+namespace mln::mtl {
+
+gfx::ShaderPtr ShaderGroup::getOrCreateShader(gfx::Context& gfxContext,
+                                              const StringIDSetsPair& propertiesAsUniforms,
+                                              std::string_view /*firstAttribName*/) {
+    std::size_t seed = 0;
+    mln::util::hash_combine(seed, propertyHash(propertiesAsUniforms));
+    mln::util::hash_combine(seed, programParameters.getDefinesHash());
+    const std::string shaderName = getShaderName(info.name, seed);
+
+    auto shader = get<mtl::ShaderProgram>(shaderName);
+    if (!shader) {
+        DefinesMap additionalDefines;
+        addAdditionalDefines(propertiesAsUniforms, additionalDefines);
+
+        auto& context = static_cast<Context&>(gfxContext);
+        std::string shaderSource(shaders::prelude());
+        shaderSource.append(info.prelude());
+        shaderSource.append(info.source());
+        shader = context.createProgram(info.id,
+                                       shaderName,
+                                       shaderSource,
+                                       info.vertexMain,
+                                       info.fragmentMain,
+                                       programParameters,
+                                       additionalDefines);
+        assert(shader);
+        if (!shader || !registerShader(shader, shaderName)) {
+            assert(false);
+            Log::Error(Event::Shader, "Failed to register " + shaderName + " with shader group!");
+            return nullptr;
+        }
+
+        for (const auto& attrib : info.attributes) {
+            if (!propertiesAsUniforms.second.count(attrib.id)) {
+                shader->initVertexAttribute(attrib);
+            }
+        }
+        for (const auto& attrib : info.instanceAttributes) {
+            if (!propertiesAsUniforms.second.count(attrib.id)) {
+                shader->initInstanceAttribute(attrib);
+            }
+        }
+        for (const auto& texture : info.textures) {
+            shader->initTexture(texture);
+        }
+    }
+    return shader;
+}
+
+} // namespace mln::mtl


### PR DESCRIPTION
> [!NOTE]  
> This PR and the content below has been written by GPT-6 Astral.

Metal instantiates the same shader-group compilation and registration code for each built-in shader. This replaces those template instantiations with one shared implementation and per-shader reflection metadata, reducing duplicated code while preserving shader selection, defines, caching, and attribute/texture registration.

This is the second layer of the shader size-reduction stack, building on the source accessors introduced by #4568. Review and merge #4568 first. It revisits the reflection idea from #1848.

- Add `ShaderInfo`, holding shader identity, lazy source accessors, entry-point names, and spans over existing static reflection arrays.
- Move `getOrCreateShader` into a single non-template `ShaderGroup` implementation in a `.cpp` file.
- Register each built-in shader with its metadata and include the shared implementation in Bazel and CMake builds.

An independent reflection-only experiment against `57d198149785cb6068ca6d62d478670c64a60358` reduced the stripped iOS arm64 library from **7,840,296 to 7,757,872 bytes: 82,424 bytes (1.05%)**. Bloaty reported the relevant `getOrCreateShader` implementations shrinking from 71,108 bytes across template instantiations to one 2,176-byte implementation. gzip size fell from 3,052,833 to 3,036,161 bytes.

Those measurements used the original uncompressed shader sources. They are not an incremental measurement on top of the tooling PR, and the two savings should not be added as a measured stack total. This stacked version keeps the preceding layer's lazy source accessors.

Measurement configuration: Xcode 26.4 (17E192), Bazel 8.6, Bloaty 1.1 with matching dSYMs; `//platform/ios:MapLibre.dynamic`, Metal, optimized Release, dead stripping, ThinLTO, and binary stripping.

Validation:

- The independent reflection experiment passed iOS Release Bazel builds for arm64 device and arm64/x86_64 simulator.
- The prior combined experiment containing this implementation and the tooling layer passed macOS Metal CMake builds and all six ShaderRegistry tests.
- The combined experiment matched baseline statuses across 97 selected render cases with no unexpected failures. 95 output images were byte-identical; the remaining two differed by one channel value in five pixels and one pixel, respectively.
- The tooling layer now runs its TypeScript generator tests in CI. Its review fixes only remove boundary blank lines from the shader fragments; Node 24 tests, type checking, and Bazel/CMake generation passed. The reflection implementation is unchanged by the restack; C++ formatting passes with the repository's clang-format 20.1.8 configuration.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
