### PR TITLE
feat: implement plugin-owned style properties and dynamic paint binders

### DIFF
--- a/src/mln/plugin/plugin_layer_factory.cpp
+++ b/src/mln/plugin/plugin_layer_factory.cpp
@@ -9,20 +9,21 @@ const style::LayerTypeInfo* PluginLayerFactory::getTypeInfo() const noexcept {
     return &registration.identity->info;
 }
 
-std::unique_ptr<style::Layer> PluginLayerFactory::createLayer(
-    const std::string& id, const style::conversion::Convertible& value) noexcept {
+std::unique_ptr<style::Layer> PluginLayerFactory::createLayer(const std::string& id,
+                                                              const style::conversion::Convertible& value) noexcept {
     const auto source = getSource(value);
     if (!source || source->empty()) return nullptr;
     return std::make_unique<style::PluginStyleLayer>(id, *source, registration);
 }
 
 std::unique_ptr<RenderLayer> PluginLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
-    return std::make_unique<RenderPluginStyleLayer>(staticImmutableCast<style::PluginStyleLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderPluginStyleLayer>(
+        staticImmutableCast<style::PluginStyleLayer::Impl>(std::move(impl)));
 }
 
-std::unique_ptr<Layout> PluginLayerFactory::createLayout(
-    const LayoutParameters& parameters, std::unique_ptr<GeometryTileLayer> tileLayer,
-    const std::vector<Immutable<style::LayerProperties>>& layers) {
+std::unique_ptr<Layout> PluginLayerFactory::createLayout(const LayoutParameters& parameters,
+                                                         std::unique_ptr<GeometryTileLayer> tileLayer,
+                                                         const std::vector<Immutable<style::LayerProperties>>& layers) {
     return std::make_unique<PluginLayout>(parameters.bucketParameters, layers, std::move(tileLayer), registration);
 }
 } // namespace mln::plugin

--- a/src/mln/plugin/plugin_registry.cpp
+++ b/src/mln/plugin/plugin_registry.cpp
@@ -82,8 +82,8 @@ bool descriptorEquals(const PluginRegistry::PluginRecord& existing,
         if (lhs.targetLayerType != rhs.targetLayerType || lhs.name != rhs.name || lhs.type != rhs.type ||
             lhs.scope != rhs.scope || lhs.defaultValue != rhs.defaultValue ||
             lhs.expressionCapabilities != rhs.expressionCapabilities ||
-            lhs.supportsTransitions != rhs.supportsTransitions ||
-            lhs.acceptsScalar != rhs.acceptsScalar || lhs.minimum != rhs.minimum || lhs.maximum != rhs.maximum ||
+            lhs.supportsTransitions != rhs.supportsTransitions || lhs.acceptsScalar != rhs.acceptsScalar ||
+            lhs.minimum != rhs.minimum || lhs.maximum != rhs.maximum ||
             lhs.maximumArrayLength != rhs.maximumArrayLength || lhs.enumValues != rhs.enumValues) {
             return false;
         }
@@ -97,8 +97,8 @@ bool descriptorEquals(const PluginRegistry::PluginRecord& existing,
             lhs.createLayout != rhs.createLayout || lhs.layoutFeature != rhs.layoutFeature ||
             lhs.finishLayout != rhs.finishLayout || lhs.destroyLayout != rhs.destroyLayout ||
             lhs.queryFeature != rhs.queryFeature || lhs.queryRadius != rhs.queryRadius ||
-            lhs.shaders.size() != rhs.shaders.size() ||
-            lhs.renderGraph != rhs.renderGraph || lhs.updateUniformBlock != rhs.updateUniformBlock) {
+            lhs.shaders.size() != rhs.shaders.size() || lhs.renderGraph != rhs.renderGraph ||
+            lhs.updateUniformBlock != rhs.updateUniformBlock) {
             return false;
         }
         for (size_t shaderIndex = 0; shaderIndex < lhs.shaders.size(); ++shaderIndex) {
@@ -380,12 +380,13 @@ bool appendShaders(const std::string& pluginID,
             const auto encodingSize = propertyEncodingSize(binding.encoding);
             const auto encodingAlignment = propertyEncodingAlignment(binding.encoding);
             const bool packed = binding.minimum_attribute_id == binding.maximum_attribute_id;
-            const auto attributeType = packed
-                ? (encodingSize == 4 ? MLN_PLUGIN_VERTEX_FLOAT_X2 : MLN_PLUGIN_VERTEX_FLOAT_X4)
-                : propertyAttributeType(binding.encoding);
-            const auto uniform = std::find_if(shader.uniformBlocks.begin(), shader.uniformBlocks.end(), [&](const auto& candidate) {
-                return candidate.id == binding.uniform_id;
-            });
+            const auto attributeType = packed ? (encodingSize == 4 ? MLN_PLUGIN_VERTEX_FLOAT_X2
+                                                                   : MLN_PLUGIN_VERTEX_FLOAT_X4)
+                                              : propertyAttributeType(binding.encoding);
+            const auto uniform = std::find_if(
+                shader.uniformBlocks.begin(), shader.uniformBlocks.end(), [&](const auto& candidate) {
+                    return candidate.id == binding.uniform_id;
+                });
             const auto interpolationUniform = std::find_if(
                 shader.uniformBlocks.begin(), shader.uniformBlocks.end(), [&](const auto& candidate) {
                     return candidate.id == binding.interpolation_uniform_id;
@@ -399,8 +400,7 @@ bool appendShaders(const std::string& pluginID,
                     return candidate.id == binding.maximum_attribute_id;
                 });
             if (binding.struct_size < sizeof(mln_plugin_shader_property_binding_v1) || propertyName.empty() ||
-                !encodingSize || !boundProperties.emplace(propertyName).second ||
-                (packed && encodingSize > 8) ||
+                !encodingSize || !boundProperties.emplace(propertyName).second || (packed && encodingSize > 8) ||
                 !boundPaintAttributes.emplace(binding.minimum_attribute_id).second ||
                 (!packed && !boundPaintAttributes.emplace(binding.maximum_attribute_id).second) ||
                 uniform == shader.uniformBlocks.end() || interpolationUniform == shader.uniformBlocks.end() ||
@@ -429,9 +429,8 @@ bool appendShaders(const std::string& pluginID,
                 return true;
             };
             if (!addUniformRange(binding.uniform_id, binding.uniform_byte_offset, encodingSize) ||
-                !addUniformRange(binding.interpolation_uniform_id,
-                                 binding.interpolation_uniform_byte_offset,
-                                 sizeof(float))) {
+                !addUniformRange(
+                    binding.interpolation_uniform_id, binding.interpolation_uniform_byte_offset, sizeof(float))) {
                 error = "plugin shader property bindings contain overlapping uniform ranges";
                 return false;
             }
@@ -462,8 +461,7 @@ bool appendProperties(const std::string& pluginID,
     }
     for (size_t p = 0; p < propertyCount; ++p) {
         const auto& property = properties[p];
-        constexpr uint32_t validExpressionCapabilities = MLN_PLUGIN_EXPRESSION_CAMERA |
-                                                         MLN_PLUGIN_EXPRESSION_FEATURE |
+        constexpr uint32_t validExpressionCapabilities = MLN_PLUGIN_EXPRESSION_CAMERA | MLN_PLUGIN_EXPRESSION_FEATURE |
                                                          MLN_PLUGIN_EXPRESSION_COMPOSITE |
                                                          MLN_PLUGIN_EXPRESSION_FEATURE_STATE;
         if (property.struct_size < sizeof(mln_plugin_property_descriptor_v1) || !validString(property.name) ||
@@ -477,8 +475,7 @@ bool appendProperties(const std::string& pluginID,
         const bool transitionableType = property.type == MLN_PLUGIN_VALUE_FLOAT ||
                                         property.type == MLN_PLUGIN_VALUE_FLOAT2 ||
                                         property.type == MLN_PLUGIN_VALUE_COLOR;
-        if (property.supports_transitions &&
-            (property.scope != MLN_PLUGIN_PROPERTY_PAINT || !transitionableType)) {
+        if (property.supports_transitions && (property.scope != MLN_PLUGIN_PROPERTY_PAINT || !transitionableType)) {
             error = "plugin transitions require an interpolatable paint property";
             return false;
         }
@@ -723,8 +720,7 @@ mln_plugin_status PluginRegistry::registerPlugin(const mln_plugin_descriptor_v1&
         return MLN_PLUGIN_STATUS_UNSUPPORTED_ABI;
     }
     if (!validString(descriptor.plugin_id) || !validString(descriptor.plugin_version) ||
-        (descriptor.layer_type_count && !descriptor.layer_types) ||
-        descriptor.layer_type_count == 0) {
+        (descriptor.layer_type_count && !descriptor.layer_types) || descriptor.layer_type_count == 0) {
         error = "plugin descriptor is missing an id, version, or layer registration";
         return MLN_PLUGIN_STATUS_INVALID_ARGUMENT;
     }
@@ -811,13 +807,17 @@ mln_plugin_status PluginRegistry::registerPlugin(const mln_plugin_descriptor_v1&
                     return item.targetLayerType == type && item.name == binding.propertyName;
                 });
                 const bool encodingMatches = property != newProperties.end() &&
-                    ((property->type == MLN_PLUGIN_VALUE_FLOAT && binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_FLOAT) ||
-                     (property->type == MLN_PLUGIN_VALUE_FLOAT2 && binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_FLOAT2) ||
-                     (property->type == MLN_PLUGIN_VALUE_COLOR && binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_COLOR) ||
-                     (property->type == MLN_PLUGIN_VALUE_BOOLEAN &&
-                      binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT) ||
-                     (property->type == MLN_PLUGIN_VALUE_STRING && !property->enumValues.empty() &&
-                      binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT));
+                                             ((property->type == MLN_PLUGIN_VALUE_FLOAT &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_FLOAT) ||
+                                              (property->type == MLN_PLUGIN_VALUE_FLOAT2 &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_FLOAT2) ||
+                                              (property->type == MLN_PLUGIN_VALUE_COLOR &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_COLOR) ||
+                                              (property->type == MLN_PLUGIN_VALUE_BOOLEAN &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT) ||
+                                              (property->type == MLN_PLUGIN_VALUE_STRING &&
+                                               !property->enumValues.empty() &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT));
                 if (property == newProperties.end() || property->scope != MLN_PLUGIN_PROPERTY_PAINT ||
                     !encodingMatches) {
                     error = "plugin shader property binding references an incompatible paint property";
@@ -827,20 +827,15 @@ mln_plugin_status PluginRegistry::registerPlugin(const mln_plugin_descriptor_v1&
         }
         for (const auto& property : newProperties) {
             if (property.targetLayerType != type) continue;
-            const auto dataDependencies = MLN_PLUGIN_EXPRESSION_FEATURE |
-                                          MLN_PLUGIN_EXPRESSION_COMPOSITE |
+            const auto dataDependencies = MLN_PLUGIN_EXPRESSION_FEATURE | MLN_PLUGIN_EXPRESSION_COMPOSITE |
                                           MLN_PLUGIN_EXPRESSION_FEATURE_STATE;
             if ((property.expressionCapabilities & dataDependencies) == 0) continue;
-            const bool bound = std::any_of(copiedLayerType.shaders.begin(),
-                                           copiedLayerType.shaders.end(),
-                                           [&](const auto& shader) {
-                                               return std::any_of(
-                                                   shader.propertyBindings.begin(),
-                                                   shader.propertyBindings.end(),
-                                                   [&](const auto& binding) {
-                                                       return binding.propertyName == property.name;
-                                                   });
-                                           });
+            const bool bound = std::any_of(
+                copiedLayerType.shaders.begin(), copiedLayerType.shaders.end(), [&](const auto& shader) {
+                    return std::any_of(shader.propertyBindings.begin(),
+                                       shader.propertyBindings.end(),
+                                       [&](const auto& binding) { return binding.propertyName == property.name; });
+                });
             if (property.scope != MLN_PLUGIN_PROPERTY_PAINT || !bound) {
                 error = "data-driven plugin properties require a shader property binding";
                 return MLN_PLUGIN_STATUS_INVALID_ARGUMENT;
@@ -1094,9 +1089,7 @@ uint8_t mln_plugin_is_registered_v1(const char* pluginID) try {
     return 0;
 }
 
-size_t mln_plugin_count_v1(void) try {
-    return mln::plugin::PluginRegistry::get().pluginIDs().size();
-} catch (...) {
+size_t mln_plugin_count_v1(void) try { return mln::plugin::PluginRegistry::get().pluginIDs().size(); } catch (...) {
     return 0;
 }
 

--- a/src/mln/renderer/buckets/plugin_bucket.cpp
+++ b/src/mln/renderer/buckets/plugin_bucket.cpp
@@ -18,7 +18,9 @@ namespace {
 class PluginFeatureSnapshot final : public GeometryTileFeature {
 public:
     PluginFeatureSnapshot(FeatureType type_, FeatureIdentifier id_, PropertyMap properties_)
-        : type(type_), id(std::move(id_)), properties(std::move(properties_)) {}
+        : type(type_),
+          id(std::move(id_)),
+          properties(std::move(properties_)) {}
 
     FeatureType getType() const override { return type; }
     std::optional<Value> getValue(const std::string& key) const override {
@@ -66,10 +68,10 @@ void encodedValue(const mln_plugin_value& value,
         case MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT: {
             const std::string_view text(value.data.string_value.data, value.data.string_value.size);
             const auto it = std::find(definition.enumValues.begin(), definition.enumValues.end(), text);
-            const auto fallback = std::find(definition.enumValues.begin(), definition.enumValues.end(),
-                                            *definition.defaultValue.getString());
-            output[0] = static_cast<float>(std::distance(definition.enumValues.begin(),
-                                                       it == definition.enumValues.end() ? fallback : it));
+            const auto fallback = std::find(
+                definition.enumValues.begin(), definition.enumValues.end(), *definition.defaultValue.getString());
+            output[0] = static_cast<float>(
+                std::distance(definition.enumValues.begin(), it == definition.enumValues.end() ? fallback : it));
             break;
         }
         case MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT:
@@ -88,8 +90,7 @@ void encodedValue(const mln_plugin_value& value,
     }
 }
 
-mln_plugin_value decodedValue(const std::array<float, 4>& input,
-                              const plugin::PropertyDefinition& definition) {
+mln_plugin_value decodedValue(const std::array<float, 4>& input, const plugin::PropertyDefinition& definition) {
     const auto type = definition.type;
     mln_plugin_value value{};
     value.struct_size = sizeof(value);
@@ -109,7 +110,8 @@ mln_plugin_value decodedValue(const std::array<float, 4>& input,
             break;
         case MLN_PLUGIN_VALUE_STRING:
             if (!definition.enumValues.empty()) {
-                const auto index = static_cast<size_t>(std::clamp(input[0], 0.0f, static_cast<float>(definition.enumValues.size() - 1)));
+                const auto index = static_cast<size_t>(
+                    std::clamp(input[0], 0.0f, static_cast<float>(definition.enumValues.size() - 1)));
                 const auto& text = definition.enumValues[index];
                 value.data.string_value = {text.data(), text.size()};
             }
@@ -122,10 +124,7 @@ mln_plugin_value decodedValue(const std::array<float, 4>& input,
 
 } // namespace
 
-void PluginPaintVertexVector::set(std::size_t first,
-                                  std::size_t length,
-                                  const float* minimum,
-                                  const float* maximum) {
+void PluginPaintVertexVector::set(std::size_t first, std::size_t length, const float* minimum, const float* maximum) {
     if (first > count || length > count - first) return;
     for (std::size_t vertex = first; vertex < first + length; ++vertex) {
         auto* destination = data.data() + vertex * components * 2;
@@ -135,8 +134,7 @@ void PluginPaintVertexVector::set(std::size_t first,
     updateModified(true);
 }
 
-void PluginPaintVertexVector::bounds(std::array<float, 4>& minimum,
-                                     std::array<float, 4>& maximum) const {
+void PluginPaintVertexVector::bounds(std::array<float, 4>& minimum, std::array<float, 4>& maximum) const {
     minimum.fill(std::numeric_limits<float>::infinity());
     maximum.fill(-std::numeric_limits<float>::infinity());
     for (std::size_t vertex = 0; vertex < count; ++vertex) {
@@ -224,8 +222,7 @@ void PluginPaintPropertyBinder::writeUniform(float zoom,
             std::memcpy(output + binding.uniformByteOffset, encoded.data(), size);
         }
     }
-    if (uniformID == binding.interpolationUniformID &&
-        binding.interpolationUniformByteOffset <= outputSize &&
+    if (uniformID == binding.interpolationUniformID && binding.interpolationUniformByteOffset <= outputSize &&
         sizeof(float) <= outputSize - binding.interpolationUniformByteOffset) {
         const auto factor = interpolationFactor(zoom);
         std::memcpy(output + binding.interpolationUniformByteOffset, &factor, sizeof(factor));
@@ -261,9 +258,7 @@ bool PluginPaintPropertyBinder::update(const FeatureStates& states, const Geomet
     return changed;
 }
 
-void PluginPaintPropertyBinder::statistics(float zoom,
-                                           mln_plugin_value& minimum,
-                                           mln_plugin_value& maximum) const {
+void PluginPaintPropertyBinder::statistics(float zoom, mln_plugin_value& minimum, mln_plugin_value& maximum) const {
     if (!dataDriven || !vertexVector) {
         style::PluginPropertyValue::EvaluationStorage storage;
         minimum = value.evaluate(zoom, definition, storage);
@@ -285,7 +280,8 @@ void PluginPaintPropertyBinder::refill(const GeometryTileLayer* layer) {
         std::unique_ptr<GeometryTileFeature> feature;
         if (layer) feature = layer->getFeature(range.featureIndex);
         PluginFeatureSnapshot snapshot(range.featureType, range.featureIdentifier, range.properties);
-        const GeometryTileFeature& sourceFeature = feature ? *feature : static_cast<const GeometryTileFeature&>(snapshot);
+        const GeometryTileFeature& sourceFeature = feature ? *feature
+                                                           : static_cast<const GeometryTileFeature&>(snapshot);
         const auto state = featureStates.find(range.featureID);
         const FeatureState empty;
         fillRange(range, sourceFeature, state == featureStates.end() ? empty : state->second);
@@ -312,15 +308,14 @@ void PluginPaintPropertyBinder::updateStatistics() {
     if (vertexVector) vertexVector->bounds(minimumValues, maximumValues);
 }
 
-PluginPaintPropertyBinders::PluginPaintPropertyBinders(
-    const plugin::LayerType& registration,
-    const plugin::ShaderDefinition& shader,
-    uint64_t drawableKey,
-    std::size_t vertexCount,
-    float bucketZoom,
-    const style::PluginPropertyMap& properties,
-    const std::vector<PluginFeatureVertexRange>& ranges,
-    const GeometryTileLayer& layer) {
+PluginPaintPropertyBinders::PluginPaintPropertyBinders(const plugin::LayerType& registration,
+                                                       const plugin::ShaderDefinition& shader,
+                                                       uint64_t drawableKey,
+                                                       std::size_t vertexCount,
+                                                       float bucketZoom,
+                                                       const style::PluginPropertyMap& properties,
+                                                       const std::vector<PluginFeatureVertexRange>& ranges,
+                                                       const GeometryTileLayer& layer) {
     const auto definitions = plugin::PluginRegistry::get().propertiesForLayer(registration.type);
     for (const auto& binding : shader.propertyBindings) {
         const auto definition = std::find_if(definitions.begin(), definitions.end(), [&](const auto& candidate) {
@@ -351,14 +346,11 @@ void PluginPaintPropertyBinders::populateVertexAttributes(gfx::VertexAttributeAr
         const auto& vector = binder.getVertexVector();
         const auto components = binder.componentCount();
         if (const auto& minimum = attributes.set(binding.minimumAttributeID)) {
-            minimum->setSharedRawData(vector,
-                                      0,
-                                      0,
-                                      vector->getRawSize(),
-                                      binder.attributeType());
+            minimum->setSharedRawData(vector, 0, 0, vector->getRawSize(), binder.attributeType());
         }
         if (auto* maximum = binding.maximumAttributeID != binding.minimumAttributeID
-                                ? attributes.set(binding.maximumAttributeID).get() : nullptr) {
+                                ? attributes.set(binding.maximumAttributeID).get()
+                                : nullptr) {
             maximum->setSharedRawData(vector,
                                       static_cast<uint32_t>(components * sizeof(float)),
                                       0,
@@ -391,8 +383,7 @@ bool PluginPaintPropertyBinders::update(const FeatureStates& states, const Geome
 }
 
 void PluginPaintPropertyBinders::appendStatistics(
-    float zoom,
-    std::map<std::string, std::pair<mln_plugin_value, mln_plugin_value>>& output) const {
+    float zoom, std::map<std::string, std::pair<mln_plugin_value, mln_plugin_value>>& output) const {
     for (const auto& binder : binders) {
         if (output.find(binder.getDefinition().name) != output.end()) continue;
         mln_plugin_value minimum{};
@@ -469,10 +460,8 @@ void PluginBucket::updateQueryRadius(const std::string& layerID,
     std::vector<mln_plugin_property_statistics_v1> statistics;
     statistics.reserve(values.size());
     for (const auto& [name, bounds] : values) {
-        statistics.push_back({sizeof(mln_plugin_property_statistics_v1),
-                              {name.data(), name.size()},
-                              bounds.first,
-                              bounds.second});
+        statistics.push_back(
+            {sizeof(mln_plugin_property_statistics_v1), {name.data(), name.size()}, bounds.first, bounds.second});
     }
 
     const auto definitions = plugin::PluginRegistry::get().propertiesForLayer(registration.type);
@@ -487,18 +476,15 @@ void PluginBucket::updateQueryRadius(const std::string& layerID,
                                     current.evaluate(zoom, definition, storage[i]),
                                     properties.find(definition.name) != properties.end()});
     }
-    const auto radius = registration.queryRadius(statistics.data(),
-                                                 statistics.size(),
-                                                 cameraProperties.data(),
-                                                 cameraProperties.size());
+    const auto radius = registration.queryRadius(
+        statistics.data(), statistics.size(), cameraProperties.data(), cameraProperties.size());
     if (std::isfinite(radius) && radius >= 0.0f) {
         queryRadii.insert_or_assign(layerID, radius);
         queryRadiusErrorsLogged.erase(layerID);
     } else {
         queryRadii.insert_or_assign(layerID, 0.0f);
         if (queryRadiusErrorsLogged.emplace(layerID).second) {
-            Log::Warning(Event::Style,
-                         "Plugin layer '" + registration.type + "' returned an invalid query radius");
+            Log::Warning(Event::Style, "Plugin layer '" + registration.type + "' returned an invalid query radius");
         }
     }
 }

--- a/src/mln/renderer/buckets/plugin_bucket.cpp
+++ b/src/mln/renderer/buckets/plugin_bucket.cpp
@@ -1,0 +1,513 @@
+#include <mln/renderer/buckets/plugin_bucket.hpp>
+
+#include <mln/plugin/plugin_registry.hpp>
+#include <mln/renderer/render_layer.hpp>
+#include <mln/style/plugin_property.hpp>
+#include <mln/tile/geometry_tile_data.hpp>
+#include <mln/util/logging.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+namespace mln {
+namespace {
+
+class PluginFeatureSnapshot final : public GeometryTileFeature {
+public:
+    PluginFeatureSnapshot(FeatureType type_, FeatureIdentifier id_, PropertyMap properties_)
+        : type(type_), id(std::move(id_)), properties(std::move(properties_)) {}
+
+    FeatureType getType() const override { return type; }
+    std::optional<Value> getValue(const std::string& key) const override {
+        const auto it = properties.find(key);
+        return it == properties.end() ? std::nullopt : std::optional<Value>{it->second};
+    }
+    const PropertyMap& getProperties() const override { return properties; }
+    FeatureIdentifier getID() const override { return id; }
+
+private:
+    FeatureType type;
+    FeatureIdentifier id;
+    PropertyMap properties;
+};
+
+style::PluginPropertyValue propertyValue(const plugin::PropertyDefinition& definition,
+                                         const style::PluginPropertyMap& properties) {
+    const auto it = properties.find(definition.name);
+    return it == properties.end() ? style::defaultPluginPropertyValue(definition) : it->second;
+}
+
+std::size_t componentCount(mln_plugin_property_encoding_v1 encoding) {
+    switch (encoding) {
+        case MLN_PLUGIN_PROPERTY_ENCODING_FLOAT:
+        case MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT:
+        case MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT:
+            return 1;
+        case MLN_PLUGIN_PROPERTY_ENCODING_FLOAT2:
+            return 2;
+        case MLN_PLUGIN_PROPERTY_ENCODING_COLOR:
+            return 4;
+    }
+    return 0;
+}
+
+void encodedValue(const mln_plugin_value& value,
+                  mln_plugin_property_encoding_v1 encoding,
+                  const plugin::PropertyDefinition& definition,
+                  std::array<float, 4>& output) {
+    output = {};
+    switch (encoding) {
+        case MLN_PLUGIN_PROPERTY_ENCODING_FLOAT:
+            output[0] = value.data.float_value;
+            break;
+        case MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT: {
+            const std::string_view text(value.data.string_value.data, value.data.string_value.size);
+            const auto it = std::find(definition.enumValues.begin(), definition.enumValues.end(), text);
+            const auto fallback = std::find(definition.enumValues.begin(), definition.enumValues.end(),
+                                            *definition.defaultValue.getString());
+            output[0] = static_cast<float>(std::distance(definition.enumValues.begin(),
+                                                       it == definition.enumValues.end() ? fallback : it));
+            break;
+        }
+        case MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT:
+            output[0] = value.data.boolean_value ? 1.0f : 0.0f;
+            break;
+        case MLN_PLUGIN_PROPERTY_ENCODING_FLOAT2:
+            output[0] = value.data.float2_value.x;
+            output[1] = value.data.float2_value.y;
+            break;
+        case MLN_PLUGIN_PROPERTY_ENCODING_COLOR:
+            output[0] = value.data.color_value.r;
+            output[1] = value.data.color_value.g;
+            output[2] = value.data.color_value.b;
+            output[3] = value.data.color_value.a;
+            break;
+    }
+}
+
+mln_plugin_value decodedValue(const std::array<float, 4>& input,
+                              const plugin::PropertyDefinition& definition) {
+    const auto type = definition.type;
+    mln_plugin_value value{};
+    value.struct_size = sizeof(value);
+    value.type = type;
+    switch (type) {
+        case MLN_PLUGIN_VALUE_BOOLEAN:
+            value.data.boolean_value = input[0] != 0.0f;
+            break;
+        case MLN_PLUGIN_VALUE_FLOAT:
+            value.data.float_value = input[0];
+            break;
+        case MLN_PLUGIN_VALUE_FLOAT2:
+            value.data.float2_value = {input[0], input[1]};
+            break;
+        case MLN_PLUGIN_VALUE_COLOR:
+            value.data.color_value = {input[0], input[1], input[2], input[3]};
+            break;
+        case MLN_PLUGIN_VALUE_STRING:
+            if (!definition.enumValues.empty()) {
+                const auto index = static_cast<size_t>(std::clamp(input[0], 0.0f, static_cast<float>(definition.enumValues.size() - 1)));
+                const auto& text = definition.enumValues[index];
+                value.data.string_value = {text.data(), text.size()};
+            }
+            break;
+        default:
+            break;
+    }
+    return value;
+}
+
+} // namespace
+
+void PluginPaintVertexVector::set(std::size_t first,
+                                  std::size_t length,
+                                  const float* minimum,
+                                  const float* maximum) {
+    if (first > count || length > count - first) return;
+    for (std::size_t vertex = first; vertex < first + length; ++vertex) {
+        auto* destination = data.data() + vertex * components * 2;
+        std::copy_n(minimum, components, destination);
+        std::copy_n(maximum, components, destination + components);
+    }
+    updateModified(true);
+}
+
+void PluginPaintVertexVector::bounds(std::array<float, 4>& minimum,
+                                     std::array<float, 4>& maximum) const {
+    minimum.fill(std::numeric_limits<float>::infinity());
+    maximum.fill(-std::numeric_limits<float>::infinity());
+    for (std::size_t vertex = 0; vertex < count; ++vertex) {
+        const auto* values = data.data() + vertex * components * 2;
+        for (std::size_t component = 0; component < components; ++component) {
+            minimum[component] = std::min({minimum[component], values[component], values[components + component]});
+            maximum[component] = std::max({maximum[component], values[component], values[components + component]});
+        }
+    }
+    if (count == 0) {
+        minimum.fill(0.0f);
+        maximum.fill(0.0f);
+    }
+}
+
+PluginPaintPropertyBinder::PluginPaintPropertyBinder(plugin::PropertyDefinition definition_,
+                                                     plugin::ShaderPropertyBindingDefinition binding_,
+                                                     style::PluginPropertyValue value_,
+                                                     float bucketZoom_,
+                                                     uint64_t drawableKey,
+                                                     std::size_t vertexCount_,
+                                                     const std::vector<PluginFeatureVertexRange>& featureRanges,
+                                                     const GeometryTileLayer& layer)
+    : definition(std::move(definition_)),
+      binding(std::move(binding_)),
+      value(std::move(value_)),
+      bucketZoom(bucketZoom_),
+      vertexCount(vertexCount_),
+      dataDriven(value.isDataDriven()) {
+    for (const auto& input : featureRanges) {
+        if (input.drawableKey != drawableKey) continue;
+        auto feature = layer.getFeature(input.featureIndex);
+        if (!feature) continue;
+        ranges.push_back({input.featureIndex,
+                          featureIDtoString(feature->getID()).value_or(std::string{}),
+                          feature->getType(),
+                          feature->getID(),
+                          feature->getProperties(),
+                          input.firstVertex,
+                          input.vertexCount});
+    }
+    if (dataDriven) {
+        vertexVector = std::make_shared<PluginPaintVertexVector>(vertexCount, componentCount());
+        refill(&layer);
+    }
+}
+
+gfx::AttributeDataType PluginPaintPropertyBinder::attributeType() const noexcept {
+    if (binding.minimumAttributeID == binding.maximumAttributeID) {
+        return componentCount() == 1 ? gfx::AttributeDataType::Float2 : gfx::AttributeDataType::Float4;
+    }
+    switch (binding.encoding) {
+        case MLN_PLUGIN_PROPERTY_ENCODING_FLOAT:
+        case MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT:
+        case MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT:
+            return gfx::AttributeDataType::Float;
+        case MLN_PLUGIN_PROPERTY_ENCODING_FLOAT2:
+            return gfx::AttributeDataType::Float2;
+        case MLN_PLUGIN_PROPERTY_ENCODING_COLOR:
+            return gfx::AttributeDataType::Float4;
+    }
+    return gfx::AttributeDataType::Invalid;
+}
+
+std::size_t PluginPaintPropertyBinder::componentCount() const noexcept {
+    return mln::componentCount(binding.encoding);
+}
+
+float PluginPaintPropertyBinder::interpolationFactor(float zoom) const noexcept {
+    return dataDriven ? value.interpolationFactor(bucketZoom, zoom) : 0.0f;
+}
+
+void PluginPaintPropertyBinder::writeUniform(float zoom,
+                                             uint32_t uniformID,
+                                             uint8_t* output,
+                                             std::size_t outputSize) const {
+    if (!output) return;
+    if (!dataDriven && uniformID == binding.uniformID) {
+        style::PluginPropertyValue::EvaluationStorage storage;
+        const auto evaluated = value.evaluate(zoom, definition, storage);
+        std::array<float, 4> encoded{};
+        encodedValue(evaluated, binding.encoding, definition, encoded);
+        const auto size = componentCount() * sizeof(float);
+        if (binding.uniformByteOffset <= outputSize && size <= outputSize - binding.uniformByteOffset) {
+            std::memcpy(output + binding.uniformByteOffset, encoded.data(), size);
+        }
+    }
+    if (uniformID == binding.interpolationUniformID &&
+        binding.interpolationUniformByteOffset <= outputSize &&
+        sizeof(float) <= outputSize - binding.interpolationUniformByteOffset) {
+        const auto factor = interpolationFactor(zoom);
+        std::memcpy(output + binding.interpolationUniformByteOffset, &factor, sizeof(factor));
+    }
+}
+
+bool PluginPaintPropertyBinder::synchronize(const style::PluginPropertyValue& replacement) {
+    if (value == replacement) return false;
+    const bool wasDataDriven = dataDriven;
+    value = replacement;
+    dataDriven = value.isDataDriven();
+    if (dataDriven && !vertexVector) {
+        vertexVector = std::make_shared<PluginPaintVertexVector>(vertexCount, componentCount());
+    }
+    if (dataDriven) refill();
+    if (!dataDriven) vertexVector.reset();
+    return wasDataDriven != dataDriven || dataDriven;
+}
+
+bool PluginPaintPropertyBinder::update(const FeatureStates& states, const GeometryTileLayer& layer) {
+    if (!dataDriven || states.empty()) return false;
+    bool changed = false;
+    for (const auto& range : ranges) {
+        const auto state = states.find(range.featureID);
+        if (state == states.end()) continue;
+        featureStates[range.featureID] = state->second;
+        auto feature = layer.getFeature(range.featureIndex);
+        if (!feature) continue;
+        fillRange(range, *feature, state->second);
+        changed = true;
+    }
+    if (changed) updateStatistics();
+    return changed;
+}
+
+void PluginPaintPropertyBinder::statistics(float zoom,
+                                           mln_plugin_value& minimum,
+                                           mln_plugin_value& maximum) const {
+    if (!dataDriven || !vertexVector) {
+        style::PluginPropertyValue::EvaluationStorage storage;
+        minimum = value.evaluate(zoom, definition, storage);
+        if (binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT) {
+            std::array<float, 4> encoded{};
+            encodedValue(minimum, binding.encoding, definition, encoded);
+            minimum = decodedValue(encoded, definition);
+        }
+        maximum = minimum;
+        return;
+    }
+    minimum = decodedValue(minimumValues, definition);
+    maximum = decodedValue(maximumValues, definition);
+}
+
+void PluginPaintPropertyBinder::refill(const GeometryTileLayer* layer) {
+    if (!vertexVector) return;
+    for (const auto& range : ranges) {
+        std::unique_ptr<GeometryTileFeature> feature;
+        if (layer) feature = layer->getFeature(range.featureIndex);
+        PluginFeatureSnapshot snapshot(range.featureType, range.featureIdentifier, range.properties);
+        const GeometryTileFeature& sourceFeature = feature ? *feature : static_cast<const GeometryTileFeature&>(snapshot);
+        const auto state = featureStates.find(range.featureID);
+        const FeatureState empty;
+        fillRange(range, sourceFeature, state == featureStates.end() ? empty : state->second);
+    }
+    updateStatistics();
+}
+
+void PluginPaintPropertyBinder::fillRange(const Range& range,
+                                          const GeometryTileFeature& feature,
+                                          const FeatureState& state) {
+    style::PluginPropertyValue::EvaluationStorage minimumStorage;
+    style::PluginPropertyValue::EvaluationStorage maximumStorage;
+    const auto minimumValue = value.evaluate(bucketZoom, feature, state, definition, minimumStorage);
+    const auto maximumValue = value.evaluate(
+        value.isZoomConstant() ? bucketZoom : bucketZoom + 1.0f, feature, state, definition, maximumStorage);
+    std::array<float, 4> minimum{};
+    std::array<float, 4> maximum{};
+    encodedValue(minimumValue, binding.encoding, definition, minimum);
+    encodedValue(maximumValue, binding.encoding, definition, maximum);
+    vertexVector->set(range.firstVertex, range.vertexCount, minimum.data(), maximum.data());
+}
+
+void PluginPaintPropertyBinder::updateStatistics() {
+    if (vertexVector) vertexVector->bounds(minimumValues, maximumValues);
+}
+
+PluginPaintPropertyBinders::PluginPaintPropertyBinders(
+    const plugin::LayerType& registration,
+    const plugin::ShaderDefinition& shader,
+    uint64_t drawableKey,
+    std::size_t vertexCount,
+    float bucketZoom,
+    const style::PluginPropertyMap& properties,
+    const std::vector<PluginFeatureVertexRange>& ranges,
+    const GeometryTileLayer& layer) {
+    const auto definitions = plugin::PluginRegistry::get().propertiesForLayer(registration.type);
+    for (const auto& binding : shader.propertyBindings) {
+        const auto definition = std::find_if(definitions.begin(), definitions.end(), [&](const auto& candidate) {
+            return candidate.name == binding.propertyName;
+        });
+        if (definition == definitions.end()) continue;
+        binders.emplace_back(*definition,
+                             binding,
+                             propertyValue(*definition, properties),
+                             bucketZoom,
+                             drawableKey,
+                             vertexCount,
+                             ranges,
+                             layer);
+    }
+}
+
+void PluginPaintPropertyBinders::populateVertexAttributes(gfx::VertexAttributeArray& attributes,
+                                                          gfx::StringIDSetsPair& uniforms) const {
+    for (const auto& binder : binders) {
+        const auto& binding = binder.getBinding();
+        if (!binder.isDataDriven()) {
+            uniforms.first.emplace(binding.propertyName);
+            uniforms.second.emplace(binding.minimumAttributeID);
+            uniforms.second.emplace(binding.maximumAttributeID);
+            continue;
+        }
+        const auto& vector = binder.getVertexVector();
+        const auto components = binder.componentCount();
+        if (const auto& minimum = attributes.set(binding.minimumAttributeID)) {
+            minimum->setSharedRawData(vector,
+                                      0,
+                                      0,
+                                      vector->getRawSize(),
+                                      binder.attributeType());
+        }
+        if (auto* maximum = binding.maximumAttributeID != binding.minimumAttributeID
+                                ? attributes.set(binding.maximumAttributeID).get() : nullptr) {
+            maximum->setSharedRawData(vector,
+                                      static_cast<uint32_t>(components * sizeof(float)),
+                                      0,
+                                      vector->getRawSize(),
+                                      binder.attributeType());
+        }
+    }
+}
+
+void PluginPaintPropertyBinders::writeUniforms(float zoom,
+                                               uint32_t uniformID,
+                                               uint8_t* output,
+                                               std::size_t outputSize) const {
+    for (const auto& binder : binders) binder.writeUniform(zoom, uniformID, output, outputSize);
+}
+
+bool PluginPaintPropertyBinders::synchronize(const style::PluginPropertyMap& properties) {
+    bool rebuildDrawable = false;
+    for (auto& binder : binders) {
+        const auto replacement = propertyValue(binder.getDefinition(), properties);
+        rebuildDrawable = binder.synchronize(replacement) || rebuildDrawable;
+    }
+    return rebuildDrawable;
+}
+
+bool PluginPaintPropertyBinders::update(const FeatureStates& states, const GeometryTileLayer& layer) {
+    bool changed = false;
+    for (auto& binder : binders) changed = binder.update(states, layer) || changed;
+    return changed;
+}
+
+void PluginPaintPropertyBinders::appendStatistics(
+    float zoom,
+    std::map<std::string, std::pair<mln_plugin_value, mln_plugin_value>>& output) const {
+    for (const auto& binder : binders) {
+        if (output.find(binder.getDefinition().name) != output.end()) continue;
+        mln_plugin_value minimum{};
+        mln_plugin_value maximum{};
+        binder.statistics(zoom, minimum, maximum);
+        output.emplace(binder.getDefinition().name, std::make_pair(minimum, maximum));
+    }
+}
+
+void PluginBucket::update(const FeatureStates& states,
+                          const GeometryTileLayer& layer,
+                          const std::string& layerID,
+                          const ImagePositions&) {
+    const auto it = paintPropertyBinders.find(layerID);
+    if (it == paintPropertyBinders.end()) return;
+    bool changed = false;
+    for (auto& [key, binders] : it->second) {
+        (void)key;
+        changed = binders.update(states, layer) || changed;
+    }
+    if (changed) {
+        uploaded = false;
+        const auto properties = latestPaintProperties.find(layerID);
+        const auto zoom = latestZoom.find(layerID);
+        if (properties != latestPaintProperties.end() && zoom != latestZoom.end()) {
+            updateQueryRadius(layerID, properties->second, zoom->second);
+        }
+    }
+}
+
+float PluginBucket::getQueryRadius(const RenderLayer& layer) const {
+    const auto it = queryRadii.find(layer.getID());
+    return it == queryRadii.end() ? queryRadius : it->second;
+}
+
+bool PluginBucket::synchronizePaint(const std::string& layerID,
+                                    const style::PluginPropertyMap& properties,
+                                    float zoom) {
+    const auto priorProperties = latestPaintProperties.find(layerID);
+    const auto priorZoom = latestZoom.find(layerID);
+    const bool propertiesChanged = priorProperties == latestPaintProperties.end() ||
+                                   priorProperties->second != properties;
+    const bool queryRadiusChanged = propertiesChanged || priorZoom == latestZoom.end() || priorZoom->second != zoom;
+    latestPaintProperties.insert_or_assign(layerID, properties);
+    latestZoom.insert_or_assign(layerID, zoom);
+    const auto it = paintPropertyBinders.find(layerID);
+    if (it == paintPropertyBinders.end()) {
+        if (queryRadiusChanged) updateQueryRadius(layerID, properties, zoom);
+        return false;
+    }
+    bool rebuildDrawable = false;
+    if (propertiesChanged) {
+        for (auto& [key, binders] : it->second) {
+            (void)key;
+            rebuildDrawable = binders.synchronize(properties) || rebuildDrawable;
+        }
+    }
+    if (rebuildDrawable) uploaded = false;
+    if (queryRadiusChanged) updateQueryRadius(layerID, properties, zoom);
+    return rebuildDrawable;
+}
+
+void PluginBucket::updateQueryRadius(const std::string& layerID,
+                                     const style::PluginPropertyMap& properties,
+                                     float zoom) {
+    if (!registration.queryRadius) return;
+    std::map<std::string, std::pair<mln_plugin_value, mln_plugin_value>> values;
+    if (const auto layer = paintPropertyBinders.find(layerID); layer != paintPropertyBinders.end()) {
+        for (const auto& [key, binders] : layer->second) {
+            (void)key;
+            binders.appendStatistics(zoom, values);
+        }
+    }
+    std::vector<mln_plugin_property_statistics_v1> statistics;
+    statistics.reserve(values.size());
+    for (const auto& [name, bounds] : values) {
+        statistics.push_back({sizeof(mln_plugin_property_statistics_v1),
+                              {name.data(), name.size()},
+                              bounds.first,
+                              bounds.second});
+    }
+
+    const auto definitions = plugin::PluginRegistry::get().propertiesForLayer(registration.type);
+    std::vector<style::PluginPropertyValue::EvaluationStorage> storage(definitions.size());
+    std::vector<mln_plugin_property_value_v1> cameraProperties;
+    cameraProperties.reserve(definitions.size());
+    for (std::size_t i = 0; i < definitions.size(); ++i) {
+        const auto& definition = definitions[i];
+        const auto current = propertyValue(definition, properties);
+        cameraProperties.push_back({sizeof(mln_plugin_property_value_v1),
+                                    {definition.name.data(), definition.name.size()},
+                                    current.evaluate(zoom, definition, storage[i]),
+                                    properties.find(definition.name) != properties.end()});
+    }
+    const auto radius = registration.queryRadius(statistics.data(),
+                                                 statistics.size(),
+                                                 cameraProperties.data(),
+                                                 cameraProperties.size());
+    if (std::isfinite(radius) && radius >= 0.0f) {
+        queryRadii.insert_or_assign(layerID, radius);
+        queryRadiusErrorsLogged.erase(layerID);
+    } else {
+        queryRadii.insert_or_assign(layerID, 0.0f);
+        if (queryRadiusErrorsLogged.emplace(layerID).second) {
+            Log::Warning(Event::Style,
+                         "Plugin layer '" + registration.type + "' returned an invalid query radius");
+        }
+    }
+}
+
+PluginPaintPropertyBinders* PluginBucket::paintBinders(const std::string& layerID, uint64_t drawableKey) {
+    const auto layer = paintPropertyBinders.find(layerID);
+    if (layer == paintPropertyBinders.end()) return nullptr;
+    const auto drawable = layer->second.find(drawableKey);
+    return drawable == layer->second.end() ? nullptr : &drawable->second;
+}
+
+} // namespace mln

--- a/src/mln/style/layers/plugin_style_layer.cpp
+++ b/src/mln/style/layers/plugin_style_layer.cpp
@@ -18,8 +18,7 @@ std::optional<std::string> pluginTransitionPropertyName(const char* layerType, c
     return definition && definition->supportsTransitions ? std::optional<std::string>{std::move(propertyName)}
                                                          : std::nullopt;
 }
-}
-
+} // namespace
 
 PluginStyleLayer::Impl::Impl(const std::string& id, const std::string& source, plugin::LayerType registration_)
     : Layer::Impl(id, source),
@@ -90,10 +89,9 @@ StyleProperty PluginStyleLayer::getProperty(const std::string& name) const {
     return definition ? defaultPluginPropertyValue(*definition).toStyleProperty() : StyleProperty{};
 }
 
-
 std::optional<conversion::Error> PluginStyleLayer::setPluginProperty(const std::string& name,
-                                                          const conversion::Convertible& value,
-                                                          std::optional<PropertyScope> scope) {
+                                                                     const conversion::Convertible& value,
+                                                                     std::optional<PropertyScope> scope) {
     using namespace conversion;
     const auto definition = plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name);
     if (!definition) return Error{"layer doesn't support this property"};
@@ -126,8 +124,8 @@ std::optional<conversion::Error> PluginStyleLayer::setPluginProperty(const std::
 }
 
 std::optional<conversion::Error> PluginStyleLayer::setPluginTransition(const std::string& name,
-                                                            const conversion::Convertible& value,
-                                                            std::optional<PropertyScope> scope) {
+                                                                       const conversion::Convertible& value,
+                                                                       std::optional<PropertyScope> scope) {
     using namespace conversion;
     const auto propertyName = pluginTransitionPropertyName(getTypeInfo()->type, name);
     if (!propertyName) return Error{"layer doesn't support this transition"};
@@ -148,8 +146,7 @@ std::optional<conversion::Error> PluginStyleLayer::setPluginTransition(const std
     auto transition = convert<TransitionOptions>(value, error);
     if (!transition) return error;
     const auto existing = impl_->pluginPropertyTransitions.find(*propertyName);
-    if (existing != impl_->pluginPropertyTransitions.end() &&
-        existing->second.serialize() == transition->serialize()) {
+    if (existing != impl_->pluginPropertyTransitions.end() && existing->second.serialize() == transition->serialize()) {
         return std::nullopt;
     }
     impl_->pluginPropertyTransitions.insert_or_assign(*propertyName, std::move(*transition));
@@ -157,7 +154,6 @@ std::optional<conversion::Error> PluginStyleLayer::setPluginTransition(const std
     observer->onLayerChanged(*this);
     return std::nullopt;
 }
-
 
 Value PluginStyleLayer::serialize() const {
     Value serialized = Layer::serialize();
@@ -182,14 +178,18 @@ Value PluginStyleLayer::serialize() const {
     return serialized;
 }
 
-std::optional<conversion::Error> PluginStyleLayer::setPropertyInternal(const std::string& name, const conversion::Convertible& value) {
+std::optional<conversion::Error> PluginStyleLayer::setPropertyInternal(const std::string& name,
+                                                                       const conversion::Convertible& value) {
     if (pluginTransitionPropertyName(getTypeInfo()->type, name)) return setPluginTransition(name, value);
     return setPluginProperty(name, value);
 }
 
-std::optional<conversion::Error> PluginStyleLayer::setProperty(const std::string& name, const conversion::Convertible& value, PropertyScope scope) {
+std::optional<conversion::Error> PluginStyleLayer::setProperty(const std::string& name,
+                                                               const conversion::Convertible& value,
+                                                               PropertyScope scope) {
     if (pluginTransitionPropertyName(getTypeInfo()->type, name)) return setPluginTransition(name, value, scope);
-    if (plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name)) return setPluginProperty(name, value, scope);
+    if (plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name))
+        return setPluginProperty(name, value, scope);
     return Layer::setProperty(name, value);
 }
 

--- a/src/mln/style/layers/plugin_style_layer.cpp
+++ b/src/mln/style/layers/plugin_style_layer.cpp
@@ -1,0 +1,207 @@
+#include <mln/style/layers/plugin_style_layer.hpp>
+#include <mln/style/layer_observer.hpp>
+#include <mln/style/conversion_impl.hpp>
+#include <mln/style/conversion/transition_options.hpp>
+
+namespace mln {
+namespace style {
+namespace {
+constexpr const char* transitionSuffix = "-transition";
+
+std::optional<std::string> pluginTransitionPropertyName(const char* layerType, const std::string& name) {
+    constexpr std::size_t suffixLength = 11;
+    if (name.size() <= suffixLength || name.compare(name.size() - suffixLength, suffixLength, transitionSuffix) != 0) {
+        return std::nullopt;
+    }
+    auto propertyName = name.substr(0, name.size() - suffixLength);
+    const auto definition = plugin::PluginRegistry::get().findProperty(layerType, propertyName);
+    return definition && definition->supportsTransitions ? std::optional<std::string>{std::move(propertyName)}
+                                                         : std::nullopt;
+}
+}
+
+
+PluginStyleLayer::Impl::Impl(const std::string& id, const std::string& source, plugin::LayerType registration_)
+    : Layer::Impl(id, source),
+      registration(std::move(registration_)) {}
+
+bool PluginStyleLayer::Impl::hasLayoutDifference(const Layer::Impl& other) const {
+    const auto& pluginOther = static_cast<const PluginStyleLayer::Impl&>(other);
+    if (visibility != pluginOther.visibility) return true;
+    const auto definitions = plugin::PluginRegistry::get().propertiesForLayer(registration.type);
+    for (const auto& definition : definitions) {
+        if (definition.scope != MLN_PLUGIN_PROPERTY_LAYOUT) continue;
+        const auto lhs = pluginProperties.find(definition.name);
+        const auto rhs = pluginOther.pluginProperties.find(definition.name);
+        if (lhs == pluginProperties.end() && rhs == pluginOther.pluginProperties.end()) continue;
+        if (lhs == pluginProperties.end() || rhs == pluginOther.pluginProperties.end() || lhs->second != rhs->second) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void PluginStyleLayer::Impl::stringifyLayout(rapidjson::Writer<rapidjson::StringBuffer>& writer) const {
+    writer.StartObject();
+    writer.EndObject();
+}
+
+const LayerTypeInfo* PluginStyleLayer::Impl::getTypeInfo() const noexcept {
+    return &registration.identity->info;
+}
+
+expression::Dependency PluginStyleLayer::Impl::getDependencies() const noexcept {
+    expression::Dependency result = expression::Dependency::None;
+    for (const auto& [name, value] : pluginProperties) {
+        (void)name;
+        result |= value.getDependencies();
+    }
+    return result;
+}
+
+PluginStyleLayer::PluginStyleLayer(const std::string& id, const std::string& source, plugin::LayerType registration)
+    : Layer(makeMutable<Impl>(id, source, std::move(registration))) {}
+
+PluginStyleLayer::PluginStyleLayer(Immutable<Impl> impl_)
+    : Layer(std::move(impl_)) {}
+
+PluginStyleLayer::~PluginStyleLayer() = default;
+
+const PluginStyleLayer::Impl& PluginStyleLayer::impl() const {
+    return static_cast<const Impl&>(*baseImpl);
+}
+
+Mutable<PluginStyleLayer::Impl> PluginStyleLayer::mutableImpl() const {
+    return makeMutable<Impl>(impl());
+}
+
+StyleProperty PluginStyleLayer::getProperty(const std::string& name) const {
+    if (const auto propertyName = pluginTransitionPropertyName(getTypeInfo()->type, name)) {
+        const auto transition = impl().pluginPropertyTransitions.find(*propertyName);
+        return transition == impl().pluginPropertyTransitions.end()
+                   ? StyleProperty{TransitionOptions{}.serialize(), StyleProperty::Kind::Transition}
+                   : StyleProperty{transition->second.serialize(), StyleProperty::Kind::Transition};
+    }
+    const auto value = impl().pluginProperties.find(name);
+    if (value != impl().pluginProperties.end()) {
+        return value->second.toStyleProperty();
+    }
+    const auto definition = plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name);
+    return definition ? defaultPluginPropertyValue(*definition).toStyleProperty() : StyleProperty{};
+}
+
+
+std::optional<conversion::Error> PluginStyleLayer::setPluginProperty(const std::string& name,
+                                                          const conversion::Convertible& value,
+                                                          std::optional<PropertyScope> scope) {
+    using namespace conversion;
+    const auto definition = plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name);
+    if (!definition) return Error{"layer doesn't support this property"};
+    if (scope) {
+        const auto expected = definition->scope == MLN_PLUGIN_PROPERTY_PAINT ? PropertyScope::Paint
+                                                                             : PropertyScope::Layout;
+        if (*scope != expected) {
+            return Error{"plugin property '" + name + "' is in the wrong style section"};
+        }
+    }
+
+    auto impl_ = mutableImpl();
+    if (isUndefined(value)) {
+        if (impl_->pluginProperties.erase(name) != 0) {
+            baseImpl = std::move(impl_);
+            observer->onLayerChanged(*this);
+        }
+        return std::nullopt;
+    }
+
+    Error conversionError;
+    auto converted = convertPluginPropertyValue(*definition, value, conversionError);
+    if (!converted) return conversionError;
+    const auto existing = impl_->pluginProperties.find(name);
+    if (existing != impl_->pluginProperties.end() && existing->second == *converted) return std::nullopt;
+    impl_->pluginProperties.insert_or_assign(name, std::move(*converted));
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+    return std::nullopt;
+}
+
+std::optional<conversion::Error> PluginStyleLayer::setPluginTransition(const std::string& name,
+                                                            const conversion::Convertible& value,
+                                                            std::optional<PropertyScope> scope) {
+    using namespace conversion;
+    const auto propertyName = pluginTransitionPropertyName(getTypeInfo()->type, name);
+    if (!propertyName) return Error{"layer doesn't support this transition"};
+    if (scope && *scope != PropertyScope::Paint) {
+        return Error{"plugin transition '" + name + "' is in the wrong style section"};
+    }
+
+    auto impl_ = mutableImpl();
+    if (isUndefined(value)) {
+        if (impl_->pluginPropertyTransitions.erase(*propertyName) != 0) {
+            baseImpl = std::move(impl_);
+            observer->onLayerChanged(*this);
+        }
+        return std::nullopt;
+    }
+
+    Error error;
+    auto transition = convert<TransitionOptions>(value, error);
+    if (!transition) return error;
+    const auto existing = impl_->pluginPropertyTransitions.find(*propertyName);
+    if (existing != impl_->pluginPropertyTransitions.end() &&
+        existing->second.serialize() == transition->serialize()) {
+        return std::nullopt;
+    }
+    impl_->pluginPropertyTransitions.insert_or_assign(*propertyName, std::move(*transition));
+    baseImpl = std::move(impl_);
+    observer->onLayerChanged(*this);
+    return std::nullopt;
+}
+
+
+Value PluginStyleLayer::serialize() const {
+    Value serialized = Layer::serialize();
+    auto& result = *serialized.getObject();
+    for (const auto& [name, value] : impl().pluginProperties) {
+        const auto definition = plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name);
+        if (!definition) continue;
+        const auto section = definition->scope == MLN_PLUGIN_PROPERTY_PAINT ? "paint" : "layout";
+        auto& object = result[section];
+        if (!object.getObject()) object = mapbox::base::ValueObject{};
+        const auto property = value.toStyleProperty();
+        if (property.getKind() != StyleProperty::Kind::Undefined) {
+            object.getObject()->insert_or_assign(name, property.getValue());
+        }
+    }
+    for (const auto& [name, transition] : impl().pluginPropertyTransitions) {
+        auto& paint = result["paint"];
+        if (!paint.getObject()) paint = mapbox::base::ValueObject{};
+        paint.getObject()->insert_or_assign(name + transitionSuffix, transition.serialize());
+    }
+
+    return serialized;
+}
+
+std::optional<conversion::Error> PluginStyleLayer::setPropertyInternal(const std::string& name, const conversion::Convertible& value) {
+    if (pluginTransitionPropertyName(getTypeInfo()->type, name)) return setPluginTransition(name, value);
+    return setPluginProperty(name, value);
+}
+
+std::optional<conversion::Error> PluginStyleLayer::setProperty(const std::string& name, const conversion::Convertible& value, PropertyScope scope) {
+    if (pluginTransitionPropertyName(getTypeInfo()->type, name)) return setPluginTransition(name, value, scope);
+    if (plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name)) return setPluginProperty(name, value, scope);
+    return Layer::setProperty(name, value);
+}
+
+std::unique_ptr<Layer> PluginStyleLayer::cloneRef(const std::string& id) const {
+    auto copy = mutableImpl();
+    copy->id = id;
+    return std::unique_ptr<PluginStyleLayer>(new PluginStyleLayer(std::move(copy)));
+}
+
+Mutable<Layer::Impl> PluginStyleLayer::mutableBaseImpl() const {
+    return staticMutableCast<Layer::Impl>(mutableImpl());
+}
+
+} // namespace style
+} // namespace mln

--- a/src/mln/style/plugin_property.cpp
+++ b/src/mln/style/plugin_property.cpp
@@ -41,14 +41,14 @@ bool usesFeatureState(const PropertyValue<T>& value) {
 
 template <class T>
 float interpolationFactor(const PropertyValue<T>& value, float bucketZoom, float currentZoom) {
-    return value.match(
-        [](const Undefined&) { return 0.0f; },
-        [](const T&) { return 0.0f; },
-        [&](const PropertyExpression<T>& expression) {
-            if (expression.isZoomConstant()) return 0.0f;
-            const auto zoom = expression.getUseIntegerZoom() ? std::floor(currentZoom) : currentZoom;
-            return std::clamp(expression.interpolationFactor({bucketZoom, bucketZoom + 1.0f}, zoom), 0.0f, 1.0f);
-        });
+    return value.match([](const Undefined&) { return 0.0f; },
+                       [](const T&) { return 0.0f; },
+                       [&](const PropertyExpression<T>& expression) {
+                           if (expression.isZoomConstant()) return 0.0f;
+                           const auto zoom = expression.getUseIntegerZoom() ? std::floor(currentZoom) : currentZoom;
+                           return std::clamp(
+                               expression.interpolationFactor({bucketZoom, bucketZoom + 1.0f}, zoom), 0.0f, 1.0f);
+                       });
 }
 
 std::string serializeRamp(const ColorRampPropertyValue& ramp) {
@@ -372,9 +372,8 @@ mln_plugin_value PluginPropertyValue::evaluate(float zoom,
     return result;
 }
 
-PluginPropertyValue PluginPropertyValue::evaluateCamera(
-    float zoom,
-    const plugin::PropertyDefinition& definition) const {
+PluginPropertyValue PluginPropertyValue::evaluateCamera(float zoom,
+                                                        const plugin::PropertyDefinition& definition) const {
     EvaluationStorage storage;
     const auto evaluated = evaluate(zoom, definition, storage);
     switch (definition.type) {
@@ -383,8 +382,8 @@ PluginPropertyValue PluginPropertyValue::evaluateCamera(
         case MLN_PLUGIN_VALUE_FLOAT:
             return PluginPropertyValue{TypedValue{PropertyValue<float>{evaluated.data.float_value}}};
         case MLN_PLUGIN_VALUE_FLOAT2:
-            return PluginPropertyValue{TypedValue{PropertyValue<std::array<float, 2>>{
-                {evaluated.data.float2_value.x, evaluated.data.float2_value.y}}}};
+            return PluginPropertyValue{TypedValue{
+                PropertyValue<std::array<float, 2>>{{evaluated.data.float2_value.x, evaluated.data.float2_value.y}}}};
         case MLN_PLUGIN_VALUE_COLOR:
             return PluginPropertyValue{TypedValue{PropertyValue<Color>{Color{evaluated.data.color_value.r,
                                                                              evaluated.data.color_value.g,
@@ -408,11 +407,10 @@ PluginPropertyValue PluginPropertyValue::evaluateCamera(
     return *this;
 }
 
-PluginPropertyValue PluginPropertyValue::interpolate(
-    const PluginPropertyValue& from,
-    const PluginPropertyValue& to,
-    float t,
-    const plugin::PropertyDefinition& definition) {
+PluginPropertyValue PluginPropertyValue::interpolate(const PluginPropertyValue& from,
+                                                     const PluginPropertyValue& to,
+                                                     float t,
+                                                     const plugin::PropertyDefinition& definition) {
     switch (definition.type) {
         case MLN_PLUGIN_VALUE_FLOAT: {
             const auto& a = std::get<PropertyValue<float>>(from.value).asConstant();
@@ -422,8 +420,7 @@ PluginPropertyValue PluginPropertyValue::interpolate(
         case MLN_PLUGIN_VALUE_FLOAT2: {
             const auto& a = std::get<PropertyValue<std::array<float, 2>>>(from.value).asConstant();
             const auto& b = std::get<PropertyValue<std::array<float, 2>>>(to.value).asConstant();
-            return PluginPropertyValue{
-                TypedValue{PropertyValue<std::array<float, 2>>{util::interpolate(a, b, t)}}};
+            return PluginPropertyValue{TypedValue{PropertyValue<std::array<float, 2>>{util::interpolate(a, b, t)}}};
         }
         case MLN_PLUGIN_VALUE_COLOR: {
             const auto& a = std::get<PropertyValue<Color>>(from.value).asConstant();
@@ -435,11 +432,10 @@ PluginPropertyValue PluginPropertyValue::interpolate(
     }
 }
 
-PluginTransitioningPropertyValue::PluginTransitioningPropertyValue(
-    PluginPropertyValue value_,
-    PluginTransitioningPropertyValue prior_,
-    const TransitionOptions& transition,
-    TimePoint now)
+PluginTransitioningPropertyValue::PluginTransitioningPropertyValue(PluginPropertyValue value_,
+                                                                   PluginTransitioningPropertyValue prior_,
+                                                                   const TransitionOptions& transition,
+                                                                   TimePoint now)
     : begin(now + transition.delay.value_or(Duration::zero())),
       end(begin + transition.duration.value_or(Duration::zero())),
       value(std::move(value_)) {
@@ -448,10 +444,9 @@ PluginTransitioningPropertyValue::PluginTransitioningPropertyValue(
     }
 }
 
-PluginPropertyValue PluginTransitioningPropertyValue::evaluate(
-    float zoom,
-    const plugin::PropertyDefinition& definition,
-    TimePoint now) {
+PluginPropertyValue PluginTransitioningPropertyValue::evaluate(float zoom,
+                                                               const plugin::PropertyDefinition& definition,
+                                                               TimePoint now) {
     if (!prior) return value;
     if (now >= end) {
         prior.reset();

--- a/src/mln/style/plugin_property.cpp
+++ b/src/mln/style/plugin_property.cpp
@@ -1,0 +1,566 @@
+#include <mln/style/plugin_property.hpp>
+
+#include <mln/plugin/plugin_registry.hpp>
+#include <mln/style/conversion/property_value.hpp>
+#include <mln/style/conversion/color_ramp_property_value.hpp>
+#include <mln/style/conversion/json.hpp>
+#include <mln/style/conversion/stringify.hpp>
+#include <mln/style/conversion_impl.hpp>
+#include <mln/style/expression/expression.hpp>
+#include <mln/tile/geometry_tile_data.hpp>
+#include <mln/util/constants.hpp>
+#include <mln/util/interpolate.hpp>
+
+#include <algorithm>
+#include <cmath>
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+namespace mln {
+namespace style {
+namespace {
+
+bool containsOperator(const mln::Value& value, const std::string& name) {
+    const auto* array = value.getArray();
+    if (!array) return false;
+    if (!array->empty()) {
+        if (const auto* operation = (*array)[0].getString(); operation && *operation == name) return true;
+    }
+    return std::any_of(array->begin(), array->end(), [&](const auto& child) { return containsOperator(child, name); });
+}
+
+template <class T>
+bool usesFeatureState(const PropertyValue<T>& value) {
+    return value.match([](const Undefined&) { return false; },
+                       [](const T&) { return false; },
+                       [](const PropertyExpression<T>& expression) {
+                           return containsOperator(expression.getExpression().serialize(), "feature-state");
+                       });
+}
+
+template <class T>
+float interpolationFactor(const PropertyValue<T>& value, float bucketZoom, float currentZoom) {
+    return value.match(
+        [](const Undefined&) { return 0.0f; },
+        [](const T&) { return 0.0f; },
+        [&](const PropertyExpression<T>& expression) {
+            if (expression.isZoomConstant()) return 0.0f;
+            const auto zoom = expression.getUseIntegerZoom() ? std::floor(currentZoom) : currentZoom;
+            return std::clamp(expression.interpolationFactor({bucketZoom, bucketZoom + 1.0f}, zoom), 0.0f, 1.0f);
+        });
+}
+
+std::string serializeRamp(const ColorRampPropertyValue& ramp) {
+    if (ramp.isUndefined()) return {};
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    conversion::stringify(writer, ramp.getExpression().serialize());
+    return {buffer.GetString(), buffer.GetSize()};
+}
+
+template <class T>
+T defaultValue(const plugin::PropertyDefinition& definition);
+
+template <>
+bool defaultValue<bool>(const plugin::PropertyDefinition& definition) {
+    return definition.defaultValue.getBool() && *definition.defaultValue.getBool();
+}
+
+template <>
+float defaultValue<float>(const plugin::PropertyDefinition& definition) {
+    return numericValue<float>(definition.defaultValue).value_or(0.0f);
+}
+
+template <>
+std::array<float, 2> defaultValue<std::array<float, 2>>(const plugin::PropertyDefinition& definition) {
+    std::array<float, 2> result{};
+    if (const auto* array = definition.defaultValue.getArray(); array && array->size() == result.size()) {
+        for (size_t i = 0; i < result.size(); ++i) result[i] = numericValue<float>((*array)[i]).value_or(0.0f);
+    }
+    return result;
+}
+
+template <>
+Color defaultValue<Color>(const plugin::PropertyDefinition& definition) {
+    std::array<float, 4> result{};
+    if (const auto* array = definition.defaultValue.getArray(); array && array->size() == result.size()) {
+        for (size_t i = 0; i < result.size(); ++i) result[i] = numericValue<float>((*array)[i]).value_or(0.0f);
+    }
+    return {result[0], result[1], result[2], result[3]};
+}
+
+template <>
+std::string defaultValue<std::string>(const plugin::PropertyDefinition& definition) {
+    return definition.defaultValue.getString() ? *definition.defaultValue.getString() : std::string{};
+}
+
+template <>
+std::vector<float> defaultValue<std::vector<float>>(const plugin::PropertyDefinition& definition) {
+    std::vector<float> result;
+    if (const auto* array = definition.defaultValue.getArray()) {
+        result.reserve(array->size());
+        for (const auto& item : *array) result.push_back(numericValue<float>(item).value_or(0.0f));
+    }
+    return result;
+}
+
+template <>
+std::vector<Color> defaultValue<std::vector<Color>>(const plugin::PropertyDefinition& definition) {
+    std::vector<Color> result;
+    if (const auto* array = definition.defaultValue.getArray()) {
+        result.reserve(array->size());
+        for (const auto& item : *array) {
+            const auto* components = item.getArray();
+            if (!components || components->size() != 4) continue;
+            result.emplace_back(numericValue<float>((*components)[0]).value_or(0.0f),
+                                numericValue<float>((*components)[1]).value_or(0.0f),
+                                numericValue<float>((*components)[2]).value_or(0.0f),
+                                numericValue<float>((*components)[3]).value_or(0.0f));
+        }
+    }
+    return result;
+}
+
+template <class T>
+T evaluateTyped(const PropertyValue<T>& value,
+                float zoom,
+                const GeometryTileFeature& feature,
+                const FeatureState& state,
+                const plugin::PropertyDefinition& definition) {
+    const auto fallback = defaultValue<T>(definition);
+    return value.match([&](const Undefined&) { return fallback; },
+                       [&](const T& constant) { return constant; },
+                       [&](const PropertyExpression<T>& expression) {
+                           return expression.evaluate(expression::EvaluationContext(zoom, &feature, &state), fallback);
+                       });
+}
+
+template <class T>
+T evaluateCameraTyped(const PropertyValue<T>& value, float zoom, const plugin::PropertyDefinition& definition) {
+    const auto fallback = defaultValue<T>(definition);
+    return value.match([&](const Undefined&) { return fallback; },
+                       [&](const T& constant) { return constant; },
+                       [&](const PropertyExpression<T>& expression) {
+                           return expression.evaluate(expression::EvaluationContext(zoom), fallback);
+                       });
+}
+
+template <class T>
+std::optional<PluginPropertyValue> convertTyped(const plugin::PropertyDefinition& definition,
+                                                const conversion::Convertible& value,
+                                                conversion::Error& error) {
+    auto converted = conversion::convert<PropertyValue<T>>(
+        value, error, definition.expressionCapabilities != MLN_PLUGIN_EXPRESSION_NONE, false);
+    if (!converted) return std::nullopt;
+    return PluginPropertyValue{PluginPropertyValue::TypedValue{std::move(*converted)}};
+}
+
+bool validateConstant(const plugin::PropertyDefinition& definition,
+                      const PluginPropertyValue& property,
+                      conversion::Error& error) {
+    const auto converted = property.toStyleProperty();
+    if (converted.getKind() != StyleProperty::Kind::Constant) return true;
+
+    const auto& value = converted.getValue();
+    if (definition.type == MLN_PLUGIN_VALUE_STRING && !definition.enumValues.empty()) {
+        const auto* string = value.getString();
+        if (!string || std::find(definition.enumValues.begin(), definition.enumValues.end(), *string) ==
+                           definition.enumValues.end()) {
+            error.message = "value is not allowed for plugin property '" + definition.name + "'";
+            return false;
+        }
+    }
+
+    const auto inRange = [&](double number) {
+        return (!definition.minimum || number >= *definition.minimum) &&
+               (!definition.maximum || number <= *definition.maximum);
+    };
+    if (definition.type == MLN_PLUGIN_VALUE_FLOAT) {
+        const auto number = numericValue<double>(value);
+        if (!number || !inRange(*number)) {
+            error.message = "value is outside the allowed range for plugin property '" + definition.name + "'";
+            return false;
+        }
+    }
+
+    if (definition.type == MLN_PLUGIN_VALUE_FLOAT_ARRAY || definition.type == MLN_PLUGIN_VALUE_COLOR_ARRAY) {
+        const auto* array = value.getArray();
+        if (!array) return true;
+        if (definition.maximumArrayLength && array->size() > definition.maximumArrayLength) {
+            error.message = "value has too many entries for plugin property '" + definition.name + "'";
+            return false;
+        }
+        if (definition.type == MLN_PLUGIN_VALUE_FLOAT_ARRAY) {
+            for (const auto& item : *array) {
+                const auto number = numericValue<double>(item);
+                if (!number || !inRange(*number)) {
+                    error.message = "array entry is outside the allowed range for plugin property '" + definition.name +
+                                    "'";
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+StyleProperty PluginPropertyValue::toStyleProperty() const {
+    return std::visit([](const auto& typed) { return conversion::makeStyleProperty(typed); }, value);
+}
+
+expression::Dependency PluginPropertyValue::getDependencies() const noexcept {
+    return std::visit([](const auto& typed) { return typed.getDependencies(); }, value);
+}
+
+bool PluginPropertyValue::isDataDriven() const noexcept {
+    return std::visit([](const auto& typed) { return typed.isDataDriven(); }, value);
+}
+
+bool PluginPropertyValue::isZoomConstant() const noexcept {
+    return std::visit(
+        [](const auto& typed) {
+            if constexpr (std::is_same_v<std::decay_t<decltype(typed)>, ColorRampPropertyValue>) {
+                return true;
+            } else {
+                return typed.isZoomConstant();
+            }
+        },
+        value);
+}
+
+bool PluginPropertyValue::usesFeatureState() const noexcept {
+    return std::visit(
+        [](const auto& typed) {
+            if constexpr (std::is_same_v<std::decay_t<decltype(typed)>, ColorRampPropertyValue>) {
+                return false;
+            } else {
+                return style::usesFeatureState(typed);
+            }
+        },
+        value);
+}
+
+float PluginPropertyValue::interpolationFactor(float bucketZoom, float currentZoom) const noexcept {
+    return std::visit(
+        [&](const auto& typed) {
+            if constexpr (std::is_same_v<std::decay_t<decltype(typed)>, ColorRampPropertyValue>) {
+                return 0.0f;
+            } else {
+                return style::interpolationFactor(typed, bucketZoom, currentZoom);
+            }
+        },
+        value);
+}
+
+const ColorRampPropertyValue* PluginPropertyValue::colorRamp() const noexcept {
+    return std::get_if<ColorRampPropertyValue>(&value);
+}
+
+mln_plugin_value PluginPropertyValue::evaluate(float zoom,
+                                               const GeometryTileFeature& feature,
+                                               const FeatureState& state,
+                                               const plugin::PropertyDefinition& definition,
+                                               EvaluationStorage& storage) const {
+    mln_plugin_value result{};
+    result.struct_size = sizeof(result);
+    result.type = definition.type;
+    switch (definition.type) {
+        case MLN_PLUGIN_VALUE_BOOLEAN:
+            result.data.boolean_value = evaluateTyped(
+                std::get<PropertyValue<bool>>(value), zoom, feature, state, definition);
+            break;
+        case MLN_PLUGIN_VALUE_FLOAT:
+            result.data.float_value = evaluateTyped(
+                std::get<PropertyValue<float>>(value), zoom, feature, state, definition);
+            break;
+        case MLN_PLUGIN_VALUE_FLOAT2: {
+            const auto evaluated = evaluateTyped(
+                std::get<PropertyValue<std::array<float, 2>>>(value), zoom, feature, state, definition);
+            result.data.float2_value = {evaluated[0], evaluated[1]};
+            break;
+        }
+        case MLN_PLUGIN_VALUE_COLOR: {
+            const auto evaluated = evaluateTyped(
+                std::get<PropertyValue<Color>>(value), zoom, feature, state, definition);
+            result.data.color_value = {evaluated.r, evaluated.g, evaluated.b, evaluated.a};
+            break;
+        }
+        case MLN_PLUGIN_VALUE_STRING:
+            storage.string = evaluateTyped(
+                std::get<PropertyValue<std::string>>(value), zoom, feature, state, definition);
+            result.data.string_value = {storage.string.data(), storage.string.size()};
+            break;
+        case MLN_PLUGIN_VALUE_FLOAT_ARRAY:
+            storage.floats = evaluateTyped(
+                std::get<PropertyValue<std::vector<float>>>(value), zoom, feature, state, definition);
+            result.data.float_array_value = {storage.floats.data(), storage.floats.size()};
+            break;
+        case MLN_PLUGIN_VALUE_COLOR_ARRAY: {
+            const auto evaluated = evaluateTyped(
+                std::get<PropertyValue<std::vector<Color>>>(value), zoom, feature, state, definition);
+            storage.colors.clear();
+            storage.colors.reserve(evaluated.size());
+            for (const auto& color : evaluated) storage.colors.push_back({color.r, color.g, color.b, color.a});
+            result.data.color_array_value = {storage.colors.data(), storage.colors.size()};
+            break;
+        }
+        case MLN_PLUGIN_VALUE_COLOR_RAMP: {
+            const auto* ramp = std::get_if<ColorRampPropertyValue>(&value);
+            if (ramp && !ramp->isUndefined()) {
+                storage.string = serializeRamp(*ramp);
+            }
+            result.data.color_ramp_json = {storage.string.data(), storage.string.size()};
+            break;
+        }
+    }
+    return result;
+}
+
+mln_plugin_value PluginPropertyValue::evaluate(float zoom,
+                                               const plugin::PropertyDefinition& definition,
+                                               EvaluationStorage& storage) const {
+    mln_plugin_value result{};
+    result.struct_size = sizeof(result);
+    result.type = definition.type;
+    switch (definition.type) {
+        case MLN_PLUGIN_VALUE_BOOLEAN:
+            result.data.boolean_value = evaluateCameraTyped(std::get<PropertyValue<bool>>(value), zoom, definition);
+            break;
+        case MLN_PLUGIN_VALUE_FLOAT:
+            result.data.float_value = evaluateCameraTyped(std::get<PropertyValue<float>>(value), zoom, definition);
+            break;
+        case MLN_PLUGIN_VALUE_FLOAT2: {
+            const auto evaluated = evaluateCameraTyped(
+                std::get<PropertyValue<std::array<float, 2>>>(value), zoom, definition);
+            result.data.float2_value = {evaluated[0], evaluated[1]};
+            break;
+        }
+        case MLN_PLUGIN_VALUE_COLOR: {
+            const auto evaluated = evaluateCameraTyped(std::get<PropertyValue<Color>>(value), zoom, definition);
+            result.data.color_value = {evaluated.r, evaluated.g, evaluated.b, evaluated.a};
+            break;
+        }
+        case MLN_PLUGIN_VALUE_STRING:
+            storage.string = evaluateCameraTyped(std::get<PropertyValue<std::string>>(value), zoom, definition);
+            result.data.string_value = {storage.string.data(), storage.string.size()};
+            break;
+        case MLN_PLUGIN_VALUE_FLOAT_ARRAY:
+            storage.floats = evaluateCameraTyped(std::get<PropertyValue<std::vector<float>>>(value), zoom, definition);
+            result.data.float_array_value = {storage.floats.data(), storage.floats.size()};
+            break;
+        case MLN_PLUGIN_VALUE_COLOR_ARRAY: {
+            const auto evaluated = evaluateCameraTyped(
+                std::get<PropertyValue<std::vector<Color>>>(value), zoom, definition);
+            storage.colors.clear();
+            storage.colors.reserve(evaluated.size());
+            for (const auto& color : evaluated) storage.colors.push_back({color.r, color.g, color.b, color.a});
+            result.data.color_array_value = {storage.colors.data(), storage.colors.size()};
+            break;
+        }
+        case MLN_PLUGIN_VALUE_COLOR_RAMP: {
+            const auto* ramp = std::get_if<ColorRampPropertyValue>(&value);
+            if (ramp && !ramp->isUndefined()) {
+                storage.string = serializeRamp(*ramp);
+            }
+            result.data.color_ramp_json = {storage.string.data(), storage.string.size()};
+            break;
+        }
+    }
+    return result;
+}
+
+PluginPropertyValue PluginPropertyValue::evaluateCamera(
+    float zoom,
+    const plugin::PropertyDefinition& definition) const {
+    EvaluationStorage storage;
+    const auto evaluated = evaluate(zoom, definition, storage);
+    switch (definition.type) {
+        case MLN_PLUGIN_VALUE_BOOLEAN:
+            return PluginPropertyValue{TypedValue{PropertyValue<bool>{evaluated.data.boolean_value != 0}}};
+        case MLN_PLUGIN_VALUE_FLOAT:
+            return PluginPropertyValue{TypedValue{PropertyValue<float>{evaluated.data.float_value}}};
+        case MLN_PLUGIN_VALUE_FLOAT2:
+            return PluginPropertyValue{TypedValue{PropertyValue<std::array<float, 2>>{
+                {evaluated.data.float2_value.x, evaluated.data.float2_value.y}}}};
+        case MLN_PLUGIN_VALUE_COLOR:
+            return PluginPropertyValue{TypedValue{PropertyValue<Color>{Color{evaluated.data.color_value.r,
+                                                                             evaluated.data.color_value.g,
+                                                                             evaluated.data.color_value.b,
+                                                                             evaluated.data.color_value.a}}}};
+        case MLN_PLUGIN_VALUE_STRING:
+            return PluginPropertyValue{TypedValue{PropertyValue<std::string>{storage.string}}};
+        case MLN_PLUGIN_VALUE_FLOAT_ARRAY:
+            return PluginPropertyValue{TypedValue{PropertyValue<std::vector<float>>{storage.floats}}};
+        case MLN_PLUGIN_VALUE_COLOR_ARRAY: {
+            std::vector<Color> colors;
+            colors.reserve(storage.colors.size());
+            for (const auto& color : storage.colors) {
+                colors.emplace_back(color.r, color.g, color.b, color.a);
+            }
+            return PluginPropertyValue{TypedValue{PropertyValue<std::vector<Color>>{std::move(colors)}}};
+        }
+        case MLN_PLUGIN_VALUE_COLOR_RAMP:
+            return *this;
+    }
+    return *this;
+}
+
+PluginPropertyValue PluginPropertyValue::interpolate(
+    const PluginPropertyValue& from,
+    const PluginPropertyValue& to,
+    float t,
+    const plugin::PropertyDefinition& definition) {
+    switch (definition.type) {
+        case MLN_PLUGIN_VALUE_FLOAT: {
+            const auto& a = std::get<PropertyValue<float>>(from.value).asConstant();
+            const auto& b = std::get<PropertyValue<float>>(to.value).asConstant();
+            return PluginPropertyValue{TypedValue{PropertyValue<float>{util::interpolate(a, b, t)}}};
+        }
+        case MLN_PLUGIN_VALUE_FLOAT2: {
+            const auto& a = std::get<PropertyValue<std::array<float, 2>>>(from.value).asConstant();
+            const auto& b = std::get<PropertyValue<std::array<float, 2>>>(to.value).asConstant();
+            return PluginPropertyValue{
+                TypedValue{PropertyValue<std::array<float, 2>>{util::interpolate(a, b, t)}}};
+        }
+        case MLN_PLUGIN_VALUE_COLOR: {
+            const auto& a = std::get<PropertyValue<Color>>(from.value).asConstant();
+            const auto& b = std::get<PropertyValue<Color>>(to.value).asConstant();
+            return PluginPropertyValue{TypedValue{PropertyValue<Color>{util::interpolate(a, b, t)}}};
+        }
+        default:
+            return t < 1.0f ? from : to;
+    }
+}
+
+PluginTransitioningPropertyValue::PluginTransitioningPropertyValue(
+    PluginPropertyValue value_,
+    PluginTransitioningPropertyValue prior_,
+    const TransitionOptions& transition,
+    TimePoint now)
+    : begin(now + transition.delay.value_or(Duration::zero())),
+      end(begin + transition.duration.value_or(Duration::zero())),
+      value(std::move(value_)) {
+    if (transition.isDefined() && !value.isDataDriven() && !prior_.value.isDataDriven()) {
+        prior = std::make_shared<PluginTransitioningPropertyValue>(std::move(prior_));
+    }
+}
+
+PluginPropertyValue PluginTransitioningPropertyValue::evaluate(
+    float zoom,
+    const plugin::PropertyDefinition& definition,
+    TimePoint now) {
+    if (!prior) return value;
+    if (now >= end) {
+        prior.reset();
+        return value;
+    }
+    if (now < begin) return prior->evaluate(zoom, definition, now);
+    const auto from = prior->evaluate(zoom, definition, now).evaluateCamera(zoom, definition);
+    const auto to = value.evaluateCamera(zoom, definition);
+    const float elapsed = std::chrono::duration<float>(now - begin).count();
+    const float duration = std::chrono::duration<float>(end - begin).count();
+    const auto progress = duration > 0.0f ? std::clamp(elapsed / duration, 0.0f, 1.0f) : 1.0f;
+    const auto eased = static_cast<float>(util::DEFAULT_TRANSITION_EASE.solve(progress, 0.001));
+    return PluginPropertyValue::interpolate(from, to, eased, definition);
+}
+
+PluginPropertyValue defaultPluginPropertyValue(const plugin::PropertyDefinition& definition) {
+    switch (definition.type) {
+        case MLN_PLUGIN_VALUE_BOOLEAN:
+            return PluginPropertyValue{
+                PluginPropertyValue::TypedValue{PropertyValue<bool>{defaultValue<bool>(definition)}}};
+        case MLN_PLUGIN_VALUE_FLOAT:
+            return PluginPropertyValue{
+                PluginPropertyValue::TypedValue{PropertyValue<float>{defaultValue<float>(definition)}}};
+        case MLN_PLUGIN_VALUE_FLOAT2:
+            return PluginPropertyValue{PluginPropertyValue::TypedValue{
+                PropertyValue<std::array<float, 2>>{defaultValue<std::array<float, 2>>(definition)}}};
+        case MLN_PLUGIN_VALUE_COLOR:
+            return PluginPropertyValue{
+                PluginPropertyValue::TypedValue{PropertyValue<Color>{defaultValue<Color>(definition)}}};
+        case MLN_PLUGIN_VALUE_STRING:
+            return PluginPropertyValue{
+                PluginPropertyValue::TypedValue{PropertyValue<std::string>{defaultValue<std::string>(definition)}}};
+        case MLN_PLUGIN_VALUE_FLOAT_ARRAY:
+            return PluginPropertyValue{PluginPropertyValue::TypedValue{
+                PropertyValue<std::vector<float>>{defaultValue<std::vector<float>>(definition)}}};
+        case MLN_PLUGIN_VALUE_COLOR_ARRAY:
+            return PluginPropertyValue{PluginPropertyValue::TypedValue{
+                PropertyValue<std::vector<Color>>{defaultValue<std::vector<Color>>(definition)}}};
+        case MLN_PLUGIN_VALUE_COLOR_RAMP: {
+            conversion::Error error;
+            const auto* json = definition.defaultValue.getString();
+            auto converted = json ? conversion::convertJSON<ColorRampPropertyValue>(*json, error) : std::nullopt;
+            return converted ? PluginPropertyValue{PluginPropertyValue::TypedValue{std::move(*converted)}}
+                             : PluginPropertyValue{};
+        }
+    }
+    return {};
+}
+
+std::optional<PluginPropertyValue> convertPluginPropertyValue(const plugin::PropertyDefinition& definition,
+                                                              const conversion::Convertible& value,
+                                                              conversion::Error& error) {
+    const bool arrayValue = definition.type == MLN_PLUGIN_VALUE_FLOAT_ARRAY ||
+                            definition.type == MLN_PLUGIN_VALUE_COLOR_ARRAY;
+    if (arrayValue && !definition.acceptsScalar && !isArray(value) && !isObject(value)) {
+        error.message = "value must be an array for plugin property '" + definition.name + "'";
+        return std::nullopt;
+    }
+
+    std::optional<PluginPropertyValue> converted;
+    switch (definition.type) {
+        case MLN_PLUGIN_VALUE_BOOLEAN:
+            converted = convertTyped<bool>(definition, value, error);
+            break;
+        case MLN_PLUGIN_VALUE_FLOAT:
+            converted = convertTyped<float>(definition, value, error);
+            break;
+        case MLN_PLUGIN_VALUE_FLOAT2:
+            converted = convertTyped<std::array<float, 2>>(definition, value, error);
+            break;
+        case MLN_PLUGIN_VALUE_COLOR:
+            converted = convertTyped<Color>(definition, value, error);
+            break;
+        case MLN_PLUGIN_VALUE_STRING:
+            converted = convertTyped<std::string>(definition, value, error);
+            break;
+        case MLN_PLUGIN_VALUE_FLOAT_ARRAY:
+            converted = convertTyped<std::vector<float>>(definition, value, error);
+            break;
+        case MLN_PLUGIN_VALUE_COLOR_ARRAY:
+            converted = convertTyped<std::vector<Color>>(definition, value, error);
+            break;
+        case MLN_PLUGIN_VALUE_COLOR_RAMP: {
+            auto ramp = conversion::convert<ColorRampPropertyValue>(value, error, false, false);
+            if (ramp) converted = PluginPropertyValue{PluginPropertyValue::TypedValue{std::move(*ramp)}};
+            break;
+        }
+    }
+    if (converted && !validateConstant(definition, *converted, error)) return std::nullopt;
+    if (converted) {
+        const auto dependencies = converted->getDependencies();
+        const bool usesZoom = static_cast<bool>(dependencies & expression::Dependency::Zoom);
+        const bool usesFeature = static_cast<bool>(dependencies & expression::Dependency::Feature);
+        uint32_t required = MLN_PLUGIN_EXPRESSION_NONE;
+        if (usesZoom && usesFeature) {
+            required |= MLN_PLUGIN_EXPRESSION_COMPOSITE;
+        } else if (usesZoom) {
+            required |= MLN_PLUGIN_EXPRESSION_CAMERA;
+        } else if (usesFeature) {
+            required |= MLN_PLUGIN_EXPRESSION_FEATURE;
+        }
+        if (converted->usesFeatureState()) required |= MLN_PLUGIN_EXPRESSION_FEATURE_STATE;
+        if ((required & ~definition.expressionCapabilities) != 0) {
+            error.message = "expression dependencies are not supported for plugin property '" + definition.name + "'";
+            return std::nullopt;
+        }
+    }
+    return converted;
+}
+
+} // namespace style
+} // namespace mln


### PR DESCRIPTION
## Scope

Keep typed plugin properties in the dedicated plugin layer, with expressions/transitions/serialization. Add host-owned packed dynamic paint buffers and enum ordinal encoding.

Depends on #4590; review only against its base branch. Layer 6/11.

1359 changed lines (+1310/-49). Within the approximately 2,000-line review budget.

This is a staged implementation foundation. Declarations/compilation units land before build wiring; plugin layer availability is connected in #4593. It is not a separately released partial ABI.

## Validation and landing

At the integrated stack tip: 19 focused core tests and 108 Metal render tests pass. The n-gon plugin builds as an Android AAR for all four ABIs and through SwiftPM/Bazel. N-gon Vulkan images pass; the full MoltenVK run has two retained heatmap/hillshade image mismatches. OpenGL ES shader variants compile, but runtime OpenGL validation is still needed on a supported ES 3 test environment.

These are deliberately draft PRs. Build jobs are skipped before runner allocation; marking a PR ready triggers normal checks. Merge only in dependency order after those checks pass. Lightweight metadata/pre-commit services may still operate.

Companion plugin stack: https://github.com/louwers/maplibre-native-plugin-template/pull/1

Roadmap: [Incremental plugin introduction](https://github.com/maplibre/maplibre-native/blob/plugins/01-draft-ci/design-proposals/2026-09-08-plugin-introduction.md).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
