### PR TITLE
ci: defer build jobs for draft pull requests

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -12,6 +12,7 @@ on:
       - "android-*"
 
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "*"
 
@@ -22,6 +23,7 @@ concurrency:
 
 jobs:
   pre_job:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ github.event_name != 'workflow_dispatch' && steps.changed-files.outputs.android_any_modified != 'true' }}
@@ -42,7 +44,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true')
     strategy:
       fail-fast: false
       matrix:
@@ -204,7 +206,7 @@ jobs:
 
     needs:
       - pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true')
 
     defaults:
       run:
@@ -253,7 +255,7 @@ jobs:
     needs:
       - pre_job
 
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true')
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -277,7 +279,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true')
     defaults:
       run:
         working-directory: platform/android
@@ -306,7 +308,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true')
     defaults:
       run:
         working-directory: platform/android
@@ -372,7 +374,7 @@ jobs:
     permissions:
       actions: write
       contents: write
-    if: needs.pre_job.outputs.should_skip != 'true' && always()
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true' && always())
     needs:
       - pre_job
       - android-build

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -7,11 +7,13 @@ permissions:
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - .github/workflows/core-release.yml
 
 jobs:
   create-release:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -43,6 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-macos:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     needs: [create-release]
     runs-on: macos-latest
     steps:
@@ -84,6 +87,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   build-linux:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     needs: [create-release]
     runs-on: ${{ matrix.runner.os }}
     env:
@@ -147,6 +151,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   build-windows:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     needs: [create-release]
     runs-on: windows-2022
     strategy:

--- a/.github/workflows/gh-pages-mdbook.yml
+++ b/.github/workflows/gh-pages-mdbook.yml
@@ -3,6 +3,7 @@ name: gh-pages-mdbook
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'docs/mdbook/**'
   push:
@@ -13,6 +14,7 @@ on:
 
 jobs:
   gh-pages-mdbook-build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -36,7 +38,7 @@ jobs:
 
   gh-pages-mdbook-deploy:
     needs: gh-pages-mdbook-build
-    if: github.event_name != 'pull_request'
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (github.event_name != 'pull_request')
     name: Deploy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -10,6 +10,7 @@ on:
       - 'ios-*'
 
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - '*'
 
@@ -18,6 +19,7 @@ permissions:
 
 jobs:
   pre_job:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ github.event_name != 'workflow_dispatch' && steps.changed-files-yaml.outputs.ios_any_modified != 'true' }}
@@ -42,7 +44,7 @@ jobs:
 
   ios-build:
     needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true')
     runs-on: macos-26
     concurrency:
       # cancel jobs on PRs only
@@ -234,7 +236,7 @@ jobs:
   ios-build-cmake:
     needs: pre_job
     runs-on: macos-14
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -266,7 +268,7 @@ jobs:
 
   ios-build-webgpu-dawn:
     needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true')
     runs-on: macos-26
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -301,7 +303,7 @@ jobs:
 
   ios-build-webgpu-wgpu:
     needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true')
     runs-on: macos-26
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -352,7 +354,7 @@ jobs:
     permissions:
       actions: write
       contents: read
-    if: needs.pre_job.outputs.should_skip != 'true' && always()
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true' && always())
     needs:
       - pre_job
       - ios-build

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -10,6 +10,7 @@ on:
       - linux-*
 
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - '*'
 
@@ -29,6 +30,7 @@ env:
 
 jobs:
   pre_job:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     outputs:
       should_skip: ${{ github.event_name != 'workflow_dispatch' && steps.changed-files.outputs.linux_any_modified != 'true' }}
@@ -52,7 +54,7 @@ jobs:
           echo "Changed file(s): ${{ steps.changed-files.outputs.linux_all_changed_files }}"
 
   linux-build-and-test:
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true')
     needs: pre_job
     strategy:
       fail-fast: true
