### PR TITLE
core: let latLngForPixel return unwrapped longitudes

### DIFF
--- a/include/mln/map/map.hpp
+++ b/include/mln/map/map.hpp
@@ -117,9 +117,10 @@ public:
 
     // Projection
     ScreenCoordinate pixelForLatLng(const LatLng&) const;
-    LatLng latLngForPixel(const ScreenCoordinate&) const;
+    LatLng latLngForPixel(const ScreenCoordinate&, LatLng::WrapMode = LatLng::Wrapped) const;
     std::vector<ScreenCoordinate> pixelsForLatLngs(const std::vector<LatLng>&) const;
-    std::vector<LatLng> latLngsForPixels(const std::vector<ScreenCoordinate>&) const;
+    std::vector<LatLng> latLngsForPixels(const std::vector<ScreenCoordinate>&,
+                                         LatLng::WrapMode = LatLng::Wrapped) const;
 
     // Transform
     TransformState getTransfromState() const;

--- a/include/mln/map/map_projection.hpp
+++ b/include/mln/map/map_projection.hpp
@@ -15,7 +15,7 @@ public:
     ~MapProjection();
 
     ScreenCoordinate pixelForLatLng(const LatLng&) const;
-    LatLng latLngForPixel(const ScreenCoordinate&) const;
+    LatLng latLngForPixel(const ScreenCoordinate&, LatLng::WrapMode = LatLng::Wrapped) const;
 
     void setCamera(const CameraOptions&);
     CameraOptions getCamera() const;

--- a/src/mln/map/map.cpp
+++ b/src/mln/map/map.cpp
@@ -432,8 +432,8 @@ ScreenCoordinate Map::pixelForLatLng(const LatLng& latLng) const {
     return impl->transform.latLngToScreenCoordinate(unwrappedLatLng);
 }
 
