### PR TITLE
feat: define the source-bound C plugin contract and host adapter types

### DIFF
--- a/include/mln/plugin/plugin_api.h
+++ b/include/mln/plugin/plugin_api.h
@@ -1,0 +1,661 @@
+#ifndef MLN_PLUGIN_API_H
+#define MLN_PLUGIN_API_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(_WIN32)
+#define MLN_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define MLN_PLUGIN_EXPORT __attribute__((visibility("default")))
+#endif
+
+#define MLN_PLUGIN_ABI_VERSION_1 1u
+
+typedef enum mln_plugin_status {
+    MLN_PLUGIN_STATUS_OK = 0,
+    MLN_PLUGIN_STATUS_ALREADY_REGISTERED = 1,
+    MLN_PLUGIN_STATUS_INVALID_ARGUMENT = 2,
+    MLN_PLUGIN_STATUS_UNSUPPORTED_ABI = 3,
+    MLN_PLUGIN_STATUS_CONFLICT = 4,
+    MLN_PLUGIN_STATUS_NOT_FOUND = 5,
+    MLN_PLUGIN_STATUS_CALLBACK_ERROR = 6
+} mln_plugin_status;
+
+typedef enum mln_plugin_backend {
+    MLN_PLUGIN_BACKEND_OPENGL = 1u << 0u,
+    MLN_PLUGIN_BACKEND_VULKAN = 1u << 1u,
+    MLN_PLUGIN_BACKEND_METAL = 1u << 2u
+} mln_plugin_backend;
+
+typedef enum mln_plugin_value_type {
+    MLN_PLUGIN_VALUE_BOOLEAN = 1,
+    MLN_PLUGIN_VALUE_FLOAT = 2,
+    MLN_PLUGIN_VALUE_FLOAT2 = 3,
+    MLN_PLUGIN_VALUE_COLOR = 4,
+    MLN_PLUGIN_VALUE_STRING = 5,
+    MLN_PLUGIN_VALUE_FLOAT_ARRAY = 6,
+    MLN_PLUGIN_VALUE_COLOR_ARRAY = 7,
+    /* UTF-8 JSON expression evaluated by the host into a 256 x 1 texture. */
+    MLN_PLUGIN_VALUE_COLOR_RAMP = 8
+} mln_plugin_value_type;
+
+typedef enum mln_plugin_property_scope {
+    MLN_PLUGIN_PROPERTY_PAINT = 1,
+    MLN_PLUGIN_PROPERTY_LAYOUT = 2
+} mln_plugin_property_scope;
+
+/* Expression dependencies accepted by a plugin property. */
+typedef enum mln_plugin_expression_capability {
+    MLN_PLUGIN_EXPRESSION_NONE = 0,
+    MLN_PLUGIN_EXPRESSION_CAMERA = 1u << 0u,
+    MLN_PLUGIN_EXPRESSION_FEATURE = 1u << 1u,
+    MLN_PLUGIN_EXPRESSION_COMPOSITE = 1u << 2u,
+    MLN_PLUGIN_EXPRESSION_FEATURE_STATE = 1u << 3u
+} mln_plugin_expression_capability;
+
+/*
+ * Custom layer source contract. Geometry sources cover GeoJSON and vector
+ * tile sources. The remaining values are reserved so adding raster and DEM
+ * adapters does not change the shape of the layer descriptor.
+ */
+typedef enum mln_plugin_source_kind {
+    MLN_PLUGIN_SOURCE_NONE = 0,
+    MLN_PLUGIN_SOURCE_GEOMETRY = 1,
+    MLN_PLUGIN_SOURCE_RASTER = 2,
+    MLN_PLUGIN_SOURCE_RASTER_DEM = 3
+} mln_plugin_source_kind;
+
+typedef enum mln_plugin_geometry_type {
+    MLN_PLUGIN_GEOMETRY_POINT = 1u << 0u,
+    MLN_PLUGIN_GEOMETRY_LINESTRING = 1u << 1u,
+    MLN_PLUGIN_GEOMETRY_POLYGON = 1u << 2u
+} mln_plugin_geometry_type;
+
+typedef struct mln_plugin_string {
+    const char* data;
+    size_t size;
+} mln_plugin_string;
+
+typedef struct mln_plugin_float2 {
+    float x;
+    float y;
+} mln_plugin_float2;
+
+typedef struct mln_plugin_color {
+    float r;
+    float g;
+    float b;
+    float a;
+} mln_plugin_color;
+
+typedef struct mln_plugin_float_array {
+    const float* data;
+    size_t count;
+} mln_plugin_float_array;
+
+typedef struct mln_plugin_color_array {
+    const mln_plugin_color* data;
+    size_t count;
+} mln_plugin_color_array;
+
+typedef union mln_plugin_value_data {
+    uint8_t boolean_value;
+    float float_value;
+    mln_plugin_float2 float2_value;
+    mln_plugin_color color_value;
+    mln_plugin_string string_value;
+    mln_plugin_float_array float_array_value;
+    mln_plugin_color_array color_array_value;
+    mln_plugin_string color_ramp_json;
+} mln_plugin_value_data;
+
+typedef struct mln_plugin_value {
+    uint32_t struct_size;
+    mln_plugin_value_type type;
+    mln_plugin_value_data data;
+} mln_plugin_value;
+
+typedef struct mln_plugin_property_descriptor_v1 {
+    uint32_t struct_size;
+    mln_plugin_string name;
+    mln_plugin_value_type type;
+    mln_plugin_property_scope scope;
+    mln_plugin_value default_value;
+    /* Bitmask of mln_plugin_expression_capability values. */
+    uint32_t expression_capabilities;
+    /* Paint properties may opt into the normal MapLibre transition system. */
+    uint8_t supports_transitions;
+    /* Array values may also be authored as a scalar/single color. */
+    uint8_t accepts_scalar;
+    uint8_t has_minimum;
+    uint8_t has_maximum;
+    float minimum;
+    float maximum;
+    /* Zero means no descriptor-specific limit. */
+    uint32_t maximum_array_length;
+    /* Optional allowed string values. */
+    const mln_plugin_string* enum_values;
+    size_t enum_value_count;
+} mln_plugin_property_descriptor_v1;
+
+typedef struct mln_plugin_property_value_v1 {
+    uint32_t struct_size;
+    mln_plugin_string name;
+    mln_plugin_value value;
+    uint8_t explicitly_set;
+} mln_plugin_property_value_v1;
+
+typedef enum mln_plugin_render_stage {
+    MLN_PLUGIN_RENDER_STAGE_PREPARE = 1,
+    MLN_PLUGIN_RENDER_STAGE_PASS_3D = 2,
+    MLN_PLUGIN_RENDER_STAGE_OPAQUE = 3,
+    MLN_PLUGIN_RENDER_STAGE_TRANSLUCENT = 4
+} mln_plugin_render_stage;
+
+typedef struct mln_plugin_resource_response_v1 {
+    uint32_t struct_size;
+    uint64_t request_id;
+    const uint8_t* data;
+    size_t data_size;
+    mln_plugin_string error_message;
+} mln_plugin_resource_response_v1;
+
+/* Response bytes and strings are borrowed and valid only during the callback. */
+typedef void (*mln_plugin_resource_callback_fn)(void* callback_context,
+                                                const mln_plugin_resource_response_v1* response);
+
+typedef struct mln_plugin_host_api_v1 {
+    uint32_t struct_size;
+    uint32_t abi_version;
+    void (*log)(int32_t severity, mln_plugin_string message);
+    void* context;
+    mln_plugin_status (*request_resource)(void* context,
+                                          mln_plugin_string url,
+                                          mln_plugin_resource_callback_fn callback,
+                                          void* callback_context,
+                                          uint64_t* request_id);
+    void (*cancel_resource_request)(void* context, uint64_t request_id);
+    void (*request_repaint)(void* context);
+} mln_plugin_host_api_v1;
+
+/* ------------------------------------------------------------------------- */
+/* Source layout and host-owned drawable API                                 */
+/* ------------------------------------------------------------------------- */
+
+typedef enum mln_plugin_vertex_attribute_type {
+    MLN_PLUGIN_VERTEX_INT16 = 1,
+    MLN_PLUGIN_VERTEX_INT16_X2 = 2,
+    MLN_PLUGIN_VERTEX_UINT16 = 3,
+    MLN_PLUGIN_VERTEX_UINT16_X2 = 4,
+    MLN_PLUGIN_VERTEX_FLOAT = 5,
+    MLN_PLUGIN_VERTEX_FLOAT_X2 = 6,
+    MLN_PLUGIN_VERTEX_FLOAT_X3 = 7,
+    MLN_PLUGIN_VERTEX_FLOAT_X4 = 8,
+    MLN_PLUGIN_VERTEX_UINT8_X4_NORMALIZED = 9
+} mln_plugin_vertex_attribute_type;
+
+typedef enum mln_plugin_draw_mode {
+    MLN_PLUGIN_DRAW_MODE_TRIANGLES = 1,
+    MLN_PLUGIN_DRAW_MODE_LINES = 2,
+    MLN_PLUGIN_DRAW_MODE_POINTS = 3
+} mln_plugin_draw_mode;
+
+typedef enum mln_plugin_depth_mode {
+    MLN_PLUGIN_DEPTH_DISABLED = 0,
+    MLN_PLUGIN_DEPTH_READ_ONLY = 1,
+    MLN_PLUGIN_DEPTH_READ_WRITE = 2
+} mln_plugin_depth_mode;
+
+typedef enum mln_plugin_blend_mode {
+    MLN_PLUGIN_BLEND_REPLACE = 0,
+    MLN_PLUGIN_BLEND_ALPHA = 1,
+    MLN_PLUGIN_BLEND_PREMULTIPLIED_ALPHA = 2,
+    MLN_PLUGIN_BLEND_MULTIPLY = 3,
+    MLN_PLUGIN_BLEND_ADDITIVE = 4
+} mln_plugin_blend_mode;
+
+/* Stable IDs are local to one registered plugin layer type. */
+typedef struct mln_plugin_shader_attribute_v1 {
+    uint32_t struct_size;
+    uint32_t attribute_id;
+    uint32_t location;
+    mln_plugin_string name;
+    mln_plugin_vertex_attribute_type type;
+} mln_plugin_shader_attribute_v1;
+
+typedef enum mln_plugin_shader_stage {
+    MLN_PLUGIN_SHADER_STAGE_VERTEX = 1u << 0u,
+    MLN_PLUGIN_SHADER_STAGE_FRAGMENT = 1u << 1u
+} mln_plugin_shader_stage;
+
+typedef enum mln_plugin_uniform_scope {
+    MLN_PLUGIN_UNIFORM_SCOPE_LAYER = 1,
+    MLN_PLUGIN_UNIFORM_SCOPE_DRAWABLE = 2
+} mln_plugin_uniform_scope;
+
+typedef struct mln_plugin_uniform_block_descriptor_v1 {
+    uint32_t struct_size;
+    uint32_t uniform_id;
+    mln_plugin_string name;
+    uint32_t byte_size;
+    uint32_t stage_mask;
+    mln_plugin_uniform_scope scope;
+} mln_plugin_uniform_block_descriptor_v1;
+
+typedef struct mln_plugin_shader_texture_v1 {
+    uint32_t struct_size;
+    uint32_t texture_id;
+    uint32_t location;
+    mln_plugin_string name;
+} mln_plugin_shader_texture_v1;
+
+typedef struct mln_plugin_shader_source_v1 {
+    uint32_t struct_size;
+    mln_plugin_backend backend;
+    /*
+     * GLSL vertex source for OpenGL/Vulkan; complete MSL source for Metal.
+     * The host prepends one numeric binding macro for every declared resource:
+     *   MLN_PLUGIN_UNIFORM_<uniform_id>_BINDING
+     *   MLN_PLUGIN_TEXTURE_<texture_id>_BINDING
+     * This keeps backend binding allocation owned by the host. A shader should
+     * use those macros in Vulkan set/binding declarations and Metal buffer,
+     * texture, and sampler attributes. OpenGL resolves uniforms by name.
+     */
+    mln_plugin_string vertex_source;
+    /* GLSL fragment source. Empty for Metal, where vertex_source is complete. */
+    mln_plugin_string fragment_source;
+    /* Metal entry points. Empty for OpenGL/Vulkan. */
+    mln_plugin_string vertex_entry_point;
+    mln_plugin_string fragment_entry_point;
+} mln_plugin_shader_source_v1;
+
+typedef enum mln_plugin_property_encoding_v1 {
+    MLN_PLUGIN_PROPERTY_ENCODING_FLOAT = 1,
+    MLN_PLUGIN_PROPERTY_ENCODING_FLOAT2 = 2,
+    MLN_PLUGIN_PROPERTY_ENCODING_COLOR = 3,
+    MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT = 4,
+    /* Zero-based index into the property descriptor enum_values. */
+    MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT = 5
+} mln_plugin_property_encoding_v1;
+
+/*
+ * Declares a host-owned dynamic paint binding. The named property is supplied
+ * either through the uniform block range or through the minimum/maximum vertex
+ * attributes. Composite expressions use both attributes plus the interpolation
+ * factor. Source-only expressions write equal minimum and maximum values.
+ * Equal minimum/maximum attribute IDs pack both endpoints into one float2
+ * (scalar/boolean/enum) or float4 (float2) attribute. Color needs two float4
+ * attributes. Enum endpoints must be selected, never linearly interpolated.
+ */
+typedef struct mln_plugin_shader_property_binding_v1 {
+    uint32_t struct_size;
+    mln_plugin_string property_name;
+    mln_plugin_property_encoding_v1 encoding;
+    uint32_t uniform_id;
+    uint32_t uniform_byte_offset;
+    uint32_t minimum_attribute_id;
+    uint32_t maximum_attribute_id;
+    uint32_t interpolation_uniform_id;
+    uint32_t interpolation_uniform_byte_offset;
+} mln_plugin_shader_property_binding_v1;
+
+typedef struct mln_plugin_shader_descriptor_v1 {
+    uint32_t struct_size;
+    mln_plugin_string shader_id;
+    const mln_plugin_shader_source_v1* sources;
+    size_t source_count;
+    const mln_plugin_shader_attribute_v1* attributes;
+    size_t attribute_count;
+    const mln_plugin_uniform_block_descriptor_v1* uniform_blocks;
+    size_t uniform_block_count;
+    const mln_plugin_shader_texture_v1* textures;
+    size_t texture_count;
+    const mln_plugin_shader_property_binding_v1* property_bindings;
+    size_t property_binding_count;
+} mln_plugin_shader_descriptor_v1;
+
+typedef enum mln_plugin_graph_geometry {
+    MLN_PLUGIN_GRAPH_GEOMETRY_PLUGIN_BUCKET = 1,
+    MLN_PLUGIN_GRAPH_GEOMETRY_RASTER_DEM_FULL_TILE = 2,
+    MLN_PLUGIN_GRAPH_GEOMETRY_RASTER_DEM_MASKED_TILE = 3,
+    /* One host-owned normalized [0, 1] viewport quad per layer. */
+    MLN_PLUGIN_GRAPH_GEOMETRY_VIEWPORT_QUAD = 4
+} mln_plugin_graph_geometry;
+
+typedef enum mln_plugin_texture_source {
+    MLN_PLUGIN_TEXTURE_SOURCE_RASTER_DEM = 1,
+    MLN_PLUGIN_TEXTURE_SOURCE_RENDER_TARGET = 2,
+    /* A 256 x 1 premultiplied texture generated from a color-ramp property. */
+    MLN_PLUGIN_TEXTURE_SOURCE_COLOR_RAMP_PROPERTY = 3
+} mln_plugin_texture_source;
+
+typedef enum mln_plugin_texture_filter {
+    MLN_PLUGIN_TEXTURE_FILTER_NEAREST = 1,
+    MLN_PLUGIN_TEXTURE_FILTER_LINEAR = 2
+} mln_plugin_texture_filter;
+
+typedef enum mln_plugin_texture_wrap {
+    MLN_PLUGIN_TEXTURE_WRAP_CLAMP = 1,
+    MLN_PLUGIN_TEXTURE_WRAP_REPEAT = 2
+} mln_plugin_texture_wrap;
+
+typedef enum mln_plugin_render_target_size {
+    MLN_PLUGIN_RENDER_TARGET_SOURCE_TILE = 1,
+    MLN_PLUGIN_RENDER_TARGET_VIEWPORT = 2
+} mln_plugin_render_target_size;
+
+typedef enum mln_plugin_render_target_format {
+    MLN_PLUGIN_RENDER_TARGET_RGBA8 = 1,
+    MLN_PLUGIN_RENDER_TARGET_RGBA16F = 2
+} mln_plugin_render_target_format;
+
+typedef enum mln_plugin_render_target_scope {
+    MLN_PLUGIN_RENDER_TARGET_PER_TILE = 1,
+    MLN_PLUGIN_RENDER_TARGET_PER_LAYER = 2
+} mln_plugin_render_target_scope;
+
+/* Projection matrix used for tile-bound geometry in a render-graph pass. */
+typedef enum mln_plugin_tile_projection {
+    /* The camera projection used by ordinary 2D geometry such as heatmaps. */
+    MLN_PLUGIN_TILE_PROJECTION_MAP = 1,
+    /* Pixel-aligned camera projection used by raster-like tile geometry. */
+    MLN_PLUGIN_TILE_PROJECTION_ALIGNED = 2,
+    /* Map projection with a farther near plane for 3D depth precision. */
+    MLN_PLUGIN_TILE_PROJECTION_NEAR_CLIPPED = 3
+} mln_plugin_tile_projection;
+
+typedef struct mln_plugin_render_target_descriptor_v1 {
+    uint32_t struct_size;
+    uint32_t target_id;
+    mln_plugin_render_target_size size;
+    mln_plugin_render_target_format format;
+    mln_plugin_render_target_scope scope;
+    /* Used for VIEWPORT targets. Zero is invalid; 0.5 creates a half-size target. */
+    float width_scale;
+    float height_scale;
+    mln_plugin_color clear_color;
+} mln_plugin_render_target_descriptor_v1;
+
+typedef struct mln_plugin_texture_binding_v1 {
+    uint32_t struct_size;
+    uint32_t texture_id;
+    mln_plugin_texture_source source;
+    /* Required only for MLN_PLUGIN_TEXTURE_SOURCE_RENDER_TARGET. */
+    uint32_t render_target_id;
+    /* Required only for COLOR_RAMP_PROPERTY. */
+    mln_plugin_string property_name;
+    mln_plugin_texture_filter filter;
+    mln_plugin_texture_wrap wrap_u;
+    mln_plugin_texture_wrap wrap_v;
+} mln_plugin_texture_binding_v1;
+
+typedef struct mln_plugin_render_pass_descriptor_v1 {
+    uint32_t struct_size;
+    uint32_t pass_id;
+    mln_plugin_string shader_id;
+    mln_plugin_graph_geometry geometry;
+    /* Zero renders into the map; non-zero names a graph render target. */
+    uint32_t render_target_id;
+    mln_plugin_render_stage render_stage;
+    mln_plugin_draw_mode draw_mode;
+    mln_plugin_depth_mode depth_mode;
+    mln_plugin_blend_mode blend_mode;
+    uint8_t enable_stencil;
+    uint8_t enable_cull_face;
+    mln_plugin_tile_projection tile_projection;
+    const mln_plugin_texture_binding_v1* textures;
+    size_t texture_count;
+} mln_plugin_render_pass_descriptor_v1;
+
+typedef struct mln_plugin_render_graph_v1 {
+    uint32_t struct_size;
+    const mln_plugin_render_target_descriptor_v1* render_targets;
+    size_t render_target_count;
+    const mln_plugin_render_pass_descriptor_v1* passes;
+    size_t pass_count;
+} mln_plugin_render_graph_v1;
+
+typedef enum mln_plugin_raster_dem_encoding {
+    MLN_PLUGIN_RASTER_DEM_MAPBOX = 1,
+    MLN_PLUGIN_RASTER_DEM_TERRARIUM = 2
+} mln_plugin_raster_dem_encoding;
+
+/* Borrowed render-thread inputs for a host-owned plugin uniform block. */
+typedef struct mln_plugin_uniform_context_v1 {
+    uint32_t struct_size;
+    uint32_t pass_id;
+    int32_t canonical_z;
+    int32_t canonical_x;
+    int32_t canonical_y;
+    int32_t wrap;
+    int32_t overscaled_z;
+    uint32_t source_max_zoom;
+    uint32_t dem_dimension;
+    uint32_t dem_stride;
+    mln_plugin_raster_dem_encoding dem_encoding;
+    double zoom;
+    double bearing;
+    float pixels_to_gl_units[2];
+    float tile_matrix[16];
+    float render_target_matrix[16];
+    float latitude_range[2];
+    uint32_t viewport_width;
+    uint32_t viewport_height;
+    uint32_t render_target_width;
+    uint32_t render_target_height;
+    float pixels_to_tile_units;
+    float camera_to_center_distance;
+    float pixel_ratio;
+    /* Column-major matrix mapping normalized viewport coordinates. */
+    float viewport_matrix[16];
+    const mln_plugin_property_value_v1* properties;
+    size_t property_count;
+} mln_plugin_uniform_context_v1;
+
+typedef mln_plugin_status (*mln_plugin_update_uniform_block_fn)(const mln_plugin_uniform_context_v1* context,
+                                                                uint32_t uniform_id,
+                                                                uint8_t* output,
+                                                                size_t output_size);
+
+/* A geometry is represented as paths into a flat tile-coordinate point list. */
+typedef struct mln_plugin_tile_point_v1 {
+    int16_t x;
+    int16_t y;
+} mln_plugin_tile_point_v1;
+
+typedef struct mln_plugin_feature_v1 {
+    uint32_t struct_size;
+    mln_plugin_geometry_type geometry_type;
+    uint64_t feature_index;
+    mln_plugin_string feature_id;
+    const mln_plugin_tile_point_v1* points;
+    size_t point_count;
+    /* path_offsets has path_count + 1 entries and ends at point_count. */
+    const uint32_t* path_offsets;
+    size_t path_count;
+    /* UTF-8 JSON object. Borrowed and valid only during layout_feature. */
+    mln_plugin_string properties_json;
+    /* Populated for query_feature with the current zoom and feature state;
+     * null during layout_feature because host binders own paint evaluation. */
+    const mln_plugin_property_value_v1* evaluated_properties;
+    size_t evaluated_property_count;
+} mln_plugin_feature_v1;
+
+typedef struct mln_plugin_layout_context_v1 {
+    uint32_t struct_size;
+    float zoom;
+    int32_t canonical_z;
+    int32_t canonical_x;
+    int32_t canonical_y;
+    uint32_t extent;
+    mln_plugin_string layer_id;
+    mln_plugin_string source_layer_id;
+    /* Serialized style values. Expressions are deliberately not evaluated here. */
+    const mln_plugin_property_value_v1* properties;
+    size_t property_count;
+    /* Resource requests use MapLibre's configured file source and cache. */
+    const mln_plugin_host_api_v1* host;
+} mln_plugin_layout_context_v1;
+
+/* Bytes are copied by the host before finish_layout returns. */
+typedef struct mln_plugin_vertex_stream_v1 {
+    uint32_t struct_size;
+    uint32_t stream_id;
+    const uint8_t* data;
+    size_t data_size;
+    uint32_t vertex_count;
+    uint32_t stride;
+} mln_plugin_vertex_stream_v1;
+
+typedef struct mln_plugin_attribute_binding_v1 {
+    uint32_t struct_size;
+    uint32_t attribute_id;
+    uint32_t stream_id;
+    uint32_t byte_offset;
+    mln_plugin_vertex_attribute_type type;
+} mln_plugin_attribute_binding_v1;
+
+typedef struct mln_plugin_segment_v1 {
+    uint32_t struct_size;
+    uint32_t vertex_offset;
+    uint32_t index_offset;
+    uint32_t vertex_length;
+    uint32_t index_length;
+    uint64_t feature_index;
+} mln_plugin_segment_v1;
+
+typedef struct mln_plugin_drawable_descriptor_v1 {
+    uint32_t struct_size;
+    uint64_t drawable_key;
+    mln_plugin_string shader_id;
+    mln_plugin_draw_mode draw_mode;
+    mln_plugin_render_stage render_stage;
+    mln_plugin_depth_mode depth_mode;
+    mln_plugin_blend_mode blend_mode;
+    uint8_t enable_stencil;
+    uint8_t enable_cull_face;
+    const mln_plugin_attribute_binding_v1* attributes;
+    size_t attribute_count;
+    const mln_plugin_segment_v1* segments;
+    size_t segment_count;
+} mln_plugin_drawable_descriptor_v1;
+
+typedef struct mln_plugin_feature_vertex_range_v1 {
+    uint32_t struct_size;
+    uint64_t feature_index;
+    uint64_t drawable_key;
+    uint32_t first_vertex;
+    uint32_t vertex_count;
+} mln_plugin_feature_vertex_range_v1;
+
+typedef struct mln_plugin_bucket_v1 {
+    uint32_t struct_size;
+    const mln_plugin_vertex_stream_v1* vertex_streams;
+    size_t vertex_stream_count;
+    const uint16_t* indices;
+    size_t index_count;
+    const mln_plugin_drawable_descriptor_v1* drawables;
+    size_t drawable_count;
+    /* Maximum screen-pixel distance used by precise rendered-feature query. */
+    float query_radius;
+    const mln_plugin_feature_vertex_range_v1* feature_vertex_ranges;
+    size_t feature_vertex_range_count;
+} mln_plugin_bucket_v1;
+
+typedef mln_plugin_status (*mln_plugin_create_layout_fn)(const mln_plugin_layout_context_v1* context,
+                                                         void** layout_instance);
+typedef mln_plugin_status (*mln_plugin_layout_feature_fn)(void* layout_instance, const mln_plugin_feature_v1* feature);
+typedef mln_plugin_status (*mln_plugin_finish_layout_fn)(void* layout_instance, mln_plugin_bucket_v1* bucket);
+typedef void (*mln_plugin_destroy_layout_fn)(void* layout_instance);
+
+/* Borrowed inputs for a rendered-feature hit test. Bearing is in radians;
+ * viewport dimensions and pixel distances are logical pixels. */
+typedef struct mln_plugin_query_context_v1 {
+    uint32_t struct_size;
+    double pixels_to_tile_units;
+    double camera_to_center_distance;
+    double bearing;
+    double tile_matrix[16];
+    uint32_t viewport_width;
+    uint32_t viewport_height;
+} mln_plugin_query_context_v1;
+
+/* Optional exact hit test. Query and feature geometry use tile coordinates.
+ * Use the projection context for pitch, translation, and viewport-aligned marks. */
+typedef uint8_t (*mln_plugin_query_feature_fn)(const mln_plugin_feature_v1* feature,
+                                               const mln_plugin_tile_point_v1* query_geometry,
+                                               size_t query_geometry_count,
+                                               const mln_plugin_query_context_v1* context,
+                                               const mln_plugin_property_value_v1* properties,
+                                               size_t property_count);
+
+typedef struct mln_plugin_property_statistics_v1 {
+    uint32_t struct_size;
+    mln_plugin_string property_name;
+    mln_plugin_value minimum;
+    mln_plugin_value maximum;
+} mln_plugin_property_statistics_v1;
+
+/* Optional conservative screen-pixel radius for broad-phase feature queries. */
+typedef float (*mln_plugin_query_radius_fn)(const mln_plugin_property_statistics_v1* statistics,
+                                            size_t statistics_count,
+                                            const mln_plugin_property_value_v1* camera_properties,
+                                            size_t camera_property_count);
+
+typedef struct mln_plugin_layer_type_v1 {
+    uint32_t struct_size;
+    mln_plugin_string layer_type;
+    uint32_t backend_mask;
+    mln_plugin_render_stage render_stage;
+    uint8_t requires_3d;
+    const mln_plugin_property_descriptor_v1* properties;
+    size_t property_count;
+    mln_plugin_source_kind source_kind;
+    uint32_t geometry_type_mask;
+    const mln_plugin_shader_descriptor_v1* shaders;
+    size_t shader_count;
+    mln_plugin_create_layout_fn create_layout;
+    mln_plugin_layout_feature_fn layout_feature;
+    mln_plugin_finish_layout_fn finish_layout;
+    mln_plugin_destroy_layout_fn destroy_layout;
+    mln_plugin_query_feature_fn query_feature;
+    /* Required for RasterDEM layers; optional for multi-pass geometry layers. */
+    const mln_plugin_render_graph_v1* render_graph;
+    mln_plugin_update_uniform_block_fn update_uniform_block;
+    /* Matches LayerTypeInfo::Pass3D without making the drawables depth-writing 3D geometry. */
+    uint8_t participates_in_3d_pass;
+    mln_plugin_query_radius_fn get_query_radius;
+} mln_plugin_layer_type_v1;
+
+typedef struct mln_plugin_descriptor_v1 {
+    uint32_t struct_size;
+    uint32_t abi_version;
+    mln_plugin_string plugin_id;
+    mln_plugin_string plugin_version;
+    uint32_t minimum_host_abi;
+    uint32_t maximum_host_abi;
+    const mln_plugin_layer_type_v1* layer_types;
+    size_t layer_type_count;
+} mln_plugin_descriptor_v1;
+
+typedef mln_plugin_status (*mln_plugin_register_function_v1)(const mln_plugin_descriptor_v1* descriptor,
+                                                             char* error_message,
+                                                             size_t error_message_capacity);
+
+MLN_PLUGIN_EXPORT mln_plugin_status mln_plugin_register_v1(const mln_plugin_descriptor_v1* descriptor,
+                                                           char* error_message,
+                                                           size_t error_message_capacity);
+MLN_PLUGIN_EXPORT uint8_t mln_plugin_is_registered_v1(const char* plugin_id);
+MLN_PLUGIN_EXPORT size_t mln_plugin_count_v1(void);
+MLN_PLUGIN_EXPORT size_t mln_plugin_id_at_v1(size_t index, char* output, size_t output_capacity);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MLN_PLUGIN_API_H */

