### PR TITLE
fix(core): enumerate OpenGL extensions with glGetStringi when available

### DIFF
--- a/src/mln/gl/context.cpp
+++ b/src/mln/gl/context.cpp
@@ -70,6 +70,26 @@ GLint getMaxVertexAttribs() {
     return value;
 }
 
+/// Space separated extension names, the format glGetString(GL_EXTENSIONS)
+/// returns on contexts that still support that query.
+std::string getExtensionList() {
+    GLint count = 0;
+    glGetIntegerv(GL_NUM_EXTENSIONS, &count);
+    if (glGetError() != GL_NO_ERROR) {
+        // Older contexts do not know GL_NUM_EXTENSIONS; glGetString still works there.
+        const auto* list = reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_EXTENSIONS)));
+        return list ? list : "";
+    }
+    std::string extensions;
+    for (GLint index = 0; index < count; ++index) {
+        if (const auto* name = reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetStringi(GL_EXTENSIONS, index)))) {
+            extensions += name;
+            extensions += ' ';
+        }
+    }
+    return extensions;
+}
+
 // Currently renderBufferByteSize is only used when Tracy profiling is enabled
 #ifdef MLN_TRACY_ENABLE
 constexpr size_t renderBufferByteSize(const gfx::RenderbufferPixelType type, const Size size) noexcept {
@@ -151,10 +171,12 @@ void Context::endFrame() {
 void Context::initializeExtensions(const std::function<gl::ProcAddress(const char*)>& getProcAddress) {
     MLN_TRACE_FUNC();
 
-    if (const auto* extensions = reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_EXTENSIONS)))) {
+    const std::string extensions = getExtensionList();
+
+    if (!extensions.empty()) {
         auto fn = [&](std::initializer_list<std::pair<const char*, const char*>> probes) -> ProcAddress {
             for (auto probe : probes) {
-                if (strstr(extensions, probe.first) != nullptr) {
+                if (extensions.find(probe.first) != std::string::npos) {
                     if (ProcAddress ptr = getProcAddress(probe.second)) {
                         return ptr;
                     }

--- a/src/mln/gl/context.cpp
+++ b/src/mln/gl/context.cpp
@@ -73,6 +73,10 @@ GLint getMaxVertexAttribs() {
 /// Space separated extension names, the format glGetString(GL_EXTENSIONS)
 /// returns on contexts that still support that query.
 std::string getExtensionList() {
+    // Report earlier errors separately so they cannot select the legacy query.
+    for (auto error = glGetError(); error != GL_NO_ERROR; error = glGetError()) {
+        Log::Warning(Event::General, "OpenGL error before extension enumeration: " + std::to_string(error));
+    }
     GLint count = 0;
     glGetIntegerv(GL_NUM_EXTENSIONS, &count);
     if (glGetError() != GL_NO_ERROR) {

--- a/src/mln/gl/context.cpp
+++ b/src/mln/gl/context.cpp
@@ -75,7 +75,7 @@ GLint getMaxVertexAttribs() {
 std::string getExtensionList() {
     // Report earlier errors separately so they cannot select the legacy query.
     for (auto error = glGetError(); error != GL_NO_ERROR; error = glGetError()) {
-        Log::Warning(Event::General, "OpenGL error before extension enumeration: " + std::to_string(error));
+        Log::Warning(Event::GraphicsBackend, "OpenGL error before extension enumeration: " + std::to_string(error));
     }
     GLint count = 0;
     glGetIntegerv(GL_NUM_EXTENSIONS, &count);


### PR DESCRIPTION
## Bug

`gl::Context::initializeExtensions()` calls `glGetString(GL_EXTENSIONS)`. On core profile contexts (OpenGL 3.1 and later) `GL_EXTENSIONS` is [not an accepted value for `glGetString`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetString.xhtml): it returns `NULL` and queues `GL_INVALID_ENUM`, so no extension is detected and the error stays queued for the next `glGetError()` caller. [`render_location_indicator_layer.cpp`](https://github.com/maplibre/maplibre-native/blob/57d198149785cb6068ca6d62d478670c64a60358/src/mln/renderer/layers/render_location_indicator_layer.cpp#L388-L392) already works around this locally.

## Repro

Create a core profile context (or run on the API 26 Android emulator, as maplibre-native-ffi CI does, which [translates GLES to the host's desktop GL](https://developer.android.com/studio/run/emulator-acceleration#accel-graphics)), create a `gl::Context`. `glGetError()` returns `GL_INVALID_ENUM` and the debugging and timestamp query extensions are not registered.

## Fix

Query `GL_NUM_EXTENSIONS` first. If it succeeds, build the list with `glGetStringi`; otherwise fall back to `glGetString`. Both are part of [OpenGL 3.0](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetString.xhtml) and [OpenGL ES 3.0](https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGetString.xhtml). Extension names are still matched as substrings, as before.

## Tests

Not unit-testable without a core profile headless context. Existing `test/gl` suites pass on a Linux Mesa build, which takes the `glGetStringi` path, and on an OpenGL 2.1 macOS context, which takes the fallback.

Carried in maplibre-native-ffi since maplibre/maplibre-native-ffi#676. AI disclosure: prepared with Claude Code (Claude Fable 5.1 for analysis, review, and this description; Claude Opus 5 for code edits under its instructions). Draft until I have reviewed the generated changes.