-LatLng Map::latLngForPixel(const ScreenCoordinate& pixel) const {
-    return impl->transform.screenCoordinateToLatLng(pixel);
+LatLng Map::latLngForPixel(const ScreenCoordinate& pixel, LatLng::WrapMode wrapMode) const {
+    return impl->transform.screenCoordinateToLatLng(pixel, wrapMode);
 }
 
 std::vector<ScreenCoordinate> Map::pixelsForLatLngs(const std::vector<LatLng>& latLngs) const {
@@ -445,11 +445,12 @@ std::vector<ScreenCoordinate> Map::pixelsForLatLngs(const std::vector<LatLng>& l
     return ret;
 }
 
-std::vector<LatLng> Map::latLngsForPixels(const std::vector<ScreenCoordinate>& screenCoords) const {
+std::vector<LatLng> Map::latLngsForPixels(const std::vector<ScreenCoordinate>& screenCoords,
+                                          LatLng::WrapMode wrapMode) const {
     std::vector<LatLng> ret;
     ret.reserve(screenCoords.size());
     for (const auto& point : screenCoords) {
-        ret.emplace_back(latLngForPixel(point));
+        ret.emplace_back(latLngForPixel(point, wrapMode));
     }
     return ret;
 }

--- a/src/mln/map/map_projection.cpp
+++ b/src/mln/map/map_projection.cpp
@@ -17,9 +17,9 @@ ScreenCoordinate MapProjection::pixelForLatLng(const LatLng& latLng) const {
     return transform->latLngToScreenCoordinate(unwrappedLatLng);
 }
 
-LatLng MapProjection::latLngForPixel(const ScreenCoordinate& pixel) const {
+LatLng MapProjection::latLngForPixel(const ScreenCoordinate& pixel, LatLng::WrapMode wrapMode) const {
     // The implementation is just a copy from map.cpp
-    return transform->screenCoordinateToLatLng(pixel);
+    return transform->screenCoordinateToLatLng(pixel, wrapMode);
 }
 
 void MapProjection::setCamera(const CameraOptions& camera) {

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -11,6 +11,7 @@
 #include <mln/gfx/headless_frontend.hpp>
 #include <mln/gfx/shader_registry.hpp>
 #include <mln/map/map_options.hpp>
+#include <mln/map/map_projection.hpp>
 #include <mln/math/log2.hpp>
 #include <mln/renderer/renderer.hpp>
 #include <mln/renderer/update_parameters.hpp>
@@ -360,6 +361,37 @@ TEST(Map, CameraToLatLngBoundsUnwrappedCrossDateLine) {
         test.map.latLngForPixel({double(size.width) / 2, double(size.height) / 2})));
 
     ASSERT_TRUE(test.map.latLngBoundsForCameraUnwrapped(camera).crossesAntimeridian());
+}
+
+TEST(Map, LatLngForPixelUnwrapped) {
+    MapTest<> test;
+    test.map.setSize({2048, 512});
+
+    test.map.jumpTo(CameraOptions().withCenter(LatLng{0.0, 0.0}).withZoom(0.0));
+    const auto left = test.map.latLngForPixel({0.0, 256.0}, LatLng::Unwrapped);
+    const auto right = test.map.latLngForPixel({2048.0, 256.0}, LatLng::Unwrapped);
+    EXPECT_NEAR(-720.0, left.longitude(), 1e-4);
+    EXPECT_NEAR(720.0, right.longitude(), 1e-4);
+    EXPECT_NEAR(0.0, test.map.latLngForPixel({0.0, 256.0}).longitude(), 1e-4);
+    EXPECT_NEAR(0.0, test.map.latLngForPixel({2048.0, 256.0}).longitude(), 1e-4);
+
+    test.map.jumpTo(CameraOptions().withCenter(LatLng{0.0, 180.0}).withZoom(4.0));
+    const auto west = test.map.latLngForPixel({0.0, 256.0}, LatLng::Unwrapped);
+    const auto east = test.map.latLngForPixel({2048.0, 256.0}, LatLng::Unwrapped);
+    EXPECT_NEAR(-225.0, west.longitude(), 1e-4);
+    EXPECT_NEAR(-135.0, east.longitude(), 1e-4);
+    EXPECT_NEAR(135.0, test.map.latLngForPixel({0.0, 256.0}).longitude(), 1e-4);
+    EXPECT_NEAR(-135.0, test.map.latLngForPixel({2048.0, 256.0}).longitude(), 1e-4);
+    EXPECT_NEAR(90.0, east.longitude() - west.longitude(), 1e-4);
+
+    const auto both = test.map.latLngsForPixels({{0.0, 256.0}, {2048.0, 256.0}}, LatLng::Unwrapped);
+    ASSERT_EQ(2u, both.size());
+    EXPECT_DOUBLE_EQ(west.longitude(), both[0].longitude());
+    EXPECT_DOUBLE_EQ(east.longitude(), both[1].longitude());
+
+    const MapProjection projection(test.map);
+    EXPECT_DOUBLE_EQ(east.longitude(), projection.latLngForPixel({2048.0, 256.0}, LatLng::Unwrapped).longitude());
+    EXPECT_NEAR(-135.0, projection.latLngForPixel({2048.0, 256.0}).longitude(), 1e-4);
 }
 
 TEST(Map, Offline) {


### PR DESCRIPTION
## Why

maplibre-native-ffi exposes `latLngForPixel` to language bindings. Callers computing visible bounds get wrapped longitudes, so a viewport across the antimeridian reports its edges as +135 and -135, and a viewport wider than one world reports overlapping values. There is no way to get the continuous longitude that MapLibre GL JS [`unproject`](https://github.com/maplibre/maplibre-gl-js/blob/4730c3a12cc31714418951c089a5a5a8e25a4241/src/geo/projection/mercator_transform.ts) returns. `TransformState::screenCoordinateToLatLng` already takes a `LatLng::WrapMode`; only the public methods hard-code `Wrapped`. Related: #1681 and #2951, which need this plus the MapLibre Android and iOS visible-region code passing `Unwrapped`.

## Change

`Map::latLngForPixel`, `Map::latLngsForPixels`, and `MapProjection::latLngForPixel` take an optional `LatLng::WrapMode`, default `Wrapped`. No change for existing callers. `pixelForLatLng` still wraps its input, so unwrapped values do not round-trip (#2960).

## Test

`Map.LatLngForPixelUnwrapped`: 2048x512 viewport at zoom 0 gives -720 and 720 unwrapped, 0 and 0 wrapped. Centered on longitude 180 at zoom 4 it gives -225 and -135 unwrapped, 135 and -135 wrapped (the transform stores the center wrapped to -180). The vector version and `MapProjection` return the same values.

Carried in maplibre-native-ffi since maplibre/maplibre-native-ffi#683, where it is written as overloads instead of a default argument. AI disclosure: prepared with Claude Code (Claude Fable 5.1 for analysis, review, and this description; Claude Opus 5 for code edits under its instructions). Draft until I have reviewed the generated changes.
