### PR TITLE
test: cover plugin registration, style semantics and packed dynamic binders

### DIFF
--- a/include/mln/style/layer.hpp
+++ b/include/mln/style/layer.hpp
@@ -142,8 +142,8 @@ public:
     };
     std::optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value);
     virtual std::optional<conversion::Error> setProperty(const std::string& name,
-                                                 const conversion::Convertible& value,
-                                                 PropertyScope scope);
+                                                         const conversion::Convertible& value,
+                                                         PropertyScope scope);
 
     virtual StyleProperty getProperty(const std::string&) const = 0;
     virtual Value serialize() const;

--- a/src/mln/layout/plugin_layout.cpp
+++ b/src/mln/layout/plugin_layout.cpp
@@ -470,14 +470,16 @@ void PluginLayout::createBucket(const ImagePositions&,
                 range.feature_index < sourceLayer->featureCount() && drawable != drawableVertexCounts.end() &&
                 range.vertex_count > 0 && validRange(range.first_vertex, range.vertex_count, drawable->second);
         if (valid) {
-            bucket->featureVertexRanges.push_back(
-                {static_cast<std::size_t>(range.feature_index), range.drawable_key, range.first_vertex, range.vertex_count});
+            bucket->featureVertexRanges.push_back({static_cast<std::size_t>(range.feature_index),
+                                                   range.drawable_key,
+                                                   range.first_vertex,
+                                                   range.vertex_count});
         }
     }
     for (const auto& drawable : bucket->drawables) {
-        const auto shader = std::find_if(registration.shaders.begin(), registration.shaders.end(), [&](const auto& candidate) {
-            return candidate.id == drawable.shaderID;
-        });
+        const auto shader = std::find_if(registration.shaders.begin(),
+                                         registration.shaders.end(),
+                                         [&](const auto& candidate) { return candidate.id == drawable.shaderID; });
         if (!valid || shader == registration.shaders.end() || shader->propertyBindings.empty()) continue;
         std::vector<uint8_t> coverage(drawable.vertexCount);
         for (const auto& range : bucket->featureVertexRanges) {
@@ -504,9 +506,9 @@ void PluginLayout::createBucket(const ImagePositions&,
         const auto& impl = static_cast<const style::PluginStyleLayer::Impl&>(*layer->baseImpl);
         auto& layerBinders = bucket->paintPropertyBinders[impl.id];
         for (const auto& drawable : bucket->drawables) {
-            const auto shader = std::find_if(registration.shaders.begin(), registration.shaders.end(), [&](const auto& candidate) {
-                return candidate.id == drawable.shaderID;
-            });
+            const auto shader = std::find_if(registration.shaders.begin(),
+                                             registration.shaders.end(),
+                                             [&](const auto& candidate) { return candidate.id == drawable.shaderID; });
             if (shader == registration.shaders.end() || shader->propertyBindings.empty()) continue;
             layerBinders.emplace(std::piecewise_construct,
                                  std::forward_as_tuple(drawable.key),

--- a/src/mln/plugin/plugin_layer_factory.cpp
+++ b/src/mln/plugin/plugin_layer_factory.cpp
@@ -9,20 +9,21 @@ const style::LayerTypeInfo* PluginLayerFactory::getTypeInfo() const noexcept {
     return &registration.identity->info;
 }
 
-std::unique_ptr<style::Layer> PluginLayerFactory::createLayer(
-    const std::string& id, const style::conversion::Convertible& value) noexcept {
+std::unique_ptr<style::Layer> PluginLayerFactory::createLayer(const std::string& id,
+                                                              const style::conversion::Convertible& value) noexcept {
     const auto source = getSource(value);
     if (!source || source->empty()) return nullptr;
     return std::make_unique<style::PluginStyleLayer>(id, *source, registration);
 }
 
 std::unique_ptr<RenderLayer> PluginLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
-    return std::make_unique<RenderPluginStyleLayer>(staticImmutableCast<style::PluginStyleLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderPluginStyleLayer>(
+        staticImmutableCast<style::PluginStyleLayer::Impl>(std::move(impl)));
 }
 
-std::unique_ptr<Layout> PluginLayerFactory::createLayout(
-    const LayoutParameters& parameters, std::unique_ptr<GeometryTileLayer> tileLayer,
-    const std::vector<Immutable<style::LayerProperties>>& layers) {
+std::unique_ptr<Layout> PluginLayerFactory::createLayout(const LayoutParameters& parameters,
+                                                         std::unique_ptr<GeometryTileLayer> tileLayer,
+                                                         const std::vector<Immutable<style::LayerProperties>>& layers) {
     return std::make_unique<PluginLayout>(parameters.bucketParameters, layers, std::move(tileLayer), registration);
 }
 } // namespace mln::plugin

--- a/src/mln/plugin/plugin_registry.cpp
+++ b/src/mln/plugin/plugin_registry.cpp
@@ -82,8 +82,8 @@ bool descriptorEquals(const PluginRegistry::PluginRecord& existing,
         if (lhs.targetLayerType != rhs.targetLayerType || lhs.name != rhs.name || lhs.type != rhs.type ||
             lhs.scope != rhs.scope || lhs.defaultValue != rhs.defaultValue ||
             lhs.expressionCapabilities != rhs.expressionCapabilities ||
-            lhs.supportsTransitions != rhs.supportsTransitions ||
-            lhs.acceptsScalar != rhs.acceptsScalar || lhs.minimum != rhs.minimum || lhs.maximum != rhs.maximum ||
+            lhs.supportsTransitions != rhs.supportsTransitions || lhs.acceptsScalar != rhs.acceptsScalar ||
+            lhs.minimum != rhs.minimum || lhs.maximum != rhs.maximum ||
             lhs.maximumArrayLength != rhs.maximumArrayLength || lhs.enumValues != rhs.enumValues) {
             return false;
         }
@@ -97,8 +97,8 @@ bool descriptorEquals(const PluginRegistry::PluginRecord& existing,
             lhs.createLayout != rhs.createLayout || lhs.layoutFeature != rhs.layoutFeature ||
             lhs.finishLayout != rhs.finishLayout || lhs.destroyLayout != rhs.destroyLayout ||
             lhs.queryFeature != rhs.queryFeature || lhs.queryRadius != rhs.queryRadius ||
-            lhs.shaders.size() != rhs.shaders.size() ||
-            lhs.renderGraph != rhs.renderGraph || lhs.updateUniformBlock != rhs.updateUniformBlock) {
+            lhs.shaders.size() != rhs.shaders.size() || lhs.renderGraph != rhs.renderGraph ||
+            lhs.updateUniformBlock != rhs.updateUniformBlock) {
             return false;
         }
         for (size_t shaderIndex = 0; shaderIndex < lhs.shaders.size(); ++shaderIndex) {
@@ -380,12 +380,13 @@ bool appendShaders(const std::string& pluginID,
             const auto encodingSize = propertyEncodingSize(binding.encoding);
             const auto encodingAlignment = propertyEncodingAlignment(binding.encoding);
             const bool packed = binding.minimum_attribute_id == binding.maximum_attribute_id;
-            const auto attributeType = packed
-                ? (encodingSize == 4 ? MLN_PLUGIN_VERTEX_FLOAT_X2 : MLN_PLUGIN_VERTEX_FLOAT_X4)
-                : propertyAttributeType(binding.encoding);
-            const auto uniform = std::find_if(shader.uniformBlocks.begin(), shader.uniformBlocks.end(), [&](const auto& candidate) {
-                return candidate.id == binding.uniform_id;
-            });
+            const auto attributeType = packed ? (encodingSize == 4 ? MLN_PLUGIN_VERTEX_FLOAT_X2
+                                                                   : MLN_PLUGIN_VERTEX_FLOAT_X4)
+                                              : propertyAttributeType(binding.encoding);
+            const auto uniform = std::find_if(
+                shader.uniformBlocks.begin(), shader.uniformBlocks.end(), [&](const auto& candidate) {
+                    return candidate.id == binding.uniform_id;
+                });
             const auto interpolationUniform = std::find_if(
                 shader.uniformBlocks.begin(), shader.uniformBlocks.end(), [&](const auto& candidate) {
                     return candidate.id == binding.interpolation_uniform_id;
@@ -399,8 +400,7 @@ bool appendShaders(const std::string& pluginID,
                     return candidate.id == binding.maximum_attribute_id;
                 });
             if (binding.struct_size < sizeof(mln_plugin_shader_property_binding_v1) || propertyName.empty() ||
-                !encodingSize || !boundProperties.emplace(propertyName).second ||
-                (packed && encodingSize > 8) ||
+                !encodingSize || !boundProperties.emplace(propertyName).second || (packed && encodingSize > 8) ||
                 !boundPaintAttributes.emplace(binding.minimum_attribute_id).second ||
                 (!packed && !boundPaintAttributes.emplace(binding.maximum_attribute_id).second) ||
                 uniform == shader.uniformBlocks.end() || interpolationUniform == shader.uniformBlocks.end() ||
@@ -429,9 +429,8 @@ bool appendShaders(const std::string& pluginID,
                 return true;
             };
             if (!addUniformRange(binding.uniform_id, binding.uniform_byte_offset, encodingSize) ||
-                !addUniformRange(binding.interpolation_uniform_id,
-                                 binding.interpolation_uniform_byte_offset,
-                                 sizeof(float))) {
+                !addUniformRange(
+                    binding.interpolation_uniform_id, binding.interpolation_uniform_byte_offset, sizeof(float))) {
                 error = "plugin shader property bindings contain overlapping uniform ranges";
                 return false;
             }
@@ -462,8 +461,7 @@ bool appendProperties(const std::string& pluginID,
     }
     for (size_t p = 0; p < propertyCount; ++p) {
         const auto& property = properties[p];
-        constexpr uint32_t validExpressionCapabilities = MLN_PLUGIN_EXPRESSION_CAMERA |
-                                                         MLN_PLUGIN_EXPRESSION_FEATURE |
+        constexpr uint32_t validExpressionCapabilities = MLN_PLUGIN_EXPRESSION_CAMERA | MLN_PLUGIN_EXPRESSION_FEATURE |
                                                          MLN_PLUGIN_EXPRESSION_COMPOSITE |
                                                          MLN_PLUGIN_EXPRESSION_FEATURE_STATE;
         if (property.struct_size < sizeof(mln_plugin_property_descriptor_v1) || !validString(property.name) ||
@@ -477,8 +475,7 @@ bool appendProperties(const std::string& pluginID,
         const bool transitionableType = property.type == MLN_PLUGIN_VALUE_FLOAT ||
                                         property.type == MLN_PLUGIN_VALUE_FLOAT2 ||
                                         property.type == MLN_PLUGIN_VALUE_COLOR;
-        if (property.supports_transitions &&
-            (property.scope != MLN_PLUGIN_PROPERTY_PAINT || !transitionableType)) {
+        if (property.supports_transitions && (property.scope != MLN_PLUGIN_PROPERTY_PAINT || !transitionableType)) {
             error = "plugin transitions require an interpolatable paint property";
             return false;
         }
@@ -723,8 +720,7 @@ mln_plugin_status PluginRegistry::registerPlugin(const mln_plugin_descriptor_v1&
         return MLN_PLUGIN_STATUS_UNSUPPORTED_ABI;
     }
     if (!validString(descriptor.plugin_id) || !validString(descriptor.plugin_version) ||
-        (descriptor.layer_type_count && !descriptor.layer_types) ||
-        descriptor.layer_type_count == 0) {
+        (descriptor.layer_type_count && !descriptor.layer_types) || descriptor.layer_type_count == 0) {
         error = "plugin descriptor is missing an id, version, or layer registration";
         return MLN_PLUGIN_STATUS_INVALID_ARGUMENT;
     }
@@ -811,13 +807,17 @@ mln_plugin_status PluginRegistry::registerPlugin(const mln_plugin_descriptor_v1&
                     return item.targetLayerType == type && item.name == binding.propertyName;
                 });
                 const bool encodingMatches = property != newProperties.end() &&
-                    ((property->type == MLN_PLUGIN_VALUE_FLOAT && binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_FLOAT) ||
-                     (property->type == MLN_PLUGIN_VALUE_FLOAT2 && binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_FLOAT2) ||
-                     (property->type == MLN_PLUGIN_VALUE_COLOR && binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_COLOR) ||
-                     (property->type == MLN_PLUGIN_VALUE_BOOLEAN &&
-                      binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT) ||
-                     (property->type == MLN_PLUGIN_VALUE_STRING && !property->enumValues.empty() &&
-                      binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT));
+                                             ((property->type == MLN_PLUGIN_VALUE_FLOAT &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_FLOAT) ||
+                                              (property->type == MLN_PLUGIN_VALUE_FLOAT2 &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_FLOAT2) ||
+                                              (property->type == MLN_PLUGIN_VALUE_COLOR &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_COLOR) ||
+                                              (property->type == MLN_PLUGIN_VALUE_BOOLEAN &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT) ||
+                                              (property->type == MLN_PLUGIN_VALUE_STRING &&
+                                               !property->enumValues.empty() &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT));
                 if (property == newProperties.end() || property->scope != MLN_PLUGIN_PROPERTY_PAINT ||
                     !encodingMatches) {
                     error = "plugin shader property binding references an incompatible paint property";
@@ -827,20 +827,15 @@ mln_plugin_status PluginRegistry::registerPlugin(const mln_plugin_descriptor_v1&
         }
         for (const auto& property : newProperties) {
             if (property.targetLayerType != type) continue;
-            const auto dataDependencies = MLN_PLUGIN_EXPRESSION_FEATURE |
-                                          MLN_PLUGIN_EXPRESSION_COMPOSITE |
+            const auto dataDependencies = MLN_PLUGIN_EXPRESSION_FEATURE | MLN_PLUGIN_EXPRESSION_COMPOSITE |
                                           MLN_PLUGIN_EXPRESSION_FEATURE_STATE;
             if ((property.expressionCapabilities & dataDependencies) == 0) continue;
-            const bool bound = std::any_of(copiedLayerType.shaders.begin(),
-                                           copiedLayerType.shaders.end(),
-                                           [&](const auto& shader) {
-                                               return std::any_of(
-                                                   shader.propertyBindings.begin(),
-                                                   shader.propertyBindings.end(),
-                                                   [&](const auto& binding) {
-                                                       return binding.propertyName == property.name;
-                                                   });
-                                           });
+            const bool bound = std::any_of(
+                copiedLayerType.shaders.begin(), copiedLayerType.shaders.end(), [&](const auto& shader) {
+                    return std::any_of(shader.propertyBindings.begin(),
+                                       shader.propertyBindings.end(),
+                                       [&](const auto& binding) { return binding.propertyName == property.name; });
+                });
             if (property.scope != MLN_PLUGIN_PROPERTY_PAINT || !bound) {
                 error = "data-driven plugin properties require a shader property binding";
                 return MLN_PLUGIN_STATUS_INVALID_ARGUMENT;
@@ -1094,9 +1089,7 @@ uint8_t mln_plugin_is_registered_v1(const char* pluginID) try {
     return 0;
 }
 
-size_t mln_plugin_count_v1(void) try {
-    return mln::plugin::PluginRegistry::get().pluginIDs().size();
-} catch (...) {
+size_t mln_plugin_count_v1(void) try { return mln::plugin::PluginRegistry::get().pluginIDs().size(); } catch (...) {
     return 0;
 }
 

--- a/src/mln/renderer/buckets/plugin_bucket.cpp
+++ b/src/mln/renderer/buckets/plugin_bucket.cpp
@@ -18,7 +18,9 @@ namespace {
 class PluginFeatureSnapshot final : public GeometryTileFeature {
 public:
     PluginFeatureSnapshot(FeatureType type_, FeatureIdentifier id_, PropertyMap properties_)
-        : type(type_), id(std::move(id_)), properties(std::move(properties_)) {}
+        : type(type_),
+          id(std::move(id_)),
+          properties(std::move(properties_)) {}
 
     FeatureType getType() const override { return type; }
     std::optional<Value> getValue(const std::string& key) const override {
@@ -66,10 +68,10 @@ void encodedValue(const mln_plugin_value& value,
         case MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT: {
             const std::string_view text(value.data.string_value.data, value.data.string_value.size);
             const auto it = std::find(definition.enumValues.begin(), definition.enumValues.end(), text);
-            const auto fallback = std::find(definition.enumValues.begin(), definition.enumValues.end(),
-                                            *definition.defaultValue.getString());
-            output[0] = static_cast<float>(std::distance(definition.enumValues.begin(),
-                                                       it == definition.enumValues.end() ? fallback : it));
+            const auto fallback = std::find(
+                definition.enumValues.begin(), definition.enumValues.end(), *definition.defaultValue.getString());
+            output[0] = static_cast<float>(
+                std::distance(definition.enumValues.begin(), it == definition.enumValues.end() ? fallback : it));
             break;
         }
         case MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT:
@@ -88,8 +90,7 @@ void encodedValue(const mln_plugin_value& value,
     }
 }
 
-mln_plugin_value decodedValue(const std::array<float, 4>& input,
-                              const plugin::PropertyDefinition& definition) {
+mln_plugin_value decodedValue(const std::array<float, 4>& input, const plugin::PropertyDefinition& definition) {
     const auto type = definition.type;
     mln_plugin_value value{};
     value.struct_size = sizeof(value);
@@ -109,7 +110,8 @@ mln_plugin_value decodedValue(const std::array<float, 4>& input,
             break;
         case MLN_PLUGIN_VALUE_STRING:
             if (!definition.enumValues.empty()) {
-                const auto index = static_cast<size_t>(std::clamp(input[0], 0.0f, static_cast<float>(definition.enumValues.size() - 1)));
+                const auto index = static_cast<size_t>(
+                    std::clamp(input[0], 0.0f, static_cast<float>(definition.enumValues.size() - 1)));
                 const auto& text = definition.enumValues[index];
                 value.data.string_value = {text.data(), text.size()};
             }
@@ -122,10 +124,7 @@ mln_plugin_value decodedValue(const std::array<float, 4>& input,
 
 } // namespace
 
-void PluginPaintVertexVector::set(std::size_t first,
-                                  std::size_t length,
-                                  const float* minimum,
-                                  const float* maximum) {
+void PluginPaintVertexVector::set(std::size_t first, std::size_t length, const float* minimum, const float* maximum) {
     if (first > count || length > count - first) return;
     for (std::size_t vertex = first; vertex < first + length; ++vertex) {
         auto* destination = data.data() + vertex * components * 2;
@@ -135,8 +134,7 @@ void PluginPaintVertexVector::set(std::size_t first,
     updateModified(true);
 }
 
-void PluginPaintVertexVector::bounds(std::array<float, 4>& minimum,
-                                     std::array<float, 4>& maximum) const {
+void PluginPaintVertexVector::bounds(std::array<float, 4>& minimum, std::array<float, 4>& maximum) const {
     minimum.fill(std::numeric_limits<float>::infinity());
     maximum.fill(-std::numeric_limits<float>::infinity());
     for (std::size_t vertex = 0; vertex < count; ++vertex) {
@@ -224,8 +222,7 @@ void PluginPaintPropertyBinder::writeUniform(float zoom,
             std::memcpy(output + binding.uniformByteOffset, encoded.data(), size);
         }
     }
-    if (uniformID == binding.interpolationUniformID &&
-        binding.interpolationUniformByteOffset <= outputSize &&
+    if (uniformID == binding.interpolationUniformID && binding.interpolationUniformByteOffset <= outputSize &&
         sizeof(float) <= outputSize - binding.interpolationUniformByteOffset) {
         const auto factor = interpolationFactor(zoom);
         std::memcpy(output + binding.interpolationUniformByteOffset, &factor, sizeof(factor));
@@ -261,9 +258,7 @@ bool PluginPaintPropertyBinder::update(const FeatureStates& states, const Geomet
     return changed;
 }
 
-void PluginPaintPropertyBinder::statistics(float zoom,
-                                           mln_plugin_value& minimum,
-                                           mln_plugin_value& maximum) const {
+void PluginPaintPropertyBinder::statistics(float zoom, mln_plugin_value& minimum, mln_plugin_value& maximum) const {
     if (!dataDriven || !vertexVector) {
         style::PluginPropertyValue::EvaluationStorage storage;
         minimum = value.evaluate(zoom, definition, storage);
@@ -285,7 +280,8 @@ void PluginPaintPropertyBinder::refill(const GeometryTileLayer* layer) {
         std::unique_ptr<GeometryTileFeature> feature;
         if (layer) feature = layer->getFeature(range.featureIndex);
         PluginFeatureSnapshot snapshot(range.featureType, range.featureIdentifier, range.properties);
-        const GeometryTileFeature& sourceFeature = feature ? *feature : static_cast<const GeometryTileFeature&>(snapshot);
+        const GeometryTileFeature& sourceFeature = feature ? *feature
+                                                           : static_cast<const GeometryTileFeature&>(snapshot);
         const auto state = featureStates.find(range.featureID);
         const FeatureState empty;
         fillRange(range, sourceFeature, state == featureStates.end() ? empty : state->second);
@@ -312,15 +308,14 @@ void PluginPaintPropertyBinder::updateStatistics() {
     if (vertexVector) vertexVector->bounds(minimumValues, maximumValues);
 }
 
-PluginPaintPropertyBinders::PluginPaintPropertyBinders(
-    const plugin::LayerType& registration,
-    const plugin::ShaderDefinition& shader,
-    uint64_t drawableKey,
-    std::size_t vertexCount,
-    float bucketZoom,
-    const style::PluginPropertyMap& properties,
-    const std::vector<PluginFeatureVertexRange>& ranges,
-    const GeometryTileLayer& layer) {
+PluginPaintPropertyBinders::PluginPaintPropertyBinders(const plugin::LayerType& registration,
+                                                       const plugin::ShaderDefinition& shader,
+                                                       uint64_t drawableKey,
+                                                       std::size_t vertexCount,
+                                                       float bucketZoom,
+                                                       const style::PluginPropertyMap& properties,
+                                                       const std::vector<PluginFeatureVertexRange>& ranges,
+                                                       const GeometryTileLayer& layer) {
     const auto definitions = plugin::PluginRegistry::get().propertiesForLayer(registration.type);
     for (const auto& binding : shader.propertyBindings) {
         const auto definition = std::find_if(definitions.begin(), definitions.end(), [&](const auto& candidate) {
@@ -351,14 +346,11 @@ void PluginPaintPropertyBinders::populateVertexAttributes(gfx::VertexAttributeAr
         const auto& vector = binder.getVertexVector();
         const auto components = binder.componentCount();
         if (const auto& minimum = attributes.set(binding.minimumAttributeID)) {
-            minimum->setSharedRawData(vector,
-                                      0,
-                                      0,
-                                      vector->getRawSize(),
-                                      binder.attributeType());
+            minimum->setSharedRawData(vector, 0, 0, vector->getRawSize(), binder.attributeType());
         }
         if (auto* maximum = binding.maximumAttributeID != binding.minimumAttributeID
-                                ? attributes.set(binding.maximumAttributeID).get() : nullptr) {
+                                ? attributes.set(binding.maximumAttributeID).get()
+                                : nullptr) {
             maximum->setSharedRawData(vector,
                                       static_cast<uint32_t>(components * sizeof(float)),
                                       0,
@@ -391,8 +383,7 @@ bool PluginPaintPropertyBinders::update(const FeatureStates& states, const Geome
 }
 
 void PluginPaintPropertyBinders::appendStatistics(
-    float zoom,
-    std::map<std::string, std::pair<mln_plugin_value, mln_plugin_value>>& output) const {
+    float zoom, std::map<std::string, std::pair<mln_plugin_value, mln_plugin_value>>& output) const {
     for (const auto& binder : binders) {
         if (output.find(binder.getDefinition().name) != output.end()) continue;
         mln_plugin_value minimum{};
@@ -469,10 +460,8 @@ void PluginBucket::updateQueryRadius(const std::string& layerID,
     std::vector<mln_plugin_property_statistics_v1> statistics;
     statistics.reserve(values.size());
     for (const auto& [name, bounds] : values) {
-        statistics.push_back({sizeof(mln_plugin_property_statistics_v1),
-                              {name.data(), name.size()},
-                              bounds.first,
-                              bounds.second});
+        statistics.push_back(
+            {sizeof(mln_plugin_property_statistics_v1), {name.data(), name.size()}, bounds.first, bounds.second});
     }
 
     const auto definitions = plugin::PluginRegistry::get().propertiesForLayer(registration.type);
@@ -487,18 +476,15 @@ void PluginBucket::updateQueryRadius(const std::string& layerID,
                                     current.evaluate(zoom, definition, storage[i]),
                                     properties.find(definition.name) != properties.end()});
     }
-    const auto radius = registration.queryRadius(statistics.data(),
-                                                 statistics.size(),
-                                                 cameraProperties.data(),
-                                                 cameraProperties.size());
+    const auto radius = registration.queryRadius(
+        statistics.data(), statistics.size(), cameraProperties.data(), cameraProperties.size());
     if (std::isfinite(radius) && radius >= 0.0f) {
         queryRadii.insert_or_assign(layerID, radius);
         queryRadiusErrorsLogged.erase(layerID);
     } else {
         queryRadii.insert_or_assign(layerID, 0.0f);
         if (queryRadiusErrorsLogged.emplace(layerID).second) {
-            Log::Warning(Event::Style,
-                         "Plugin layer '" + registration.type + "' returned an invalid query radius");
+            Log::Warning(Event::Style, "Plugin layer '" + registration.type + "' returned an invalid query radius");
         }
     }
 }

--- a/src/mln/renderer/layers/plugin_layer_tweaker.cpp
+++ b/src/mln/renderer/layers/plugin_layer_tweaker.cpp
@@ -154,10 +154,8 @@ void PluginLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
                 }
                 if (const auto* baseBinders = drawable.getBinders()) {
                     const auto* binders = static_cast<const PluginPaintPropertyBinders*>(baseBinders);
-                    binders->writeUniforms(static_cast<float>(parameters.state.getZoom()),
-                                           uniform.id,
-                                           bytes.data(),
-                                           bytes.size());
+                    binders->writeUniforms(
+                        static_cast<float>(parameters.state.getZoom()), uniform.id, bytes.data(), bytes.size());
                 }
                 if (uniform.scope == MLN_PLUGIN_UNIFORM_SCOPE_LAYER) {
                     auto& buffer = layerUniformBuffers[{callbackContext.pass_id, uniform.id}];

--- a/src/mln/renderer/layers/render_plugin_style_layer.cpp
+++ b/src/mln/renderer/layers/render_plugin_style_layer.cpp
@@ -150,11 +150,9 @@ RenderPluginStyleLayer::RenderPluginStyleLayer(Immutable<style::PluginStyleLayer
     for (const auto& definition : definitions) {
         if (definition.scope != MLN_PLUGIN_PROPERTY_PAINT) continue;
         const auto property = layerImpl.pluginProperties.find(definition.name);
-        auto value = property == layerImpl.pluginProperties.end()
-                         ? style::defaultPluginPropertyValue(definition)
-                         : property->second;
-        transitioningPaintProperties.emplace(
-            definition.name, style::PluginTransitioningPropertyValue{value});
+        auto value = property == layerImpl.pluginProperties.end() ? style::defaultPluginPropertyValue(definition)
+                                                                  : property->second;
+        transitioningPaintProperties.emplace(definition.name, style::PluginTransitioningPropertyValue{value});
         evaluatedPluginProperties.emplace(definition.name, std::move(value));
     }
     passes = renderPassFor(registration.renderStage);
@@ -167,13 +165,11 @@ void RenderPluginStyleLayer::transition(const TransitionParameters& parameters) 
     for (const auto& definition : definitions) {
         if (definition.scope != MLN_PLUGIN_PROPERTY_PAINT) continue;
         const auto property = impl.pluginProperties.find(definition.name);
-        auto value = property == impl.pluginProperties.end()
-                         ? style::defaultPluginPropertyValue(definition)
-                         : property->second;
+        auto value = property == impl.pluginProperties.end() ? style::defaultPluginPropertyValue(definition)
+                                                             : property->second;
         auto prior = transitioningPaintProperties.find(definition.name);
         auto priorValue = prior == transitioningPaintProperties.end()
-                              ? style::PluginTransitioningPropertyValue{
-                                    style::defaultPluginPropertyValue(definition)}
+                              ? style::PluginTransitioningPropertyValue{style::defaultPluginPropertyValue(definition)}
                               : std::move(prior->second);
         const auto options = impl.pluginPropertyTransitions.find(definition.name);
         const auto transition = options == impl.pluginPropertyTransitions.end()
@@ -198,16 +194,14 @@ void RenderPluginStyleLayer::evaluate(const PropertyEvaluationParameters& parame
         if (definition.scope != MLN_PLUGIN_PROPERTY_PAINT) continue;
         const auto transition = transitioningPaintProperties.find(definition.name);
         if (transition != transitioningPaintProperties.end()) {
-            evaluatedPluginProperties.emplace(
-                definition.name,
-                transition->second.evaluate(parameters.z, definition, parameters.now));
+            evaluatedPluginProperties.emplace(definition.name,
+                                              transition->second.evaluate(parameters.z, definition, parameters.now));
         } else {
             const auto property = impl.pluginProperties.find(definition.name);
-            evaluatedPluginProperties.emplace(
-                definition.name,
-                property == impl.pluginProperties.end()
-                    ? style::defaultPluginPropertyValue(definition)
-                    : property->second);
+            evaluatedPluginProperties.emplace(definition.name,
+                                              property == impl.pluginProperties.end()
+                                                  ? style::defaultPluginPropertyValue(definition)
+                                                  : property->second);
         }
     }
     auto properties = makeMutable<style::PluginStyleLayerProperties>(
@@ -333,8 +327,7 @@ void RenderPluginStyleLayer::update(gfx::ShaderRegistry& shaders,
             continue;
         }
         auto& bucket = static_cast<PluginBucket&>(*renderData->bucket);
-        if (bucket.synchronizePaint(
-                getID(), evaluatedPluginProperties, static_cast<float>(state.getZoom()))) {
+        if (bucket.synchronizePaint(getID(), evaluatedPluginProperties, static_cast<float>(state.getZoom()))) {
             removeTile(renderPass, tileID);
         }
         const auto previousBucket = getRenderTileBucketID(tileID);
@@ -730,8 +723,7 @@ void RenderPluginStyleLayer::updateGeometryGraph(gfx::ShaderRegistry& shaders,
             return item.shaderID == pass.shaderID;
         });
         if (definitionIt == bucket.drawables.end() || definitionIt->segments.empty()) return;
-        bucket.synchronizePaint(
-            getID(), evaluatedPluginProperties, static_cast<float>(state.getZoom()));
+        bucket.synchronizePaint(getID(), evaluatedPluginProperties, static_cast<float>(state.getZoom()));
         StringIDSetsPair propertiesAsUniforms;
         auto* paintBinders = bucket.paintBinders(getID(), definitionIt->key);
         auto attributes = context.createVertexAttributeArray();
@@ -942,9 +934,8 @@ bool RenderPluginStyleLayer::queryIntersectsFeature(const GeometryCoordinates& q
     for (size_t i = 0; i < definitions.size(); ++i) {
         const auto& definition = definitions[i];
         const auto propertyIt = evaluatedPluginProperties.find(definition.name);
-        const auto value = propertyIt == evaluatedPluginProperties.end()
-                               ? style::defaultPluginPropertyValue(definition)
-                               : propertyIt->second;
+        const auto value = propertyIt == evaluatedPluginProperties.end() ? style::defaultPluginPropertyValue(definition)
+                                                                         : propertyIt->second;
         mln_plugin_property_value_v1 property{};
         property.struct_size = sizeof(property);
         property.name = {definition.name.data(), definition.name.size()};
@@ -963,8 +954,7 @@ bool RenderPluginStyleLayer::queryIntersectsFeature(const GeometryCoordinates& q
     queryContext.viewport_width = transformState.getSize().width;
     queryContext.viewport_height = transformState.getSize().height;
     return registration.queryFeature(
-               &pluginFeature, query.data(), query.size(), &queryContext, properties.data(), properties.size()) !=
-           0;
+               &pluginFeature, query.data(), query.size(), &queryContext, properties.data(), properties.size()) != 0;
 }
 
 } // namespace mln

--- a/src/mln/style/layer.cpp
+++ b/src/mln/style/layer.cpp
@@ -206,8 +206,8 @@ std::optional<conversion::Error> Layer::setProperty(const std::string& name, con
 }
 
 std::optional<conversion::Error> Layer::setProperty(const std::string& name,
-                                                  const conversion::Convertible& value,
-                                                  PropertyScope) {
+                                                    const conversion::Convertible& value,
+                                                    PropertyScope) {
     return setProperty(name, value);
 }
 

--- a/src/mln/style/layers/plugin_style_layer.cpp
+++ b/src/mln/style/layers/plugin_style_layer.cpp
@@ -18,8 +18,7 @@ std::optional<std::string> pluginTransitionPropertyName(const char* layerType, c
     return definition && definition->supportsTransitions ? std::optional<std::string>{std::move(propertyName)}
                                                          : std::nullopt;
 }
-}
-
+} // namespace
 
 PluginStyleLayer::Impl::Impl(const std::string& id, const std::string& source, plugin::LayerType registration_)
     : Layer::Impl(id, source),
@@ -90,10 +89,9 @@ StyleProperty PluginStyleLayer::getProperty(const std::string& name) const {
     return definition ? defaultPluginPropertyValue(*definition).toStyleProperty() : StyleProperty{};
 }
 
-
 std::optional<conversion::Error> PluginStyleLayer::setPluginProperty(const std::string& name,
-                                                          const conversion::Convertible& value,
-                                                          std::optional<PropertyScope> scope) {
+                                                                     const conversion::Convertible& value,
+                                                                     std::optional<PropertyScope> scope) {
     using namespace conversion;
     const auto definition = plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name);
     if (!definition) return Error{"layer doesn't support this property"};
@@ -126,8 +124,8 @@ std::optional<conversion::Error> PluginStyleLayer::setPluginProperty(const std::
 }
 
 std::optional<conversion::Error> PluginStyleLayer::setPluginTransition(const std::string& name,
-                                                            const conversion::Convertible& value,
-                                                            std::optional<PropertyScope> scope) {
+                                                                       const conversion::Convertible& value,
+                                                                       std::optional<PropertyScope> scope) {
     using namespace conversion;
     const auto propertyName = pluginTransitionPropertyName(getTypeInfo()->type, name);
     if (!propertyName) return Error{"layer doesn't support this transition"};
@@ -148,8 +146,7 @@ std::optional<conversion::Error> PluginStyleLayer::setPluginTransition(const std
     auto transition = convert<TransitionOptions>(value, error);
     if (!transition) return error;
     const auto existing = impl_->pluginPropertyTransitions.find(*propertyName);
-    if (existing != impl_->pluginPropertyTransitions.end() &&
-        existing->second.serialize() == transition->serialize()) {
+    if (existing != impl_->pluginPropertyTransitions.end() && existing->second.serialize() == transition->serialize()) {
         return std::nullopt;
     }
     impl_->pluginPropertyTransitions.insert_or_assign(*propertyName, std::move(*transition));
@@ -157,7 +154,6 @@ std::optional<conversion::Error> PluginStyleLayer::setPluginTransition(const std
     observer->onLayerChanged(*this);
     return std::nullopt;
 }
-
 
 Value PluginStyleLayer::serialize() const {
     Value serialized = Layer::serialize();
@@ -182,14 +178,18 @@ Value PluginStyleLayer::serialize() const {
     return serialized;
 }
 
-std::optional<conversion::Error> PluginStyleLayer::setPropertyInternal(const std::string& name, const conversion::Convertible& value) {
+std::optional<conversion::Error> PluginStyleLayer::setPropertyInternal(const std::string& name,
+                                                                       const conversion::Convertible& value) {
     if (pluginTransitionPropertyName(getTypeInfo()->type, name)) return setPluginTransition(name, value);
     return setPluginProperty(name, value);
 }
 
-std::optional<conversion::Error> PluginStyleLayer::setProperty(const std::string& name, const conversion::Convertible& value, PropertyScope scope) {
+std::optional<conversion::Error> PluginStyleLayer::setProperty(const std::string& name,
+                                                               const conversion::Convertible& value,
+                                                               PropertyScope scope) {
     if (pluginTransitionPropertyName(getTypeInfo()->type, name)) return setPluginTransition(name, value, scope);
-    if (plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name)) return setPluginProperty(name, value, scope);
+    if (plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name))
+        return setPluginProperty(name, value, scope);
     return Layer::setProperty(name, value);
 }
 

--- a/src/mln/style/plugin_property.cpp
+++ b/src/mln/style/plugin_property.cpp
@@ -41,14 +41,14 @@ bool usesFeatureState(const PropertyValue<T>& value) {
 
 template <class T>
 float interpolationFactor(const PropertyValue<T>& value, float bucketZoom, float currentZoom) {
-    return value.match(
-        [](const Undefined&) { return 0.0f; },
-        [](const T&) { return 0.0f; },
-        [&](const PropertyExpression<T>& expression) {
-            if (expression.isZoomConstant()) return 0.0f;
-            const auto zoom = expression.getUseIntegerZoom() ? std::floor(currentZoom) : currentZoom;
-            return std::clamp(expression.interpolationFactor({bucketZoom, bucketZoom + 1.0f}, zoom), 0.0f, 1.0f);
-        });
+    return value.match([](const Undefined&) { return 0.0f; },
+                       [](const T&) { return 0.0f; },
+                       [&](const PropertyExpression<T>& expression) {
+                           if (expression.isZoomConstant()) return 0.0f;
+                           const auto zoom = expression.getUseIntegerZoom() ? std::floor(currentZoom) : currentZoom;
+                           return std::clamp(
+                               expression.interpolationFactor({bucketZoom, bucketZoom + 1.0f}, zoom), 0.0f, 1.0f);
+                       });
 }
 
 std::string serializeRamp(const ColorRampPropertyValue& ramp) {
@@ -372,9 +372,8 @@ mln_plugin_value PluginPropertyValue::evaluate(float zoom,
     return result;
 }
 
-PluginPropertyValue PluginPropertyValue::evaluateCamera(
-    float zoom,
-    const plugin::PropertyDefinition& definition) const {
+PluginPropertyValue PluginPropertyValue::evaluateCamera(float zoom,
+                                                        const plugin::PropertyDefinition& definition) const {
     EvaluationStorage storage;
     const auto evaluated = evaluate(zoom, definition, storage);
     switch (definition.type) {
@@ -383,8 +382,8 @@ PluginPropertyValue PluginPropertyValue::evaluateCamera(
         case MLN_PLUGIN_VALUE_FLOAT:
             return PluginPropertyValue{TypedValue{PropertyValue<float>{evaluated.data.float_value}}};
         case MLN_PLUGIN_VALUE_FLOAT2:
-            return PluginPropertyValue{TypedValue{PropertyValue<std::array<float, 2>>{
-                {evaluated.data.float2_value.x, evaluated.data.float2_value.y}}}};
+            return PluginPropertyValue{TypedValue{
+                PropertyValue<std::array<float, 2>>{{evaluated.data.float2_value.x, evaluated.data.float2_value.y}}}};
         case MLN_PLUGIN_VALUE_COLOR:
             return PluginPropertyValue{TypedValue{PropertyValue<Color>{Color{evaluated.data.color_value.r,
                                                                              evaluated.data.color_value.g,
@@ -408,11 +407,10 @@ PluginPropertyValue PluginPropertyValue::evaluateCamera(
     return *this;
 }
 
-PluginPropertyValue PluginPropertyValue::interpolate(
-    const PluginPropertyValue& from,
-    const PluginPropertyValue& to,
-    float t,
-    const plugin::PropertyDefinition& definition) {
+PluginPropertyValue PluginPropertyValue::interpolate(const PluginPropertyValue& from,
+                                                     const PluginPropertyValue& to,
+                                                     float t,
+                                                     const plugin::PropertyDefinition& definition) {
     switch (definition.type) {
         case MLN_PLUGIN_VALUE_FLOAT: {
             const auto& a = std::get<PropertyValue<float>>(from.value).asConstant();
@@ -422,8 +420,7 @@ PluginPropertyValue PluginPropertyValue::interpolate(
         case MLN_PLUGIN_VALUE_FLOAT2: {
             const auto& a = std::get<PropertyValue<std::array<float, 2>>>(from.value).asConstant();
             const auto& b = std::get<PropertyValue<std::array<float, 2>>>(to.value).asConstant();
-            return PluginPropertyValue{
-                TypedValue{PropertyValue<std::array<float, 2>>{util::interpolate(a, b, t)}}};
+            return PluginPropertyValue{TypedValue{PropertyValue<std::array<float, 2>>{util::interpolate(a, b, t)}}};
         }
         case MLN_PLUGIN_VALUE_COLOR: {
             const auto& a = std::get<PropertyValue<Color>>(from.value).asConstant();
@@ -435,11 +432,10 @@ PluginPropertyValue PluginPropertyValue::interpolate(
     }
 }
 
-PluginTransitioningPropertyValue::PluginTransitioningPropertyValue(
-    PluginPropertyValue value_,
-    PluginTransitioningPropertyValue prior_,
-    const TransitionOptions& transition,
-    TimePoint now)
+PluginTransitioningPropertyValue::PluginTransitioningPropertyValue(PluginPropertyValue value_,
+                                                                   PluginTransitioningPropertyValue prior_,
+                                                                   const TransitionOptions& transition,
+                                                                   TimePoint now)
     : begin(now + transition.delay.value_or(Duration::zero())),
       end(begin + transition.duration.value_or(Duration::zero())),
       value(std::move(value_)) {
@@ -448,10 +444,9 @@ PluginTransitioningPropertyValue::PluginTransitioningPropertyValue(
     }
 }
 
-PluginPropertyValue PluginTransitioningPropertyValue::evaluate(
-    float zoom,
-    const plugin::PropertyDefinition& definition,
-    TimePoint now) {
+PluginPropertyValue PluginTransitioningPropertyValue::evaluate(float zoom,
+                                                               const plugin::PropertyDefinition& definition,
+                                                               TimePoint now) {
     if (!prior) return value;
     if (now >= end) {
         prior.reset();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,8 @@ add_library(
     ${PROJECT_SOURCE_DIR}/test/math/minmax.test.cpp
     ${PROJECT_SOURCE_DIR}/test/math/wrap.test.cpp
     ${PROJECT_SOURCE_DIR}/test/platform/settings.test.cpp
+    ${PROJECT_SOURCE_DIR}/test/plugin/plugin.test.cpp
+    ${PROJECT_SOURCE_DIR}/test/plugin/property_binding.test.cpp
     ${PROJECT_SOURCE_DIR}/test/renderer/image_manager.test.cpp
     ${PROJECT_SOURCE_DIR}/test/renderer/pattern_atlas.test.cpp
     ${PROJECT_SOURCE_DIR}/test/renderer/renderable.test.cpp

--- a/test/plugin/plugin.test.cpp
+++ b/test/plugin/plugin.test.cpp
@@ -1,0 +1,739 @@
+#include <gtest/gtest.h>
+
+#include <mln/plugin/plugin_api.h>
+#include <mln/plugin/plugin_registry.hpp>
+#include <mln/layermanager/layer_manager.hpp>
+#include <mln/renderer/render_layer.hpp>
+#include <mln/style/conversion_impl.hpp>
+#include <mln/style/layers/fill_extrusion_layer.hpp>
+#include <mln/style/layers/plugin_style_layer.hpp>
+#include <mln/style/rapidjson_conversion.hpp>
+#include <mln/style/style_impl.hpp>
+#include <mln/test/stub_file_source.hpp>
+#include <mln/test/stub_layer_observer.hpp>
+#include <mln/util/run_loop.hpp>
+
+#include <algorithm>
+#include <array>
+#include <string>
+
+using namespace mln;
+using namespace mln::style;
+
+namespace {
+
+mln_plugin_string cString(const char* value) {
+    return {value, std::char_traits<char>::length(value)};
+}
+
+mln_plugin_status createLayout(const mln_plugin_layout_context_v1*, void** instance) {
+    static int layout;
+    *instance = &layout;
+    return MLN_PLUGIN_STATUS_OK;
+}
+
+mln_plugin_status layoutFeature(void*, const mln_plugin_feature_v1*) {
+    return MLN_PLUGIN_STATUS_OK;
+}
+
+mln_plugin_status finishLayout(void*, mln_plugin_bucket_v1* bucket) {
+    bucket->query_radius = 0.0f;
+    return MLN_PLUGIN_STATUS_OK;
+}
+
+void destroyLayout(void*) {}
+
+mln_plugin_status updateUniform(const mln_plugin_uniform_context_v1*, uint32_t, uint8_t*, size_t) {
+    return MLN_PLUGIN_STATUS_OK;
+}
+
+struct LayerTypeDescriptor {
+    LayerTypeDescriptor() {
+        defaultURI.struct_size = sizeof(defaultURI);
+        defaultURI.type = MLN_PLUGIN_VALUE_STRING;
+        defaultURI.data.string_value = {"", 0};
+        property.struct_size = sizeof(property);
+        property.name = cString("test-model-uri");
+        property.type = MLN_PLUGIN_VALUE_STRING;
+        property.scope = MLN_PLUGIN_PROPERTY_LAYOUT;
+        property.default_value = defaultURI;
+        properties = {property};
+        shaderSource = {sizeof(shaderSource),
+                        MLN_PLUGIN_BACKEND_METAL,
+                        cString("shader source"),
+                        {},
+                        cString("testVertex"),
+                        cString("testFragment")};
+        shaderAttribute = {sizeof(shaderAttribute), 0, 0, cString("a_position"), MLN_PLUGIN_VERTEX_FLOAT_X2};
+        shader.struct_size = sizeof(shader);
+        shader.shader_id = cString("test");
+        shader.sources = &shaderSource;
+        shader.source_count = 1;
+        shader.attributes = &shaderAttribute;
+        shader.attribute_count = 1;
+        layerType.struct_size = sizeof(layerType);
+        layerType.layer_type = cString("test-plugin-layer");
+        layerType.backend_mask = MLN_PLUGIN_BACKEND_METAL;
+        layerType.render_stage = MLN_PLUGIN_RENDER_STAGE_TRANSLUCENT;
+        layerType.requires_3d = 1;
+        layerType.properties = properties.data();
+        layerType.property_count = properties.size();
+        layerType.source_kind = MLN_PLUGIN_SOURCE_GEOMETRY;
+        layerType.geometry_type_mask = MLN_PLUGIN_GEOMETRY_POINT;
+        layerType.shaders = &shader;
+        layerType.shader_count = 1;
+        layerType.create_layout = createLayout;
+        layerType.layout_feature = layoutFeature;
+        layerType.finish_layout = finishLayout;
+        layerType.destroy_layout = destroyLayout;
+        descriptor = {sizeof(descriptor),
+                      MLN_PLUGIN_ABI_VERSION_1,
+                      cString("org.maplibre.test.layer-type"),
+                      cString("1.0.0"),
+                      MLN_PLUGIN_ABI_VERSION_1,
+                      MLN_PLUGIN_ABI_VERSION_1,
+                      &layerType,
+                      1};
+    }
+
+    mln_plugin_value defaultURI{};
+    mln_plugin_property_descriptor_v1 property{};
+    std::array<mln_plugin_property_descriptor_v1, 1> properties{};
+    mln_plugin_shader_source_v1 shaderSource{};
+    mln_plugin_shader_attribute_v1 shaderAttribute{};
+    mln_plugin_shader_descriptor_v1 shader{};
+    mln_plugin_layer_type_v1 layerType{};
+    mln_plugin_descriptor_v1 descriptor{};
+};
+
+struct Descriptor : LayerTypeDescriptor {
+    Descriptor(const char* id_, const char* propertyName_) : propertyName(propertyName_), id(id_) {
+        defaultValue.struct_size = sizeof(defaultValue);
+        defaultValue.type = MLN_PLUGIN_VALUE_BOOLEAN;
+        property.name = cString(propertyName);
+        property.type = MLN_PLUGIN_VALUE_BOOLEAN;
+        property.scope = MLN_PLUGIN_PROPERTY_PAINT;
+        property.default_value = defaultValue;
+        layerType.layer_type = cString(id);
+        layerType.properties = &property;
+        descriptor.plugin_id = cString(id);
+    }
+    const char* propertyName;
+    const char* id;
+    mln_plugin_value defaultValue{};
+};
+
+struct DynamicLayerTypeDescriptor {
+    DynamicLayerTypeDescriptor(const char* pluginID_,
+                               const char* layerType_,
+                               uint32_t capabilities = MLN_PLUGIN_EXPRESSION_CAMERA |
+                                                       MLN_PLUGIN_EXPRESSION_FEATURE |
+                                                       MLN_PLUGIN_EXPRESSION_COMPOSITE |
+                                                       MLN_PLUGIN_EXPRESSION_FEATURE_STATE)
+        : pluginID(pluginID_), layerTypeName(layerType_) {
+        defaultValue.struct_size = sizeof(defaultValue);
+        defaultValue.type = MLN_PLUGIN_VALUE_FLOAT;
+        defaultValue.data.float_value = 4.0f;
+        property.struct_size = sizeof(property);
+        property.name = cString("test-size");
+        property.type = MLN_PLUGIN_VALUE_FLOAT;
+        property.scope = MLN_PLUGIN_PROPERTY_PAINT;
+        property.default_value = defaultValue;
+        property.expression_capabilities = capabilities;
+        property.supports_transitions = 1;
+        shaderSource = {sizeof(shaderSource),
+                        MLN_PLUGIN_BACKEND_METAL,
+                        cString("shader source"),
+                        {},
+                        cString("testVertex"),
+                        cString("testFragment")};
+        shaderAttributes = {{
+            {sizeof(mln_plugin_shader_attribute_v1), 0, 0, cString("a_position"), MLN_PLUGIN_VERTEX_FLOAT_X2},
+            {sizeof(mln_plugin_shader_attribute_v1), 1, 1, cString("a_size_min"), MLN_PLUGIN_VERTEX_FLOAT},
+            {sizeof(mln_plugin_shader_attribute_v1), 2, 2, cString("a_size_max"), MLN_PLUGIN_VERTEX_FLOAT},
+        }};
+        uniform = {sizeof(uniform),
+                   0,
+                   cString("TestDrawableUBO"),
+                   16,
+                   MLN_PLUGIN_SHADER_STAGE_VERTEX,
+                   MLN_PLUGIN_UNIFORM_SCOPE_DRAWABLE};
+        binding = {sizeof(binding),
+                   cString("test-size"),
+                   MLN_PLUGIN_PROPERTY_ENCODING_FLOAT,
+                   0,
+                   0,
+                   1,
+                   2,
+                   0,
+                   4};
+        shader.struct_size = sizeof(shader);
+        shader.shader_id = cString("test-dynamic");
+        shader.sources = &shaderSource;
+        shader.source_count = 1;
+        shader.attributes = shaderAttributes.data();
+        shader.attribute_count = shaderAttributes.size();
+        shader.uniform_blocks = &uniform;
+        shader.uniform_block_count = 1;
+        shader.property_bindings = &binding;
+        shader.property_binding_count = 1;
+        layerType.struct_size = sizeof(layerType);
+        layerType.layer_type = cString(layerTypeName);
+        layerType.backend_mask = MLN_PLUGIN_BACKEND_METAL;
+        layerType.render_stage = MLN_PLUGIN_RENDER_STAGE_TRANSLUCENT;
+        layerType.properties = &property;
+        layerType.property_count = 1;
+        layerType.source_kind = MLN_PLUGIN_SOURCE_GEOMETRY;
+        layerType.geometry_type_mask = MLN_PLUGIN_GEOMETRY_POINT;
+        layerType.shaders = &shader;
+        layerType.shader_count = 1;
+        layerType.create_layout = createLayout;
+        layerType.layout_feature = layoutFeature;
+        layerType.finish_layout = finishLayout;
+        layerType.destroy_layout = destroyLayout;
+        layerType.update_uniform_block = updateUniform;
+        descriptor = {sizeof(descriptor),
+                      MLN_PLUGIN_ABI_VERSION_1,
+                      cString(pluginID),
+                      cString("1.0.0"),
+                      MLN_PLUGIN_ABI_VERSION_1,
+                      MLN_PLUGIN_ABI_VERSION_1,
+                      &layerType,
+                      1};
+    }
+
+    const char* pluginID;
+    const char* layerTypeName;
+    mln_plugin_value defaultValue{};
+    mln_plugin_property_descriptor_v1 property{};
+    mln_plugin_shader_source_v1 shaderSource{};
+    std::array<mln_plugin_shader_attribute_v1, 3> shaderAttributes{};
+    mln_plugin_uniform_block_descriptor_v1 uniform{};
+    mln_plugin_shader_property_binding_v1 binding{};
+    mln_plugin_shader_descriptor_v1 shader{};
+    mln_plugin_layer_type_v1 layerType{};
+    mln_plugin_descriptor_v1 descriptor{};
+};
+
+} // namespace
+
+TEST(PluginRegistry, RegistersAndAcceptsIdenticalRepeat) {
+    Descriptor plugin("org.maplibre.test.registry-repeat", "test-registry-repeat");
+    std::array<char, 256> error{};
+    EXPECT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&plugin.descriptor, error.data(), error.size()));
+    EXPECT_EQ(MLN_PLUGIN_STATUS_ALREADY_REGISTERED,
+              mln_plugin_register_v1(&plugin.descriptor, error.data(), error.size()));
+    EXPECT_TRUE(mln_plugin_is_registered_v1("org.maplibre.test.registry-repeat"));
+}
+
+TEST(PluginRegistry, RejectsAbiMismatchAndConflictingProperty) {
+    Descriptor badABI("org.maplibre.test.bad-abi", "test-bad-abi");
+    badABI.descriptor.maximum_host_abi = 0;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_UNSUPPORTED_ABI, mln_plugin_register_v1(&badABI.descriptor, nullptr, 0));
+
+    Descriptor first("org.maplibre.test.conflict-a", "test-conflicting-property");
+    Descriptor second("org.maplibre.test.conflict-b", "test-conflicting-property");
+    second.layerType.layer_type = first.layerType.layer_type;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&first.descriptor, nullptr, 0));
+    EXPECT_EQ(MLN_PLUGIN_STATUS_CONFLICT, mln_plugin_register_v1(&second.descriptor, nullptr, 0));
+}
+
+TEST(PluginRegistry, RejectsMalformedAndDuplicateDescriptors) {
+    Descriptor truncatedProperty("org.maplibre.test.truncated-property", "test-truncated-property");
+    truncatedProperty.property.struct_size = sizeof(truncatedProperty.property) - 1;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&truncatedProperty.descriptor, nullptr, 0));
+
+    Descriptor missingDestroy("org.maplibre.test.missing-destroy", "test-missing-destroy");
+    missingDestroy.layerType.destroy_layout = nullptr;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&missingDestroy.descriptor, nullptr, 0));
+
+    Descriptor layout("org.maplibre.test.layout", "test-layout");
+    layout.property.scope = MLN_PLUGIN_PROPERTY_LAYOUT;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&layout.descriptor, nullptr, 0));
+
+    Descriptor duplicate("org.maplibre.test.duplicate", "test-duplicate");
+    std::array<mln_plugin_property_descriptor_v1, 2> properties{duplicate.property, duplicate.property};
+    duplicate.layerType.properties = properties.data();
+    duplicate.layerType.property_count = properties.size();
+    EXPECT_EQ(MLN_PLUGIN_STATUS_CONFLICT, mln_plugin_register_v1(&duplicate.descriptor, nullptr, 0));
+}
+
+TEST(PluginRegistry, RegistersRasterDEMRenderGraphAndRejectsForwardDependencies) {
+    const mln_plugin_shader_source_v1 source{sizeof(mln_plugin_shader_source_v1),
+                                             MLN_PLUGIN_BACKEND_METAL,
+                                             cString("shader source"),
+                                             {},
+                                             cString("testVertex"),
+                                             cString("testFragment")};
+    const mln_plugin_shader_attribute_v1 attribute{
+        sizeof(mln_plugin_shader_attribute_v1), 0, 0, cString("a_position"), MLN_PLUGIN_VERTEX_INT16_X2};
+    const mln_plugin_uniform_block_descriptor_v1 uniform{sizeof(mln_plugin_uniform_block_descriptor_v1),
+                                                         0,
+                                                         cString("TestDrawableUBO"),
+                                                         16,
+                                                         MLN_PLUGIN_SHADER_STAGE_VERTEX,
+                                                         MLN_PLUGIN_UNIFORM_SCOPE_DRAWABLE};
+    const mln_plugin_shader_texture_v1 texture{sizeof(mln_plugin_shader_texture_v1), 0, 0, cString("u_image")};
+    const mln_plugin_shader_descriptor_v1 shader{sizeof(mln_plugin_shader_descriptor_v1),
+                                                 cString("dem-shader"),
+                                                 &source,
+                                                 1,
+                                                 &attribute,
+                                                 1,
+                                                 &uniform,
+                                                 1,
+                                                 &texture,
+                                                 1,
+                                                 nullptr,
+                                                 0};
+    const mln_plugin_render_target_descriptor_v1 target{sizeof(mln_plugin_render_target_descriptor_v1),
+                                                        1,
+                                                        MLN_PLUGIN_RENDER_TARGET_SOURCE_TILE,
+                                                        MLN_PLUGIN_RENDER_TARGET_RGBA8,
+                                                        MLN_PLUGIN_RENDER_TARGET_PER_TILE,
+                                                        1.0f,
+                                                        1.0f,
+                                                        {0.0f, 0.0f, 0.0f, 1.0f}};
+    const mln_plugin_texture_binding_v1 prepareTexture{sizeof(mln_plugin_texture_binding_v1),
+                                                       0,
+                                                       MLN_PLUGIN_TEXTURE_SOURCE_RASTER_DEM,
+                                                       0,
+                                                       {},
+                                                       MLN_PLUGIN_TEXTURE_FILTER_NEAREST,
+                                                       MLN_PLUGIN_TEXTURE_WRAP_CLAMP,
+                                                       MLN_PLUGIN_TEXTURE_WRAP_CLAMP};
+    mln_plugin_texture_binding_v1 finalTexture{sizeof(mln_plugin_texture_binding_v1),
+                                               0,
+                                               MLN_PLUGIN_TEXTURE_SOURCE_RENDER_TARGET,
+                                               1,
+                                               {},
+                                               MLN_PLUGIN_TEXTURE_FILTER_LINEAR,
+                                               MLN_PLUGIN_TEXTURE_WRAP_CLAMP,
+                                               MLN_PLUGIN_TEXTURE_WRAP_CLAMP};
+    std::array<mln_plugin_render_pass_descriptor_v1, 2> passes{{
+        {sizeof(mln_plugin_render_pass_descriptor_v1),
+         1,
+         cString("dem-shader"),
+         MLN_PLUGIN_GRAPH_GEOMETRY_RASTER_DEM_FULL_TILE,
+         1,
+         MLN_PLUGIN_RENDER_STAGE_PREPARE,
+         MLN_PLUGIN_DRAW_MODE_TRIANGLES,
+         MLN_PLUGIN_DEPTH_DISABLED,
+         MLN_PLUGIN_BLEND_REPLACE,
+         0,
+         0,
+         MLN_PLUGIN_TILE_PROJECTION_ALIGNED,
+         &prepareTexture,
+         1},
+        {sizeof(mln_plugin_render_pass_descriptor_v1),
+         2,
+         cString("dem-shader"),
+         MLN_PLUGIN_GRAPH_GEOMETRY_RASTER_DEM_MASKED_TILE,
+         0,
+         MLN_PLUGIN_RENDER_STAGE_TRANSLUCENT,
+         MLN_PLUGIN_DRAW_MODE_TRIANGLES,
+         MLN_PLUGIN_DEPTH_DISABLED,
+         MLN_PLUGIN_BLEND_PREMULTIPLIED_ALPHA,
+         0,
+         0,
+         MLN_PLUGIN_TILE_PROJECTION_ALIGNED,
+         &finalTexture,
+         1},
+    }};
+    const mln_plugin_render_graph_v1 graph{
+        sizeof(mln_plugin_render_graph_v1), &target, 1, passes.data(), passes.size()};
+    mln_plugin_layer_type_v1 layerType{};
+    layerType.struct_size = sizeof(layerType);
+    layerType.layer_type = cString("org.maplibre.test.raster-dem-graph");
+    layerType.backend_mask = MLN_PLUGIN_BACKEND_METAL;
+    layerType.render_stage = MLN_PLUGIN_RENDER_STAGE_TRANSLUCENT;
+    layerType.source_kind = MLN_PLUGIN_SOURCE_RASTER_DEM;
+    layerType.shaders = &shader;
+    layerType.shader_count = 1;
+    layerType.render_graph = &graph;
+    layerType.update_uniform_block = updateUniform;
+    layerType.participates_in_3d_pass = 1;
+    mln_plugin_descriptor_v1 descriptor{sizeof(mln_plugin_descriptor_v1),
+                                        MLN_PLUGIN_ABI_VERSION_1,
+                                        cString("org.maplibre.test.raster-dem-graph-plugin"),
+                                        cString("1.0.0"),
+                                        MLN_PLUGIN_ABI_VERSION_1,
+                                        MLN_PLUGIN_ABI_VERSION_1,
+                                        &layerType,
+                                        1};
+    char errorBuffer[256]{};
+    layerType.update_uniform_block = nullptr;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT,
+              mln_plugin_register_v1(&descriptor, errorBuffer, sizeof(errorBuffer)));
+    EXPECT_NE(std::string::npos, std::string(errorBuffer).find("uniforms without an update callback"));
+
+    layerType.update_uniform_block = updateUniform;
+    passes[0].tile_projection = static_cast<mln_plugin_tile_projection>(0);
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&descriptor, nullptr, 0));
+    passes[0].tile_projection = MLN_PLUGIN_TILE_PROJECTION_ALIGNED;
+    passes[0].draw_mode = MLN_PLUGIN_DRAW_MODE_LINES;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&descriptor, nullptr, 0));
+    passes[0].draw_mode = MLN_PLUGIN_DRAW_MODE_TRIANGLES;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&descriptor, nullptr, 0));
+    const auto registration = plugin::PluginRegistry::get().findLayerType("org.maplibre.test.raster-dem-graph");
+    ASSERT_TRUE(registration);
+    ASSERT_TRUE(registration->renderGraph);
+    EXPECT_TRUE(registration->participatesIn3DPass);
+    EXPECT_EQ(2u, registration->renderGraph->passes.size());
+    EXPECT_EQ(MLN_PLUGIN_TILE_PROJECTION_ALIGNED, registration->renderGraph->passes.front().tileProjection);
+
+    finalTexture.render_target_id = 9;
+    layerType.layer_type = cString("org.maplibre.test.raster-dem-forward-reference");
+    descriptor.plugin_id = cString("org.maplibre.test.raster-dem-forward-reference-plugin");
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&descriptor, nullptr, 0));
+}
+
+TEST(PluginStyleProperty, BuiltInLayersRejectPluginProperties) {
+    Descriptor plugin("org.maplibre.test.isolated-properties", "test-isolated-boolean");
+    ASSERT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&plugin.descriptor, nullptr, 0));
+    FillExtrusionLayer layer("buildings", "source");
+    const JSValue enabled(true);
+    EXPECT_TRUE(layer.setProperty("test-isolated-boolean", conversion::Convertible(&enabled)));
+    EXPECT_EQ(StyleProperty::Kind::Undefined, static_cast<const Layer&>(layer).getProperty("test-isolated-boolean").getKind());
+}
+
+TEST(PluginRegistry, RegistersSourceBoundLayerTypeAndScopedProperties) {
+    LayerTypeDescriptor custom;
+    ASSERT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&custom.descriptor, nullptr, 0));
+    const auto registration = plugin::PluginRegistry::get().findLayerType("test-plugin-layer");
+    ASSERT_TRUE(registration);
+    EXPECT_TRUE(registration->requires3D);
+    EXPECT_TRUE(registration->participatesIn3DPass);
+
+    JSDocument missingSource;
+    missingSource.Parse("{}");
+    const JSValue* missingSourceValue = &missingSource;
+    conversion::Error error;
+    EXPECT_FALSE(LayerManager::get()->createLayer(
+        "test-plugin-layer", "missing-source", conversion::Convertible(missingSourceValue), error));
+    EXPECT_NE(std::string::npos, error.message.find("requires a source"));
+
+    JSDocument input;
+    input.Parse(R"JSON({"source":"points"})JSON");
+    const JSValue* inputValue = &input;
+    auto layer = LayerManager::get()->createLayer(
+        "test-plugin-layer", "model", conversion::Convertible(inputValue), error);
+    ASSERT_TRUE(layer) << error.message;
+    EXPECT_STREQ("test-plugin-layer", layer->getTypeInfo()->type);
+    EXPECT_EQ("points", layer->getSourceID());
+    auto renderLayer = LayerManager::get()->createRenderLayer(layer->baseImpl);
+    ASSERT_TRUE(renderLayer);
+    EXPECT_TRUE(renderLayer->needsRendering());
+
+    const JSValue uri("https://example.test/model.glb");
+    EXPECT_FALSE(layer->setProperty("test-model-uri", conversion::Convertible(&uri), Layer::PropertyScope::Layout));
+    EXPECT_TRUE(layer->setProperty("test-model-uri", conversion::Convertible(&uri), Layer::PropertyScope::Paint));
+    const auto serialized = layer->serialize();
+    EXPECT_EQ("https://example.test/model.glb",
+              *serialized.getObject()->at("layout").getObject()->at("test-model-uri").getString());
+
+    util::RunLoop loop;
+    auto fileSource = std::make_shared<StubFileSource>();
+    Style::Impl style{fileSource, 1.0, {Scheduler::GetBackground(), {}}};
+    style.loadJSON(R"JSON({
+      "version": 8,
+      "sources": {
+        "points": {
+          "type": "geojson",
+          "data": {"type":"FeatureCollection","features":[]}
+        }
+      },
+      "layers": [{
+        "id": "model-from-json",
+        "type": "test-plugin-layer",
+        "source": "points",
+        "layout": {
+          "test-model-uri": "https://example.test/from-style.glb"
+        }
+      }]
+    })JSON");
+    const auto* parsedLayer = style.getLayer("model-from-json");
+    ASSERT_NE(nullptr, parsedLayer);
+    EXPECT_EQ("https://example.test/from-style.glb",
+              *parsedLayer->serialize().getObject()->at("layout").getObject()->at("test-model-uri").getString());
+}
+
+TEST(PluginRegistry, ValidatesDynamicShaderPropertyBindings) {
+    DynamicLayerTypeDescriptor valid("org.maplibre.test.dynamic-valid", "test-dynamic-valid");
+    ASSERT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&valid.descriptor, nullptr, 0));
+    const auto registration = plugin::PluginRegistry::get().findLayerType("test-dynamic-valid");
+    ASSERT_TRUE(registration);
+    ASSERT_EQ(1u, registration->shaders.size());
+    ASSERT_EQ(1u, registration->shaders.front().propertyBindings.size());
+    EXPECT_EQ("test-size", registration->shaders.front().propertyBindings.front().propertyName);
+
+    DynamicLayerTypeDescriptor overlap("org.maplibre.test.dynamic-overlap", "test-dynamic-overlap");
+    overlap.binding.interpolation_uniform_byte_offset = 0;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&overlap.descriptor, nullptr, 0));
+
+    DynamicLayerTypeDescriptor unaligned("org.maplibre.test.dynamic-unaligned", "test-dynamic-unaligned");
+    unaligned.binding.uniform_byte_offset = 2;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&unaligned.descriptor, nullptr, 0));
+
+    DynamicLayerTypeDescriptor missingBinding("org.maplibre.test.dynamic-unbound", "test-dynamic-unbound");
+    missingBinding.shader.property_bindings = nullptr;
+    missingBinding.shader.property_binding_count = 0;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT,
+              mln_plugin_register_v1(&missingBinding.descriptor, nullptr, 0));
+
+    DynamicLayerTypeDescriptor wrongProperty("org.maplibre.test.dynamic-wrong-property",
+                                             "test-dynamic-wrong-property");
+    wrongProperty.binding.property_name = cString("not-a-property");
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT,
+              mln_plugin_register_v1(&wrongProperty.descriptor, nullptr, 0));
+
+    Descriptor booleanTransition("org.maplibre.test.boolean-transition", "test-boolean-transition");
+    booleanTransition.property.supports_transitions = 1;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT,
+              mln_plugin_register_v1(&booleanTransition.descriptor, nullptr, 0));
+}
+
+TEST(PluginRegistry, ValidatesPackedEndpointsEnumsAndAttributeLimits) {
+    DynamicLayerTypeDescriptor packed("org.maplibre.test.packed", "test-packed");
+    packed.binding.maximum_attribute_id = 1;
+    packed.shaderAttributes[1].type = MLN_PLUGIN_VERTEX_FLOAT_X2;
+    packed.shader.attribute_count = 2;
+    ASSERT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&packed.descriptor, nullptr, 0));
+
+    DynamicLayerTypeDescriptor wrongPackedType("org.maplibre.test.packed-wrong", "test-packed-wrong");
+    wrongPackedType.binding.maximum_attribute_id = 1;
+    wrongPackedType.shader.attribute_count = 2;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&wrongPackedType.descriptor, nullptr, 0));
+
+    DynamicLayerTypeDescriptor outOfRange("org.maplibre.test.attribute-limit", "test-attribute-limit");
+    outOfRange.shaderAttributes[0].attribute_id = 16;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&outOfRange.descriptor, nullptr, 0));
+    outOfRange.shaderAttributes[0].attribute_id = 0;
+    outOfRange.shaderAttributes[0].location = 16;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&outOfRange.descriptor, nullptr, 0));
+
+    DynamicLayerTypeDescriptor enumerated("org.maplibre.test.enum-binding", "test-enum-binding");
+    const mln_plugin_string options[] = {cString("map"), cString("viewport")};
+    enumerated.property.type = MLN_PLUGIN_VALUE_STRING;
+    enumerated.property.default_value.type = MLN_PLUGIN_VALUE_STRING;
+    enumerated.property.default_value.data.string_value = options[1];
+    enumerated.property.supports_transitions = 0;
+    enumerated.property.enum_values = options;
+    enumerated.property.enum_value_count = 2;
+    enumerated.binding.encoding = MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&enumerated.descriptor, nullptr, 0));
+
+    Descriptor builtIn("org.maplibre.test.built-in-conflict", "test-property");
+    builtIn.layerType.layer_type = cString("circle");
+    EXPECT_EQ(MLN_PLUGIN_STATUS_CONFLICT, mln_plugin_register_v1(&builtIn.descriptor, nullptr, 0));
+    EXPECT_FALSE(mln_plugin_is_registered_v1("org.maplibre.test.built-in-conflict"));
+}
+
+TEST(PluginStyleProperty, EnforcesExpressionDependencyCapabilities) {
+    DynamicLayerTypeDescriptor cameraOnly("org.maplibre.test.dynamic-camera", "test-dynamic-camera",
+                                          MLN_PLUGIN_EXPRESSION_CAMERA);
+    ASSERT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&cameraOnly.descriptor, nullptr, 0));
+    JSDocument layerJSON;
+    layerJSON.Parse(R"JSON({"source":"points"})JSON");
+    const JSValue* layerValue = &layerJSON;
+    conversion::Error createError;
+    auto layer = LayerManager::get()->createLayer(
+        "test-dynamic-camera", "dynamic", conversion::Convertible(layerValue), createError);
+    ASSERT_TRUE(layer) << createError.message;
+
+    JSDocument camera;
+    camera.Parse(R"JSON(["interpolate",["linear"],["zoom"],0,2,20,20])JSON");
+    const JSValue* cameraValue = &camera;
+    EXPECT_FALSE(layer->setProperty("test-size", conversion::Convertible(cameraValue)));
+
+    JSDocument feature;
+    feature.Parse(R"JSON(["get","size"])JSON");
+    const JSValue* featureValue = &feature;
+    EXPECT_TRUE(layer->setProperty("test-size", conversion::Convertible(featureValue)));
+
+    JSDocument composite;
+    composite.Parse(R"JSON(["interpolate",["linear"],["zoom"],0,["get","small"],20,["get","large"]])JSON");
+    const JSValue* compositeValue = &composite;
+    EXPECT_TRUE(layer->setProperty("test-size", conversion::Convertible(compositeValue)));
+
+    JSDocument featureState;
+    featureState.Parse(R"JSON(["coalesce",["feature-state","size"],4])JSON");
+    const JSValue* featureStateValue = &featureState;
+    EXPECT_TRUE(layer->setProperty("test-size", conversion::Convertible(featureStateValue)));
+}
+
+TEST(PluginStyleProperty, StoresSerializesAndInterpolatesTransitions) {
+    DynamicLayerTypeDescriptor dynamic("org.maplibre.test.dynamic-transition", "test-dynamic-transition");
+    ASSERT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&dynamic.descriptor, nullptr, 0));
+    JSDocument layerJSON;
+    layerJSON.Parse(R"JSON({"source":"points"})JSON");
+    const JSValue* layerValue = &layerJSON;
+    conversion::Error createError;
+    auto layer = LayerManager::get()->createLayer(
+        "test-dynamic-transition", "dynamic-transition", conversion::Convertible(layerValue), createError);
+    ASSERT_TRUE(layer) << createError.message;
+
+    JSDocument transitionJSON;
+    transitionJSON.Parse(R"JSON({"duration":100,"delay":20})JSON");
+    const JSValue* transitionValue = &transitionJSON;
+    EXPECT_FALSE(layer->setProperty("test-size-transition",
+                                    conversion::Convertible(transitionValue),
+                                    Layer::PropertyScope::Paint));
+    EXPECT_TRUE(layer->setProperty("test-size-transition",
+                                   conversion::Convertible(transitionValue),
+                                   Layer::PropertyScope::Layout));
+    const auto serialized = layer->serialize();
+    const auto* paint = serialized.getObject()->at("paint").getObject();
+    ASSERT_NE(nullptr, paint);
+    const auto* transition = paint->at("test-size-transition").getObject();
+    ASSERT_NE(nullptr, transition);
+    EXPECT_EQ(100, *transition->at("duration").getInt());
+    EXPECT_EQ(20, *transition->at("delay").getInt());
+
+    plugin::PropertyDefinition definition{"test", "test-dynamic-transition", "test-size",
+                                          MLN_PLUGIN_VALUE_FLOAT, MLN_PLUGIN_PROPERTY_PAINT, Value{4.0},
+                                          MLN_PLUGIN_EXPRESSION_CAMERA, true, false, {}, {}, 0, {}};
+    style::PluginPropertyValue from{
+        style::PluginPropertyValue::TypedValue{PropertyValue<float>{0.0f}}};
+    style::PluginPropertyValue to{
+        style::PluginPropertyValue::TypedValue{PropertyValue<float>{10.0f}}};
+    const auto start = Clock::now();
+    style::PluginTransitioningPropertyValue transitioning{
+        std::move(to),
+        style::PluginTransitioningPropertyValue{std::move(from)},
+        TransitionOptions{std::chrono::milliseconds(100), Duration::zero()},
+        start};
+    const auto midpoint = transitioning.evaluate(0.0f, definition, start + std::chrono::milliseconds(50));
+    const auto midpointStyle = midpoint.toStyleProperty();
+    const auto value = numericValue<double>(midpointStyle.getValue());
+    ASSERT_TRUE(value);
+    EXPECT_GT(*value, 0.0);
+    EXPECT_LT(*value, 10.0);
+    EXPECT_TRUE(transitioning.hasTransition());
+    const auto completed = transitioning.evaluate(0.0f, definition, start + std::chrono::milliseconds(100));
+    EXPECT_DOUBLE_EQ(10.0, *numericValue<double>(completed.toStyleProperty().getValue()));
+    EXPECT_FALSE(transitioning.hasTransition());
+}
+
+TEST(PluginStyleProperty, DefaultSetCloneAndSerialize) {
+    Descriptor plugin("org.maplibre.test.style-property", "test-plugin-boolean");
+    ASSERT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&plugin.descriptor, nullptr, 0));
+
+    PluginStyleLayer layer("buildings", "source", *plugin::PluginRegistry::get().findLayerType(plugin.id));
+    EXPECT_FALSE(*layer.getProperty("test-plugin-boolean").getValue().getBool());
+
+    const JSValue enabled(true);
+    EXPECT_FALSE(layer.setProperty("test-plugin-boolean", conversion::Convertible(&enabled)));
+    EXPECT_TRUE(*layer.getProperty("test-plugin-boolean").getValue().getBool());
+
+    auto clone = static_cast<const Layer&>(layer).cloneRef("buildings-copy");
+    EXPECT_TRUE(*clone->getProperty("test-plugin-boolean").getValue().getBool());
+
+    const auto serialized = clone->serialize();
+    const auto* paint = serialized.getObject()->at("paint").getObject();
+    ASSERT_NE(nullptr, paint);
+    EXPECT_TRUE(*paint->at("test-plugin-boolean").getBool());
+
+    StubLayerObserver observer;
+    layer.setObserver(&observer);
+    int notifications = 0;
+    observer.layerChanged = [&](Layer&) {
+        ++notifications;
+    };
+    const JSValue disabled(false);
+    EXPECT_FALSE(layer.setProperty("test-plugin-boolean", conversion::Convertible(&disabled)));
+    EXPECT_EQ(1, notifications);
+    EXPECT_FALSE(*layer.getProperty("test-plugin-boolean").getValue().getBool());
+    EXPECT_FALSE(layer.setProperty("test-plugin-boolean", conversion::Convertible(&disabled)));
+    EXPECT_EQ(1, notifications);
+    const auto disabledSerialized = static_cast<const Layer&>(layer).serialize();
+    EXPECT_FALSE(*disabledSerialized.getObject()->at("paint").getObject()->at("test-plugin-boolean").getBool());
+
+    const JSValue wrongType("true");
+    EXPECT_TRUE(layer.setProperty("test-plugin-boolean", conversion::Convertible(&wrongType)));
+
+    JSDocument expression;
+    expression.Parse(R"(["get", "enabled"])");
+    const JSValue* expressionValue = &expression;
+    EXPECT_TRUE(layer.setProperty("test-plugin-boolean", conversion::Convertible(expressionValue)));
+
+    const JSValue unknown(true);
+    EXPECT_TRUE(layer.setProperty("test-unregistered-property", conversion::Convertible(&unknown)));
+}
+
+TEST(PluginStyleProperty, EnforcesArrayNumericAndEnumConstraints) {
+    Descriptor numeric("org.maplibre.test.constrained-array", "test-constrained-array");
+    const std::array<float, 1> defaultArray{45.0f};
+    numeric.defaultValue.type = MLN_PLUGIN_VALUE_FLOAT_ARRAY;
+    numeric.defaultValue.data.float_array_value = {defaultArray.data(), defaultArray.size()};
+    numeric.property.type = MLN_PLUGIN_VALUE_FLOAT_ARRAY;
+    numeric.property.default_value = numeric.defaultValue;
+    numeric.property.accepts_scalar = 1;
+    numeric.property.has_minimum = 1;
+    numeric.property.minimum = 0.0f;
+    numeric.property.has_maximum = 1;
+    numeric.property.maximum = 90.0f;
+    numeric.property.maximum_array_length = 4;
+    ASSERT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&numeric.descriptor, nullptr, 0));
+
+    PluginStyleLayer layer("constrained", "source", *plugin::PluginRegistry::get().findLayerType(numeric.id));
+    const JSValue scalar(30);
+    EXPECT_FALSE(layer.setProperty("test-constrained-array", conversion::Convertible(&scalar)));
+
+    JSDocument tooLong;
+    tooLong.Parse("[0, 1, 2, 3, 4]");
+    const JSValue* tooLongValue = &tooLong;
+    EXPECT_TRUE(layer.setProperty("test-constrained-array", conversion::Convertible(tooLongValue)));
+
+    JSDocument outOfRange;
+    outOfRange.Parse("[91]");
+    const JSValue* outOfRangeValue = &outOfRange;
+    EXPECT_TRUE(layer.setProperty("test-constrained-array", conversion::Convertible(outOfRangeValue)));
+
+    Descriptor enumeration("org.maplibre.test.constrained-enum", "test-constrained-enum");
+    enumeration.defaultValue.type = MLN_PLUGIN_VALUE_STRING;
+    enumeration.defaultValue.data.string_value = cString("first");
+    enumeration.property.type = MLN_PLUGIN_VALUE_STRING;
+    enumeration.property.default_value = enumeration.defaultValue;
+    const std::array<mln_plugin_string, 2> allowed{cString("first"), cString("second")};
+    enumeration.property.enum_values = allowed.data();
+    enumeration.property.enum_value_count = allowed.size();
+    ASSERT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&enumeration.descriptor, nullptr, 0));
+
+    PluginStyleLayer enumLayer("enum", "source", *plugin::PluginRegistry::get().findLayerType(enumeration.id));
+    const JSValue allowedValue("second");
+    EXPECT_FALSE(enumLayer.setProperty("test-constrained-enum", conversion::Convertible(&allowedValue)));
+    const JSValue rejectedValue("third");
+    EXPECT_TRUE(enumLayer.setProperty("test-constrained-enum", conversion::Convertible(&rejectedValue)));
+}
+
+TEST(PluginStyleProperty, ParsesSerializesAndValidatesColorRamps) {
+    constexpr char defaultRamp[] =
+        R"JSON(["interpolate",["linear"],["heatmap-density"],0,"rgba(0, 0, 255, 0)",1,"red"])JSON";
+    Descriptor ramp("org.maplibre.test.color-ramp", "test-color-ramp");
+    ramp.defaultValue.type = MLN_PLUGIN_VALUE_COLOR_RAMP;
+    ramp.defaultValue.data.color_ramp_json = {defaultRamp, sizeof(defaultRamp) - 1};
+    ramp.property.type = MLN_PLUGIN_VALUE_COLOR_RAMP;
+    ramp.property.default_value = ramp.defaultValue;
+    ramp.property.expression_capabilities = MLN_PLUGIN_EXPRESSION_CAMERA;
+    ASSERT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&ramp.descriptor, nullptr, 0));
+
+    PluginStyleLayer layer("color-ramp", "source", *plugin::PluginRegistry::get().findLayerType(ramp.id));
+    JSDocument expression;
+    expression.Parse(R"JSON(["interpolate",["linear"],["heatmap-density"],0,"rgba(0, 255, 0, 0)",1,"yellow"])JSON");
+    const JSValue* expressionValue = &expression;
+    EXPECT_FALSE(layer.setProperty("test-color-ramp", conversion::Convertible(expressionValue)));
+    const auto serialized = static_cast<const Layer&>(layer).serialize();
+    const auto* paint = serialized.getObject()->at("paint").getObject();
+    ASSERT_NE(nullptr, paint);
+    EXPECT_NE(nullptr, paint->at("test-color-ramp").getArray());
+
+    constexpr char invalidRamp[] = R"JSON(["not-a-color-ramp"])JSON";
+    Descriptor invalid("org.maplibre.test.invalid-color-ramp", "test-invalid-color-ramp");
+    invalid.defaultValue.type = MLN_PLUGIN_VALUE_COLOR_RAMP;
+    invalid.defaultValue.data.color_ramp_json = {invalidRamp, sizeof(invalidRamp) - 1};
+    invalid.property.type = MLN_PLUGIN_VALUE_COLOR_RAMP;
+    invalid.property.default_value = invalid.defaultValue;
+    invalid.property.expression_capabilities = MLN_PLUGIN_EXPRESSION_CAMERA;
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&invalid.descriptor, nullptr, 0));
+}

--- a/test/plugin/plugin.test.cpp
+++ b/test/plugin/plugin.test.cpp
@@ -107,7 +107,9 @@ struct LayerTypeDescriptor {
 };
 
 struct Descriptor : LayerTypeDescriptor {
-    Descriptor(const char* id_, const char* propertyName_) : propertyName(propertyName_), id(id_) {
+    Descriptor(const char* id_, const char* propertyName_)
+        : propertyName(propertyName_),
+          id(id_) {
         defaultValue.struct_size = sizeof(defaultValue);
         defaultValue.type = MLN_PLUGIN_VALUE_BOOLEAN;
         property.name = cString(propertyName);
@@ -126,11 +128,11 @@ struct Descriptor : LayerTypeDescriptor {
 struct DynamicLayerTypeDescriptor {
     DynamicLayerTypeDescriptor(const char* pluginID_,
                                const char* layerType_,
-                               uint32_t capabilities = MLN_PLUGIN_EXPRESSION_CAMERA |
-                                                       MLN_PLUGIN_EXPRESSION_FEATURE |
+                               uint32_t capabilities = MLN_PLUGIN_EXPRESSION_CAMERA | MLN_PLUGIN_EXPRESSION_FEATURE |
                                                        MLN_PLUGIN_EXPRESSION_COMPOSITE |
                                                        MLN_PLUGIN_EXPRESSION_FEATURE_STATE)
-        : pluginID(pluginID_), layerTypeName(layerType_) {
+        : pluginID(pluginID_),
+          layerTypeName(layerType_) {
         defaultValue.struct_size = sizeof(defaultValue);
         defaultValue.type = MLN_PLUGIN_VALUE_FLOAT;
         defaultValue.data.float_value = 4.0f;
@@ -158,15 +160,7 @@ struct DynamicLayerTypeDescriptor {
                    16,
                    MLN_PLUGIN_SHADER_STAGE_VERTEX,
                    MLN_PLUGIN_UNIFORM_SCOPE_DRAWABLE};
-        binding = {sizeof(binding),
-                   cString("test-size"),
-                   MLN_PLUGIN_PROPERTY_ENCODING_FLOAT,
-                   0,
-                   0,
-                   1,
-                   2,
-                   0,
-                   4};
+        binding = {sizeof(binding), cString("test-size"), MLN_PLUGIN_PROPERTY_ENCODING_FLOAT, 0, 0, 1, 2, 0, 4};
         shader.struct_size = sizeof(shader);
         shader.shader_id = cString("test-dynamic");
         shader.sources = &shaderSource;
@@ -394,7 +388,8 @@ TEST(PluginStyleProperty, BuiltInLayersRejectPluginProperties) {
     FillExtrusionLayer layer("buildings", "source");
     const JSValue enabled(true);
     EXPECT_TRUE(layer.setProperty("test-isolated-boolean", conversion::Convertible(&enabled)));
-    EXPECT_EQ(StyleProperty::Kind::Undefined, static_cast<const Layer&>(layer).getProperty("test-isolated-boolean").getKind());
+    EXPECT_EQ(StyleProperty::Kind::Undefined,
+              static_cast<const Layer&>(layer).getProperty("test-isolated-boolean").getKind());
 }
 
 TEST(PluginRegistry, RegistersSourceBoundLayerTypeAndScopedProperties) {
@@ -478,19 +473,15 @@ TEST(PluginRegistry, ValidatesDynamicShaderPropertyBindings) {
     DynamicLayerTypeDescriptor missingBinding("org.maplibre.test.dynamic-unbound", "test-dynamic-unbound");
     missingBinding.shader.property_bindings = nullptr;
     missingBinding.shader.property_binding_count = 0;
-    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT,
-              mln_plugin_register_v1(&missingBinding.descriptor, nullptr, 0));
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&missingBinding.descriptor, nullptr, 0));
 
-    DynamicLayerTypeDescriptor wrongProperty("org.maplibre.test.dynamic-wrong-property",
-                                             "test-dynamic-wrong-property");
+    DynamicLayerTypeDescriptor wrongProperty("org.maplibre.test.dynamic-wrong-property", "test-dynamic-wrong-property");
     wrongProperty.binding.property_name = cString("not-a-property");
-    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT,
-              mln_plugin_register_v1(&wrongProperty.descriptor, nullptr, 0));
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&wrongProperty.descriptor, nullptr, 0));
 
     Descriptor booleanTransition("org.maplibre.test.boolean-transition", "test-boolean-transition");
     booleanTransition.property.supports_transitions = 1;
-    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT,
-              mln_plugin_register_v1(&booleanTransition.descriptor, nullptr, 0));
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&booleanTransition.descriptor, nullptr, 0));
 }
 
 TEST(PluginRegistry, ValidatesPackedEndpointsEnumsAndAttributeLimits) {
@@ -530,8 +521,8 @@ TEST(PluginRegistry, ValidatesPackedEndpointsEnumsAndAttributeLimits) {
 }
 
 TEST(PluginStyleProperty, EnforcesExpressionDependencyCapabilities) {
-    DynamicLayerTypeDescriptor cameraOnly("org.maplibre.test.dynamic-camera", "test-dynamic-camera",
-                                          MLN_PLUGIN_EXPRESSION_CAMERA);
+    DynamicLayerTypeDescriptor cameraOnly(
+        "org.maplibre.test.dynamic-camera", "test-dynamic-camera", MLN_PLUGIN_EXPRESSION_CAMERA);
     ASSERT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&cameraOnly.descriptor, nullptr, 0));
     JSDocument layerJSON;
     layerJSON.Parse(R"JSON({"source":"points"})JSON");
@@ -576,12 +567,10 @@ TEST(PluginStyleProperty, StoresSerializesAndInterpolatesTransitions) {
     JSDocument transitionJSON;
     transitionJSON.Parse(R"JSON({"duration":100,"delay":20})JSON");
     const JSValue* transitionValue = &transitionJSON;
-    EXPECT_FALSE(layer->setProperty("test-size-transition",
-                                    conversion::Convertible(transitionValue),
-                                    Layer::PropertyScope::Paint));
-    EXPECT_TRUE(layer->setProperty("test-size-transition",
-                                   conversion::Convertible(transitionValue),
-                                   Layer::PropertyScope::Layout));
+    EXPECT_FALSE(layer->setProperty(
+        "test-size-transition", conversion::Convertible(transitionValue), Layer::PropertyScope::Paint));
+    EXPECT_TRUE(layer->setProperty(
+        "test-size-transition", conversion::Convertible(transitionValue), Layer::PropertyScope::Layout));
     const auto serialized = layer->serialize();
     const auto* paint = serialized.getObject()->at("paint").getObject();
     ASSERT_NE(nullptr, paint);
@@ -590,13 +579,21 @@ TEST(PluginStyleProperty, StoresSerializesAndInterpolatesTransitions) {
     EXPECT_EQ(100, *transition->at("duration").getInt());
     EXPECT_EQ(20, *transition->at("delay").getInt());
 
-    plugin::PropertyDefinition definition{"test", "test-dynamic-transition", "test-size",
-                                          MLN_PLUGIN_VALUE_FLOAT, MLN_PLUGIN_PROPERTY_PAINT, Value{4.0},
-                                          MLN_PLUGIN_EXPRESSION_CAMERA, true, false, {}, {}, 0, {}};
-    style::PluginPropertyValue from{
-        style::PluginPropertyValue::TypedValue{PropertyValue<float>{0.0f}}};
-    style::PluginPropertyValue to{
-        style::PluginPropertyValue::TypedValue{PropertyValue<float>{10.0f}}};
+    plugin::PropertyDefinition definition{"test",
+                                          "test-dynamic-transition",
+                                          "test-size",
+                                          MLN_PLUGIN_VALUE_FLOAT,
+                                          MLN_PLUGIN_PROPERTY_PAINT,
+                                          Value{4.0},
+                                          MLN_PLUGIN_EXPRESSION_CAMERA,
+                                          true,
+                                          false,
+                                          {},
+                                          {},
+                                          0,
+                                          {}};
+    style::PluginPropertyValue from{style::PluginPropertyValue::TypedValue{PropertyValue<float>{0.0f}}};
+    style::PluginPropertyValue to{style::PluginPropertyValue::TypedValue{PropertyValue<float>{10.0f}}};
     const auto start = Clock::now();
     style::PluginTransitioningPropertyValue transitioning{
         std::move(to),

--- a/test/plugin/property_binding.test.cpp
+++ b/test/plugin/property_binding.test.cpp
@@ -1,0 +1,88 @@
+#include <mln/renderer/buckets/plugin_bucket.hpp>
+#include <mln/style/rapidjson_conversion.hpp>
+#include <mln/tile/geojson_tile_data.hpp>
+#include <gtest/gtest.h>
+
+using namespace mln;
+
+namespace {
+GeoJSONTileLayer source() {
+    auto features = std::make_shared<mapbox::feature::feature_collection<int16_t>>();
+    mapbox::feature::feature<int16_t> feature{mapbox::geometry::point<int16_t>(10, 20)};
+    feature.id = uint64_t(1);
+    feature.properties = {{"small", 10.0}, {"large", 30.0}, {"anchor", std::string("viewport")}};
+    features->push_back(std::move(feature));
+    return GeoJSONTileLayer(features);
+}
+
+style::PluginPropertyValue expression(const plugin::PropertyDefinition& definition, const char* json) {
+    JSDocument document;
+    document.Parse(json);
+    const JSValue* value = &document;
+    style::conversion::Error error;
+    auto parsed = style::convertPluginPropertyValue(definition, style::conversion::Convertible(value), error);
+    EXPECT_TRUE(parsed) << error.message;
+    return parsed.value_or(style::defaultPluginPropertyValue(definition));
+}
+
+plugin::PropertyDefinition numberDefinition() {
+    plugin::PropertyDefinition definition;
+    definition.name = "test-size";
+    definition.type = MLN_PLUGIN_VALUE_FLOAT;
+    definition.defaultValue = 5.0;
+    definition.expressionCapabilities = MLN_PLUGIN_EXPRESSION_CAMERA | MLN_PLUGIN_EXPRESSION_FEATURE |
+        MLN_PLUGIN_EXPRESSION_COMPOSITE | MLN_PLUGIN_EXPRESSION_FEATURE_STATE;
+    return definition;
+}
+}
+
+TEST(PluginPaintBinder, PackedCompositeEndpointsAndFeatureStateUpdates) {
+    auto definition = numberDefinition();
+    const auto layer = source();
+    plugin::ShaderPropertyBindingDefinition binding{"test-size", MLN_PLUGIN_PROPERTY_ENCODING_FLOAT, 0, 0, 1, 1, 0, 4};
+    auto value = expression(definition, R"(["interpolate",["linear"],["zoom"],10,["get","small"],11,["get","large"]])");
+    PluginPaintPropertyBinder binder(definition, binding, value, 10, 1, 4, {{0,1,0,4}}, layer);
+    ASSERT_TRUE(binder.isDataDriven());
+    EXPECT_EQ(gfx::AttributeDataType::Float2, binder.attributeType());
+    const auto* bytes = static_cast<const float*>(binder.getVertexVector()->getRawData());
+    EXPECT_FLOAT_EQ(10, bytes[0]);
+    EXPECT_FLOAT_EQ(30, bytes[1]);
+    EXPECT_FLOAT_EQ(0.5, binder.interpolationFactor(10.5));
+    EXPECT_EQ(8u, binder.getVertexVector()->getRawSize());
+
+    value = expression(definition, R"(["coalesce",["feature-state","size"],12])");
+    EXPECT_TRUE(binder.synchronize(value)); // Refill and rebind the changed attribute data.
+    FeatureStates states;
+    states["1"] = {{"size", 42.0}};
+    EXPECT_TRUE(binder.update(states, layer));
+    bytes = static_cast<const float*>(binder.getVertexVector()->getRawData());
+    EXPECT_FLOAT_EQ(42, bytes[0]);
+    EXPECT_FLOAT_EQ(42, bytes[1]);
+    mln_plugin_value minimum{}, maximum{};
+    binder.statistics(10, minimum, maximum);
+    EXPECT_FLOAT_EQ(42, maximum.data.float_value);
+}
+
+TEST(PluginPaintBinder, EnumOrdinalsAndOwnedStatisticsStrings) {
+    auto definition = numberDefinition();
+    definition.type = MLN_PLUGIN_VALUE_STRING;
+    definition.defaultValue = std::string("map");
+    definition.enumValues = {"map", "viewport"};
+    const auto layer = source();
+    plugin::ShaderPropertyBindingDefinition binding{"test-size", MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT, 0, 0, 1, 1, 0, 4};
+    auto value = expression(definition, R"(["get","anchor"])");
+    PluginPaintPropertyBinder binder(definition, binding, value, 10, 1, 4, {{0,1,0,4}}, layer);
+    const auto* bytes = static_cast<const float*>(binder.getVertexVector()->getRawData());
+    EXPECT_FLOAT_EQ(1, bytes[0]);
+    EXPECT_FLOAT_EQ(1, bytes[1]);
+    mln_plugin_value minimum{}, maximum{};
+    binder.statistics(10, minimum, maximum);
+    EXPECT_EQ("viewport", std::string(maximum.data.string_value.data, maximum.data.string_value.size));
+    value = expression(definition, R"("viewport")");
+    EXPECT_TRUE(binder.synchronize(value));
+    binder.statistics(10, minimum, maximum);
+    EXPECT_EQ("viewport", std::string(maximum.data.string_value.data, maximum.data.string_value.size));
+    float uniform[2]{};
+    binder.writeUniform(10, 0, reinterpret_cast<uint8_t*>(uniform), sizeof(uniform));
+    EXPECT_FLOAT_EQ(1, uniform[0]);
+}

--- a/test/plugin/property_binding.test.cpp
+++ b/test/plugin/property_binding.test.cpp
@@ -31,17 +31,17 @@ plugin::PropertyDefinition numberDefinition() {
     definition.type = MLN_PLUGIN_VALUE_FLOAT;
     definition.defaultValue = 5.0;
     definition.expressionCapabilities = MLN_PLUGIN_EXPRESSION_CAMERA | MLN_PLUGIN_EXPRESSION_FEATURE |
-        MLN_PLUGIN_EXPRESSION_COMPOSITE | MLN_PLUGIN_EXPRESSION_FEATURE_STATE;
+                                        MLN_PLUGIN_EXPRESSION_COMPOSITE | MLN_PLUGIN_EXPRESSION_FEATURE_STATE;
     return definition;
 }
-}
+} // namespace
 
 TEST(PluginPaintBinder, PackedCompositeEndpointsAndFeatureStateUpdates) {
     auto definition = numberDefinition();
     const auto layer = source();
     plugin::ShaderPropertyBindingDefinition binding{"test-size", MLN_PLUGIN_PROPERTY_ENCODING_FLOAT, 0, 0, 1, 1, 0, 4};
     auto value = expression(definition, R"(["interpolate",["linear"],["zoom"],10,["get","small"],11,["get","large"]])");
-    PluginPaintPropertyBinder binder(definition, binding, value, 10, 1, 4, {{0,1,0,4}}, layer);
+    PluginPaintPropertyBinder binder(definition, binding, value, 10, 1, 4, {{0, 1, 0, 4}}, layer);
     ASSERT_TRUE(binder.isDataDriven());
     EXPECT_EQ(gfx::AttributeDataType::Float2, binder.attributeType());
     const auto* bytes = static_cast<const float*>(binder.getVertexVector()->getRawData());
@@ -69,9 +69,10 @@ TEST(PluginPaintBinder, EnumOrdinalsAndOwnedStatisticsStrings) {
     definition.defaultValue = std::string("map");
     definition.enumValues = {"map", "viewport"};
     const auto layer = source();
-    plugin::ShaderPropertyBindingDefinition binding{"test-size", MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT, 0, 0, 1, 1, 0, 4};
+    plugin::ShaderPropertyBindingDefinition binding{
+        "test-size", MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT, 0, 0, 1, 1, 0, 4};
     auto value = expression(definition, R"(["get","anchor"])");
-    PluginPaintPropertyBinder binder(definition, binding, value, 10, 1, 4, {{0,1,0,4}}, layer);
+    PluginPaintPropertyBinder binder(definition, binding, value, 10, 1, 4, {{0, 1, 0, 4}}, layer);
     const auto* bytes = static_cast<const float*>(binder.getVertexVector()->getRawData());
     EXPECT_FLOAT_EQ(1, bytes[0]);
     EXPECT_FLOAT_EQ(1, bytes[1]);


### PR DESCRIPTION
## Scope

Exercise ABI validation, registration conflicts, typed style behavior, packed endpoints, enum statistics, composite interpolation and feature-state updates.

Depends on #4593; review only against its base branch. Layer 9/11.

1154 changed lines (+973/-181). Within the approximately 2,000-line review budget.

## Validation and landing

At the integrated stack tip: 19 focused core tests and 108 Metal render tests pass. The n-gon plugin builds as an Android AAR for all four ABIs and through SwiftPM/Bazel. N-gon Vulkan images pass; the full MoltenVK run has two retained heatmap/hillshade image mismatches. OpenGL ES shader variants compile, but runtime OpenGL validation is still needed on a supported ES 3 test environment.

These are deliberately draft PRs. Build jobs are skipped before runner allocation; marking a PR ready triggers normal checks. Merge only in dependency order after those checks pass. Lightweight metadata/pre-commit services may still operate.

Companion plugin stack: https://github.com/louwers/maplibre-native-plugin-template/pull/1

Roadmap: [Incremental plugin introduction](https://github.com/maplibre/maplibre-native/blob/plugins/01-draft-ci/design-proposals/2026-09-08-plugin-introduction.md).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
