### PR TITLE
fix(core): keep in-use on-demand images registered when a request also has missing images

### DIFF
--- a/src/mln/renderer/image_manager.cpp
+++ b/src/mln/renderer/image_manager.cpp
@@ -226,10 +226,10 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
     for (const auto& dependency : pair.first) {
         if (!images.contains(dependency.first)) {
             missingDependencies.emplace(dependency);
-        } else if (auto it = requestedImages.find(dependency.first); it != requestedImages.end()) {
+        } else if (requestedImages.contains(dependency.first)) {
             // The missing-image path below never registers images that are
             // already present.
-            it->second.emplace(&requestor);
+            requestedImages.at(dependency.first).emplace(&requestor);
         }
     }
 

--- a/src/mln/renderer/image_manager.cpp
+++ b/src/mln/renderer/image_manager.cpp
@@ -226,6 +226,10 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
     for (const auto& dependency : pair.first) {
         if (!images.contains(dependency.first)) {
             missingDependencies.emplace(dependency);
+        } else if (auto it = requestedImages.find(dependency.first); it != requestedImages.end()) {
+            // The missing-image path below never registers images that are
+            // already present.
+            it->second.emplace(&requestor);
         }
     }
 
@@ -277,12 +281,6 @@ void ImageManager::checkMissingAndNotify(ImageRequestor& requestor, const ImageR
                                           Scheduler::GetCurrent()->bindOnce(std::move(removePendingRequests)));
         }
     } else {
-        // Associate requestor with an image that was provided by the client.
-        for (const auto& dependency : pair.first) {
-            if (requestedImages.contains(dependency.first)) {
-                requestedImages[dependency.first].emplace(&requestor);
-            }
-        }
         notify(requestor, pair);
     }
 }

--- a/test/renderer/image_manager.test.cpp
+++ b/test/renderer/image_manager.test.cpp
@@ -6,6 +6,7 @@
 #include <mln/renderer/image_manager_observer.hpp>
 #include <mln/sprite/sprite_parser.hpp>
 #include <mln/style/image_impl.hpp>
+#include <mln/util/constants.hpp>
 #include <mln/util/io.hpp>
 #include <mln/util/image.hpp>
 #include <mln/util/run_loop.hpp>
