### PR TITLE
fix(core): load file:///C:/ URLs and non-ASCII paths on Windows

### DIFF
--- a/platform/default/src/mln/storage/local_file_request.cpp
+++ b/platform/default/src/mln/storage/local_file_request.cpp
@@ -3,8 +3,7 @@
 #include <mln/util/filesystem.hpp>
 #include <mln/util/io.hpp>
 
-#if defined(_WIN32)
-#include <filesystem>
+#if MLN_HAS_STD_FILESYSTEM
 #include <system_error>
 #else
 #include <sys/types.h>
@@ -17,7 +16,7 @@ void requestLocalFile(const std::string& path,
                       const ActorRef<FileSourceRequest>& req,
                       const std::optional<std::pair<uint64_t, uint64_t>>& dataRange) {
     Response response;
-#if defined(_WIN32)
+#if MLN_HAS_STD_FILESYSTEM
     std::error_code error;
     std::filesystem::file_status status;
     try {

--- a/platform/default/src/mln/storage/local_file_request.cpp
+++ b/platform/default/src/mln/storage/local_file_request.cpp
@@ -1,12 +1,14 @@
 #include <mln/storage/file_source_request.hpp>
 #include <mln/storage/response.hpp>
+#include <mln/util/filesystem.hpp>
 #include <mln/util/io.hpp>
 
+#if defined(_WIN32)
+#include <filesystem>
+#include <system_error>
+#else
 #include <sys/types.h>
 #include <sys/stat.h>
-
-#if defined(_WIN32) && !defined(S_ISDIR)
-#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
 #endif
 
 namespace mln {
@@ -15,12 +17,19 @@ void requestLocalFile(const std::string& path,
                       const ActorRef<FileSourceRequest>& req,
                       const std::optional<std::pair<uint64_t, uint64_t>>& dataRange) {
     Response response;
+#if defined(_WIN32)
+    std::error_code error;
+    const auto status = std::filesystem::status(util::pathFromUTF8(path), error);
+    const bool notFound = status.type() == std::filesystem::file_type::not_found;
+    const bool isDirectory = std::filesystem::is_directory(status);
+#else
     struct stat buf;
-    int result = stat(path.c_str(), &buf);
+    const int result = stat(path.c_str(), &buf);
+    const bool notFound = result == -1 && errno == ENOENT;
+    const bool isDirectory = result == 0 && S_ISDIR(buf.st_mode);
+#endif
 
-    if (result == 0 && (S_IFDIR & buf.st_mode)) {
-        response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
-    } else if (result == -1 && errno == ENOENT) {
+    if (notFound || isDirectory) {
         response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
     } else {
         auto data = util::readFile(path, dataRange);

--- a/platform/default/src/mln/storage/local_file_request.cpp
+++ b/platform/default/src/mln/storage/local_file_request.cpp
@@ -19,7 +19,14 @@ void requestLocalFile(const std::string& path,
     Response response;
 #if defined(_WIN32)
     std::error_code error;
-    const auto status = std::filesystem::status(util::pathFromUTF8(path), error);
+    std::filesystem::file_status status;
+    try {
+        status = std::filesystem::status(util::pathFromUTF8(path), error);
+    } catch (const std::filesystem::filesystem_error& exception) {
+        response.error = std::make_unique<Response::Error>(Response::Error::Reason::Other, exception.what());
+        req.invoke(&FileSourceRequest::setResponse, response);
+        return;
+    }
     const bool notFound = status.type() == std::filesystem::file_type::not_found;
     const bool isDirectory = std::filesystem::is_directory(status);
 #else

--- a/platform/default/src/mln/storage/local_file_source.cpp
+++ b/platform/default/src/mln/storage/local_file_source.cpp
@@ -11,9 +11,23 @@
 #include <mln/util/url.hpp>
 #include <mln/storage/resource_options.hpp>
 
+#include <cctype>
+#include <string>
+
 namespace {
 bool acceptsURL(const std::string& url) {
     return url.starts_with(mln::util::FILE_PROTOCOL);
+}
+
+std::string pathFromFileURL(const std::string& url) {
+    auto path = mln::util::percentDecode(url.substr(std::char_traits<char>::length(mln::util::FILE_PROTOCOL)));
+#if defined(_WIN32)
+    // file:///C:/path minus the scheme is /C:/path, which Windows rejects.
+    if (path.size() >= 3 && path[0] == '/' && path[2] == ':' && std::isalpha(static_cast<unsigned char>(path[1]))) {
+        path.erase(0, 1);
+    }
+#endif
+    return path;
 }
 } // namespace
 
@@ -33,9 +47,7 @@ public:
             return;
         }
 
-        // Cut off the protocol and prefix with path.
-        const auto path = mln::util::percentDecode(
-            resource.url.substr(std::char_traits<char>::length(util::FILE_PROTOCOL)));
+        const auto path = pathFromFileURL(resource.url);
         requestLocalFile(path, req, resource.dataRange);
     }
 

--- a/src/mln/util/filesystem.hpp
+++ b/src/mln/util/filesystem.hpp
@@ -2,8 +2,24 @@
 
 #include <string>
 
+#if defined(_WIN32)
+#include <filesystem>
+#endif
+
 namespace mln {
 namespace util {
 bool is_absolute_path(std::string path);
+
+#if defined(_WIN32)
+/// The narrow std::filesystem::path constructor decodes with the active code
+/// page on Windows, so the UTF-8 bytes go through the char8_t constructor.
+inline std::filesystem::path pathFromUTF8(const std::string& path) {
+    return std::filesystem::path(std::u8string(reinterpret_cast<const char8_t*>(path.data()), path.size()));
 }
+#else
+inline const std::string& pathFromUTF8(const std::string& path) {
+    return path;
+}
+#endif
+} // namespace util
 } // namespace mln

--- a/src/mln/util/filesystem.hpp
+++ b/src/mln/util/filesystem.hpp
@@ -2,7 +2,22 @@
 
 #include <string>
 
-#if defined(_WIN32)
+// libc++ filesystem requires macOS 10.15, iOS/tvOS 13, or watchOS 6.
+// Check the deployment target, not the SDK version used to compile.
+#if defined(__APPLE__) &&                                                                                            \
+    ((defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) &&                                                      \
+      __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101500) ||                                                     \
+     (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) &&                                                     \
+      __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 130000) ||                                                    \
+     (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 130000) || \
+     (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) &&                                                      \
+      __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 60000))
+#define MLN_HAS_STD_FILESYSTEM 0
+#else
+#define MLN_HAS_STD_FILESYSTEM 1
+#endif
+
+#if MLN_HAS_STD_FILESYSTEM
 #include <filesystem>
 #endif
 

--- a/src/mln/util/io.cpp
+++ b/src/mln/util/io.cpp
@@ -1,4 +1,5 @@
 #include <mln/util/io.hpp>
+#include <mln/util/filesystem.hpp>
 #include <mln/util/instrumentation.hpp>
 
 #include <cstdio>
@@ -36,7 +37,7 @@ void write_file(const std::string &filename, const std::string &data) {
 std::string read_file(const std::string &filename) {
     MLN_TRACE_FUNC();
 
-    std::ifstream file(filename, std::ios::binary);
+    std::ifstream file(util::pathFromUTF8(filename), std::ios::binary);
     if (file.good()) {
         std::stringstream data;
         data << file.rdbuf();
@@ -50,7 +51,7 @@ std::optional<std::string> readFile(const std::string &filename,
                                     const std::optional<std::pair<uint64_t, uint64_t>> &dataRange) {
     MLN_TRACE_FUNC();
 
-    std::ifstream file(filename, std::ios::binary);
+    std::ifstream file(util::pathFromUTF8(filename), std::ios::binary);
     if (file.good()) {
         if (dataRange) {
             size_t size = static_cast<size_t>(dataRange->second - dataRange->first + 1);
@@ -79,11 +80,11 @@ void deleteFile(const std::string &filename) {
 void copyFile(const std::string &destination, const std::string &source) {
     MLN_TRACE_FUNC();
 
-    std::ifstream src(source, std::ios::binary);
+    std::ifstream src(util::pathFromUTF8(source), std::ios::binary);
     if (!src.good()) {
         throw IOException(errno, "Cannot read file " + source);
     }
-    std::ofstream dst(destination, std::ios::binary);
+    std::ofstream dst(util::pathFromUTF8(destination), std::ios::binary);
     if (!dst.good()) {
         throw IOException(errno, "Cannot write file " + destination);
     }

--- a/test/storage/local_file_source.test.cpp
+++ b/test/storage/local_file_source.test.cpp
@@ -6,11 +6,19 @@
 #include <mln/util/run_loop.hpp>
 #include <mln/util/scoped.hpp>
 
+#include <climits>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <string>
 #include <gtest/gtest.h>
+
+#if defined(WIN32)
+#include <Windows.h>
+#ifndef PATH_MAX
+#define PATH_MAX MAX_PATH
+#endif
+#endif
 
 namespace {
 

--- a/test/storage/local_file_source.test.cpp
+++ b/test/storage/local_file_source.test.cpp
@@ -4,20 +4,13 @@
 #include <mln/util/constants.hpp>
 #include <mln/util/platform.hpp>
 #include <mln/util/run_loop.hpp>
+#include <mln/util/scoped.hpp>
 
-#include <climits>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <string>
 #include <gtest/gtest.h>
-
-#if defined(WIN32)
-#include <Windows.h>
-#ifndef PATH_MAX
-#define PATH_MAX MAX_PATH
-#endif /* PATH_MAX */
-#endif
 
 namespace {
 
@@ -94,13 +87,10 @@ TEST(LocalFileSource, NonEmptyFile) {
 TEST(LocalFileSource, NonASCIIPath) {
     const auto root = std::filesystem::temp_directory_path() / "mln-local-file-source-non-ascii";
 
-    struct Cleanup {
-        std::filesystem::path root;
-        ~Cleanup() {
-            std::error_code error;
-            std::filesystem::remove_all(root, error);
-        }
-    } cleanup{root};
+    const Scoped cleanup([&] {
+        std::error_code error;
+        std::filesystem::remove_all(root, error);
+    });
 
     std::error_code error;
     std::filesystem::remove_all(root, error);
@@ -130,6 +120,19 @@ TEST(LocalFileSource, NonASCIIPath) {
 
     loop.run();
 }
+
+#if defined(_WIN32)
+TEST(LocalFileSource, InvalidUTF8Path) {
+    util::RunLoop loop;
+    LocalFileSource fs(ResourceOptions::Default(), ClientOptions());
+    auto req = fs.request(Resource::style("file:///C:/%FF.json"), [&](Response res) {
+        EXPECT_NE(nullptr, res.error);
+        EXPECT_EQ(nullptr, res.data);
+        loop.stop();
+    });
+    loop.run();
+}
+#endif
 
 TEST(LocalFileSource, PartialFile) {
     util::RunLoop loop;

--- a/test/storage/local_file_source.test.cpp
+++ b/test/storage/local_file_source.test.cpp
@@ -1,11 +1,15 @@
 #include <mln/storage/local_file_source.hpp>
 #include <mln/storage/resource.hpp>
 #include <mln/storage/resource_options.hpp>
+#include <mln/util/constants.hpp>
 #include <mln/util/platform.hpp>
 #include <mln/util/run_loop.hpp>
 
 #include <climits>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
 #include <gtest/gtest.h>
 
 #if defined(WIN32)
@@ -13,23 +17,32 @@
 #ifndef PATH_MAX
 #define PATH_MAX MAX_PATH
 #endif /* PATH_MAX */
-#else
-#include <unistd.h>
 #endif
 
 namespace {
 
+std::string fileURL(const std::filesystem::path& path) {
+    const auto generic = path.generic_u8string();
+    const std::string bytes(reinterpret_cast<const char*>(generic.data()), generic.size());
+
+    constexpr char hex[] = "0123456789ABCDEF";
+    std::string encoded;
+    for (unsigned char byte : bytes) {
+        if ((byte >= 'A' && byte <= 'Z') || (byte >= 'a' && byte <= 'z') || (byte >= '0' && byte <= '9') ||
+            byte == '-' || byte == '.' || byte == '_' || byte == '~' || byte == '/' || byte == ':') {
+            encoded += static_cast<char>(byte);
+        } else {
+            encoded += '%';
+            encoded += hex[byte >> 4];
+            encoded += hex[byte & 0xF];
+        }
+    }
+
+    return std::string(mln::util::FILE_PROTOCOL) + (encoded.starts_with('/') ? "" : "/") + encoded;
+}
+
 std::string toAbsoluteURL(const std::string& fileName) {
-    char buff[PATH_MAX + 1];
-#ifdef _MSC_VER
-    char* cwd = _getcwd(buff, PATH_MAX + 1);
-#else
-    char* cwd = getcwd(buff, PATH_MAX + 1);
-#endif
-    // NOLINTNEXTLINE(clang-analyzer-nullability.NullPassedToNonnull)
-    std::string url = {mln::util::FILE_PROTOCOL + std::string(cwd) + "/test/fixtures/storage/assets/" + fileName};
-    assert(url.size() <= PATH_MAX);
-    return url;
+    return fileURL(std::filesystem::current_path() / "test" / "fixtures" / "storage" / "assets" / fileName);
 }
 
 } // namespace
@@ -72,6 +85,46 @@ TEST(LocalFileSource, NonEmptyFile) {
         EXPECT_EQ(nullptr, res.error);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("content is here\n", *res.data);
+        loop.stop();
+    });
+
+    loop.run();
+}
+
+TEST(LocalFileSource, NonASCIIPath) {
+    const auto root = std::filesystem::temp_directory_path() / "mln-local-file-source-non-ascii";
+
+    struct Cleanup {
+        std::filesystem::path root;
+        ~Cleanup() {
+            std::error_code error;
+            std::filesystem::remove_all(root, error);
+        }
+    } cleanup{root};
+
+    std::error_code error;
+    std::filesystem::remove_all(root, error);
+
+    const auto directory = root / u8"ké 地図";
+    ASSERT_TRUE(std::filesystem::create_directories(directory));
+
+    const std::string body = "content is here\n";
+    const auto file = directory / u8"スタイル.json";
+    {
+        std::ofstream out(file, std::ios::binary);
+        ASSERT_TRUE(out.good());
+        out << body;
+    }
+
+    util::RunLoop loop;
+
+    LocalFileSource fs(ResourceOptions::Default(), ClientOptions());
+
+    std::unique_ptr<AsyncRequest> req = fs.request(Resource::style(fileURL(file)), [&](Response res) {
+        req.reset();
+        EXPECT_EQ(nullptr, res.error);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ(body, *res.data);
         loop.stop();
     });
 
@@ -154,7 +207,9 @@ TEST(LocalFileSource, URLEncoding) {
 
     LocalFileSource fs(ResourceOptions::Default(), ClientOptions());
 
-    std::unique_ptr<AsyncRequest> req = fs.request({Resource::Unknown, toAbsoluteURL("%6eonempty")}, [&](Response res) {
+    const std::string url = toAbsoluteURL("") + "%6eonempty";
+
+    std::unique_ptr<AsyncRequest> req = fs.request({Resource::Unknown, url}, [&](Response res) {
         req.reset();
         EXPECT_EQ(nullptr, res.error);
         ASSERT_TRUE(res.data.get());


### PR DESCRIPTION
## Bug

Two problems with `file:` URLs on Windows.

1. `LocalFileSource` strips `file://` and passes the rest to the filesystem. For `file:///C:/dir/style.json`, the form defined in [RFC 8089 appendix E.2](https://www.rfc-editor.org/rfc/rfc8089#appendix-E.2) and produced by Java's [`Path.toUri()`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/nio/file/Path.html#toUri()), Rust's [`Url::from_file_path`](https://docs.rs/url/latest/url/struct.Url.html#method.from_file_path), and [browsers](https://url.spec.whatwg.org/#file-state), that leaves `/C:/dir/style.json`, which is not a valid [Windows path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats). Only `file://C:/dir/style.json` works, and that is what the existing test builds from `getcwd()`.
2. Percent-decoded paths are UTF-8, but `stat()` and `std::ifstream(std::string)` decode narrow strings with the ANSI code page on Windows (the [native narrow encoding](https://en.cppreference.com/w/cpp/filesystem/path) of `std::filesystem::path`). Paths with characters outside that code page fail to open. [`/utf-8`](https://learn.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8) only affects source and execution character sets, not runtime path decoding.

## Repro

On Windows, `Map::getStyle().loadURL("file:///C:/data/style.json")` fails with `NotFound`. Same for `file://C:/data/ké/style.json` with percent-encoded UTF-8.

## Fix

- `util::pathFromUTF8()` builds a `std::filesystem::path` through the `char8_t` constructor on Windows and returns the string unchanged elsewhere. [`u8path`](https://en.cppreference.com/w/cpp/filesystem/path/u8path) is deprecated in C++20 and MSVC warns under `/WX`.
- `read_file`, `readFile`, `copyFile` open through it. `write_file` and `deleteFile` are not used by the file source and are unchanged.
- `requestLocalFile` uses `std::filesystem::status` wherever the deployment target supports it. `MLN_HAS_STD_FILESYSTEM` centralizes the availability check in the filesystem helper header; older Apple deployment targets, including the supported iOS 12 minimum, retain `stat`.
- `LocalFileSource` drops the slash before a drive letter. UNC paths are unchanged.

## Tests

`toAbsoluteURL()` now builds `file:///C:/...` URLs on Windows, so the existing tests cover that form. `LocalFileSource.NonASCIIPath` loads a file from a directory named `ké 地図`. The file-source tests also exercise the filesystem status path on supported POSIX platforms. Windows CI covers drive-letter and UTF-8 conversion behavior.

Related: #4498, the `file:///android_asset/` form, which #4501 handles on the MapLibre Android side.

Carried in maplibre-native-ffi since maplibre/maplibre-native-ffi#562. AI disclosure: prepared with Claude Code (Claude Fable 5.1 for analysis, review, and this description; Claude Opus 5 for code edits under its instructions).