### PR TITLE
feat: adapt source-tile layout and backend shaders to plugin callbacks

### DIFF
--- a/src/mln/layout/plugin_layout.cpp
+++ b/src/mln/layout/plugin_layout.cpp
@@ -470,14 +470,16 @@ void PluginLayout::createBucket(const ImagePositions&,
                 range.feature_index < sourceLayer->featureCount() && drawable != drawableVertexCounts.end() &&
                 range.vertex_count > 0 && validRange(range.first_vertex, range.vertex_count, drawable->second);
         if (valid) {
-            bucket->featureVertexRanges.push_back(
-                {static_cast<std::size_t>(range.feature_index), range.drawable_key, range.first_vertex, range.vertex_count});
+            bucket->featureVertexRanges.push_back({static_cast<std::size_t>(range.feature_index),
+                                                   range.drawable_key,
+                                                   range.first_vertex,
+                                                   range.vertex_count});
         }
     }
     for (const auto& drawable : bucket->drawables) {
-        const auto shader = std::find_if(registration.shaders.begin(), registration.shaders.end(), [&](const auto& candidate) {
-            return candidate.id == drawable.shaderID;
-        });
+        const auto shader = std::find_if(registration.shaders.begin(),
+                                         registration.shaders.end(),
+                                         [&](const auto& candidate) { return candidate.id == drawable.shaderID; });
         if (!valid || shader == registration.shaders.end() || shader->propertyBindings.empty()) continue;
         std::vector<uint8_t> coverage(drawable.vertexCount);
         for (const auto& range : bucket->featureVertexRanges) {
@@ -504,9 +506,9 @@ void PluginLayout::createBucket(const ImagePositions&,
         const auto& impl = static_cast<const style::PluginStyleLayer::Impl&>(*layer->baseImpl);
         auto& layerBinders = bucket->paintPropertyBinders[impl.id];
         for (const auto& drawable : bucket->drawables) {
-            const auto shader = std::find_if(registration.shaders.begin(), registration.shaders.end(), [&](const auto& candidate) {
-                return candidate.id == drawable.shaderID;
-            });
+            const auto shader = std::find_if(registration.shaders.begin(),
+                                             registration.shaders.end(),
+                                             [&](const auto& candidate) { return candidate.id == drawable.shaderID; });
             if (shader == registration.shaders.end() || shader->propertyBindings.empty()) continue;
             layerBinders.emplace(std::piecewise_construct,
                                  std::forward_as_tuple(drawable.key),

--- a/src/mln/layout/plugin_layout.cpp
+++ b/src/mln/layout/plugin_layout.cpp
@@ -1,0 +1,533 @@
+#include <mln/layout/plugin_layout.hpp>
+
+#include <mln/geometry/feature_index.hpp>
+#include <mln/renderer/buckets/plugin_bucket.hpp>
+#include <mln/renderer/render_layer.hpp>
+#include <mln/storage/file_source.hpp>
+#include <mln/storage/resource.hpp>
+#include <mln/style/conversion/stringify.hpp>
+#include <mln/style/layers/plugin_style_layer.hpp>
+#include <mln/util/constants.hpp>
+#include <mln/util/logging.hpp>
+#include <mln/util/rapidjson.hpp>
+#include <mln/util/run_loop.hpp>
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <cstring>
+#include <limits>
+#include <set>
+#include <thread>
+
+namespace mln {
+namespace {
+
+mln_plugin_string borrowed(const std::string& value) {
+    return {value.data(), value.size()};
+}
+
+std::string featurePropertiesJSON(const GeometryTileFeature& feature) {
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    style::conversion::stringify(writer, feature.getProperties());
+    return {buffer.GetString(), buffer.GetSize()};
+}
+
+std::string valueJSON(const Value& value) {
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    style::conversion::stringify(writer, value);
+    return {buffer.GetString(), buffer.GetSize()};
+}
+
+mln_plugin_geometry_type geometryType(FeatureType type) {
+    switch (type) {
+        case FeatureType::Point:
+            return MLN_PLUGIN_GEOMETRY_POINT;
+        case FeatureType::LineString:
+            return MLN_PLUGIN_GEOMETRY_LINESTRING;
+        case FeatureType::Polygon:
+            return MLN_PLUGIN_GEOMETRY_POLYGON;
+        case FeatureType::Unknown:
+            return static_cast<mln_plugin_geometry_type>(0);
+    }
+    return static_cast<mln_plugin_geometry_type>(0);
+}
+
+bool validRange(std::size_t offset, std::size_t length, std::size_t size) {
+    return offset <= size && length <= size - offset;
+}
+
+std::size_t attributeSize(mln_plugin_vertex_attribute_type type) {
+    switch (type) {
+        case MLN_PLUGIN_VERTEX_INT16:
+        case MLN_PLUGIN_VERTEX_UINT16:
+            return 2;
+        case MLN_PLUGIN_VERTEX_INT16_X2:
+        case MLN_PLUGIN_VERTEX_UINT16_X2:
+        case MLN_PLUGIN_VERTEX_FLOAT:
+        case MLN_PLUGIN_VERTEX_UINT8_X4_NORMALIZED:
+            return 4;
+        case MLN_PLUGIN_VERTEX_FLOAT_X2:
+            return 8;
+        case MLN_PLUGIN_VERTEX_FLOAT_X3:
+            return 12;
+        case MLN_PLUGIN_VERTEX_FLOAT_X4:
+            return 16;
+    }
+    return 0;
+}
+
+bool validDrawMode(mln_plugin_draw_mode mode) {
+    return mode == MLN_PLUGIN_DRAW_MODE_TRIANGLES || mode == MLN_PLUGIN_DRAW_MODE_LINES ||
+           mode == MLN_PLUGIN_DRAW_MODE_POINTS;
+}
+
+bool validDepthMode(mln_plugin_depth_mode mode) {
+    return mode >= MLN_PLUGIN_DEPTH_DISABLED && mode <= MLN_PLUGIN_DEPTH_READ_WRITE;
+}
+
+bool validBlendMode(mln_plugin_blend_mode mode) {
+    return mode >= MLN_PLUGIN_BLEND_REPLACE && mode <= MLN_PLUGIN_BLEND_ADDITIVE;
+}
+
+class LayoutResourceHost {
+public:
+    explicit LayoutResourceHost(std::shared_ptr<FileSource> fileSource_)
+        : fileSource(std::move(fileSource_)) {
+        api.struct_size = sizeof(api);
+        api.abi_version = MLN_PLUGIN_ABI_VERSION_1;
+        api.log = log;
+        api.context = this;
+        api.request_resource = requestResource;
+        api.cancel_resource_request = cancelResourceRequest;
+        api.request_repaint = requestRepaint;
+    }
+
+    const mln_plugin_host_api_v1* getAPI() const noexcept { return &api; }
+
+private:
+    static void log(int32_t severity, mln_plugin_string message) {
+        const std::string text = message.data ? std::string(message.data, message.size) : std::string{};
+        if (severity >= 3) {
+            Log::Error(Event::Style, text);
+        } else if (severity == 2) {
+            Log::Warning(Event::Style, text);
+        } else {
+            Log::Info(Event::Style, text);
+        }
+    }
+
+    static mln_plugin_status requestResource(void* context,
+                                             mln_plugin_string url,
+                                             mln_plugin_resource_callback_fn callback,
+                                             void* callbackContext,
+                                             uint64_t* requestID) {
+        auto* self = static_cast<LayoutResourceHost*>(context);
+        if (!self || !self->fileSource || !url.data || !url.size || !callback || !requestID) {
+            return MLN_PLUGIN_STATUS_INVALID_ARGUMENT;
+        }
+        const auto id = self->nextRequestID++;
+        *requestID = id;
+        const std::string resourceURL(url.data, url.size);
+        Response response;
+        bool receivedResponse = false;
+        auto fileSource = self->fileSource;
+        // FileSource delivers onto the scheduler that starts a request. Layout
+        // callbacks already run on a tile worker, so waiting for a request
+        // started there would deadlock that scheduler. Give the resource its
+        // own short-lived run loop and return its result on the layout thread.
+        std::thread loader([&] {
+            // A layout request runs on its own worker thread. On libuv
+            // platforms the default RunLoop is process-global and may already
+            // be active on the renderer thread, so this bridge needs an
+            // independent loop to receive the FileSource callback.
+            util::RunLoop runLoop(util::RunLoop::Type::New);
+            auto request = fileSource->request(Resource(Resource::Kind::Unknown, resourceURL), [&](Response result) {
+                response = std::move(result);
+                receivedResponse = true;
+                runLoop.stop();
+            });
+            if (!request) return;
+            runLoop.run();
+        });
+        loader.join();
+        if (!receivedResponse) return MLN_PLUGIN_STATUS_CALLBACK_ERROR;
+
+        std::string error;
+        if (response.error) error = response.error->message;
+        mln_plugin_resource_response_v1 result{};
+        result.struct_size = sizeof(result);
+        result.request_id = id;
+        if (response.data) {
+            result.data = reinterpret_cast<const uint8_t*>(response.data->data());
+            result.data_size = response.data->size();
+        }
+        result.error_message = {error.data(), error.size()};
+        callback(callbackContext, &result);
+        return MLN_PLUGIN_STATUS_OK;
+    }
+
+    static void cancelResourceRequest(void*, uint64_t) {}
+
+    static void requestRepaint(void*) {}
+
+    mln_plugin_host_api_v1 api{};
+    std::shared_ptr<FileSource> fileSource;
+    uint64_t nextRequestID = 1;
+};
+
+} // namespace
+
+PluginLayout::PluginLayout(const BucketParameters& parameters,
+                           std::vector<Immutable<style::LayerProperties>> layers_,
+                           std::unique_ptr<GeometryTileLayer> sourceLayer_,
+                           plugin::LayerType registration_)
+    : tileID(parameters.tileID),
+      zoom(parameters.tileID.overscaledZ),
+      fileSource(parameters.fileSource),
+      layers(std::move(layers_)),
+      sourceLayer(std::move(sourceLayer_)),
+      registration(std::move(registration_)) {}
+
+void PluginLayout::createBucket(const ImagePositions&,
+                                std::unique_ptr<FeatureIndex>& featureIndex,
+                                mln::unordered_map<std::string, LayerRenderData>& renderData,
+                                bool,
+                                bool,
+                                const CanonicalTileID& canonical) {
+    if (!sourceLayer || layers.empty()) return;
+
+    const auto& leader = static_cast<const style::PluginStyleLayer::Impl&>(*layers.front()->baseImpl);
+    const auto propertyDefinitions = plugin::PluginRegistry::get().propertiesForLayer(registration.type);
+    std::vector<mln_plugin_property_value_v1> properties;
+    std::vector<std::string> propertyStrings(propertyDefinitions.size());
+    std::vector<std::vector<float>> propertyFloatArrays(propertyDefinitions.size());
+    std::vector<std::vector<mln_plugin_color>> propertyColorArrays(propertyDefinitions.size());
+    properties.reserve(propertyDefinitions.size());
+    for (size_t propertyIndex = 0; propertyIndex < propertyDefinitions.size(); ++propertyIndex) {
+        const auto& definition = propertyDefinitions[propertyIndex];
+        mln_plugin_property_value_v1 property{};
+        property.struct_size = sizeof(property);
+        property.name = borrowed(definition.name);
+        property.value.struct_size = sizeof(property.value);
+        property.value.type = definition.type;
+        const auto it = leader.pluginProperties.find(definition.name);
+        const auto styleProperty = it == leader.pluginProperties.end() ? style::StyleProperty{}
+                                                                       : it->second.toStyleProperty();
+        const auto& value = styleProperty.getKind() == style::StyleProperty::Kind::Constant ? styleProperty.getValue()
+                                                                                            : definition.defaultValue;
+        property.explicitly_set = it != leader.pluginProperties.end();
+        switch (definition.type) {
+            case MLN_PLUGIN_VALUE_BOOLEAN:
+                property.value.data.boolean_value = value.getBool() && *value.getBool();
+                break;
+            case MLN_PLUGIN_VALUE_FLOAT:
+                property.value.data.float_value = static_cast<float>(numericValue<double>(value).value_or(0.0));
+                break;
+            case MLN_PLUGIN_VALUE_FLOAT2:
+            case MLN_PLUGIN_VALUE_COLOR: {
+                const auto* array = value.getArray();
+                const auto number = [&](size_t index) {
+                    return array && index < array->size() ? numericValue<float>((*array)[index]).value_or(0.0f) : 0.0f;
+                };
+                if (definition.type == MLN_PLUGIN_VALUE_FLOAT2) {
+                    property.value.data.float2_value = {number(0), number(1)};
+                } else {
+                    property.value.data.color_value = {number(0), number(1), number(2), number(3)};
+                }
+                break;
+            }
+            case MLN_PLUGIN_VALUE_STRING: {
+                const auto* string = value.getString();
+                if (string) propertyStrings[propertyIndex] = *string;
+                property.value.data.string_value = borrowed(propertyStrings[propertyIndex]);
+                break;
+            }
+            case MLN_PLUGIN_VALUE_FLOAT_ARRAY: {
+                const auto* array = value.getArray();
+                auto& output = propertyFloatArrays[propertyIndex];
+                if (array) {
+                    output.reserve(array->size());
+                    for (const auto& item : *array) {
+                        output.push_back(numericValue<float>(item).value_or(0.0f));
+                    }
+                }
+                property.value.data.float_array_value = {output.data(), output.size()};
+                break;
+            }
+            case MLN_PLUGIN_VALUE_COLOR_ARRAY: {
+                const auto* array = value.getArray();
+                auto& output = propertyColorArrays[propertyIndex];
+                if (array) {
+                    output.reserve(array->size());
+                    for (const auto& item : *array) {
+                        const auto* components = item.getArray();
+                        if (!components || components->size() != 4) continue;
+                        output.push_back({numericValue<float>((*components)[0]).value_or(0.0f),
+                                          numericValue<float>((*components)[1]).value_or(0.0f),
+                                          numericValue<float>((*components)[2]).value_or(0.0f),
+                                          numericValue<float>((*components)[3]).value_or(0.0f)});
+                    }
+                }
+                property.value.data.color_array_value = {output.data(), output.size()};
+                break;
+            }
+            case MLN_PLUGIN_VALUE_COLOR_RAMP:
+                propertyStrings[propertyIndex] = valueJSON(value);
+                property.value.data.color_ramp_json = borrowed(propertyStrings[propertyIndex]);
+                break;
+        }
+        properties.push_back(property);
+    }
+
+    LayoutResourceHost resourceHost(fileSource);
+    mln_plugin_layout_context_v1 context{};
+    context.struct_size = sizeof(context);
+    context.zoom = zoom;
+    context.canonical_z = canonical.z;
+    context.canonical_x = canonical.x;
+    context.canonical_y = canonical.y;
+    context.extent = util::EXTENT;
+    context.layer_id = borrowed(leader.id);
+    context.source_layer_id = borrowed(leader.sourceLayer);
+    context.properties = properties.data();
+    context.property_count = properties.size();
+    context.host = resourceHost.getAPI();
+
+    void* layoutInstance = nullptr;
+    if (registration.createLayout(&context, &layoutInstance) != MLN_PLUGIN_STATUS_OK || !layoutInstance) {
+        Log::Error(Event::Style, "Plugin layer '" + leader.id + "' failed to create a layout instance");
+        return;
+    }
+    const auto destroyLayout = [&] {
+        registration.destroyLayout(layoutInstance);
+    };
+
+    for (std::size_t i = 0; i < sourceLayer->featureCount(); ++i) {
+        auto feature = sourceLayer->getFeature(i);
+        if (!feature) continue;
+        const auto type = geometryType(feature->getType());
+        if (type == 0 || (registration.geometryTypeMask & type) == 0) continue;
+        if (!leader.filter(style::expression::EvaluationContext(zoom, feature.get()).withCanonicalTileID(&canonical))) {
+            continue;
+        }
+
+        const auto& geometry = feature->getGeometries();
+        std::vector<mln_plugin_tile_point_v1> points;
+        std::vector<uint32_t> offsets;
+        offsets.reserve(geometry.size() + 1);
+        offsets.push_back(0);
+        for (const auto& path : geometry) {
+            points.reserve(points.size() + path.size());
+            for (const auto& point : path) points.push_back({point.x, point.y});
+            offsets.push_back(static_cast<uint32_t>(points.size()));
+        }
+
+        const auto id = featureIDtoString(feature->getID()).value_or(std::string{});
+        const auto propertiesJSON = featurePropertiesJSON(*feature);
+        mln_plugin_feature_v1 pluginFeature{};
+        pluginFeature.struct_size = sizeof(pluginFeature);
+        pluginFeature.geometry_type = type;
+        pluginFeature.feature_index = i;
+        pluginFeature.feature_id = borrowed(id);
+        pluginFeature.points = points.data();
+        pluginFeature.point_count = points.size();
+        pluginFeature.path_offsets = offsets.data();
+        pluginFeature.path_count = geometry.size();
+        pluginFeature.properties_json = borrowed(propertiesJSON);
+        // Paint expressions are evaluated by the host-owned binders after the
+        // plugin has described its geometry. The evaluated property channel is
+        // reserved for query callbacks, where values are specific to the
+        // queried feature and current feature state.
+        pluginFeature.evaluated_properties = nullptr;
+        pluginFeature.evaluated_property_count = 0;
+        if (registration.layoutFeature(layoutInstance, &pluginFeature) != MLN_PLUGIN_STATUS_OK) {
+            Log::Error(Event::Style, "Plugin layer '" + leader.id + "' failed while laying out a feature");
+            destroyLayout();
+            return;
+        }
+        featureIndex->insert(geometry, i, leader.sourceLayer, leader.id);
+    }
+
+    mln_plugin_bucket_v1 output{};
+    output.struct_size = sizeof(output);
+    if (registration.finishLayout(layoutInstance, &output) != MLN_PLUGIN_STATUS_OK) {
+        Log::Error(Event::Style, "Plugin layer '" + leader.id + "' failed to finish its bucket");
+        destroyLayout();
+        return;
+    }
+
+    auto bucket = std::make_shared<PluginBucket>(registration);
+    std::set<uint32_t> streamIDs;
+    bool valid = output.query_radius >= 0.0f && (output.vertex_stream_count == 0 || output.vertex_streams) &&
+                 (output.index_count == 0 || output.indices) && (output.drawable_count == 0 || output.drawables);
+    for (size_t i = 0; valid && i < output.vertex_stream_count; ++i) {
+        const auto& stream = output.vertex_streams[i];
+        valid = stream.struct_size >= sizeof(stream) && stream.stride > 0 && stream.vertex_count > 0 && stream.data &&
+                stream.vertex_count <= std::numeric_limits<size_t>::max() / stream.stride &&
+                stream.data_size == static_cast<size_t>(stream.stride) * stream.vertex_count &&
+                streamIDs.emplace(stream.stream_id).second;
+        if (valid) {
+            std::vector<uint8_t> copied(stream.data_size);
+            std::memcpy(copied.data(), stream.data, copied.size());
+            bucket->vertexStreams.emplace(
+                stream.stream_id,
+                std::make_shared<PluginVertexVector>(std::move(copied), stream.vertex_count, stream.stride));
+        }
+    }
+    if (valid) {
+        std::vector<uint16_t> indices;
+        if (output.index_count) indices.assign(output.indices, output.indices + output.index_count);
+        bucket->indices = std::make_shared<gfx::IndexVectorBase>(std::move(indices));
+    }
+
+    std::set<uint64_t> drawableKeys;
+    for (size_t i = 0; valid && i < output.drawable_count; ++i) {
+        const auto& input = output.drawables[i];
+        valid = input.struct_size >= sizeof(input) && input.shader_id.data && input.shader_id.size &&
+                input.attribute_count && input.attributes && input.segment_count && input.segments &&
+                input.render_stage == registration.renderStage && validDrawMode(input.draw_mode) &&
+                validDepthMode(input.depth_mode) && validBlendMode(input.blend_mode) &&
+                drawableKeys.emplace(input.drawable_key).second;
+        PluginDrawableDefinition drawable;
+        if (!valid) break;
+        drawable.key = input.drawable_key;
+        drawable.shaderID.assign(input.shader_id.data, input.shader_id.size);
+        const auto shaderIt = std::find_if(registration.shaders.begin(),
+                                           registration.shaders.end(),
+                                           [&](const auto& shader) { return shader.id == drawable.shaderID; });
+        std::set<uint32_t> hostAttributeIDs;
+        if (shaderIt != registration.shaders.end()) {
+            for (const auto& binding : shaderIt->propertyBindings) {
+                hostAttributeIDs.emplace(binding.minimumAttributeID);
+                hostAttributeIDs.emplace(binding.maximumAttributeID);
+            }
+        }
+        valid = shaderIt != registration.shaders.end() &&
+                input.attribute_count + hostAttributeIDs.size() == shaderIt->attributes.size();
+        if (!valid) break;
+        drawable.drawMode = input.draw_mode;
+        drawable.renderStage = input.render_stage;
+        drawable.depthMode = input.depth_mode;
+        drawable.blendMode = input.blend_mode;
+        drawable.enableStencil = input.enable_stencil != 0;
+        drawable.enableCullFace = input.enable_cull_face != 0;
+        std::set<uint32_t> boundAttributeIDs;
+        std::optional<std::size_t> drawableVertexCount;
+        for (size_t bindingIndex = 0; valid && bindingIndex < input.attribute_count; ++bindingIndex) {
+            const auto& binding = input.attributes[bindingIndex];
+            const auto streamIt = bucket->vertexStreams.find(binding.stream_id);
+            const auto attributeIt = std::find_if(
+                shaderIt->attributes.begin(), shaderIt->attributes.end(), [&](const auto& attribute) {
+                    return attribute.id == binding.attribute_id;
+                });
+            const auto size = attributeSize(binding.type);
+            valid = binding.struct_size >= sizeof(binding) && streamIt != bucket->vertexStreams.end() &&
+                    attributeIt != shaderIt->attributes.end() && attributeIt->type == binding.type && size > 0 &&
+                    hostAttributeIDs.find(binding.attribute_id) == hostAttributeIDs.end() &&
+                    binding.byte_offset <= streamIt->second->getRawSize() &&
+                    size <= streamIt->second->getRawSize() - binding.byte_offset &&
+                    boundAttributeIDs.emplace(binding.attribute_id).second &&
+                    (!drawableVertexCount || *drawableVertexCount == streamIt->second->getRawCount());
+            if (valid) {
+                drawableVertexCount = streamIt->second->getRawCount();
+                drawable.attributes.push_back(
+                    {binding.attribute_id, binding.stream_id, binding.byte_offset, binding.type});
+            }
+        }
+        if (drawableVertexCount) drawable.vertexCount = *drawableVertexCount;
+        for (size_t segmentIndex = 0; valid && segmentIndex < input.segment_count; ++segmentIndex) {
+            const auto& segment = input.segments[segmentIndex];
+            valid = segment.struct_size >= sizeof(segment) &&
+                    validRange(segment.index_offset, segment.index_length, output.index_count) && drawableVertexCount &&
+                    validRange(segment.vertex_offset, segment.vertex_length, *drawableVertexCount);
+            if (valid) {
+                for (size_t index = segment.index_offset; index < segment.index_offset + segment.index_length;
+                     ++index) {
+                    if (output.indices[index] >= segment.vertex_length) {
+                        valid = false;
+                        break;
+                    }
+                }
+            }
+            if (valid) {
+                drawable.segments.emplace_back(
+                    segment.vertex_offset, segment.index_offset, segment.vertex_length, segment.index_length);
+            }
+        }
+        if (valid) bucket->drawables.push_back(std::move(drawable));
+    }
+
+    if (valid && output.feature_vertex_range_count && !output.feature_vertex_ranges) valid = false;
+    std::map<uint64_t, std::size_t> drawableVertexCounts;
+    for (const auto& drawable : bucket->drawables) drawableVertexCounts.emplace(drawable.key, drawable.vertexCount);
+    for (size_t rangeIndex = 0; valid && rangeIndex < output.feature_vertex_range_count; ++rangeIndex) {
+        const auto& range = output.feature_vertex_ranges[rangeIndex];
+        const auto drawable = drawableVertexCounts.find(range.drawable_key);
+        valid = range.struct_size >= sizeof(mln_plugin_feature_vertex_range_v1) &&
+                range.feature_index < sourceLayer->featureCount() && drawable != drawableVertexCounts.end() &&
+                range.vertex_count > 0 && validRange(range.first_vertex, range.vertex_count, drawable->second);
+        if (valid) {
+            bucket->featureVertexRanges.push_back(
+                {static_cast<std::size_t>(range.feature_index), range.drawable_key, range.first_vertex, range.vertex_count});
+        }
+    }
+    for (const auto& drawable : bucket->drawables) {
+        const auto shader = std::find_if(registration.shaders.begin(), registration.shaders.end(), [&](const auto& candidate) {
+            return candidate.id == drawable.shaderID;
+        });
+        if (!valid || shader == registration.shaders.end() || shader->propertyBindings.empty()) continue;
+        std::vector<uint8_t> coverage(drawable.vertexCount);
+        for (const auto& range : bucket->featureVertexRanges) {
+            if (range.drawableKey != drawable.key) continue;
+            for (std::size_t vertex = range.firstVertex; vertex < range.firstVertex + range.vertexCount; ++vertex) {
+                if (coverage[vertex] != 0) {
+                    valid = false;
+                    break;
+                }
+                coverage[vertex] = 1;
+            }
+            if (!valid) break;
+        }
+        if (valid && std::find(coverage.begin(), coverage.end(), 0) != coverage.end()) valid = false;
+    }
+    bucket->queryRadius = output.query_radius;
+
+    if (!valid) {
+        destroyLayout();
+        Log::Error(Event::Style, "Plugin layer '" + leader.id + "' returned a malformed bucket");
+        return;
+    }
+    for (const auto& layer : layers) {
+        const auto& impl = static_cast<const style::PluginStyleLayer::Impl&>(*layer->baseImpl);
+        auto& layerBinders = bucket->paintPropertyBinders[impl.id];
+        for (const auto& drawable : bucket->drawables) {
+            const auto shader = std::find_if(registration.shaders.begin(), registration.shaders.end(), [&](const auto& candidate) {
+                return candidate.id == drawable.shaderID;
+            });
+            if (shader == registration.shaders.end() || shader->propertyBindings.empty()) continue;
+            layerBinders.emplace(std::piecewise_construct,
+                                 std::forward_as_tuple(drawable.key),
+                                 std::forward_as_tuple(registration,
+                                                       *shader,
+                                                       drawable.key,
+                                                       drawable.vertexCount,
+                                                       zoom,
+                                                       impl.pluginProperties,
+                                                       bucket->featureVertexRanges,
+                                                       *sourceLayer));
+        }
+        bucket->updateQueryRadius(impl.id, impl.pluginProperties, zoom);
+    }
+    destroyLayout();
+    if (!bucket->hasData()) return;
+
+    for (const auto& layer : layers) {
+        const auto& impl = static_cast<const style::PluginStyleLayer::Impl&>(*layer->baseImpl);
+        renderData.emplace(impl.id, LayerRenderData{.bucket = bucket, .layerProperties = layer});
+    }
+}
+
+} // namespace mln

--- a/src/mln/plugin/plugin_shader.cpp
+++ b/src/mln/plugin/plugin_shader.cpp
@@ -1,0 +1,224 @@
+#include <mln/plugin/plugin_shader.hpp>
+
+#include <mln/gfx/backend.hpp>
+#include <mln/gfx/gfx_types.hpp>
+#include <mln/gfx/shader_group.hpp>
+#include <mln/gfx/shader_registry.hpp>
+#include <mln/plugin/plugin_registry.hpp>
+#include <mln/shaders/program_parameters.hpp>
+#include <mln/shaders/shader_defines.hpp>
+#include <mln/util/logging.hpp>
+
+#if MLN_RENDER_BACKEND_OPENGL
+#include <mln/gl/context.hpp>
+#include <mln/shaders/gl/shader_info.hpp>
+#include <mln/shaders/gl/shader_program_gl.hpp>
+#elif MLN_RENDER_BACKEND_VULKAN
+#include <mln/vulkan/context.hpp>
+#include <mln/shaders/vulkan/shader_program.hpp>
+#elif MLN_RENDER_BACKEND_METAL
+#include <mln/mtl/context.hpp>
+#include <mln/shaders/mtl/common.hpp>
+#include <mln/shaders/mtl/shader_program.hpp>
+#endif
+
+#include <stdexcept>
+#include <sstream>
+#include <cctype>
+
+namespace mln {
+namespace plugin {
+namespace {
+
+#if MLN_RENDER_BACKEND_VULKAN || MLN_RENDER_BACKEND_METAL
+gfx::AttributeDataType attributeType(mln_plugin_vertex_attribute_type type) {
+    switch (type) {
+        case MLN_PLUGIN_VERTEX_INT16:
+            return gfx::AttributeDataType::Short;
+        case MLN_PLUGIN_VERTEX_INT16_X2:
+            return gfx::AttributeDataType::Short2;
+        case MLN_PLUGIN_VERTEX_UINT16:
+            return gfx::AttributeDataType::UShort;
+        case MLN_PLUGIN_VERTEX_UINT16_X2:
+            return gfx::AttributeDataType::UShort2;
+        case MLN_PLUGIN_VERTEX_FLOAT:
+            return gfx::AttributeDataType::Float;
+        case MLN_PLUGIN_VERTEX_FLOAT_X2:
+            return gfx::AttributeDataType::Float2;
+        case MLN_PLUGIN_VERTEX_FLOAT_X3:
+            return gfx::AttributeDataType::Float3;
+        case MLN_PLUGIN_VERTEX_FLOAT_X4:
+            return gfx::AttributeDataType::Float4;
+        case MLN_PLUGIN_VERTEX_UINT8_X4_NORMALIZED:
+            return gfx::AttributeDataType::UByte4;
+    }
+    return gfx::AttributeDataType::Invalid;
+}
+#endif
+
+#if MLN_RENDER_BACKEND_OPENGL || MLN_RENDER_BACKEND_VULKAN || MLN_RENDER_BACKEND_METAL
+const ShaderSource* findSource(const ShaderDefinition& shader, mln_plugin_backend backend) {
+    for (const auto& source : shader.sources) {
+        if (source.backend == backend) return &source;
+    }
+    return nullptr;
+}
+#endif
+
+std::string resourcePrelude(const ShaderDefinition& shader) {
+    std::ostringstream output;
+    for (const auto& uniform : shader.uniformBlocks) {
+        auto bindingID = uniform.bindingID;
+#if MLN_RENDER_BACKEND_VULKAN
+        // Uniform arrays use MapLibre's global IDs, while Vulkan descriptor
+        // bindings are local to their descriptor set. Built-in shaders perform
+        // this same mapping through their backend-specific prelude constants.
+        bindingID -= uniform.scope == MLN_PLUGIN_UNIFORM_SCOPE_LAYER ? shaders::layerSSBOStartId
+                                                                     : shaders::drawableSSBOStartId;
+#endif
+        output << "#define MLN_PLUGIN_UNIFORM_" << uniform.id << "_BINDING " << bindingID << '\n';
+    }
+    for (const auto& texture : shader.textures) {
+        output << "#define MLN_PLUGIN_TEXTURE_" << texture.id << "_BINDING " << texture.location << '\n';
+    }
+    return output.str();
+}
+
+std::string propertyMacro(const std::string& propertyName) {
+    std::string result = "MLN_PLUGIN_PROPERTY_";
+    result.reserve(result.size() + propertyName.size() + 11);
+    for (const unsigned char character : propertyName) {
+        result.push_back(std::isalnum(character) ? static_cast<char>(std::toupper(character)) : '_');
+    }
+    result += "_IS_UNIFORM";
+    return result;
+}
+
+std::string propertyPrelude(const ShaderDefinition& shader, const StringIDSetsPair& propertiesAsUniforms) {
+    std::ostringstream output;
+    for (const auto& binding : shader.propertyBindings) {
+        output << "#define " << propertyMacro(binding.propertyName) << ' '
+               << (propertiesAsUniforms.first.contains(binding.propertyName) ? 1 : 0) << '\n';
+    }
+    return output.str();
+}
+
+class PluginShaderGroup final : public gfx::ShaderGroup {
+public:
+    PluginShaderGroup(ShaderDefinition definition_, ProgramParameters parameters_)
+        : definition(std::move(definition_)),
+          parameters(std::move(parameters_)) {}
+
+    gfx::ShaderPtr getOrCreateShader(gfx::Context& context,
+                                     const StringIDSetsPair& propertiesAsUniforms,
+                                     std::string_view) override {
+        const auto groupName = shaderGroupName(definition.pluginID, definition.id);
+        const auto name = getShaderName(groupName, propertyHash(propertiesAsUniforms));
+        if (auto existing = getShader(name)) return existing;
+        const auto pluginPrelude = resourcePrelude(definition) + propertyPrelude(definition, propertiesAsUniforms);
+
+        gfx::ShaderPtr shader;
+#if MLN_RENDER_BACKEND_OPENGL
+        const auto* source = findSource(definition, MLN_PLUGIN_BACKEND_OPENGL);
+        if (!source) return {};
+        std::vector<shaders::AttributeInfo> attributes;
+        attributes.reserve(definition.attributes.size());
+        for (const auto& attr : definition.attributes) {
+            if (!propertiesAsUniforms.second.contains(attr.id)) attributes.emplace_back(attr.name, attr.id);
+        }
+        std::vector<shaders::UniformBlockInfo> uniformBlocks;
+        uniformBlocks.reserve(definition.uniformBlocks.size());
+        for (const auto& uniform : definition.uniformBlocks) {
+            uniformBlocks.emplace_back(uniform.name, uniform.bindingID);
+        }
+        std::vector<shaders::TextureInfo> textures;
+        textures.reserve(definition.textures.size());
+        for (const auto& texture : definition.textures) {
+            textures.emplace_back(texture.name, texture.id);
+        }
+        shader = gl::ShaderProgramGL::create(static_cast<gl::Context&>(context),
+                                             parameters.withProgramType(shaders::BuiltIn::None),
+                                             definition.attributes.front().name,
+                                             uniformBlocks,
+                                             textures,
+                                             attributes,
+                                             pluginPrelude + source->vertex,
+                                             pluginPrelude + source->fragment);
+#elif MLN_RENDER_BACKEND_VULKAN
+        const auto* source = findSource(definition, MLN_PLUGIN_BACKEND_VULKAN);
+        if (!source) return {};
+        auto created = static_cast<vulkan::Context&>(context).createProgram(shaders::BuiltIn::None,
+                                                                            name,
+                                                                            pluginPrelude + source->vertex,
+                                                                            pluginPrelude + source->fragment,
+                                                                            parameters,
+                                                                            {});
+        if (!created) return {};
+        auto typed = std::shared_ptr<vulkan::ShaderProgram>(std::move(created));
+        for (const auto& attr : definition.attributes) {
+            if (!propertiesAsUniforms.second.contains(attr.id)) {
+                typed->initVertexAttribute({attr.location, attributeType(attr.type), attr.id});
+            }
+        }
+        for (const auto& texture : definition.textures) {
+            typed->initTexture({texture.location, texture.id});
+        }
+        shader = std::move(typed);
+#elif MLN_RENDER_BACKEND_METAL
+        const auto* source = findSource(definition, MLN_PLUGIN_BACKEND_METAL);
+        if (!source) return {};
+        auto created = static_cast<mtl::Context&>(context).createProgram(
+            shaders::BuiltIn::None,
+            name,
+            std::string(shaders::prelude) + pluginPrelude + source->vertex,
+            source->vertexEntryPoint,
+            source->fragmentEntryPoint,
+            parameters,
+            {});
+        if (!created) return {};
+        auto typed = std::shared_ptr<mtl::ShaderProgram>(std::move(created));
+        for (const auto& attr : definition.attributes) {
+            if (!propertiesAsUniforms.second.contains(attr.id)) {
+                typed->initVertexAttribute(
+                    {attr.location, attributeType(attr.type), shaders::maxUBOCountPerShader + attr.location, attr.id});
+            }
+        }
+        for (const auto& texture : definition.textures) {
+            typed->initTexture({texture.location, texture.id});
+        }
+        shader = std::move(typed);
+#else
+        (void)context;
+#endif
+        if (!shader) return {};
+        if (!registerShader(gfx::ShaderPtr(shader), name)) {
+            return getShader(name);
+        }
+        return shader;
+    }
+
+private:
+    ShaderDefinition definition;
+    ProgramParameters parameters;
+};
+
+} // namespace
+
+std::string shaderGroupName(const std::string& pluginID, const std::string& shaderID) {
+    return "plugin/" + pluginID + "/" + shaderID;
+}
+
+void registerPluginShaderGroups(gfx::ShaderRegistry& registry, const ProgramParameters& parameters) {
+    for (const auto& layerType : PluginRegistry::get().allLayerTypes()) {
+        for (const auto& shader : layerType.shaders) {
+            const auto name = shaderGroupName(shader.pluginID, shader.id);
+            if (registry.isShaderGroup(name)) continue;
+            if (!registry.registerShaderGroup(std::make_shared<PluginShaderGroup>(shader, parameters), name)) {
+                throw std::runtime_error("Failed to register plugin shader group '" + name + "'");
+            }
+        }
+    }
+}
+
+} // namespace plugin
+} // namespace mln

--- a/src/mln/renderer/layers/plugin_layer_tweaker.cpp
+++ b/src/mln/renderer/layers/plugin_layer_tweaker.cpp
@@ -1,0 +1,178 @@
+#include <mln/renderer/layers/plugin_layer_tweaker.hpp>
+
+#include <mln/gfx/context.hpp>
+#include <mln/gfx/drawable.hpp>
+#include <mln/gfx/plugin_render_graph_drawable_data.hpp>
+#include <mln/renderer/layer_group.hpp>
+#include <mln/renderer/paint_parameters.hpp>
+#include <mln/renderer/buckets/plugin_bucket.hpp>
+#include <mln/renderer/render_tile.hpp>
+#include <mln/style/layers/plugin_style_layer.hpp>
+#include <mln/style/plugin_property.hpp>
+#include <mln/style/types.hpp>
+#include <mln/util/convert.hpp>
+#include <mln/util/geo.hpp>
+#include <mln/util/logging.hpp>
+
+#include <algorithm>
+#include <cstring>
+
+namespace mln {
+namespace {
+
+std::array<float, 2> getLatRange(const UnwrappedTileID& id) {
+    const LatLng north = LatLng(id);
+    const LatLng south = LatLng(UnwrappedTileID(id.canonical.z, id.canonical.x, id.canonical.y + 1));
+    return {static_cast<float>(north.latitude()), static_cast<float>(south.latitude())};
+}
+
+const plugin::ShaderDefinition* findShader(const plugin::LayerType& registration,
+                                           const plugin::RenderPassDefinition& pass) {
+    const auto it = std::find_if(registration.shaders.begin(), registration.shaders.end(), [&](const auto& shader) {
+        return shader.id == pass.shaderID;
+    });
+    return it == registration.shaders.end() ? nullptr : &*it;
+}
+
+const plugin::RenderPassDefinition* findPass(const plugin::LayerType& registration, uint32_t passID) {
+    if (!registration.renderGraph) return nullptr;
+    const auto& passes = registration.renderGraph->passes;
+    const auto it = std::find_if(passes.begin(), passes.end(), [&](const auto& pass) { return pass.id == passID; });
+    return it == passes.end() ? nullptr : &*it;
+}
+
+} // namespace
+
+void PluginLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParameters& parameters) {
+    if (layerGroup.empty()) return;
+
+    {
+        const auto& properties = static_cast<const style::PluginStyleLayerProperties&>(*evaluatedProperties);
+        const auto& impl = static_cast<const style::PluginStyleLayer::Impl&>(*properties.baseImpl);
+        const auto propertyDefinitions = plugin::PluginRegistry::get().propertiesForLayer(registration.type);
+        std::vector<style::PluginPropertyValue::EvaluationStorage> propertyStorage(propertyDefinitions.size());
+        std::vector<mln_plugin_property_value_v1> propertyValues;
+        propertyValues.reserve(propertyDefinitions.size());
+        for (size_t i = 0; i < propertyDefinitions.size(); ++i) {
+            const auto& definition = propertyDefinitions[i];
+            const auto propertyIt = properties.evaluatedPaintProperties.find(definition.name);
+            const auto value = propertyIt == properties.evaluatedPaintProperties.end()
+                                   ? style::defaultPluginPropertyValue(definition)
+                                   : propertyIt->second;
+            mln_plugin_property_value_v1 property{};
+            property.struct_size = sizeof(property);
+            property.name = {definition.name.data(), definition.name.size()};
+            property.value = value.evaluate(
+                static_cast<float>(parameters.state.getZoom()), definition, propertyStorage[i]);
+            property.explicitly_set = impl.pluginProperties.find(definition.name) != impl.pluginProperties.end();
+            propertyValues.push_back(property);
+        }
+
+        visitLayerGroupDrawables(layerGroup, [&](gfx::Drawable& drawable) {
+            if (!drawable.getData() || !checkTweakDrawable(drawable)) return;
+            const auto& data = static_cast<const gfx::PluginRenderGraphDrawableData&>(*drawable.getData());
+            const auto* pass = registration.renderGraph ? findPass(registration, data.passID) : nullptr;
+            const auto* shader = pass ? findShader(registration, *pass) : [&]() -> const plugin::ShaderDefinition* {
+                const auto it = std::find_if(registration.shaders.begin(),
+                                             registration.shaders.end(),
+                                             [&](const auto& candidate) { return candidate.id == data.shaderID; });
+                return it == registration.shaders.end() ? nullptr : &*it;
+            }();
+            if (!shader) return;
+
+            const bool hasTile = drawable.getTileID().has_value();
+            const std::optional<UnwrappedTileID> tileID =
+                hasTile ? std::optional<UnwrappedTileID>{drawable.getTileID()->toUnwrapped()} : std::nullopt;
+            mat4 tileMatrix = matrix::identity4();
+            if (hasTile) {
+                const bool nearClipped = pass ? pass->tileProjection == MLN_PLUGIN_TILE_PROJECTION_NEAR_CLIPPED
+                                              : requires3D;
+                const bool aligned = pass ? pass->tileProjection == MLN_PLUGIN_TILE_PROJECTION_ALIGNED : true;
+                tileMatrix = getTileMatrix(*tileID,
+                                           parameters,
+                                           {0.0f, 0.0f},
+                                           style::TranslateAnchorType::Viewport,
+                                           nearClipped,
+                                           false,
+                                           drawable,
+                                           aligned);
+            }
+            mat4 targetMatrix;
+            matrix::ortho(targetMatrix, 0, util::EXTENT, -util::EXTENT, 0, -1, 1);
+            matrix::translate(targetMatrix, targetMatrix, 0, -util::EXTENT, 0);
+            const auto latitudeRange = hasTile ? getLatRange(*tileID) : std::array<float, 2>{0.0f, 0.0f};
+            mat4 viewportMatrix;
+            matrix::ortho(viewportMatrix, 0, 1, 1, 0, -1, 1);
+
+            mln_plugin_uniform_context_v1 callbackContext{};
+            callbackContext.struct_size = sizeof(callbackContext);
+            callbackContext.pass_id = pass ? pass->id : 0;
+            callbackContext.canonical_z = hasTile ? tileID->canonical.z : 0;
+            callbackContext.canonical_x = hasTile ? tileID->canonical.x : 0;
+            callbackContext.canonical_y = hasTile ? tileID->canonical.y : 0;
+            callbackContext.wrap = hasTile ? tileID->wrap : 0;
+            callbackContext.overscaled_z = hasTile ? drawable.getTileID()->overscaledZ : 0;
+            callbackContext.source_max_zoom = data.sourceMaxZoom;
+            callbackContext.dem_dimension = data.dimension;
+            callbackContext.dem_stride = data.stride;
+            callbackContext.dem_encoding = data.encoding;
+            callbackContext.zoom = parameters.state.getZoom();
+            callbackContext.bearing = parameters.state.getBearing();
+            callbackContext.camera_to_center_distance = parameters.state.getCameraToCenterDistance();
+            callbackContext.pixel_ratio = parameters.pixelRatio;
+            callbackContext.pixels_to_gl_units[0] = parameters.pixelsToGLUnits[0];
+            callbackContext.pixels_to_gl_units[1] = parameters.pixelsToGLUnits[1];
+            const auto tileMatrixFloats = util::cast<float>(tileMatrix);
+            const auto targetMatrixFloats = util::cast<float>(targetMatrix);
+            std::copy(tileMatrixFloats.begin(), tileMatrixFloats.end(), callbackContext.tile_matrix);
+            std::copy(targetMatrixFloats.begin(), targetMatrixFloats.end(), callbackContext.render_target_matrix);
+            std::copy(latitudeRange.begin(), latitudeRange.end(), callbackContext.latitude_range);
+            const auto viewportSize = parameters.state.getSize();
+            callbackContext.viewport_width = viewportSize.width;
+            callbackContext.viewport_height = viewportSize.height;
+            callbackContext.render_target_width = data.renderTargetWidth;
+            callbackContext.render_target_height = data.renderTargetHeight;
+            callbackContext.pixels_to_tile_units = hasTile ? tileID->pixelsToTileUnits(
+                                                                 1.0f, static_cast<float>(parameters.state.getZoom()))
+                                                           : 0.0f;
+            const auto viewportMatrixFloats = util::cast<float>(viewportMatrix);
+            std::copy(viewportMatrixFloats.begin(), viewportMatrixFloats.end(), callbackContext.viewport_matrix);
+            callbackContext.properties = propertyValues.data();
+            callbackContext.property_count = propertyValues.size();
+
+            for (const auto& uniform : shader->uniformBlocks) {
+                if (!registration.updateUniformBlock) continue;
+                std::vector<uint8_t> bytes(uniform.byteSize);
+                const auto status = registration.updateUniformBlock(
+                    &callbackContext, uniform.id, bytes.data(), bytes.size());
+                if (status != MLN_PLUGIN_STATUS_OK) {
+                    Log::Error(Event::General,
+                               "Plugin '" + registration.pluginID + "' failed to update uniform " +
+                                   std::to_string(uniform.id) + " for pass " + std::to_string(callbackContext.pass_id) +
+                                   " (status " + std::to_string(static_cast<int>(status)) + ")");
+                    continue;
+                }
+                if (const auto* baseBinders = drawable.getBinders()) {
+                    const auto* binders = static_cast<const PluginPaintPropertyBinders*>(baseBinders);
+                    binders->writeUniforms(static_cast<float>(parameters.state.getZoom()),
+                                           uniform.id,
+                                           bytes.data(),
+                                           bytes.size());
+                }
+                if (uniform.scope == MLN_PLUGIN_UNIFORM_SCOPE_LAYER) {
+                    auto& buffer = layerUniformBuffers[{callbackContext.pass_id, uniform.id}];
+                    parameters.context.emplaceOrUpdateUniformBuffer(
+                        buffer, static_cast<const void*>(bytes.data()), bytes.size());
+                    layerGroup.mutableUniformBuffers().set(uniform.bindingID, buffer);
+                } else {
+                    drawable.mutableUniformBuffers().createOrUpdate(
+                        uniform.bindingID, bytes.data(), bytes.size(), parameters.context);
+                }
+            }
+        });
+        propertiesUpdated = false;
+        return;
+    }
+}
+
+} // namespace mln

--- a/src/mln/renderer/layers/plugin_layer_tweaker.cpp
+++ b/src/mln/renderer/layers/plugin_layer_tweaker.cpp
@@ -154,10 +154,8 @@ void PluginLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
                 }
                 if (const auto* baseBinders = drawable.getBinders()) {
                     const auto* binders = static_cast<const PluginPaintPropertyBinders*>(baseBinders);
-                    binders->writeUniforms(static_cast<float>(parameters.state.getZoom()),
-                                           uniform.id,
-                                           bytes.data(),
-                                           bytes.size());
+                    binders->writeUniforms(
+                        static_cast<float>(parameters.state.getZoom()), uniform.id, bytes.data(), bytes.size());
                 }
                 if (uniform.scope == MLN_PLUGIN_UNIFORM_SCOPE_LAYER) {
                     auto& buffer = layerUniformBuffers[{callbackContext.pass_id, uniform.id}];


### PR DESCRIPTION
## Scope

Adapt worker feature layout and FileSource requests to C callbacks. Build platform shader variants and write borrowed camera/tile/property uniforms.

Depends on #4591; review only against its base branch. Layer 7/11.

935 changed lines (+935/-0). Within the approximately 2,000-line review budget.

This is a staged implementation foundation. Declarations/compilation units land before build wiring; plugin layer availability is connected in #4593. It is not a separately released partial ABI.

## Validation and landing

At the integrated stack tip: 19 focused core tests and 108 Metal render tests pass. The n-gon plugin builds as an Android AAR for all four ABIs and through SwiftPM/Bazel. N-gon Vulkan images pass; the full MoltenVK run has two retained heatmap/hillshade image mismatches. OpenGL ES shader variants compile, but runtime OpenGL validation is still needed on a supported ES 3 test environment.

These are deliberately draft PRs. Build jobs are skipped before runner allocation; marking a PR ready triggers normal checks. Merge only in dependency order after those checks pass. Lightweight metadata/pre-commit services may still operate.

Companion plugin stack: https://github.com/louwers/maplibre-native-plugin-template/pull/1

Roadmap: [Incremental plugin introduction](https://github.com/maplibre/maplibre-native/blob/plugins/01-draft-ci/design-proposals/2026-09-08-plugin-introduction.md).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
