### PR TITLE
feat: register owned runtime C++ layer factories

### DIFF
--- a/include/mln/layermanager/layer_manager.hpp
+++ b/include/mln/layermanager/layer_manager.hpp
@@ -3,6 +3,8 @@
 #include <mln/style/layer.hpp>
 
 #include <vector>
+#include <map>
+#include <mutex>
 
 namespace mln {
 namespace style {
@@ -33,6 +35,18 @@ public:
      * @return LayerManager*
      */
     static LayerManager* get() noexcept;
+
+    /**
+     * Registers runtime layer factories as one atomic operation. The manager
+     * takes ownership, including on failure. Existing types cannot be replaced.
+     * Factories and their immutable LayerTypeInfo must remain valid for the
+     * manager's lifetime. Call before loading styles that use these types.
+     * Registration and lookups are thread-safe; callbacks run without the lock.
+     * This is a C++ API for code built against the same core, not a DSO ABI.
+     */
+    bool registerLayerFactories(std::vector<std::unique_ptr<LayerFactory>>, std::string& error);
+    bool registerLayerFactory(std::unique_ptr<LayerFactory>, std::string& error);
+    bool hasLayerType(const std::string&) noexcept;
 
     /// Returns a new Layer instance on success call; returns `nullptr` otherwise.
     std::unique_ptr<style::Layer> createLayer(const std::string& type,
@@ -77,9 +91,15 @@ public:
     virtual void addLayerTypeCoreOnly(std::unique_ptr<mln::LayerFactory>);
 
 protected:
-    virtual ~LayerManager() = default;
+    virtual ~LayerManager();
     virtual LayerFactory* getFactory(const std::string& type) noexcept = 0;
     virtual LayerFactory* getFactory(const style::LayerTypeInfo*) noexcept = 0;
+
+private:
+    LayerFactory* findFactory(const std::string&) noexcept;
+    LayerFactory* findFactory(const style::LayerTypeInfo*) noexcept;
+    std::mutex runtimeMutex;
+    std::map<std::string, std::unique_ptr<LayerFactory>> runtimeFactories;
 };
 
 } // namespace mln

--- a/src/mln/layermanager/layer_manager.cpp
+++ b/src/mln/layermanager/layer_manager.cpp
@@ -9,7 +9,64 @@
 #include <mln/style/layer_impl.hpp>
 #include <mln/style/conversion_impl.hpp>
 
+#include <set>
+
 namespace mln {
+
+LayerManager::~LayerManager() = default;
+
+bool LayerManager::registerLayerFactories(std::vector<std::unique_ptr<LayerFactory>> factories, std::string& error) {
+    std::lock_guard lock(runtimeMutex);
+    error.clear();
+    std::set<std::string> names;
+    for (const auto& factory : factories) {
+        const auto* info = factory ? factory->getTypeInfo() : nullptr;
+        if (!info || !info->type || !*info->type) {
+            error = "Layer factory must have a non-empty, immutable type name";
+            return false;
+        }
+        if (getFactory(info->type) || runtimeFactories.contains(info->type) || !names.emplace(info->type).second) {
+            error = "Layer type is already registered: " + std::string(info->type);
+            return false;
+        }
+    }
+    // Allocate all nodes before publishing any factory. In addition to conflict
+    // validation, this keeps allocation failure from partially registering a batch.
+    std::map<std::string, std::unique_ptr<LayerFactory>> pending;
+    for (auto& factory : factories) {
+        const std::string name = factory->getTypeInfo()->type;
+        pending.emplace(name, std::move(factory));
+    }
+    runtimeFactories.merge(pending);
+    return true;
+}
+
+bool LayerManager::registerLayerFactory(std::unique_ptr<LayerFactory> factory, std::string& error) {
+    std::vector<std::unique_ptr<LayerFactory>> factories;
+    factories.push_back(std::move(factory));
+    return registerLayerFactories(std::move(factories), error);
+}
+
+LayerFactory* LayerManager::findFactory(const std::string& type) noexcept {
+    if (auto* factory = getFactory(type)) return factory;
+    std::lock_guard lock(runtimeMutex);
+    const auto found = runtimeFactories.find(type);
+    return found == runtimeFactories.end() ? nullptr : found->second.get();
+}
+
+LayerFactory* LayerManager::findFactory(const style::LayerTypeInfo* info) noexcept {
+    if (!info || !info->type) return nullptr;
+    // Factory-owned type identity prevents an unrelated C++ layer from being
+    // dispatched merely by using the same name. Resolve by name first: some
+    // platform implementations assert when their built-in-only pointer lookup
+    // encounters a runtime type.
+    auto* factory = findFactory(info->type);
+    return factory && factory->getTypeInfo() == info ? factory : nullptr;
+}
+
+bool LayerManager::hasLayerType(const std::string& type) noexcept {
+    return findFactory(type) != nullptr;
+}
 
 void LayerManager::addLayerTypeCoreOnly(std::unique_ptr<mln::LayerFactory>) {}
 
@@ -17,8 +74,16 @@ std::unique_ptr<style::Layer> LayerManager::createLayer(const std::string& type,
                                                         const std::string& id,
                                                         const style::conversion::Convertible& value,
                                                         style::conversion::Error& error) noexcept {
-    LayerFactory* factory = getFactory(type);
+    LayerFactory* factory = findFactory(type);
     if (factory) {
+        if (factory->getTypeInfo()->source == style::LayerTypeInfo::Source::Required) {
+            const auto member = objectMember(value, "source");
+            const auto source = member ? toString(*member) : std::nullopt;
+            if (!source || source->empty()) {
+                error.message = "Layer '" + id + "' of type '" + type + "' requires a source";
+                return nullptr;
+            }
+        }
         auto layer = factory->createLayer(id, value);
         if (!layer) {
             error.message = "Error parsing layer " + id + " of type: " + type;
@@ -35,7 +100,7 @@ std::unique_ptr<Bucket> LayerManager::createBucket(const BucketParameters& param
                                                    const std::vector<Immutable<style::LayerProperties>>& layers) {
     assert(!layers.empty());
     assert(parameters.layerType->layout == style::LayerTypeInfo::Layout::NotRequired);
-    LayerFactory* factory = getFactory(parameters.layerType);
+    LayerFactory* factory = findFactory(parameters.layerType);
     assert(factory);
     return factory->createBucket(parameters, layers);
 }
@@ -45,13 +110,13 @@ std::unique_ptr<Layout> LayerManager::createLayout(const LayoutParameters& param
                                                    const std::vector<Immutable<style::LayerProperties>>& layers) {
     assert(!layers.empty());
     assert(parameters.bucketParameters.layerType->layout == style::LayerTypeInfo::Layout::Required);
-    LayerFactory* factory = getFactory(parameters.bucketParameters.layerType);
+    LayerFactory* factory = findFactory(parameters.bucketParameters.layerType);
     assert(factory);
     return factory->createLayout(parameters, std::move(tileLayer), layers);
 }
 
 std::unique_ptr<RenderLayer> LayerManager::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
-    LayerFactory* factory = getFactory(impl->getTypeInfo());
+    LayerFactory* factory = findFactory(impl->getTypeInfo());
     assert(factory);
     return factory->createRenderLayer(std::move(impl));
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
     ${PROJECT_SOURCE_DIR}/test/api/recycle_map.cpp
     ${PROJECT_SOURCE_DIR}/test/geometry/dem_data.test.cpp
     ${PROJECT_SOURCE_DIR}/test/geometry/line_atlas.test.cpp
+    ${PROJECT_SOURCE_DIR}/test/layermanager/layer_manager.test.cpp
     ${PROJECT_SOURCE_DIR}/test/map/map.test.cpp
     ${PROJECT_SOURCE_DIR}/test/map/prefetch.test.cpp
     ${PROJECT_SOURCE_DIR}/test/map/transform.test.cpp

--- a/test/layermanager/layer_manager.test.cpp
+++ b/test/layermanager/layer_manager.test.cpp
@@ -13,18 +13,25 @@ namespace {
 class Factory final : public LayerFactory {
 public:
     Factory(std::string name_, std::atomic<int>& destroyed_, std::atomic<int>& created_)
-        : name(std::move(name_)), destroyed(destroyed_), created(created_),
-          info{name.c_str(), style::LayerTypeInfo::Source::NotRequired,
-               style::LayerTypeInfo::Pass3D::NotRequired, style::LayerTypeInfo::Layout::NotRequired,
-               style::LayerTypeInfo::FadingTiles::NotRequired, style::LayerTypeInfo::CrossTileIndex::NotRequired,
+        : name(std::move(name_)),
+          destroyed(destroyed_),
+          created(created_),
+          info{name.c_str(),
+               style::LayerTypeInfo::Source::NotRequired,
+               style::LayerTypeInfo::Pass3D::NotRequired,
+               style::LayerTypeInfo::Layout::NotRequired,
+               style::LayerTypeInfo::FadingTiles::NotRequired,
+               style::LayerTypeInfo::CrossTileIndex::NotRequired,
                style::LayerTypeInfo::TileKind::NotRequired} {}
     ~Factory() override { ++destroyed; }
     const style::LayerTypeInfo* getTypeInfo() const noexcept override { return &info; }
-    std::unique_ptr<style::Layer> createLayer(const std::string&, const style::conversion::Convertible&) noexcept override {
+    std::unique_ptr<style::Layer> createLayer(const std::string&,
+                                              const style::conversion::Convertible&) noexcept override {
         ++created;
         return nullptr;
     }
     std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept override { return nullptr; }
+
 private:
     const std::string name;
     std::atomic<int>& destroyed;
@@ -36,11 +43,12 @@ private:
 class Manager final : public LayerManager {
 public:
     ~Manager() override = default;
+
 private:
     LayerFactory* getFactory(const std::string&) noexcept override { return nullptr; }
     LayerFactory* getFactory(const style::LayerTypeInfo*) noexcept override { return nullptr; }
 };
-}
+} // namespace
 
 TEST(LayerManager, OwnsFactoriesAndDispatchesOutsideRegistrationLock) {
     std::atomic<int> destroyed{0}, created{0};
@@ -54,7 +62,8 @@ TEST(LayerManager, OwnsFactoriesAndDispatchesOutsideRegistrationLock) {
         json.SetObject();
         style::conversion::Error parseError;
         const JSValue* value = &json;
-        EXPECT_EQ(nullptr, manager.createLayer("test-owned", "test", style::conversion::Convertible(value), parseError));
+        EXPECT_EQ(nullptr,
+                  manager.createLayer("test-owned", "test", style::conversion::Convertible(value), parseError));
         EXPECT_EQ(1, created);
         EXPECT_EQ(0, destroyed);
         EXPECT_FALSE(manager.hasLayerType("unknown"));
@@ -85,7 +94,8 @@ TEST(LayerManager, RejectsBuiltInNames) {
     std::atomic<int> destroyed{0}, created{0};
     std::string error;
     ASSERT_TRUE(LayerManager::get()->hasLayerType("circle"));
-    EXPECT_FALSE(LayerManager::get()->registerLayerFactory(std::make_unique<Factory>("circle", destroyed, created), error));
+    EXPECT_FALSE(
+        LayerManager::get()->registerLayerFactory(std::make_unique<Factory>("circle", destroyed, created), error));
     EXPECT_EQ(1, destroyed);
 }
 

--- a/test/layermanager/layer_manager.test.cpp
+++ b/test/layermanager/layer_manager.test.cpp
@@ -1,0 +1,106 @@
+#include <mln/layermanager/layer_manager.hpp>
+#include <mln/layermanager/layer_factory.hpp>
+#include <mln/renderer/render_layer.hpp>
+#include <mln/style/rapidjson_conversion.hpp>
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <thread>
+
+using namespace mln;
+
+namespace {
+class Factory final : public LayerFactory {
+public:
+    Factory(std::string name_, std::atomic<int>& destroyed_, std::atomic<int>& created_)
+        : name(std::move(name_)), destroyed(destroyed_), created(created_),
+          info{name.c_str(), style::LayerTypeInfo::Source::NotRequired,
+               style::LayerTypeInfo::Pass3D::NotRequired, style::LayerTypeInfo::Layout::NotRequired,
+               style::LayerTypeInfo::FadingTiles::NotRequired, style::LayerTypeInfo::CrossTileIndex::NotRequired,
+               style::LayerTypeInfo::TileKind::NotRequired} {}
+    ~Factory() override { ++destroyed; }
+    const style::LayerTypeInfo* getTypeInfo() const noexcept override { return &info; }
+    std::unique_ptr<style::Layer> createLayer(const std::string&, const style::conversion::Convertible&) noexcept override {
+        ++created;
+        return nullptr;
+    }
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept override { return nullptr; }
+private:
+    const std::string name;
+    std::atomic<int>& destroyed;
+    std::atomic<int>& created;
+    const style::LayerTypeInfo info;
+};
+
+// An isolated manager keeps tests independent of process-wide registration.
+class Manager final : public LayerManager {
+public:
+    ~Manager() override = default;
+private:
+    LayerFactory* getFactory(const std::string&) noexcept override { return nullptr; }
+    LayerFactory* getFactory(const style::LayerTypeInfo*) noexcept override { return nullptr; }
+};
+}
+
+TEST(LayerManager, OwnsFactoriesAndDispatchesOutsideRegistrationLock) {
+    std::atomic<int> destroyed{0}, created{0};
+    {
+        Manager manager;
+        std::string error;
+        ASSERT_TRUE(manager.registerLayerFactory(std::make_unique<Factory>("test-owned", destroyed, created), error));
+        EXPECT_TRUE(error.empty());
+        EXPECT_TRUE(manager.hasLayerType("test-owned"));
+        JSDocument json;
+        json.SetObject();
+        style::conversion::Error parseError;
+        const JSValue* value = &json;
+        EXPECT_EQ(nullptr, manager.createLayer("test-owned", "test", style::conversion::Convertible(value), parseError));
+        EXPECT_EQ(1, created);
+        EXPECT_EQ(0, destroyed);
+        EXPECT_FALSE(manager.hasLayerType("unknown"));
+    }
+    EXPECT_EQ(1, destroyed);
+}
+
+TEST(LayerManager, RejectsMalformedFactoriesAndAtomicBatchConflicts) {
+    std::atomic<int> destroyed{0}, created{0};
+    Manager manager;
+    std::string error;
+    EXPECT_FALSE(manager.registerLayerFactory(nullptr, error));
+    EXPECT_FALSE(manager.registerLayerFactory(std::make_unique<Factory>("", destroyed, created), error));
+    ASSERT_TRUE(manager.registerLayerFactory(std::make_unique<Factory>("occupied", destroyed, created), error));
+    std::vector<std::unique_ptr<LayerFactory>> batch;
+    batch.push_back(std::make_unique<Factory>("new", destroyed, created));
+    batch.push_back(std::make_unique<Factory>("occupied", destroyed, created));
+    EXPECT_FALSE(manager.registerLayerFactories(std::move(batch), error));
+    EXPECT_FALSE(manager.hasLayerType("new"));
+    EXPECT_NE(std::string::npos, error.find("occupied"));
+    batch.push_back(std::make_unique<Factory>("duplicate", destroyed, created));
+    batch.push_back(std::make_unique<Factory>("duplicate", destroyed, created));
+    EXPECT_FALSE(manager.registerLayerFactories(std::move(batch), error));
+    EXPECT_FALSE(manager.hasLayerType("duplicate"));
+}
+
+TEST(LayerManager, RejectsBuiltInNames) {
+    std::atomic<int> destroyed{0}, created{0};
+    std::string error;
+    ASSERT_TRUE(LayerManager::get()->hasLayerType("circle"));
+    EXPECT_FALSE(LayerManager::get()->registerLayerFactory(std::make_unique<Factory>("circle", destroyed, created), error));
+    EXPECT_EQ(1, destroyed);
+}
+
+TEST(LayerManager, ConcurrentRegistrationHasOneWinner) {
+    std::atomic<int> destroyed{0}, created{0}, winners{0};
+    Manager manager;
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 8; ++i) {
+        threads.emplace_back([&] {
+            std::string error;
+            if (manager.registerLayerFactory(std::make_unique<Factory>("raced", destroyed, created), error)) ++winners;
+            EXPECT_TRUE(manager.hasLayerType("raced"));
+        });
+    }
+    for (auto& thread : threads) thread.join();
+    EXPECT_EQ(1, winners);
+    EXPECT_EQ(7, destroyed);
+}


### PR DESCRIPTION
## Scope

Introduce owned, atomic runtime C++ LayerFactory registration. Use normal factory dispatch with immutable type identity; reject duplicates and built-in name conflicts.

Depends on #4581; review only against its base branch. Layer 2/11.

212 changed lines (+207/-5). Within the approximately 2,000-line review budget.

## Validation and landing

At the integrated stack tip: 19 focused core tests and 108 Metal render tests pass. The n-gon plugin builds as an Android AAR for all four ABIs and through SwiftPM/Bazel. N-gon Vulkan images pass; the full MoltenVK run has two retained heatmap/hillshade image mismatches. OpenGL ES shader variants compile, but runtime OpenGL validation is still needed on a supported ES 3 test environment.

These are deliberately draft PRs. Build jobs are skipped before runner allocation; marking a PR ready triggers normal checks. Merge only in dependency order after those checks pass. Lightweight metadata/pre-commit services may still operate.

Companion plugin stack: https://github.com/louwers/maplibre-native-plugin-template/pull/1

Roadmap: [Incremental plugin introduction](https://github.com/maplibre/maplibre-native/blob/plugins/01-draft-ci/design-proposals/2026-09-08-plugin-introduction.md).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
