### PR TITLE
fix(core): stop attributing stale OpenGL errors to buffer and texture allocation

### DIFF
--- a/src/mln/gl/context.hpp
+++ b/src/mln/gl/context.hpp
@@ -9,6 +9,7 @@
 #include <mln/gl/object.hpp>
 #include <mln/gl/state.hpp>
 #include <mln/gl/value.hpp>
+#include <mln/gl/defines.hpp>
 #include <mln/gl/framebuffer.hpp>
 #include <mln/gl/resource_pool.hpp>
 #include <mln/gl/vertex_array.hpp>
@@ -35,6 +36,17 @@ namespace extension {
 class VertexArray;
 class Debugging;
 } // namespace extension
+
+/// Reads and clears every pending GL error; true if one was GL_OUT_OF_MEMORY.
+/// The call being checked must not be wrapped in MBGL_CHECK_ERROR, which
+/// consumes the error in debug builds.
+inline bool hadOutOfMemoryError() {
+    bool outOfMemory = false;
+    for (auto error = platform::glGetError(); error != GL_NO_ERROR; error = platform::glGetError()) {
+        outOfMemory |= error == GL_OUT_OF_MEMORY;
+    }
+    return outOfMemory;
+}
 
 class Context final : public gfx::Context {
 public:

--- a/src/mln/gl/resource_pool.cpp
+++ b/src/mln/gl/resource_pool.cpp
@@ -145,16 +145,16 @@ TextureID Texture2DPool::allocateGLMemory(const Texture2DDesc& desc) {
     // Bind to TU 0 and upload
     context->activeTextureUnit = 0;
     context->texture[0] = id;
-    MBGL_CHECK_ERROR(glTexImage2D(GL_TEXTURE_2D,
-                                  0,
-                                  Enum<gfx::TexturePixelType>::sizedFor(desc.pixelFormat, desc.channelType),
-                                  desc.size.width,
-                                  desc.size.height,
-                                  0,
-                                  Enum<gfx::TexturePixelType>::to(desc.pixelFormat),
-                                  Enum<gfx::TextureChannelDataType>::to(desc.channelType),
-                                  nullptr));
-    if (glGetError()) {
+    glTexImage2D(GL_TEXTURE_2D,
+                 0,
+                 Enum<gfx::TexturePixelType>::sizedFor(desc.pixelFormat, desc.channelType),
+                 desc.size.width,
+                 desc.size.height,
+                 0,
+                 Enum<gfx::TexturePixelType>::to(desc.pixelFormat),
+                 Enum<gfx::TextureChannelDataType>::to(desc.channelType),
+                 nullptr);
+    if (hadOutOfMemoryError()) {
         throw std::bad_alloc();
     }
 

--- a/src/mln/gl/uniform_buffer_gl.cpp
+++ b/src/mln/gl/uniform_buffer_gl.cpp
@@ -84,14 +84,19 @@ UniformBufferGL::UniformBufferGL(const UniformBufferGL& other)
 #endif
       managedBuffer(other.managedBuffer.allocator, this) {
     MLN_TRACE_ALLOC_CONST_BUFFER(uniqueDebugId, other.size);
+    context.renderingStats().numUniformBuffers++;
+    context.renderingStats().memUniformBuffers += size;
+    context.renderingStats().totalBuffers++;
+    context.renderingStats().numBuffers++;
+    context.renderingStats().memBuffers += size;
     managedBuffer.setOwner(this);
     if (other.isManagedAllocation) {
         managedBuffer.allocate(other.managedBuffer.getContents().data(), other.size);
     } else {
         MBGL_CHECK_ERROR(glGenBuffers(1, &localID));
-        MBGL_CHECK_ERROR(glCopyBufferSubData(other.localID, localID, 0, 0, size));
         MBGL_CHECK_ERROR(glBindBuffer(GL_COPY_READ_BUFFER, other.localID));
         MBGL_CHECK_ERROR(glBindBuffer(GL_COPY_WRITE_BUFFER, localID));
+        MBGL_CHECK_ERROR(glBufferData(GL_COPY_WRITE_BUFFER, size, nullptr, GL_DYNAMIC_DRAW));
         MBGL_CHECK_ERROR(glCopyBufferSubData(GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER, 0, 0, size));
     }
 }

--- a/src/mln/gl/upload_pass.cpp
+++ b/src/mln/gl/upload_pass.cpp
@@ -35,8 +35,8 @@ std::unique_ptr<gfx::VertexBufferResource> UploadPass::createVertexBufferResourc
     // NOLINTNEXTLINE(performance-move-const-arg)
     UniqueBuffer result{std::move(id), {commandEncoder.context}};
     commandEncoder.context.vertexBuffer = result;
-    MBGL_CHECK_ERROR(glBufferData(GL_ARRAY_BUFFER, size, data, Enum<gfx::BufferUsageType>::to(usage)));
-    if (glGetError()) {
+    glBufferData(GL_ARRAY_BUFFER, size, data, Enum<gfx::BufferUsageType>::to(usage));
+    if (hadOutOfMemoryError()) {
         throw std::bad_alloc();
     }
     return std::make_unique<gl::VertexBufferResource>(std::move(result), static_cast<int>(size));
@@ -63,8 +63,8 @@ std::unique_ptr<gfx::IndexBufferResource> UploadPass::createIndexBufferResource(
     UniqueBuffer result{std::move(id), {commandEncoder.context}};
     commandEncoder.context.bindVertexArray = 0;
     commandEncoder.context.globalVertexArrayState.indexBuffer = result;
-    MBGL_CHECK_ERROR(glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, data, Enum<gfx::BufferUsageType>::to(usage)));
-    if (glGetError()) {
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, data, Enum<gfx::BufferUsageType>::to(usage));
+    if (hadOutOfMemoryError()) {
         throw std::bad_alloc();
     }
     return std::make_unique<gl::IndexBufferResource>(std::move(result), static_cast<int>(size));

--- a/test/gl/context.test.cpp
+++ b/test/gl/context.test.cpp
@@ -6,7 +6,12 @@
 #include <mln/gl/context.hpp>
 #include <mln/style/layers/custom_layer.hpp>
 #include <mln/gl/defines.hpp>
+#include <mln/gl/headless_backend.hpp>
 #include <mln/gl/renderable_resource.hpp>
+#include <mln/gl/uniform_buffer_gl.hpp>
+#include <mln/gfx/types.hpp>
+#include <mln/gfx/upload_pass.hpp>
+#include <mln/gl/upload_pass.hpp>
 #include <mln/map/map.hpp>
 #include <mln/map/map_options.hpp>
 #include <mln/platform/gl_functions.hpp>
@@ -18,6 +23,10 @@
 #include <mln/util/io.hpp>
 #include <mln/util/mat4.hpp>
 #include <mln/util/run_loop.hpp>
+
+#include <array>
+#include <cstring>
+#include <vector>
 
 using namespace mln;
 using namespace mln::style;
@@ -122,6 +131,58 @@ TEST(GLContextMode, Shared) {
     }
 
     test::checkImage("test/fixtures/shared_context", frontend.render(map).image, 0.5, 0.1);
+}
+
+TEST(GLContext, BufferAllocationIgnoresEarlierErrors) {
+    gl::HeadlessBackend backend{{32, 32}};
+    gfx::BackendScope scope{backend};
+
+    gl::Context context{backend};
+    auto commandEncoder = context.createCommandEncoder();
+    auto uploadPass = commandEncoder->createUploadPass("upload", backend.getDefaultRenderable());
+    auto& glUploadPass = static_cast<gl::UploadPass&>(*uploadPass);
+
+    const std::array<float, 6> vertices = {{0.0f, 0.5f, 0.5f, -0.5f, -0.5f, -0.5f}};
+    const std::array<uint16_t, 3> indices = {{0, 1, 2}};
+
+    glBindBuffer(0, 0);
+    EXPECT_NO_THROW(glUploadPass.createVertexBufferResource(
+        vertices.data(), vertices.size() * sizeof(float), gfx::BufferUsageType::StaticDraw, false));
+    EXPECT_EQ(glGetError(), GL_NO_ERROR);
+
+    glBindBuffer(0, 0);
+    EXPECT_NO_THROW(glUploadPass.createIndexBufferResource(
+        indices.data(), indices.size() * sizeof(uint16_t), gfx::BufferUsageType::StaticDraw, false));
+    EXPECT_EQ(glGetError(), GL_NO_ERROR);
+}
+
+TEST(GLContext, UniformBufferCloneCopiesLargeBuffer) {
+    gl::HeadlessBackend backend{{32, 32}};
+    gfx::BackendScope scope{backend};
+
+    gl::Context context{backend};
+
+    constexpr std::size_t size = 16384;
+    std::vector<uint8_t> data(size);
+    for (std::size_t i = 0; i < size; ++i) {
+        data[i] = static_cast<uint8_t>(i % 251);
+    }
+
+    auto buffer = context.createUniformBuffer(data.data(), size, /*persistent=*/false, /*ssbo=*/false);
+    ASSERT_TRUE(buffer);
+    auto& glBuffer = static_cast<gl::UniformBufferGL&>(*buffer);
+    ASSERT_EQ(glGetError(), GL_NO_ERROR);
+
+    auto clone = glBuffer.clone();
+    EXPECT_EQ(glGetError(), GL_NO_ERROR);
+
+    MBGL_CHECK_ERROR(glBindBuffer(GL_COPY_READ_BUFFER, clone.getID()));
+    const auto* contents = static_cast<const uint8_t*>(
+        MBGL_CHECK_ERROR(glMapBufferRange(GL_COPY_READ_BUFFER, 0, size, GL_MAP_READ_BIT)));
+    ASSERT_NE(contents, nullptr);
+    EXPECT_EQ(0, std::memcmp(contents, data.data(), size));
+    MBGL_CHECK_ERROR(glUnmapBuffer(GL_COPY_READ_BUFFER));
+    MBGL_CHECK_ERROR(glBindBuffer(GL_COPY_READ_BUFFER, 0));
 }
 
 #endif

--- a/test/gl/resource_pool.test.cpp
+++ b/test/gl/resource_pool.test.cpp
@@ -7,8 +7,11 @@
 #include <mln/gfx/types.hpp>
 #include <mln/gl/headless_backend.hpp>
 #include <mln/gl/context.hpp>
+#include <mln/gl/defines.hpp>
+#include <mln/platform/gl_functions.hpp>
 
 using namespace mln;
+using namespace mln::platform;
 
 namespace {
 
@@ -118,6 +121,24 @@ TEST(ResourcePool, TexturePool) {
     EXPECT_FALSE(pool.isUnused(id));
     EXPECT_FALSE(pool.isPooled(id));
     EXPECT_TRUE(context.empty(true));
+}
+
+TEST(ResourcePool, TextureAllocationIgnoresEarlierErrors) {
+    gl::HeadlessBackend backend{{32, 32}};
+    gfx::BackendScope scope{backend};
+
+    gl::Context context{backend};
+    auto& pool = context.getTexturePool();
+
+    glBindBuffer(0, 0);
+
+    gl::TextureID id = 0;
+    EXPECT_NO_THROW(id = pool.alloc(makeDescOneMB()));
+    EXPECT_EQ(glGetError(), GL_NO_ERROR);
+
+    pool.release(id);
+    context.reduceMemoryUsage();
+    context.renderingStats().numActiveTextures = 0;
 }
 
 #endif


### PR DESCRIPTION
## Bug

#4178 added `if (glGetError()) throw std::bad_alloc();` after `glBufferData` and `glTexImage2D` without clearing the error queue first. A GL error [stays set until `glGetError` reads it](https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGetError.xhtml), and [`MBGL_CHECK_ERROR`](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/include/mln/platform/gl_functions.hpp#L9-L21) is a no-op in release builds, so any error queued earlier in the frame, by MapLibre Native itself or by an embedding application that shares the GL context, is reported as an allocation failure by the next allocation.

The `UniformBufferGL` copy constructor is one in-tree source: it calls [`glCopyBufferSubData(other.localID, localID, ...)`](https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glCopyBufferSubData.xhtml) with buffer names where target enums are expected (`GL_INVALID_ENUM`), then copies into a destination with no data store (`GL_INVALID_VALUE`, since the write offset plus size exceeds the buffer's size of zero). This path runs from `UniformBufferGL::clone()` for buffers larger than the [8 KiB allocator page](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/src/mln/gl/buffer_allocator.cpp#L22-L30). It also never counts the new buffer in the rendering stats the destructor decrements, which fails `assert(stats.isZero())` in `~Context` in debug builds.

## Repro

Queue any GL error (for example `glBindBuffer(0, 0)`) in a release build, then trigger a vertex buffer upload or texture allocation. `std::bad_alloc` is thrown, although [`glBufferData`](https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glBufferData.xhtml) and [`glTexImage2D`](https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glTexImage2D.xhtml) only report allocation failure as `GL_OUT_OF_MEMORY`. Seen with maplibre-native-ffi on the API 26 Android emulator, as crashes on repeated style reloads (maplibre/maplibre-native-ffi#675), and in embeddings that render into a GL context they own.

## Fix

`gl::hadOutOfMemoryError()` reads and clears every pending flag after each of the three allocating calls and reports whether one was `GL_OUT_OF_MEMORY`, the only error [`glBufferData`](https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glBufferData.xhtml) and [`glTexImage2D`](https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glTexImage2D.xhtml) raise for an allocation failure, so other flags, stale or not, no longer turn into `std::bad_alloc`. The calls are unwrapped from `MBGL_CHECK_ERROR`, which in debug builds read the error before the check could see it. The copy constructor drops the invalid call, allocates the destination with `glBufferData` before copying, and updates the stats.

## Tests

`test/gl`: `ResourcePool.TextureAllocationIgnoresEarlierErrors`, `GLContext.BufferAllocationIgnoresEarlierErrors`, `GLContext.UniformBufferCloneCopiesLargeBuffer`. All three fail on main and pass with the fix on a Linux ES3 build (`linux-opengl`, RelWithDebInfo). In debug builds the first two pass trivially because earlier `MBGL_CHECK_ERROR` calls read the queued error first. The macOS headless GL context is [OpenGL 2.1](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/platform/darwin/src/headless_backend_cgl.mm#L28) and has no UBOs; macOS CI does not build the GL backend.

Carried in maplibre-native-ffi since maplibre/maplibre-native-ffi#676. AI disclosure: prepared with Claude Code (Claude Fable 5.1 for analysis, review, and this description; Claude Opus 5 for code edits under its instructions). Draft until I have reviewed the generated changes.