@@ -197,6 +199,7 @@ jobs:
         run: build-linux-${{ matrix.variant.renderer }}/expression-test/mbgl-expression-test
 
   linux-coverage:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -242,7 +245,7 @@ jobs:
 
   linux-ci-result:
     name: Linux CI Result
-    if: needs.pre_job.outputs.should_skip != 'true' && always()
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pre_job.outputs.should_skip != 'true' && always())
     runs-on: ubuntu-24.04
     needs:
       - pre_job

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -29,6 +29,7 @@ on:
       - 'cmake/**'
 
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
     paths:
@@ -61,6 +62,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: MacOS Metal CI Tests
     runs-on: [macos-15]
     defaults:
@@ -94,6 +96,7 @@ jobs:
         run: bazel run //platform/macos:xcodeproj --@rules_xcodeproj//xcodeproj:extra_common_flags="--//:renderer=metal"
 
   webgpu-cmake:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: macOS WebGPU (${{ matrix.variant.name }})
     runs-on: macos-15
     strategy:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -35,6 +35,7 @@ on:
       - "package-lock.json"
 
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "*"
     paths:
@@ -69,6 +70,7 @@ concurrency:
 
 jobs:
   test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false

--- a/.github/workflows/qt-ci.yml
+++ b/.github/workflows/qt-ci.yml
@@ -28,6 +28,7 @@ on:
       - "!**/*.md"
 
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "*"
     paths:
@@ -56,6 +57,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
         include:

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ main ]
   workflow_dispatch:
 
@@ -17,6 +18,7 @@ defaults:
 
 jobs:
   test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Rust tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -35,6 +37,7 @@ jobs:
       - run: just -v ci-test
 
   msrv:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Rust tests MSRV (Minimal Supported Rust Version)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -2,10 +2,11 @@ name: Validate PR title
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, edited]
+    types: [labeled, unlabeled, opened, edited, ready_for_review]
 
 jobs:
   validate-tags-match-title:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/validate-scripts.yml
+++ b/.github/workflows/validate-scripts.yml
@@ -3,10 +3,13 @@ name: validate-scripts
 on:
   workflow_dispatch:
   push:
