### PR TITLE
core: add RunLoop::runOnce(Duration) to bound one iteration by time

### DIFF
--- a/include/mln/util/run_loop.hpp
+++ b/include/mln/util/run_loop.hpp
@@ -53,7 +53,8 @@ public:
     /// At least one queued task runs. Tasks left behind stay queued and the
     /// loop is woken again, so the next runOnce() or run() picks them up.
     void runOnce(Duration budget) {
-        processDeadline = Clock::now() + budget;
+        const auto now = Clock::now();
+        processDeadline = budget > TimePoint::max() - now ? TimePoint::max() : now + budget;
         const Scoped clearDeadline([this] { processDeadline.reset(); });
         runOnce();
     }
@@ -138,6 +139,9 @@ private:
             if (ranTask && processDeadline && Clock::now() >= *processDeadline) {
                 // Re-arm the wake so the remaining tasks run on the next iteration.
                 wake();
+                if (platformCallback) {
+                    platformCallback();
+                }
                 break;
             }
             if (!highPriorityQueue.empty()) {

--- a/include/mln/util/run_loop.hpp
+++ b/include/mln/util/run_loop.hpp
@@ -2,13 +2,16 @@
 
 #include <mln/actor/scheduler.hpp>
 #include <mln/actor/mailbox.hpp>
+#include <mln/util/chrono.hpp>
 #include <mln/util/noncopyable.hpp>
+#include <mln/util/scoped.hpp>
 #include <mln/util/util.hpp>
 #include <mln/util/work_task.hpp>
 #include <mln/util/work_request.hpp>
 
 #include <functional>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <utility>
 
@@ -45,6 +48,15 @@ public:
 
     void run();
     void runOnce();
+
+    /// Like runOnce(), but stops dequeuing tasks once `budget` has elapsed.
+    /// At least one queued task runs. Tasks left behind stay queued and the
+    /// loop is woken again, so the next runOnce() or run() picks them up.
+    void runOnce(Duration budget) {
+        processDeadline = Clock::now() + budget;
+        const Scoped clearDeadline([this] { processDeadline.reset(); });
+        runOnce();
+    }
     void stop();
 
     void updateTime();
@@ -118,24 +130,33 @@ private:
     void process() {
         std::shared_ptr<WorkTask> task;
         std::unique_lock<std::mutex> lock(mutex);
+        bool ranTask = false;
         while (true) {
+            if (highPriorityQueue.empty() && defaultQueue.empty()) {
+                break;
+            }
+            if (ranTask && processDeadline && Clock::now() >= *processDeadline) {
+                // Re-arm the wake so the remaining tasks run on the next iteration.
+                wake();
+                break;
+            }
             if (!highPriorityQueue.empty()) {
                 task = std::move(highPriorityQueue.front());
                 highPriorityQueue.pop();
-            } else if (!defaultQueue.empty()) {
+            } else {
                 task = std::move(defaultQueue.front());
                 defaultQueue.pop();
-            } else {
-                break;
             }
             lock.unlock();
             (*task)();
             task.reset();
             lock.lock();
+            ranTask = true;
         }
     }
 
     std::function<void()> platformCallback;
+    std::optional<TimePoint> processDeadline;
 
     Queue defaultQueue;
     Queue highPriorityQueue;

--- a/test/util/run_loop.test.cpp
+++ b/test/util/run_loop.test.cpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <thread>
+#include <vector>
 
 using namespace mln::util;
 
@@ -63,6 +64,24 @@ TEST(RunLoop, Priorities) {
     loop.run();
 
     EXPECT_EQ((std::vector<int>{2, 4, 1, 3}), order);
+}
+
+TEST(RunLoop, RunOnceBudget) {
+    std::vector<int> order;
+
+    RunLoop loop(RunLoop::Type::New);
+    loop.invoke([&] { order.push_back(1); });
+    loop.invoke(RunLoop::Priority::High, [&] { order.push_back(2); });
+    loop.invoke([&] { order.push_back(3); });
+
+    loop.runOnce(mln::Duration::zero());
+    EXPECT_EQ((std::vector<int>{2}), order);
+
+    loop.runOnce(mln::Duration::zero());
+    EXPECT_EQ((std::vector<int>{2, 1}), order);
+
+    loop.runOnce();
+    EXPECT_EQ((std::vector<int>{2, 1, 3}), order);
 }
 
 TEST(RunLoop, PlatformIntegration) {

--- a/test/util/run_loop.test.cpp
+++ b/test/util/run_loop.test.cpp
@@ -84,6 +84,34 @@ TEST(RunLoop, RunOnceBudget) {
     EXPECT_EQ((std::vector<int>{2, 1, 3}), order);
 }
 
+TEST(RunLoop, RunOnceMaximumBudget) {
+    RunLoop loop(RunLoop::Type::New);
+    int count = 0;
+    loop.invoke([&] { ++count; });
+    loop.invoke([&] { ++count; });
+
+    loop.runOnce(mln::Duration::max());
+    EXPECT_EQ(count, 2);
+}
+
+TEST(RunLoop, RunOnceBudgetNotifiesPlatform) {
+    RunLoop loop(RunLoop::Type::New);
+    int notifications = 0;
+    int count = 0;
+    loop.setPlatformCallback([&] { ++notifications; });
+    loop.invoke([&] { ++count; });
+    loop.invoke([&] { ++count; });
+    notifications = 0;
+
+    loop.runOnce(mln::Duration::zero());
+    EXPECT_EQ(count, 1);
+    EXPECT_EQ(notifications, 1);
+
+    loop.runOnce(mln::Duration::zero());
+    EXPECT_EQ(count, 2);
+    EXPECT_EQ(notifications, 1);
+}
+
 TEST(RunLoop, PlatformIntegration) {
     std::atomic<int> count1(0);
 


### PR DESCRIPTION
## Why

maplibre-native-ffi hosts drive the map from their own frame loop and call `RunLoop::runOnce()` once per frame. `process()` runs every queued task plus everything those tasks add to the queue. A style load queues enough work that one `runOnce()` can take many frames, and there is no way to stop at a task boundary: `process()` is private, the queues are not observable, and nothing takes a deadline. The FFI exposes a per-pump time budget (`mln_runtime_pump(budget_ms)`) and needs a core hook for it.

## Change

`RunLoop::runOnce(Duration budget)` sets a deadline and calls the per-platform `runOnce()` implementation. `process()` checks the deadline between tasks, only when one is set. At least one task runs per call. When the deadline stops it early, `process()` calls `wake()` so the deferred tasks run on the next iteration. This relies on each of MapLibre Native's run loop implementations clearing its wake flag before it calls `process()`, which holds for [CoreFoundation](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/platform/darwin/core/async_task.cpp#L27-L34), [libuv](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/platform/default/src/mln/util/run_loop.cpp#L95) (see [`uv_async_send`](https://docs.libuv.org/en/v1.x/async.html#c.uv_async_send)), the MapLibre Android [looper](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/platform/android/src/run_loop.cpp#L38), and [Qt](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/platform/qt/src/mln/async_task.cpp#L18-L26). Unbudgeted `runOnce()` and `run()` are unchanged. The deadline is cleared if a task throws.

The FFI currently carries a "keep going?" predicate on the loop instead. That runs under the loop mutex and a predicate that stays false makes `run()` spin, so this PR proposes a deadline instead.

## Test

`RunLoop.RunOnceBudget`: a zero budget runs exactly one task per call, highest priority first; deferred tasks survive; a call without a budget runs the rest. Passes on the CoreFoundation and libuv loops.

Carried in maplibre-native-ffi since maplibre/maplibre-native-ffi#628 as the callback version. AI disclosure: prepared with Claude Code (Claude Fable 5.1 for analysis, review, and this description; Claude Opus 5 for code edits under its instructions). Draft until I have reviewed the generated changes.
