### PR TITLE
fix(core): keep the global logger alive for the whole process

### DIFF
--- a/src/mln/util/logging.cpp
+++ b/src/mln/util/logging.cpp
@@ -15,10 +15,8 @@ namespace mln {
 
 namespace {
 
-std::unique_ptr<Log::Observer> currentObserver;
 constexpr auto SeverityCount = underlying_type(EventSeverity::SeverityCount);
 std::atomic<bool> useThread[SeverityCount] = {true, true, true, false};
-std::mutex mutex;
 
 } // namespace
 
@@ -43,6 +41,9 @@ public:
 #endif
     }
 
+    std::unique_ptr<Observer> observer;
+    std::mutex mutex;
+
 private:
     const std::shared_ptr<Scheduler> scheduler;
 };
@@ -53,8 +54,17 @@ Log::Log()
 Log::~Log() = default;
 
 Log* Log::get() noexcept {
-    static Log instance;
-    return &instance;
+    // Never destroyed: the worker thread may be attached to a host VM (JNI in
+    // MapLibre Android, Java FFM upcalls elsewhere) that is gone by static
+    // destruction, and joining it then deadlocks. The worker never drained its
+    // queue on termination, so nothing is lost.
+    static auto* const instance = new Log();
+    // Releasing the observer at exit keeps host cleanup that ran from its
+    // destructor; the logger and its thread stay alive.
+    static const struct ObserverRelease {
+        ~ObserverRelease() { removeObserver(); }
+    } observerRelease;
+    return instance;
 }
 
 void Log::useLogThread(bool enable, std::optional<EventSeverity> severity) {
@@ -69,14 +79,16 @@ void Log::useLogThread(bool enable, std::optional<EventSeverity> severity) {
 }
 
 void Log::setObserver(std::unique_ptr<Observer> observer) {
-    std::scoped_lock lock(mutex);
-    currentObserver = std::move(observer);
+    auto& state = *get()->impl;
+    std::scoped_lock lock(state.mutex);
+    state.observer = std::move(observer);
 }
 
 std::unique_ptr<Log::Observer> Log::removeObserver() {
-    std::scoped_lock lock(mutex);
+    auto& state = *get()->impl;
+    std::scoped_lock lock(state.mutex);
     std::unique_ptr<Observer> observer;
-    std::swap(observer, currentObserver);
+    std::swap(observer, state.observer);
     return observer;
 }
 
@@ -93,8 +105,9 @@ void Log::record(EventSeverity severity,
                  int64_t code,
                  const std::string& msg,
                  const std::optional<std::string>& threadName) {
-    std::scoped_lock lock(mutex);
-    if (currentObserver && severity != EventSeverity::Debug && currentObserver->onRecord(severity, event, code, msg)) {
+    auto& state = *get()->impl;
+    std::scoped_lock lock(state.mutex);
+    if (state.observer && severity != EventSeverity::Debug && state.observer->onRecord(severity, event, code, msg)) {
         return;
     }
 

--- a/src/mln/util/logging.cpp
+++ b/src/mln/util/logging.cpp
@@ -10,6 +10,7 @@
 #include <exception>
 #include <sstream>
 #include <mutex>
+#include <utility>
 
 namespace mln {
 
@@ -22,12 +23,11 @@ std::atomic<bool> useThread[SeverityCount] = {true, true, true, false};
 
 class Log::Impl {
 public:
-    Impl()
-        : scheduler(Scheduler::GetSequenced()) {}
-
     void record(EventSeverity severity, Event event, int64_t code, const std::string& msg) try {
         if (useThread[underlying_type(severity)]) {
             auto threadName = platform::getCurrentThreadName();
+            // Construct the worker only when an asynchronous record needs it.
+            std::call_once(schedulerOnce, [this] { scheduler = Scheduler::GetSequenced(); });
             scheduler->schedule([=]() { Log::record(severity, event, code, msg, threadName); });
         } else {
             Log::record(severity, event, code, msg, {});
@@ -45,7 +45,8 @@ public:
     std::mutex mutex;
 
 private:
-    const std::shared_ptr<Scheduler> scheduler;
+    std::once_flag schedulerOnce;
+    std::shared_ptr<Scheduler> scheduler;
 };
 
 Log::Log()
@@ -87,9 +88,7 @@ void Log::setObserver(std::unique_ptr<Observer> observer) {
 std::unique_ptr<Log::Observer> Log::removeObserver() {
     auto& state = *get()->impl;
     std::scoped_lock lock(state.mutex);
-    std::unique_ptr<Observer> observer;
-    std::swap(observer, state.observer);
-    return observer;
+    return std::exchange(state.observer, nullptr);
 }
 
 void Log::record(EventSeverity severity, Event event, const std::string& msg) noexcept {


### PR DESCRIPTION
## Bug

Static destruction of the `Log` singleton releases its `SequencedScheduler`, whose destructor joins the logging thread. If a `Log::Observer` is Java code, that thread is attached to the JVM (in MapLibre Android through [`platform::attachThread`](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/platform/android/src/thread.cpp#L51-L61), which calls JNI [`AttachCurrentThread`](https://docs.oracle.com/en/java/javase/21/docs/specs/jni/invocation.html#attachcurrentthread), or in a maplibre-native-ffi JVM host implicitly by a Java [FFM upcall](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/foreign/Linker.html#upcall-stubs)). By the time C++ static destructors run the JVM is gone, the thread's detach on exit never returns, and the join blocks forever. The process hangs instead of exiting. Removing the observer before exit does not help; the attach already happened.

## Repro

JVM host using maplibre-native-ffi, native log observer registered through FFM. Log one async record, call `System.exit`. The process never exits. Repro in maplibre/maplibre-native-ffi#686. The same path exists in MapLibre Android via JNI.

## Fix

Allocate the singleton with `new` and never destroy it. Move the observer and its mutex from namespace statics into `Log::Impl` so the worker cannot touch destroyed statics. A guard inside `Log::get()` still releases the observer at exit, so cleanup that a host runs from its observer destructor (the Node addon's `NodeLogObserver` closes its `uv_async_t` there) happens as before; only the logger and its thread outlive it. `useThread` stays a plain static array of atomics, so `useLogThread()` still does not create the logger or its thread.

Skipping the join loses nothing: [`ThreadedScheduler`](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/src/mln/util/thread_pool.cpp#L39-L46) stops as soon as `terminated` is set and does not run the tasks still in its queue.

## Tests

None possible in gtest: without a VM, `attachThread`/`detachThread` are no-ops and the join succeeds. Verified with the JVM repro above.

Carried in maplibre-native-ffi since maplibre/maplibre-native-ffi#686. AI disclosure: prepared with Claude Code (Claude Fable 5.1 for analysis, review, and this description; Claude Opus 5 for code edits under its instructions). Draft until I have reviewed the generated changes.