@@ -358,4 +359,82 @@ TEST(ImageManager, RemoveUnusedStyleImages) {
     ASSERT_TRUE(imageManager->getImage("missing") == nullptr);
     ASSERT_TRUE(imageManager->getImage("1024px") == nullptr);
     ASSERT_FALSE(imageManager->getImage("sprite") == nullptr);
+}
+
+TEST(ImageManager, MixedDependenciesRetainProvidedImages) {
+    constexpr std::size_t onDemandImageCount = 6;
+    constexpr uint32_t onDemandImageSide = 256;
+    static_assert(onDemandImageCount * onDemandImageSide * onDemandImageSide * 4 >
+                  util::DEFAULT_ON_DEMAND_IMAGES_CACHE_SIZE);
+
+    util::RunLoop runLoop;
+    auto imageManager = ImageManager::create();
+    StubImageManagerObserver observer;
+    imageManager->setObserver(&observer);
+    imageManager->setLoaded(true);
+
+    observer.imageMissing = [&](const std::string& id) {
+        imageManager->addImage(
+            makeMutable<style::Image::Impl>(id, PremultipliedImage({onDemandImageSide, onDemandImageSide}), 3.0f));
+    };
+    std::vector<std::string> evicted;
+    observer.removeUnusedStyleImages = [&](const std::vector<std::string>& ids) {
+        evicted.insert(evicted.end(), ids.begin(), ids.end());
+        for (const auto& id : ids) {
+            imageManager->removeImage(id);
+        }
+    };
+
+    auto requestor = std::make_unique<StubImageRequestor>(imageManager);
+    imageManager->addImage(makeMutable<style::Image::Impl>("sprite", PremultipliedImage({16, 16}), 1.0f));
+    ImageDependencies dependencies{{"sprite", ImageType::Icon}};
+    for (std::size_t i = 0; i < onDemandImageCount; ++i) {
+        dependencies.emplace("a" + std::to_string(i), ImageType::Icon);
+    }
+    bool notified = false;
+    requestor->imagesAvailable = [&](ImageMap icons, ImageMap, ImageVersionMap) {
+        notified = true;
+        EXPECT_EQ(icons.size(), dependencies.size());
+        for (const auto& dependency : dependencies) {
+            EXPECT_TRUE(icons.contains(dependency.first));
+        }
+    };
+    auto request = [&] {
+        notified = false;
+        imageManager->getImages(*requestor, std::make_pair(dependencies, ++requestor->imageCorrelationID));
+        imageManager->reduceMemoryUseIfCacheSizeExceedsLimit();
+        EXPECT_TRUE(evicted.empty());
+        runLoop.runOnce();
+        imageManager->notifyIfMissingImageAdded();
+        EXPECT_TRUE(notified);
+    };
+    request();
+    ASSERT_EQ(observer.count, 6);
+    imageManager->reduceMemoryUseIfCacheSizeExceedsLimit();
+    ASSERT_TRUE(evicted.empty());
+
+    request();
+    EXPECT_EQ(observer.count, 6);
+
+    for (std::size_t i = 0; i < onDemandImageCount; ++i) {
+        dependencies.emplace("b" + std::to_string(i), ImageType::Icon);
+    }
+    for (int round = 0; round < 2; ++round) {
+        request();
+        imageManager->reduceMemoryUseIfCacheSizeExceedsLimit();
+        EXPECT_TRUE(evicted.empty());
+        EXPECT_EQ(observer.count, 12);
+        for (const auto& dependency : dependencies) {
+            EXPECT_NE(imageManager->getImage(dependency.first), nullptr);
+        }
+    }
+
+    requestor.reset();
+    imageManager->reduceMemoryUseIfCacheSizeExceedsLimit();
+    EXPECT_EQ(evicted.size(), 12u);
+    dependencies.erase("sprite");
+    for (const auto& dependency : dependencies) {
+        EXPECT_EQ(imageManager->getImage(dependency.first), nullptr);
+    }
+    EXPECT_NE(imageManager->getImage("sprite"), nullptr);
 }


### PR DESCRIPTION
## Bug

[`ImageManager::getImages()`](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/src/mln/renderer/image_manager.cpp#L123) calls `removeRequestor()` first, which drops the requestor from every entry in `requestedImages`. `checkMissingAndNotify()` re-registers it [only in the branch where nothing is missing](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/src/mln/renderer/image_manager.cpp#L280-L285). A request that mixes on-demand images the manager already has with images it still needs leaves the present ones unregistered. [`reduceMemoryUse()`](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/src/mln/renderer/image_manager.cpp#L176) treats them as unused and evicts them through `onRemoveUnusedStyleImages` while the tile still shows them.

## Repro

Host supplies icons through `onStyleImageMissing`. Enough icons to exceed `DEFAULT_ON_DEMAND_IMAGES_CACHE_SIZE`. A tile requests icons a0..a5 (all present) plus b0..b5 (missing). Next cleanup evicts a0..a5; they get re-requested; then b0..b5 are evicted. This alternates indefinitely. maplibre/maplibre-native-ffi#694, maplibre/maplibre-compose#1344.

## Fix

Register the requestor for the on-demand images that are already present in the same loop that finds the missing ones, whether or not anything is missing. Remove the now-redundant loop in the else branch. Images added with `addImage` are unaffected; they have no `requestedImages` entry.

## Test

`ImageManager.MixedDependenciesRetainProvidedImages`. Fails on main at the first mixed request, passes with the fix. Also checks the images are reclaimed once the requestor is gone.

Carried in maplibre-native-ffi since maplibre/maplibre-native-ffi#695. AI disclosure: prepared with Claude Code (Claude Fable 5.1 for analysis, review, and this description; Claude Opus 5 for code edits under its instructions).