--- a/src/mln/layout/plugin_layout.hpp
+++ b/src/mln/layout/plugin_layout.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <mln/layout/layout.hpp>
+#include <mln/plugin/plugin_registry.hpp>
+#include <mln/renderer/bucket_parameters.hpp>
+#include <mln/style/layer_properties.hpp>
+
+namespace mln {
+
+class PluginLayout final : public Layout {
+public:
+    PluginLayout(const BucketParameters&,
+                 std::vector<Immutable<style::LayerProperties>>,
+                 std::unique_ptr<GeometryTileLayer>,
+                 plugin::LayerType);
+
+    bool hasDependencies() const override { return false; }
+
+    void createBucket(const ImagePositions&,
+                      std::unique_ptr<FeatureIndex>&,
+                      mln::unordered_map<std::string, LayerRenderData>&,
+                      bool,
+                      bool,
+                      const CanonicalTileID&) override;
+
+private:
+    const OverscaledTileID tileID;
+    const float zoom;
+    std::shared_ptr<FileSource> fileSource;
+    std::vector<Immutable<style::LayerProperties>> layers;
+    std::unique_ptr<GeometryTileLayer> sourceLayer;
+    plugin::LayerType registration;
+};
+
+} // namespace mln

--- a/src/mln/plugin/plugin_layer_factory.hpp
+++ b/src/mln/plugin/plugin_layer_factory.hpp
@@ -7,12 +7,16 @@ namespace mln::plugin {
 // C descriptors adapt ordinary C++ factories instead of adding a dispatch path.
 class PluginLayerFactory final : public LayerFactory {
 public:
-    explicit PluginLayerFactory(LayerType registration_) : registration(std::move(registration_)) {}
+    explicit PluginLayerFactory(LayerType registration_)
+        : registration(std::move(registration_)) {}
     const style::LayerTypeInfo* getTypeInfo() const noexcept override;
-    std::unique_ptr<style::Layer> createLayer(const std::string&, const style::conversion::Convertible&) noexcept override;
+    std::unique_ptr<style::Layer> createLayer(const std::string&,
+                                              const style::conversion::Convertible&) noexcept override;
     std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept override;
-    std::unique_ptr<Layout> createLayout(const LayoutParameters&, std::unique_ptr<GeometryTileLayer>,
-                                       const std::vector<Immutable<style::LayerProperties>>&) override;
+    std::unique_ptr<Layout> createLayout(const LayoutParameters&,
+                                         std::unique_ptr<GeometryTileLayer>,
+                                         const std::vector<Immutable<style::LayerProperties>>&) override;
+
 private:
     const LayerType registration;
 };

--- a/src/mln/plugin/plugin_layer_factory.hpp
+++ b/src/mln/plugin/plugin_layer_factory.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <mln/layermanager/layer_factory.hpp>
+#include <mln/plugin/plugin_registry.hpp>
+
+namespace mln::plugin {
+// C descriptors adapt ordinary C++ factories instead of adding a dispatch path.
+class PluginLayerFactory final : public LayerFactory {
+public:
+    explicit PluginLayerFactory(LayerType registration_) : registration(std::move(registration_)) {}
+    const style::LayerTypeInfo* getTypeInfo() const noexcept override;
+    std::unique_ptr<style::Layer> createLayer(const std::string&, const style::conversion::Convertible&) noexcept override;
+    std::unique_ptr<RenderLayer> createRenderLayer(Immutable<style::Layer::Impl>) noexcept override;
+    std::unique_ptr<Layout> createLayout(const LayoutParameters&, std::unique_ptr<GeometryTileLayer>,
+                                       const std::vector<Immutable<style::LayerProperties>>&) override;
+private:
+    const LayerType registration;
+};
+} // namespace mln::plugin

--- a/src/mln/plugin/plugin_registry.hpp
+++ b/src/mln/plugin/plugin_registry.hpp
@@ -156,7 +156,8 @@ struct LayerTypeIdentity {
           info{name.c_str(),
                registration.sourceKind == MLN_PLUGIN_SOURCE_NONE ? style::LayerTypeInfo::Source::NotRequired
                                                                  : style::LayerTypeInfo::Source::Required,
-               registration.participatesIn3DPass ? style::LayerTypeInfo::Pass3D::Required : style::LayerTypeInfo::Pass3D::NotRequired,
+               registration.participatesIn3DPass ? style::LayerTypeInfo::Pass3D::Required
+                                                 : style::LayerTypeInfo::Pass3D::NotRequired,
                registration.sourceKind == MLN_PLUGIN_SOURCE_GEOMETRY ? style::LayerTypeInfo::Layout::Required
                                                                      : style::LayerTypeInfo::Layout::NotRequired,
                style::LayerTypeInfo::FadingTiles::NotRequired,
@@ -164,7 +165,7 @@ struct LayerTypeIdentity {
                registration.sourceKind == MLN_PLUGIN_SOURCE_GEOMETRY     ? style::LayerTypeInfo::TileKind::Geometry
                : registration.sourceKind == MLN_PLUGIN_SOURCE_RASTER_DEM ? style::LayerTypeInfo::TileKind::RasterDEM
                : registration.sourceKind == MLN_PLUGIN_SOURCE_RASTER     ? style::LayerTypeInfo::TileKind::Raster
-                                                                         : style::LayerTypeInfo::TileKind::NotRequired} {}
+                                                                     : style::LayerTypeInfo::TileKind::NotRequired} {}
 
     std::string name;
     style::LayerTypeInfo info;

--- a/src/mln/plugin/plugin_registry.hpp
+++ b/src/mln/plugin/plugin_registry.hpp
@@ -1,0 +1,201 @@
+#pragma once
+
+#include <mln/plugin/plugin_api.h>
+#include <mln/style/style_property.hpp>
+#include <mln/style/layer.hpp>
+
+#include <array>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace mln {
+namespace plugin {
+
+struct PropertyDefinition {
+    std::string pluginID;
+    std::string targetLayerType;
+    std::string name;
+    mln_plugin_value_type type = MLN_PLUGIN_VALUE_BOOLEAN;
+    mln_plugin_property_scope scope = MLN_PLUGIN_PROPERTY_PAINT;
+    Value defaultValue;
+    uint32_t expressionCapabilities = MLN_PLUGIN_EXPRESSION_NONE;
+    bool supportsTransitions = false;
+    bool acceptsScalar = false;
+    std::optional<float> minimum;
+    std::optional<float> maximum;
+    uint32_t maximumArrayLength = 0;
+    std::vector<std::string> enumValues;
+};
+
+struct ShaderAttribute {
+    uint32_t id = 0;
+    uint32_t location = 0;
+    std::string name;
+    mln_plugin_vertex_attribute_type type = MLN_PLUGIN_VERTEX_FLOAT;
+};
+
+struct ShaderSource {
+    mln_plugin_backend backend = MLN_PLUGIN_BACKEND_OPENGL;
+    std::string vertex;
+    std::string fragment;
+    std::string vertexEntryPoint;
+    std::string fragmentEntryPoint;
+};
+
+struct UniformBlockDefinition {
+    uint32_t id = 0;
+    std::string name;
+    uint32_t byteSize = 0;
+    uint32_t stageMask = 0;
+    mln_plugin_uniform_scope scope = MLN_PLUGIN_UNIFORM_SCOPE_DRAWABLE;
+    uint32_t bindingID = 0;
+};
+
+struct ShaderTextureDefinition {
+    uint32_t id = 0;
+    uint32_t location = 0;
+    std::string name;
+};
+
+struct ShaderPropertyBindingDefinition {
+    std::string propertyName;
+    mln_plugin_property_encoding_v1 encoding = MLN_PLUGIN_PROPERTY_ENCODING_FLOAT;
+    uint32_t uniformID = 0;
+    uint32_t uniformByteOffset = 0;
+    uint32_t minimumAttributeID = 0;
+    uint32_t maximumAttributeID = 0;
+    uint32_t interpolationUniformID = 0;
+    uint32_t interpolationUniformByteOffset = 0;
+    bool operator==(const ShaderPropertyBindingDefinition&) const = default;
+};
+
+struct ShaderDefinition {
+    std::string pluginID;
+    std::string id;
+    std::vector<ShaderSource> sources;
+    std::vector<ShaderAttribute> attributes;
+    std::vector<UniformBlockDefinition> uniformBlocks;
+    std::vector<ShaderTextureDefinition> textures;
+    std::vector<ShaderPropertyBindingDefinition> propertyBindings;
+};
+
+struct TextureBindingDefinition {
+    uint32_t textureID = 0;
+    mln_plugin_texture_source source = MLN_PLUGIN_TEXTURE_SOURCE_RASTER_DEM;
+    uint32_t renderTargetID = 0;
+    std::string propertyName;
+    mln_plugin_texture_filter filter = MLN_PLUGIN_TEXTURE_FILTER_LINEAR;
+    mln_plugin_texture_wrap wrapU = MLN_PLUGIN_TEXTURE_WRAP_CLAMP;
+    mln_plugin_texture_wrap wrapV = MLN_PLUGIN_TEXTURE_WRAP_CLAMP;
+    bool operator==(const TextureBindingDefinition&) const = default;
+};
+
+struct RenderTargetDefinition {
+    uint32_t id = 0;
+    mln_plugin_render_target_size size = MLN_PLUGIN_RENDER_TARGET_SOURCE_TILE;
+    mln_plugin_render_target_format format = MLN_PLUGIN_RENDER_TARGET_RGBA8;
+    mln_plugin_render_target_scope scope = MLN_PLUGIN_RENDER_TARGET_PER_TILE;
+    float widthScale = 1.0f;
+    float heightScale = 1.0f;
+    std::array<float, 4> clearColor{0.0f, 0.0f, 0.0f, 1.0f};
+    bool operator==(const RenderTargetDefinition&) const = default;
+};
+
+struct RenderPassDefinition {
+    uint32_t id = 0;
+    std::string shaderID;
+    mln_plugin_graph_geometry geometry = MLN_PLUGIN_GRAPH_GEOMETRY_PLUGIN_BUCKET;
+    uint32_t renderTargetID = 0;
+    mln_plugin_render_stage renderStage = MLN_PLUGIN_RENDER_STAGE_TRANSLUCENT;
+    mln_plugin_draw_mode drawMode = MLN_PLUGIN_DRAW_MODE_TRIANGLES;
+    mln_plugin_depth_mode depthMode = MLN_PLUGIN_DEPTH_DISABLED;
+    mln_plugin_blend_mode blendMode = MLN_PLUGIN_BLEND_ALPHA;
+    bool enableStencil = false;
+    bool enableCullFace = false;
+    mln_plugin_tile_projection tileProjection = MLN_PLUGIN_TILE_PROJECTION_MAP;
+    std::vector<TextureBindingDefinition> textures;
+    bool operator==(const RenderPassDefinition&) const = default;
+};
+
+struct RenderGraphDefinition {
+    std::vector<RenderTargetDefinition> renderTargets;
+    std::vector<RenderPassDefinition> passes;
+    bool operator==(const RenderGraphDefinition&) const = default;
+};
+
+struct LayerTypeIdentity;
+
+struct LayerType {
+    std::shared_ptr<const LayerTypeIdentity> identity;
+    std::string pluginID;
+    std::string pluginVersion;
+    std::string type;
+    uint32_t backendMask = 0;
+    mln_plugin_render_stage renderStage = MLN_PLUGIN_RENDER_STAGE_TRANSLUCENT;
+    bool requires3D = false;
+    bool participatesIn3DPass = false;
+    mln_plugin_source_kind sourceKind = MLN_PLUGIN_SOURCE_NONE;
+    uint32_t geometryTypeMask = 0;
+    std::vector<ShaderDefinition> shaders;
+    mln_plugin_create_layout_fn createLayout = nullptr;
+    mln_plugin_layout_feature_fn layoutFeature = nullptr;
+    mln_plugin_finish_layout_fn finishLayout = nullptr;
+    mln_plugin_destroy_layout_fn destroyLayout = nullptr;
+    mln_plugin_query_feature_fn queryFeature = nullptr;
+    mln_plugin_query_radius_fn queryRadius = nullptr;
+    std::optional<RenderGraphDefinition> renderGraph;
+    mln_plugin_update_uniform_block_fn updateUniformBlock = nullptr;
+};
+
+struct LayerTypeIdentity {
+    explicit LayerTypeIdentity(const plugin::LayerType& registration)
+        : name(registration.type),
+          info{name.c_str(),
+               registration.sourceKind == MLN_PLUGIN_SOURCE_NONE ? style::LayerTypeInfo::Source::NotRequired
+                                                                 : style::LayerTypeInfo::Source::Required,
+               registration.participatesIn3DPass ? style::LayerTypeInfo::Pass3D::Required : style::LayerTypeInfo::Pass3D::NotRequired,
+               registration.sourceKind == MLN_PLUGIN_SOURCE_GEOMETRY ? style::LayerTypeInfo::Layout::Required
+                                                                     : style::LayerTypeInfo::Layout::NotRequired,
+               style::LayerTypeInfo::FadingTiles::NotRequired,
+               style::LayerTypeInfo::CrossTileIndex::NotRequired,
+               registration.sourceKind == MLN_PLUGIN_SOURCE_GEOMETRY     ? style::LayerTypeInfo::TileKind::Geometry
+               : registration.sourceKind == MLN_PLUGIN_SOURCE_RASTER_DEM ? style::LayerTypeInfo::TileKind::RasterDEM
+               : registration.sourceKind == MLN_PLUGIN_SOURCE_RASTER     ? style::LayerTypeInfo::TileKind::Raster
+                                                                         : style::LayerTypeInfo::TileKind::NotRequired} {}
+
+    std::string name;
+    style::LayerTypeInfo info;
+};
+
+class PluginRegistry final {
+public:
+    static PluginRegistry& get();
+
+    mln_plugin_status registerPlugin(const mln_plugin_descriptor_v1&, std::string& error);
+    std::optional<PropertyDefinition> findProperty(const std::string& layerType, const std::string& name) const;
+    std::vector<PropertyDefinition> propertiesForLayer(const std::string& layerType) const;
+    std::optional<LayerType> findLayerType(const std::string& layerType) const;
+    std::vector<LayerType> allLayerTypes() const;
+    bool isRegistered(const std::string& pluginID) const;
+    std::vector<std::string> pluginIDs() const;
+
+    static bool valueMatches(mln_plugin_value_type, const Value&);
+
+    struct PluginRecord {
+        std::string version;
+        std::vector<PropertyDefinition> properties;
+        std::vector<LayerType> layerTypes;
+    };
+
+private:
+    mutable std::mutex mutex;
+    std::map<std::string, PluginRecord> plugins;
+    std::map<std::pair<std::string, std::string>, PropertyDefinition> properties;
+    std::map<std::string, LayerType> layerTypes;
+};
+
+} // namespace plugin
+} // namespace mln

--- a/src/mln/plugin/plugin_shader.hpp
+++ b/src/mln/plugin/plugin_shader.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+namespace mln {
+class ProgramParameters;
+namespace gfx {
+class ShaderRegistry;
+}
+namespace plugin {
+
+std::string shaderGroupName(const std::string& pluginID, const std::string& shaderID);
+void registerPluginShaderGroups(gfx::ShaderRegistry&, const ProgramParameters&);
+
+} // namespace plugin
+} // namespace mln

--- a/src/mln/renderer/buckets/plugin_bucket.hpp
+++ b/src/mln/renderer/buckets/plugin_bucket.hpp
@@ -124,8 +124,7 @@ public:
     void writeUniforms(float zoom, uint32_t uniformID, uint8_t* output, std::size_t outputSize) const;
     bool synchronize(const style::PluginPropertyMap&);
     bool update(const FeatureStates&, const GeometryTileLayer&);
-    void appendStatistics(float,
-                          std::map<std::string, std::pair<mln_plugin_value, mln_plugin_value>>&) const;
+    void appendStatistics(float, std::map<std::string, std::pair<mln_plugin_value, mln_plugin_value>>&) const;
 
 private:
     std::vector<PluginPaintPropertyBinder> binders;

--- a/src/mln/renderer/buckets/plugin_bucket.hpp
+++ b/src/mln/renderer/buckets/plugin_bucket.hpp
@@ -1,0 +1,183 @@
+#pragma once
+
+#include <mln/gfx/index_vector.hpp>
+#include <mln/gfx/vertex_attribute.hpp>
+#include <mln/gfx/vertex_vector.hpp>
+#include <mln/plugin/plugin_registry.hpp>
+#include <mln/renderer/bucket.hpp>
+#include <mln/renderer/paint_property_binder.hpp>
+#include <mln/shaders/segment.hpp>
+#include <mln/style/plugin_property.hpp>
+
+#include <map>
+#include <set>
+
+namespace mln {
+
+class PluginVertexVector final : public gfx::VertexVectorBase {
+public:
+    PluginVertexVector(std::vector<uint8_t> data_, std::size_t count_, std::size_t stride_)
+        : data(std::move(data_)),
+          count(count_),
+          stride(stride_) {}
+
+    const void* getRawData() const override { return data.data(); }
+    std::size_t getRawSize() const override { return stride; }
+    std::size_t getRawCount() const override { return count; }
+
+private:
+    std::vector<uint8_t> data;
+    std::size_t count;
+    std::size_t stride;
+};
+
+class PluginPaintVertexVector final : public gfx::VertexVectorBase {
+public:
+    PluginPaintVertexVector(std::size_t count_, std::size_t components_)
+        : data(count_ * components_ * 2),
+          count(count_),
+          components(components_) {}
+
+    const void* getRawData() const override { return data.data(); }
+    std::size_t getRawSize() const override { return components * 2 * sizeof(float); }
+    std::size_t getRawCount() const override { return count; }
+
+    void set(std::size_t first, std::size_t length, const float* minimum, const float* maximum);
+    void bounds(std::array<float, 4>& minimum, std::array<float, 4>& maximum) const;
+
+private:
+    std::vector<float> data;
+    std::size_t count;
+    std::size_t components;
+};
+
+struct PluginFeatureVertexRange {
+    std::size_t featureIndex = 0;
+    uint64_t drawableKey = 0;
+    std::size_t firstVertex = 0;
+    std::size_t vertexCount = 0;
+};
+
+class PluginPaintPropertyBinder {
+public:
+    PluginPaintPropertyBinder(plugin::PropertyDefinition,
+                              plugin::ShaderPropertyBindingDefinition,
+                              style::PluginPropertyValue,
+                              float bucketZoom,
+                              uint64_t drawableKey,
+                              std::size_t vertexCount,
+                              const std::vector<PluginFeatureVertexRange>&,
+                              const GeometryTileLayer&);
+
+    bool isDataDriven() const noexcept { return dataDriven; }
+    const plugin::ShaderPropertyBindingDefinition& getBinding() const noexcept { return binding; }
+    const plugin::PropertyDefinition& getDefinition() const noexcept { return definition; }
+    const std::shared_ptr<PluginPaintVertexVector>& getVertexVector() const noexcept { return vertexVector; }
+    gfx::AttributeDataType attributeType() const noexcept;
+    std::size_t componentCount() const noexcept;
+    float interpolationFactor(float zoom) const noexcept;
+    void writeUniform(float zoom, uint32_t uniformID, uint8_t* output, std::size_t outputSize) const;
+    bool synchronize(const style::PluginPropertyValue&);
+    bool update(const FeatureStates&, const GeometryTileLayer&);
+    void statistics(float zoom, mln_plugin_value& minimum, mln_plugin_value& maximum) const;
+
+private:
+    struct Range {
+        std::size_t featureIndex = 0;
+        std::string featureID;
+        FeatureType featureType = FeatureType::Unknown;
+        FeatureIdentifier featureIdentifier;
+        PropertyMap properties;
+        std::size_t firstVertex = 0;
+        std::size_t vertexCount = 0;
+    };
+
+    void refill(const GeometryTileLayer* = nullptr);
+    void fillRange(const Range&, const GeometryTileFeature&, const FeatureState&);
+    void updateStatistics();
+
+    plugin::PropertyDefinition definition;
+    plugin::ShaderPropertyBindingDefinition binding;
+    style::PluginPropertyValue value;
+    float bucketZoom;
+    std::size_t vertexCount;
+    bool dataDriven = false;
+    std::vector<Range> ranges;
+    std::map<std::string, FeatureState> featureStates;
+    std::shared_ptr<PluginPaintVertexVector> vertexVector;
+    std::array<float, 4> minimumValues{};
+    std::array<float, 4> maximumValues{};
+};
+
+class PluginPaintPropertyBinders final : public PaintPropertyBindersBase {
+public:
+    PluginPaintPropertyBinders(const plugin::LayerType&,
+                               const plugin::ShaderDefinition&,
+                               uint64_t drawableKey,
+                               std::size_t vertexCount,
+                               float bucketZoom,
+                               const style::PluginPropertyMap&,
+                               const std::vector<PluginFeatureVertexRange>&,
+                               const GeometryTileLayer&);
+
+    void populateVertexAttributes(gfx::VertexAttributeArray&, gfx::StringIDSetsPair&) const;
+    void writeUniforms(float zoom, uint32_t uniformID, uint8_t* output, std::size_t outputSize) const;
+    bool synchronize(const style::PluginPropertyMap&);
+    bool update(const FeatureStates&, const GeometryTileLayer&);
+    void appendStatistics(float,
+                          std::map<std::string, std::pair<mln_plugin_value, mln_plugin_value>>&) const;
+
+private:
+    std::vector<PluginPaintPropertyBinder> binders;
+};
+
+struct PluginAttributeBinding {
+    uint32_t attributeID = 0;
+    uint32_t streamID = 0;
+    uint32_t byteOffset = 0;
+    mln_plugin_vertex_attribute_type type = MLN_PLUGIN_VERTEX_FLOAT;
+};
+
+struct PluginDrawableDefinition {
+    uint64_t key = 0;
+    std::string shaderID;
+    mln_plugin_draw_mode drawMode = MLN_PLUGIN_DRAW_MODE_TRIANGLES;
+    mln_plugin_render_stage renderStage = MLN_PLUGIN_RENDER_STAGE_TRANSLUCENT;
+    mln_plugin_depth_mode depthMode = MLN_PLUGIN_DEPTH_READ_ONLY;
+    mln_plugin_blend_mode blendMode = MLN_PLUGIN_BLEND_ALPHA;
+    bool enableStencil = false;
+    bool enableCullFace = false;
+    std::vector<PluginAttributeBinding> attributes;
+    SegmentVector segments;
+    std::size_t vertexCount = 0;
+};
+
+class PluginBucket final : public Bucket {
+public:
+    explicit PluginBucket(plugin::LayerType registration_)
+        : registration(std::move(registration_)) {}
+    ~PluginBucket() override = default;
+
+    void upload(gfx::UploadPass&) override { uploaded = true; }
+    bool hasData() const override { return indices && !indices->empty() && !drawables.empty(); }
+    float getQueryRadius(const RenderLayer&) const override;
+    void update(const FeatureStates&, const GeometryTileLayer&, const std::string&, const ImagePositions&) override;
+
+    bool synchronizePaint(const std::string& layerID, const style::PluginPropertyMap&, float zoom);
+    void updateQueryRadius(const std::string& layerID, const style::PluginPropertyMap&, float zoom);
+    PluginPaintPropertyBinders* paintBinders(const std::string& layerID, uint64_t drawableKey);
+
+    plugin::LayerType registration;
+    std::map<uint32_t, std::shared_ptr<PluginVertexVector>> vertexStreams;
+    std::shared_ptr<gfx::IndexVectorBase> indices;
+    std::vector<PluginDrawableDefinition> drawables;
+    std::vector<PluginFeatureVertexRange> featureVertexRanges;
+    std::map<std::string, std::map<uint64_t, PluginPaintPropertyBinders>> paintPropertyBinders;
+    std::map<std::string, style::PluginPropertyMap> latestPaintProperties;
+    std::map<std::string, float> latestZoom;
+    float queryRadius = 0.0f;
+    std::map<std::string, float> queryRadii;
+    std::set<std::string> queryRadiusErrorsLogged;
+};
+
+} // namespace mln

--- a/src/mln/renderer/layers/plugin_layer_tweaker.hpp
+++ b/src/mln/renderer/layers/plugin_layer_tweaker.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <mln/plugin/plugin_registry.hpp>
+#include <mln/renderer/layer_tweaker.hpp>
+
+#include <map>
+
+namespace mln {
+
+class PluginLayerTweaker final : public LayerTweaker {
+public:
+    PluginLayerTweaker(std::string id, Immutable<style::LayerProperties> properties, plugin::LayerType registration_)
+        : LayerTweaker(std::move(id), std::move(properties)),
+          requires3D(registration_.requires3D),
+          registration(std::move(registration_)) {}
+
+    void execute(LayerGroupBase&, const PaintParameters&) override;
+
+private:
+    const bool requires3D;
+    const plugin::LayerType registration;
+    std::map<std::pair<uint32_t, uint32_t>, gfx::UniformBufferPtr> layerUniformBuffers;
+};
+
+} // namespace mln

--- a/src/mln/renderer/layers/render_plugin_style_layer.hpp
+++ b/src/mln/renderer/layers/render_plugin_style_layer.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <mln/gfx/index_buffer.hpp>
+#include <mln/gfx/vertex_vector.hpp>
+#include <mln/renderer/buckets/hillshade_bucket.hpp>
+#include <mln/renderer/render_layer.hpp>
+#include <mln/shaders/attributes.hpp>
+#include <mln/shaders/segment.hpp>
+#include <mln/style/layers/plugin_style_layer.hpp>
+
+#include <map>
+
+namespace mln {
+
+using PluginViewportLayoutVertex = gfx::Vertex<TypeList<attributes::pos>>;
+
+class RenderPluginStyleLayer final : public RenderLayer {
+public:
+    explicit RenderPluginStyleLayer(Immutable<style::PluginStyleLayer::Impl>);
+    ~RenderPluginStyleLayer() override = default;
+
+    void update(gfx::ShaderRegistry&,
+                gfx::Context&,
+                const TransformState&,
+                const std::shared_ptr<UpdateParameters>&,
+                const PaintParameters&,
+                const RenderTree&,
+                UniqueChangeRequestVec&) override;
+
+    bool is3D() const override;
+
+    void prepare(const LayerPrepareParameters&) override;
+    void markLayerRenderable(bool, UniqueChangeRequestVec&) override;
+    void layerRemoved(UniqueChangeRequestVec&) override;
+
+    bool queryIntersectsFeature(const GeometryCoordinates&,
+                                const GeometryTileFeature&,
+                                float,
+                                const TransformState&,
+                                float,
+                                const mat4&,
+                                const FeatureState&) const override;
+
+private:
+    void transition(const TransitionParameters&) override;
+    void evaluate(const PropertyEvaluationParameters&) override;
+    void layerChanged(const TransitionParameters&,
+                      const Immutable<style::Layer::Impl>&,
+                      UniqueChangeRequestVec&) override;
+    bool hasTransition() const override;
+    bool hasCrossfade() const override { return false; }
+    void markContextDestroyed() override;
+
+    void updateRasterDEMGraph(gfx::ShaderRegistry&, gfx::Context&, const PaintParameters&, UniqueChangeRequestVec&);
+    void updateGeometryGraph(
+        gfx::ShaderRegistry&, gfx::Context&, const TransformState&, const PaintParameters&, UniqueChangeRequestVec&);
+    void addRenderTarget(const RenderTargetPtr&, UniqueChangeRequestVec&);
+    void removeRenderTargets(UniqueChangeRequestVec&);
+
+    struct RasterGraphTileState {
+        util::SimpleIdentity bucketID = util::SimpleIdentity::Empty;
+        uint64_t demRevision = 0;
+        uint64_t maskRevision = 0;
+        gfx::Texture2DPtr sourceTexture;
+        std::map<uint32_t, RenderTargetPtr> renderTargets;
+    };
+
+    uint8_t sourceMaxZoom = util::TERRAIN_RGB_MAXZOOM;
+    std::map<OverscaledTileID, RasterGraphTileState> rasterGraphTiles;
+    std::vector<RenderTargetPtr> activatedRenderTargets;
+    std::shared_ptr<gfx::VertexVector<HillshadeLayoutVertex>> rasterSharedVertices;
+
+    struct GeometryGraphState {
+        std::map<uint32_t, RenderTargetPtr> renderTargets;
+        std::map<std::string, gfx::Texture2DPtr> propertyTextures;
+    } geometryGraph;
+    std::shared_ptr<gfx::VertexVector<PluginViewportLayoutVertex>> viewportVertices;
+    std::shared_ptr<gfx::IndexVector<gfx::Triangles>> viewportIndices;
+    SegmentVector viewportSegments;
+    std::map<std::string, style::PluginTransitioningPropertyValue> transitioningPaintProperties;
+    style::PluginPropertyMap evaluatedPluginProperties;
+};
+
+} // namespace mln

--- a/src/mln/style/layers/plugin_style_layer.hpp
+++ b/src/mln/style/layers/plugin_style_layer.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <mln/plugin/plugin_registry.hpp>
+#include <mln/style/layer_impl.hpp>
+#include <mln/style/plugin_property.hpp>
+#include <mln/style/layer_properties.hpp>
+
+#include <memory>
+
+namespace mln {
+namespace style {
+
+class PluginStyleLayer final : public Layer {
+public:
+    PluginStyleLayer(const std::string& id, const std::string& source, plugin::LayerType);
+    ~PluginStyleLayer() final;
+
+    using Layer::setProperty;
+    std::optional<conversion::Error> setProperty(const std::string&, const conversion::Convertible&, PropertyScope) final;
+    Value serialize() const final;
+    StyleProperty getProperty(const std::string&) const final;
+
+    class Impl;
+    const Impl& impl() const;
+    Mutable<Impl> mutableImpl() const;
+
+private:
+    explicit PluginStyleLayer(Immutable<Impl>);
+    std::optional<conversion::Error> setPluginProperty(const std::string&, const conversion::Convertible&, std::optional<PropertyScope> = std::nullopt);
+    std::optional<conversion::Error> setPluginTransition(const std::string&, const conversion::Convertible&, std::optional<PropertyScope> = std::nullopt);
+
+    std::optional<conversion::Error> setPropertyInternal(const std::string&, const conversion::Convertible&) final;
+    std::unique_ptr<Layer> cloneRef(const std::string& id) const final;
+    Mutable<Layer::Impl> mutableBaseImpl() const final;
+};
+
+class PluginStyleLayer::Impl final : public Layer::Impl {
+public:
+    Impl(const std::string& id, const std::string& source, plugin::LayerType);
+    Impl(const Impl&) = default;
+
+    bool hasLayoutDifference(const Layer::Impl&) const override;
+    void stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
+    const LayerTypeInfo* getTypeInfo() const noexcept override;
+    expression::Dependency getDependencies() const noexcept override;
+
+    std::map<std::string, PluginPropertyValue> pluginProperties;
+    std::map<std::string, TransitionOptions> pluginPropertyTransitions;
+    plugin::LayerType registration;
+};
+
+class PluginStyleLayerProperties final : public LayerProperties {
+public:
+    explicit PluginStyleLayerProperties(Immutable<PluginStyleLayer::Impl> impl,
+                                        PluginPropertyMap evaluatedPaintProperties_ = {})
+        : LayerProperties(std::move(impl)),
+          evaluatedPaintProperties(std::move(evaluatedPaintProperties_)) {
+        const auto& registration = static_cast<const PluginStyleLayer::Impl&>(*baseImpl).registration;
+        switch (registration.renderStage) {
+            case MLN_PLUGIN_RENDER_STAGE_PASS_3D:
+                renderPasses = 1u << 2u;
+                break;
+            case MLN_PLUGIN_RENDER_STAGE_OPAQUE:
+                renderPasses = 1u << 0u;
+                break;
+            case MLN_PLUGIN_RENDER_STAGE_TRANSLUCENT:
+                renderPasses = 1u << 1u;
+                break;
+            default:
+                renderPasses = 0;
+                break;
+        }
+        if (registration.participatesIn3DPass) renderPasses |= 1u << 2u;
+    }
+
+    expression::Dependency getDependencies() const noexcept override { return baseImpl->getDependencies(); }
+
+    PluginPropertyMap evaluatedPaintProperties;
+};
+
+} // namespace style
+} // namespace mln

--- a/src/mln/style/layers/plugin_style_layer.hpp
+++ b/src/mln/style/layers/plugin_style_layer.hpp
@@ -16,7 +16,9 @@ public:
     ~PluginStyleLayer() final;
 
     using Layer::setProperty;
-    std::optional<conversion::Error> setProperty(const std::string&, const conversion::Convertible&, PropertyScope) final;
+    std::optional<conversion::Error> setProperty(const std::string&,
+                                                 const conversion::Convertible&,
+                                                 PropertyScope) final;
     Value serialize() const final;
     StyleProperty getProperty(const std::string&) const final;
 
@@ -26,8 +28,12 @@ public:
 
 private:
     explicit PluginStyleLayer(Immutable<Impl>);
-    std::optional<conversion::Error> setPluginProperty(const std::string&, const conversion::Convertible&, std::optional<PropertyScope> = std::nullopt);
-    std::optional<conversion::Error> setPluginTransition(const std::string&, const conversion::Convertible&, std::optional<PropertyScope> = std::nullopt);
+    std::optional<conversion::Error> setPluginProperty(const std::string&,
+                                                       const conversion::Convertible&,
+                                                       std::optional<PropertyScope> = std::nullopt);
+    std::optional<conversion::Error> setPluginTransition(const std::string&,
+                                                         const conversion::Convertible&,
+                                                         std::optional<PropertyScope> = std::nullopt);
 
     std::optional<conversion::Error> setPropertyInternal(const std::string&, const conversion::Convertible&) final;
     std::unique_ptr<Layer> cloneRef(const std::string& id) const final;

--- a/src/mln/style/plugin_property.hpp
+++ b/src/mln/style/plugin_property.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <mln/plugin/plugin_api.h>
+#include <mln/style/property_value.hpp>
+#include <mln/style/color_ramp_property_value.hpp>
+#include <mln/style/style_property.hpp>
+#include <mln/style/transition_options.hpp>
+#include <mln/util/chrono.hpp>
+#include <mln/util/color.hpp>
+
+#include <array>
+#include <map>
+#include <memory>
+#include <vector>
+#include <variant>
+
+namespace mln {
+class GeometryTileFeature;
+namespace plugin {
+struct PropertyDefinition;
+}
+namespace style {
+namespace conversion {
+class Convertible;
+struct Error;
+} // namespace conversion
+
+class PluginPropertyValue {
+public:
+    using TypedValue = std::variant<PropertyValue<bool>,
+                                    PropertyValue<float>,
+                                    PropertyValue<std::array<float, 2>>,
+                                    PropertyValue<Color>,
+                                    PropertyValue<std::string>,
+                                    PropertyValue<std::vector<float>>,
+                                    PropertyValue<std::vector<Color>>,
+                                    ColorRampPropertyValue>;
+
+    struct EvaluationStorage {
+        std::string string;
+        std::vector<float> floats;
+        std::vector<mln_plugin_color> colors;
+    };
+
+    PluginPropertyValue() = default;
+    explicit PluginPropertyValue(TypedValue value_)
+        : value(std::move(value_)) {}
+
+    StyleProperty toStyleProperty() const;
+    expression::Dependency getDependencies() const noexcept;
+    bool isDataDriven() const noexcept;
+    bool isZoomConstant() const noexcept;
+    bool usesFeatureState() const noexcept;
+    float interpolationFactor(float bucketZoom, float currentZoom) const noexcept;
+    const ColorRampPropertyValue* colorRamp() const noexcept;
+
+    mln_plugin_value evaluate(float zoom,
+                              const GeometryTileFeature&,
+                              const FeatureState&,
+                              const plugin::PropertyDefinition&,
+                              EvaluationStorage&) const;
+    mln_plugin_value evaluate(float zoom, const plugin::PropertyDefinition&, EvaluationStorage&) const;
+    PluginPropertyValue evaluateCamera(float zoom, const plugin::PropertyDefinition&) const;
+    static PluginPropertyValue interpolate(const PluginPropertyValue&,
+                                           const PluginPropertyValue&,
+                                           float,
+                                           const plugin::PropertyDefinition&);
+
+    friend bool operator==(const PluginPropertyValue& lhs, const PluginPropertyValue& rhs) {
+        return lhs.value == rhs.value;
+    }
+    friend bool operator!=(const PluginPropertyValue& lhs, const PluginPropertyValue& rhs) { return !(lhs == rhs); }
+
+private:
+    TypedValue value;
+};
+
+class PluginTransitioningPropertyValue {
+public:
+    explicit PluginTransitioningPropertyValue(PluginPropertyValue value_ = {})
+        : value(std::move(value_)) {}
+    PluginTransitioningPropertyValue(PluginPropertyValue,
+                                     PluginTransitioningPropertyValue,
+                                     const TransitionOptions&,
+                                     TimePoint);
+
+    PluginPropertyValue evaluate(float zoom, const plugin::PropertyDefinition&, TimePoint);
+    bool hasTransition() const noexcept { return static_cast<bool>(prior); }
+
+private:
+    std::shared_ptr<PluginTransitioningPropertyValue> prior;
+    TimePoint begin{};
+    TimePoint end{};
+    PluginPropertyValue value;
+};
+
+using PluginPropertyMap = std::map<std::string, PluginPropertyValue>;
+
+PluginPropertyValue defaultPluginPropertyValue(const plugin::PropertyDefinition&);
+std::optional<PluginPropertyValue> convertPluginPropertyValue(const plugin::PropertyDefinition&,
+                                                              const conversion::Convertible&,
+                                                              conversion::Error&);
+
+} // namespace style
+} // namespace mln


### PR DESCRIPTION
## Scope

Define the unpublished v1 C contract and internal adapter declarations: new source-bound types, typed properties, meshes, shaders, queries and render graphs. No built-in layer property extensions or raw graphics callbacks.

Depends on #4588; review only against its base branch. Layer 4/11.

1421 changed lines (+1421/-0). Within the approximately 2,000-line review budget.

This is a staged implementation foundation. Declarations/compilation units land before build wiring; plugin layer availability is connected in #4593. It is not a separately released partial ABI.

## Validation and landing

At the integrated stack tip: 19 focused core tests and 108 Metal render tests pass. The n-gon plugin builds as an Android AAR for all four ABIs and through SwiftPM/Bazel. N-gon Vulkan images pass; the full MoltenVK run has two retained heatmap/hillshade image mismatches. OpenGL ES shader variants compile, but runtime OpenGL validation is still needed on a supported ES 3 test environment.

These are deliberately draft PRs. Build jobs are skipped before runner allocation; marking a PR ready triggers normal checks. Merge only in dependency order after those checks pass. Lightweight metadata/pre-commit services may still operate.

Companion plugin stack: https://github.com/louwers/maplibre-native-plugin-template/pull/1

Roadmap: [Incremental plugin introduction](https://github.com/maplibre/maplibre-native/blob/plugins/01-draft-ci/design-proposals/2026-09-08-plugin-introduction.md).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
