### PR TITLE
fix(core): keep the padding-dependent pitch limit at or above the minimum pitch

### DIFF
--- a/src/mln/map/transform.cpp
+++ b/src/mln/map/transform.cpp
@@ -12,6 +12,7 @@
 #include <mln/util/logging.hpp>
 #include <mln/util/platform.hpp>
 
+#include <algorithm>
 #include <cstdio>
 #include <utility>
 #include <numbers>
@@ -739,7 +740,7 @@ double Transform::getMaxPitchForEdgeInsets(const EdgeInsets& insets) const {
     // Half of fov is the field of view above perspective center.
     const double tangentOfFovAboveCenterAngle = (0.5 + centerOffsetY / height) * 2.0 * tan(getFieldOfView() / 2.0);
     const double fovAboveCenter = std::atan(tangentOfFovAboveCenterAngle);
-    return state.getMaxPitch() + getFieldOfView() / 2.0 - fovAboveCenter;
+    return std::max(state.getMinPitch(), state.getMaxPitch() + getFieldOfView() / 2.0 - fovAboveCenter);
 }
 
 FreeCameraOptions Transform::getFreeCameraOptions() const {

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -925,6 +925,31 @@ TEST(Transform, InvalidPitch) {
     ASSERT_DOUBLE_EQ(util::deg2rad(60), transform.getPitch());
 }
 
+TEST(Transform, PaddingPreservesMinimumPitch) {
+    for (const uint32_t size : {1u, 64u}) {
+        for (const double minPitch : {0.0, 15.0}) {
+            SCOPED_TRACE(::testing::Message() << "size=" << size << ", minPitch=" << minPitch);
+            Transform transform;
+            transform.resize({size, size});
+            transform.setMinPitch(minPitch);
+            transform.setMaxPitch(60);
+            transform.jumpTo(CameraOptions().withCenter(LatLng{40.7128, -74.006}).withZoom(9.5).withPitch(minPitch));
+
+            transform.jumpTo(CameraOptions().withPadding(EdgeInsets{size * 28.0, 392, 0, 0}));
+            EXPECT_DOUBLE_EQ(util::deg2rad(minPitch), transform.getPitch());
+
+            transform.jumpTo(CameraOptions().withPadding(EdgeInsets{size * 24.0, 392, 0, 0}));
+            EXPECT_DOUBLE_EQ(util::deg2rad(minPitch), transform.getPitch());
+            EXPECT_DOUBLE_EQ(size * 24.0, transform.getState().getEdgeInsets().top());
+
+            transform.resize({800, 600});
+            EXPECT_DOUBLE_EQ(util::deg2rad(minPitch), transform.getPitch());
+            transform.jumpTo(CameraOptions().withPadding(EdgeInsets{}).withPitch(45));
+            EXPECT_DOUBLE_EQ(util::deg2rad(45), transform.getPitch());
+        }
+    }
+}
+
 TEST(Transform, MinMaxPitch) {
     Transform transform;
     transform.resize({1, 1});


### PR DESCRIPTION
## Bug

`Transform::getMaxPitchForEdgeInsets()` has no lower bound. With top padding large relative to the viewport height it returns less than the minimum pitch, including negative values. `easeTo` applies it with [`std::min(maxPitch, pitch)`](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/src/mln/map/transform.cpp#L200), and [`TransformState::setPitch`](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/src/mln/map/transform_state.cpp#L691) does not range-check, so the camera ends up below min pitch.

## Repro

1x1 viewport, min pitch 0, max pitch 60, default FOV. `jumpTo` with padding top 24. `getPitch()` returns -4.7 degrees. The invalid pitch survives a later resize; the lower map geometry is clipped while labels still draw. maplibre/maplibre-native-ffi#693, maplibre/maplibre-compose#1333 (apps apply padding while the map still has a bootstrap size).

## Fix

Clamp the limit to `getMinPitch()`. The upper side is unchanged: bottom-heavy padding returns more than max pitch and the call site already takes the minimum.

An alternative is clamping in `TransformState::setPitch` as [MapLibre GL JS does](https://github.com/maplibre/maplibre-gl-js/blob/4730c3a12cc31714418951c089a5a5a8e25a4241/src/geo/transform_helper.ts), which would also cover `flyTo` and `setProperties` but changes behavior for every caller.

## Test

`Transform.PaddingPreservesMinimumPitch` at 1x1 and 64x64 with min pitch 0 and 15. Fails on main, passes with the fix.

Carried in maplibre-native-ffi since maplibre/maplibre-native-ffi#696. AI disclosure: prepared with Claude Code (Claude Fable 5.1 for analysis, review, and this description; Claude Opus 5 for code edits under its instructions).