+    branches-ignore: ["plugins/**"]
   pull_request:
 
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   validate-scripts:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/design-proposals/2026-09-08-plugin-introduction.md
+++ b/design-proposals/2026-09-08-plugin-introduction.md
@@ -1,0 +1,75 @@
+# Incremental plugin introduction
+
+The implementation is reviewed as a linear stack of draft PRs. Each PR targets
+the preceding branch, not `main`, and has a budget of approximately 2,000 changed
+lines of code. Generated fixtures are called out separately. This document is
+the implementation sequence, not a promise of a stable, released ABI.
+
+## Scope and invariants
+
+- Plugins register **new layer types**. They cannot add properties to, intercept,
+  or borrow private GPU geometry from built-in layers.
+- Built-in circle, heatmap, and hillshade remain available and unchanged.
+- C++ is the internal extension mechanism; an owned, validated C descriptor is an
+  adapter to it. No STL objects, virtual tables, or allocations cross the C ABI.
+- The host owns sources, tile scheduling, drawables, GPU uploads, shader variants,
+  resource binding, transitions, and dynamic paint-property binders.
+- Plugins own layout algorithms and shader sources. Callbacks receive borrowed
+  inputs; results are copied before callback-owned storage can be destroyed.
+- Registration precedes dependent styles, is process-wide, and cannot be undone.
+  Identical registration succeeds; conflicting registrations fail atomically.
+
+## Review sequence
+
+1. **Review infrastructure.** Skip draft PR jobs before allocating build runners;
+   enable `ready_for_review` so normal checks start when a PR leaves draft.
+2. **C++ factory foundation.** Add owned runtime factory registration to
+   `LayerManager`. Use the existing factory path for style, layout, bucket, and
+   render-layer construction; test ownership, conflicts, and lookup.
+3. **Retire experimental interfaces.** Remove the earlier plugin-layer and custom
+   drawable-layer APIs in separately reviewable platform, implementation, shader,
+   and fixture changes. Do not remove shaders used by ordinary built-in layers.
+4. **C descriptor vocabulary.** Introduce the C-only layer/property/geometry and
+   shader descriptors, explicit ownership, validation, and registration tests.
+5. **Plugin style values.** Add a dedicated plugin style implementation with typed
+   constants, expressions, transitions, clone/serialization, and error tests.
+   Built-in `Layer::Impl` does not acquire a plugin property bag.
+6. **Worker layout and buckets.** Adapt source tiles to callbacks and copy validated
+   meshes into host buckets. Add asynchronous resource loading and query hooks.
+7. **Drawable and shader adapter.** Register backend shader sources and resource
+   layouts, build/update/remove host drawables, and bind camera/tile uniforms.
+8. **Render graph.** Add generic offscreen targets, raster/DEM inputs, sampled
+   textures, and ordered passes. Heatmap and hillshade are external consumers,
+   not special cases in the host.
+9. **Dynamic paint binding.** Reuse expression evaluation, zoom interpolation,
+   feature state, transitions, and vertex ranges; validate uniform/attribute
+   layouts. Pack small endpoint pairs to stay within mobile attribute limits.
+10. **Platform packaging.** Export the C API on Android and Darwin, package the
+    header, and expose generic platform layer wrappers and registration queries.
+11. **Integration and regression coverage.** Wire builds and shared render-test
+    registration, verify the retained examples, and document consumption.
+
+Large implementation steps are split at compilation-unit boundaries into smaller
+PRs. Declaration-only foundations are allowed, but no intermediate PR advertises
+an available plugin layer before its host implementation is linked. Each PR
+description records its prerequisite, changed-line count, and validation scope.
+
+## Companion plugin repository
+
+The companion stack first removes `fill-extrusion-shadows` and all sample,
+publication, and render-test references to it. The remaining source-bound
+examples keep their behavior and migrate to the simplified descriptor.
+
+The new `ngon` plugin uses one quad per point and analytic convex-polygon coverage.
+Changing corner count or rotation does not rebuild tile geometry. Tests cover
+constant, feature-driven, composite, and feature-state paint; fractional zoom;
+fill/stroke/opacity; translation; and pitched map/viewport alignment. Android,
+Vulkan, OpenGL, and Metal share the same property and layout implementation.
+
+## CI and landing
+
+Use `gh stack submit --auto` without `--open`. The first PR's draft guards are
+inherited by every later PR. Manual dispatch and main-branch jobs remain enabled;
+no global workflow disabling or repository settings changes are required.
+Lightweight GitHub metadata automation may still run. Promote and merge in order,
+running normal CI on each ready PR and full backend render suites on the top.


### PR DESCRIPTION
## Scope

Skip all pull-request build jobs while a PR is draft; add ready_for_review triggers. Normal main/manual release behavior is unchanged.

Bottom of the stack, based on main. Layer 1/11.

133 changed lines (+118/-15). Within the approximately 2,000-line review budget.

## Validation and landing

At the integrated stack tip: 19 focused core tests and 108 Metal render tests pass. The n-gon plugin builds as an Android AAR for all four ABIs and through SwiftPM/Bazel. N-gon Vulkan images pass; the full MoltenVK run has two retained heatmap/hillshade image mismatches. OpenGL ES shader variants compile, but runtime OpenGL validation is still needed on a supported ES 3 test environment.

These are deliberately draft PRs. Build jobs are skipped before runner allocation; marking a PR ready triggers normal checks. Merge only in dependency order after those checks pass. Lightweight metadata/pre-commit services may still operate.

Companion plugin stack: https://github.com/louwers/maplibre-native-plugin-template/pull/1

Roadmap: [Incremental plugin introduction](https://github.com/maplibre/maplibre-native/blob/plugins/01-draft-ci/design-proposals/2026-09-08-plugin-introduction.md).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
