### PR TITLE
feat: package the C plugin API and runtime registry for Android

### DIFF
--- a/include/mln/style/layer.hpp
+++ b/include/mln/style/layer.hpp
@@ -142,8 +142,8 @@ public:
     };
     std::optional<conversion::Error> setProperty(const std::string& name, const conversion::Convertible& value);
     virtual std::optional<conversion::Error> setProperty(const std::string& name,
-                                                 const conversion::Convertible& value,
-                                                 PropertyScope scope);
+                                                         const conversion::Convertible& value,
+                                                         PropertyScope scope);
 
     virtual StyleProperty getProperty(const std::string&) const = 0;
     virtual Value serialize() const;

--- a/platform/android/MapLibreAndroid/build.gradle.kts
+++ b/platform/android/MapLibreAndroid/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 }
 
 dependencies {
+    api(project(":android-plugin-api"))
     lintChecks(project(":MapLibreAndroidLint"))
     api(libs.maplibreJavaGeoJSON)
     api(libs.maplibreGestures)
@@ -229,6 +230,7 @@ val syncPrefabHeaders by tasks.registering(Sync::class) {
         include("mln/style/layers/custom_layer_render_parameters.hpp")
         include("mln/style/layers/vulkan/custom_layer_init_parameters.hpp")
         include("mln/style/layers/vulkan/custom_layer_render_parameters.hpp")
+        include("mln/plugin/plugin_api.h")
     }
     into(project.rootDir.resolve("prefab-headers"))
 }

--- a/platform/android/MapLibreAndroid/src/cpp/CMakeLists.txt
+++ b/platform/android/MapLibreAndroid/src/cpp/CMakeLists.txt
@@ -122,6 +122,8 @@ add_library(maplibre SHARED
             ${PROJECT_SOURCE_DIR}/native_map_view.hpp
             ${PROJECT_SOURCE_DIR}/native_map_options.cpp
             ${PROJECT_SOURCE_DIR}/native_map_options.hpp
+            ${PROJECT_SOURCE_DIR}/plugin_registry.cpp
+            ${PROJECT_SOURCE_DIR}/plugin_registry.hpp
             ${PROJECT_SOURCE_DIR}/offline/offline_manager.cpp
             ${PROJECT_SOURCE_DIR}/offline/offline_manager.hpp
             ${PROJECT_SOURCE_DIR}/offline/offline_region.cpp

--- a/platform/android/MapLibreAndroid/src/cpp/jni_native.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/jni_native.cpp
@@ -35,6 +35,7 @@
 #include "maplibre.hpp"
 #include "native_map_view.hpp"
 #include "native_map_options.hpp"
+#include "plugin_registry.hpp"
 #include "rendering_stats.hpp"
 #include "util/tile_server_options.hpp"
 #ifndef MBGL_MODULE_OFFLINE_DISABLE
@@ -113,6 +114,7 @@ void registerNatives(JavaVM* vm) {
     NativeMapView::registerNative(env);
     NativeMapOptions::registerNative(env);
     RenderingStats::registerNative(env);
+    PluginRegistry::registerNative(env);
 
     // Http
     RegisterNativeHTTPRequest(env);

--- a/platform/android/MapLibreAndroid/src/cpp/plugin_registry.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/plugin_registry.cpp
@@ -1,0 +1,47 @@
+#include "plugin_registry.hpp"
+
+#include <mln/plugin/plugin_api.h>
+#include <mln/plugin/plugin_registry.hpp>
+
+#include <cstdint>
+
+namespace mln {
+namespace android {
+
+jni::jboolean PluginRegistry::isRegistered(jni::JNIEnv& env,
+                                           const jni::Class<PluginRegistry>&,
+                                           const jni::String& pluginID) {
+    return plugin::PluginRegistry::get().isRegistered(jni::Make<std::string>(env, pluginID));
+}
+
+jni::jint PluginRegistry::count(jni::JNIEnv&, const jni::Class<PluginRegistry>&) {
+    return static_cast<jni::jint>(plugin::PluginRegistry::get().pluginIDs().size());
+}
+
+jni::Local<jni::String> PluginRegistry::idAt(jni::JNIEnv& env, const jni::Class<PluginRegistry>&, jni::jint index) {
+    const auto ids = plugin::PluginRegistry::get().pluginIDs();
+    if (index < 0 || static_cast<std::size_t>(index) >= ids.size()) {
+        return jni::Make<jni::String>(env, std::string{});
+    }
+    return jni::Make<jni::String>(env, ids[static_cast<std::size_t>(index)]);
+}
+
+jni::jlong PluginRegistry::registrationFunctionAddress(jni::JNIEnv&, const jni::Class<PluginRegistry>&) {
+    return static_cast<jni::jlong>(reinterpret_cast<std::uintptr_t>(&mln_plugin_register_v1));
+}
+
+void PluginRegistry::registerNative(jni::JNIEnv& env) {
+    static auto& javaClass = jni::Class<PluginRegistry>::Singleton(env);
+    jni::RegisterNatives(
+        env,
+        *javaClass,
+        jni::MakeNativeMethod<decltype(&PluginRegistry::isRegistered), &PluginRegistry::isRegistered>(
+            "nativeIsRegistered"),
+        jni::MakeNativeMethod<decltype(&PluginRegistry::count), &PluginRegistry::count>("nativeCount"),
+        jni::MakeNativeMethod<decltype(&PluginRegistry::idAt), &PluginRegistry::idAt>("nativeIdAt"),
+        jni::MakeNativeMethod<decltype(&PluginRegistry::registrationFunctionAddress),
+                              &PluginRegistry::registrationFunctionAddress>("nativeRegistrationFunctionAddress"));
+}
+
+} // namespace android
+} // namespace mln

--- a/platform/android/MapLibreAndroid/src/cpp/plugin_registry.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/plugin_registry.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <jni/jni.hpp>
+
+namespace mln {
+namespace android {
+
+class PluginRegistry {
+public:
+    static constexpr auto Name() { return "org/maplibre/android/plugins/MapLibrePluginRegistry"; }
+
+    static jni::jboolean isRegistered(jni::JNIEnv&, const jni::Class<PluginRegistry>&, const jni::String&);
+    static jni::jint count(jni::JNIEnv&, const jni::Class<PluginRegistry>&);
+    static jni::Local<jni::String> idAt(jni::JNIEnv&, const jni::Class<PluginRegistry>&, jni::jint);
+    static jni::jlong registrationFunctionAddress(jni::JNIEnv&, const jni::Class<PluginRegistry>&);
+    static void registerNative(jni::JNIEnv&);
+};
+
+} // namespace android
+} // namespace mln

--- a/platform/android/MapLibrePluginApi/.gitignore
+++ b/platform/android/MapLibrePluginApi/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/.cxx/
+/.externalNativeBuild/

--- a/platform/android/MapLibrePluginApi/build.gradle.kts
+++ b/platform/android/MapLibrePluginApi/build.gradle.kts
@@ -1,0 +1,103 @@
+plugins {
+    id("com.android.library")
+    id("maven-publish")
+    id("maplibre.artifact-settings")
+}
+
+group = project.extra["mapLibreArtifactGroupId"] as String
+version = project.extra["versionName"] as String
+
+android {
+    namespace = "org.maplibre.android.plugins.api"
+    compileSdk = 34
+    ndkVersion = Versions.ndkVersion
+
+    defaultConfig {
+        minSdk = 23
+        externalNativeBuild {
+            cmake {
+                arguments("-DANDROID_STL=none")
+                targets("plugin_api")
+            }
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = Versions.cmakeVersion
+        }
+    }
+
+    buildFeatures { prefabPublishing = true }
+    prefab {
+        create("plugin_api") {
+            headers = "../prefab-plugin-api-headers"
+            libraryName = "libplugin_api"
+        }
+    }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
+}
+
+dependencies {
+    api(libs.supportAnnotations)
+}
+
+val syncPluginApiHeaders by tasks.registering(Sync::class) {
+    val nativeRoot = rootProject.rootDir.resolve("../..")
+    from(nativeRoot.resolve("include")) {
+        include("mln/plugin/plugin_api.h")
+    }
+    into(project.rootDir.resolve("prefab-plugin-api-headers"))
+}
+
+tasks.configureEach {
+    if (name == "syncPluginApiHeaders") return@configureEach
+    if (name.contains("Prefab", ignoreCase = true) || name.contains("bundleLibRuntimeTo", ignoreCase = true)) {
+        dependsOn(syncPluginApiHeaders)
+    }
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            groupId = project.group.toString()
+            artifactId = "android-plugin-api"
+            version = project.version.toString()
+            afterEvaluate { from(components["release"]) }
+            pom {
+                name.set("MapLibre Android Plugin API")
+                description.set("Pure-C native plugin ABI and Android registry contract for MapLibre Native")
+                url.set(project.extra["mapLibreArtifactUrl"].toString())
+            }
+        }
+    }
+    repositories {
+        val target = providers.gradleProperty("reposiliteUrl")
+            .orElse(providers.environmentVariable("REPOSILITE_URL"))
+        if (target.isPresent) {
+            val repositoryUri = uri(target.get())
+            val repositoryUsername = providers.gradleProperty("reposiliteUsername")
+                .orElse(providers.environmentVariable("REPOSILITE_USERNAME"))
+            val repositoryPassword = providers.gradleProperty("reposilitePassword")
+                .orElse(providers.environmentVariable("REPOSILITE_PASSWORD"))
+            maven {
+                name = "reposilite"
+                url = repositoryUri
+                if (repositoryUri.scheme in setOf("http", "https") &&
+                    repositoryUsername.isPresent && repositoryPassword.isPresent
+                ) {
+                    credentials {
+                        username = repositoryUsername.get()
+                        password = repositoryPassword.get()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/platform/android/MapLibrePluginApi/src/main/AndroidManifest.xml
+++ b/platform/android/MapLibrePluginApi/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/platform/android/MapLibrePluginApi/src/main/cpp/CMakeLists.txt
+++ b/platform/android/MapLibrePluginApi/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(MapLibrePluginApi LANGUAGES C)
+
+add_library(plugin_api STATIC plugin_api.c)

--- a/platform/android/MapLibrePluginApi/src/main/cpp/plugin_api.c
+++ b/platform/android/MapLibrePluginApi/src/main/cpp/plugin_api.c
@@ -1,0 +1,3 @@
+/* The plugin API is implemented by libmaplibre. This archive carries only the
+ * pure-C Prefab module identity and intentionally has no C++ runtime. */
+void maplibre_plugin_api_prefab_anchor(void) {}

--- a/platform/android/MapLibrePluginApi/src/main/java/org/maplibre/android/plugins/MapLibrePluginRegistry.java
+++ b/platform/android/MapLibrePluginApi/src/main/java/org/maplibre/android/plugins/MapLibrePluginRegistry.java
@@ -1,0 +1,66 @@
+package org.maplibre.android.plugins;
+
+import androidx.annotation.Keep;
+import androidx.annotation.NonNull;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Process-wide MapLibre native plugin registration and inspection API. */
+@Keep
+public final class MapLibrePluginRegistry {
+
+  private MapLibrePluginRegistry() {
+  }
+
+  /** Loads the renderer-selected MapLibre native library through its configured loader. */
+  public static void ensureMapLibreLoaded() {
+    try {
+      Class<?> loader = Class.forName("org.maplibre.android.LibraryLoader");
+      loader.getMethod("load").invoke(null);
+    } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException error) {
+      throw new IllegalStateException("A compatible MapLibre Android renderer is not installed", error);
+    } catch (InvocationTargetException error) {
+      Throwable cause = error.getCause();
+      if (cause instanceof RuntimeException) throw (RuntimeException) cause;
+      if (cause instanceof Error) throw (Error) cause;
+      throw new IllegalStateException("MapLibre Android could not be loaded", cause);
+    }
+  }
+
+  public static boolean isRegistered(@NonNull String pluginId) {
+    ensureMapLibreLoaded();
+    return nativeIsRegistered(pluginId);
+  }
+
+  @NonNull
+  public static List<String> registeredPluginIds() {
+    ensureMapLibreLoaded();
+    int count = nativeCount();
+    List<String> result = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      result.add(nativeIdAt(i));
+    }
+    return Collections.unmodifiableList(result);
+  }
+
+  /**
+   * Returns the process-lifetime address of the v1 C registration function.
+   * Android plugin wrappers pass this value to their own JNI entry point so
+   * neither DSO needs to link against the other's C++ runtime.
+   */
+  public static long registrationFunctionAddress() {
+    ensureMapLibreLoaded();
+    return nativeRegistrationFunctionAddress();
+  }
+
+  private static native boolean nativeIsRegistered(String pluginId);
+
+  private static native int nativeCount();
+
+  private static native String nativeIdAt(int index);
+
+  private static native long nativeRegistrationFunctionAddress();
+}

--- a/platform/android/buildSrc/src/main/kotlin/NativeBuildPlugin.kt
+++ b/platform/android/buildSrc/src/main/kotlin/NativeBuildPlugin.kt
@@ -35,6 +35,8 @@ fun Project.nativeBuild(nativeTargets: List<String>) =
             abi = project.property("maplibre.abis") as String
         }
 
+        // The plugin ABI is pure C. MapLibre keeps its C++ runtime private and
+        // plugins are expected to build without an Android STL dependency.
         var stl = "c++_static"
         if (project.hasProperty("mapbox.stl")) {
             stl = project.property("mapbox.stl") as String

--- a/platform/android/buildSrc/src/main/kotlin/maplibre.artifact-settings.gradle.kts
+++ b/platform/android/buildSrc/src/main/kotlin/maplibre.artifact-settings.gradle.kts
@@ -10,10 +10,13 @@ extra["mapLibreArtifactLicenseName"] = "BSD"
 extra["mapLibreArtifactLicenseUrl"] = "https://opensource.org/licenses/BSD-2-Clause"
 
 val versionFilePath = rootDir.resolve("VERSION")
-val versionName = if (versionFilePath.exists()) {
-    versionFilePath.readText().trim()
-} else {
-    throw GradleException("VERSION file not found at ${versionFilePath.absolutePath}")
-}
+val versionName = providers.gradleProperty("maplibreVersion")
+    .orElse(providers.environmentVariable("MAPLIBRE_VERSION"))
+    .orNull
+    ?: if (versionFilePath.exists()) {
+        versionFilePath.readText().trim()
+    } else {
+        throw GradleException("VERSION file not found at ${versionFilePath.absolutePath}")
+    }
 
 extra["versionName"] = versionName

--- a/platform/android/prefab-plugin-api-headers/mln/plugin/plugin_api.h
+++ b/platform/android/prefab-plugin-api-headers/mln/plugin/plugin_api.h
@@ -1,0 +1,661 @@
+#ifndef MLN_PLUGIN_API_H
+#define MLN_PLUGIN_API_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(_WIN32)
+#define MLN_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define MLN_PLUGIN_EXPORT __attribute__((visibility("default")))
+#endif
+
+#define MLN_PLUGIN_ABI_VERSION_1 1u
+
+typedef enum mln_plugin_status {
+    MLN_PLUGIN_STATUS_OK = 0,
+    MLN_PLUGIN_STATUS_ALREADY_REGISTERED = 1,
+    MLN_PLUGIN_STATUS_INVALID_ARGUMENT = 2,
+    MLN_PLUGIN_STATUS_UNSUPPORTED_ABI = 3,
+    MLN_PLUGIN_STATUS_CONFLICT = 4,
+    MLN_PLUGIN_STATUS_NOT_FOUND = 5,
+    MLN_PLUGIN_STATUS_CALLBACK_ERROR = 6
+} mln_plugin_status;
+
+typedef enum mln_plugin_backend {
+    MLN_PLUGIN_BACKEND_OPENGL = 1u << 0u,
+    MLN_PLUGIN_BACKEND_VULKAN = 1u << 1u,
+    MLN_PLUGIN_BACKEND_METAL = 1u << 2u
+} mln_plugin_backend;
+
+typedef enum mln_plugin_value_type {
+    MLN_PLUGIN_VALUE_BOOLEAN = 1,
+    MLN_PLUGIN_VALUE_FLOAT = 2,
+    MLN_PLUGIN_VALUE_FLOAT2 = 3,
+    MLN_PLUGIN_VALUE_COLOR = 4,
+    MLN_PLUGIN_VALUE_STRING = 5,
+    MLN_PLUGIN_VALUE_FLOAT_ARRAY = 6,
+    MLN_PLUGIN_VALUE_COLOR_ARRAY = 7,
+    /* UTF-8 JSON expression evaluated by the host into a 256 x 1 texture. */
+    MLN_PLUGIN_VALUE_COLOR_RAMP = 8
+} mln_plugin_value_type;
+
+typedef enum mln_plugin_property_scope {
+    MLN_PLUGIN_PROPERTY_PAINT = 1,
+    MLN_PLUGIN_PROPERTY_LAYOUT = 2
+} mln_plugin_property_scope;
+
+/* Expression dependencies accepted by a plugin property. */
+typedef enum mln_plugin_expression_capability {
+    MLN_PLUGIN_EXPRESSION_NONE = 0,
+    MLN_PLUGIN_EXPRESSION_CAMERA = 1u << 0u,
+    MLN_PLUGIN_EXPRESSION_FEATURE = 1u << 1u,
+    MLN_PLUGIN_EXPRESSION_COMPOSITE = 1u << 2u,
+    MLN_PLUGIN_EXPRESSION_FEATURE_STATE = 1u << 3u
+} mln_plugin_expression_capability;
+
+/*
+ * Custom layer source contract. Geometry sources cover GeoJSON and vector
+ * tile sources. The remaining values are reserved so adding raster and DEM
+ * adapters does not change the shape of the layer descriptor.
+ */
+typedef enum mln_plugin_source_kind {
+    MLN_PLUGIN_SOURCE_NONE = 0,
+    MLN_PLUGIN_SOURCE_GEOMETRY = 1,
+    MLN_PLUGIN_SOURCE_RASTER = 2,
+    MLN_PLUGIN_SOURCE_RASTER_DEM = 3
+} mln_plugin_source_kind;
+
+typedef enum mln_plugin_geometry_type {
+    MLN_PLUGIN_GEOMETRY_POINT = 1u << 0u,
+    MLN_PLUGIN_GEOMETRY_LINESTRING = 1u << 1u,
+    MLN_PLUGIN_GEOMETRY_POLYGON = 1u << 2u
+} mln_plugin_geometry_type;
+
+typedef struct mln_plugin_string {
+    const char* data;
+    size_t size;
+} mln_plugin_string;
+
+typedef struct mln_plugin_float2 {
+    float x;
+    float y;
+} mln_plugin_float2;
+
+typedef struct mln_plugin_color {
+    float r;
+    float g;
+    float b;
+    float a;
+} mln_plugin_color;
+
+typedef struct mln_plugin_float_array {
+    const float* data;
+    size_t count;
+} mln_plugin_float_array;
+
+typedef struct mln_plugin_color_array {
+    const mln_plugin_color* data;
+    size_t count;
+} mln_plugin_color_array;
+
+typedef union mln_plugin_value_data {
+    uint8_t boolean_value;
+    float float_value;
+    mln_plugin_float2 float2_value;
+    mln_plugin_color color_value;
+    mln_plugin_string string_value;
+    mln_plugin_float_array float_array_value;
+    mln_plugin_color_array color_array_value;
+    mln_plugin_string color_ramp_json;
+} mln_plugin_value_data;
+
+typedef struct mln_plugin_value {
+    uint32_t struct_size;
+    mln_plugin_value_type type;
+    mln_plugin_value_data data;
+} mln_plugin_value;
+
+typedef struct mln_plugin_property_descriptor_v1 {
+    uint32_t struct_size;
+    mln_plugin_string name;
+    mln_plugin_value_type type;
+    mln_plugin_property_scope scope;
+    mln_plugin_value default_value;
+    /* Bitmask of mln_plugin_expression_capability values. */
+    uint32_t expression_capabilities;
+    /* Paint properties may opt into the normal MapLibre transition system. */
+    uint8_t supports_transitions;
+    /* Array values may also be authored as a scalar/single color. */
+    uint8_t accepts_scalar;
+    uint8_t has_minimum;
+    uint8_t has_maximum;
+    float minimum;
+    float maximum;
+    /* Zero means no descriptor-specific limit. */
+    uint32_t maximum_array_length;
+    /* Optional allowed string values. */
+    const mln_plugin_string* enum_values;
+    size_t enum_value_count;
+} mln_plugin_property_descriptor_v1;
+
+typedef struct mln_plugin_property_value_v1 {
+    uint32_t struct_size;
+    mln_plugin_string name;
+    mln_plugin_value value;
+    uint8_t explicitly_set;
+} mln_plugin_property_value_v1;
+
+typedef enum mln_plugin_render_stage {
+    MLN_PLUGIN_RENDER_STAGE_PREPARE = 1,
+    MLN_PLUGIN_RENDER_STAGE_PASS_3D = 2,
+    MLN_PLUGIN_RENDER_STAGE_OPAQUE = 3,
+    MLN_PLUGIN_RENDER_STAGE_TRANSLUCENT = 4
+} mln_plugin_render_stage;
+
+typedef struct mln_plugin_resource_response_v1 {
+    uint32_t struct_size;
+    uint64_t request_id;
+    const uint8_t* data;
+    size_t data_size;
+    mln_plugin_string error_message;
+} mln_plugin_resource_response_v1;
+
+/* Response bytes and strings are borrowed and valid only during the callback. */
+typedef void (*mln_plugin_resource_callback_fn)(void* callback_context,
+                                                const mln_plugin_resource_response_v1* response);
+
+typedef struct mln_plugin_host_api_v1 {
+    uint32_t struct_size;
+    uint32_t abi_version;
+    void (*log)(int32_t severity, mln_plugin_string message);
+    void* context;
+    mln_plugin_status (*request_resource)(void* context,
+                                          mln_plugin_string url,
+                                          mln_plugin_resource_callback_fn callback,
+                                          void* callback_context,
+                                          uint64_t* request_id);
+    void (*cancel_resource_request)(void* context, uint64_t request_id);
+    void (*request_repaint)(void* context);
+} mln_plugin_host_api_v1;
+
+/* ------------------------------------------------------------------------- */
+/* Source layout and host-owned drawable API                                 */
+/* ------------------------------------------------------------------------- */
+
+typedef enum mln_plugin_vertex_attribute_type {
+    MLN_PLUGIN_VERTEX_INT16 = 1,
+    MLN_PLUGIN_VERTEX_INT16_X2 = 2,
+    MLN_PLUGIN_VERTEX_UINT16 = 3,
+    MLN_PLUGIN_VERTEX_UINT16_X2 = 4,
+    MLN_PLUGIN_VERTEX_FLOAT = 5,
+    MLN_PLUGIN_VERTEX_FLOAT_X2 = 6,
+    MLN_PLUGIN_VERTEX_FLOAT_X3 = 7,
+    MLN_PLUGIN_VERTEX_FLOAT_X4 = 8,
+    MLN_PLUGIN_VERTEX_UINT8_X4_NORMALIZED = 9
+} mln_plugin_vertex_attribute_type;
+
+typedef enum mln_plugin_draw_mode {
+    MLN_PLUGIN_DRAW_MODE_TRIANGLES = 1,
+    MLN_PLUGIN_DRAW_MODE_LINES = 2,
+    MLN_PLUGIN_DRAW_MODE_POINTS = 3
+} mln_plugin_draw_mode;
+
+typedef enum mln_plugin_depth_mode {
+    MLN_PLUGIN_DEPTH_DISABLED = 0,
+    MLN_PLUGIN_DEPTH_READ_ONLY = 1,
+    MLN_PLUGIN_DEPTH_READ_WRITE = 2
+} mln_plugin_depth_mode;
+
+typedef enum mln_plugin_blend_mode {
+    MLN_PLUGIN_BLEND_REPLACE = 0,
+    MLN_PLUGIN_BLEND_ALPHA = 1,
+    MLN_PLUGIN_BLEND_PREMULTIPLIED_ALPHA = 2,
+    MLN_PLUGIN_BLEND_MULTIPLY = 3,
+    MLN_PLUGIN_BLEND_ADDITIVE = 4
+} mln_plugin_blend_mode;
+
+/* Stable IDs are local to one registered plugin layer type. */
+typedef struct mln_plugin_shader_attribute_v1 {
+    uint32_t struct_size;
+    uint32_t attribute_id;
+    uint32_t location;
+    mln_plugin_string name;
+    mln_plugin_vertex_attribute_type type;
+} mln_plugin_shader_attribute_v1;
+
+typedef enum mln_plugin_shader_stage {
+    MLN_PLUGIN_SHADER_STAGE_VERTEX = 1u << 0u,
+    MLN_PLUGIN_SHADER_STAGE_FRAGMENT = 1u << 1u
+} mln_plugin_shader_stage;
+
+typedef enum mln_plugin_uniform_scope {
+    MLN_PLUGIN_UNIFORM_SCOPE_LAYER = 1,
+    MLN_PLUGIN_UNIFORM_SCOPE_DRAWABLE = 2
+} mln_plugin_uniform_scope;
+
+typedef struct mln_plugin_uniform_block_descriptor_v1 {
+    uint32_t struct_size;
+    uint32_t uniform_id;
+    mln_plugin_string name;
+    uint32_t byte_size;
+    uint32_t stage_mask;
+    mln_plugin_uniform_scope scope;
+} mln_plugin_uniform_block_descriptor_v1;
+
+typedef struct mln_plugin_shader_texture_v1 {
+    uint32_t struct_size;
+    uint32_t texture_id;
+    uint32_t location;
+    mln_plugin_string name;
+} mln_plugin_shader_texture_v1;
+
+typedef struct mln_plugin_shader_source_v1 {
+    uint32_t struct_size;
+    mln_plugin_backend backend;
+    /*
+     * GLSL vertex source for OpenGL/Vulkan; complete MSL source for Metal.
+     * The host prepends one numeric binding macro for every declared resource:
+     *   MLN_PLUGIN_UNIFORM_<uniform_id>_BINDING
+     *   MLN_PLUGIN_TEXTURE_<texture_id>_BINDING
+     * This keeps backend binding allocation owned by the host. A shader should
+     * use those macros in Vulkan set/binding declarations and Metal buffer,
+     * texture, and sampler attributes. OpenGL resolves uniforms by name.
+     */
+    mln_plugin_string vertex_source;
+    /* GLSL fragment source. Empty for Metal, where vertex_source is complete. */
+    mln_plugin_string fragment_source;
+    /* Metal entry points. Empty for OpenGL/Vulkan. */
+    mln_plugin_string vertex_entry_point;
+    mln_plugin_string fragment_entry_point;
+} mln_plugin_shader_source_v1;
+
+typedef enum mln_plugin_property_encoding_v1 {
+    MLN_PLUGIN_PROPERTY_ENCODING_FLOAT = 1,
+    MLN_PLUGIN_PROPERTY_ENCODING_FLOAT2 = 2,
+    MLN_PLUGIN_PROPERTY_ENCODING_COLOR = 3,
+    MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT = 4,
+    /* Zero-based index into the property descriptor enum_values. */
+    MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT = 5
+} mln_plugin_property_encoding_v1;
+
+/*
+ * Declares a host-owned dynamic paint binding. The named property is supplied
+ * either through the uniform block range or through the minimum/maximum vertex
+ * attributes. Composite expressions use both attributes plus the interpolation
+ * factor. Source-only expressions write equal minimum and maximum values.
+ * Equal minimum/maximum attribute IDs pack both endpoints into one float2
+ * (scalar/boolean/enum) or float4 (float2) attribute. Color needs two float4
+ * attributes. Enum endpoints must be selected, never linearly interpolated.
+ */
+typedef struct mln_plugin_shader_property_binding_v1 {
+    uint32_t struct_size;
+    mln_plugin_string property_name;
+    mln_plugin_property_encoding_v1 encoding;
+    uint32_t uniform_id;
+    uint32_t uniform_byte_offset;
+    uint32_t minimum_attribute_id;
+    uint32_t maximum_attribute_id;
+    uint32_t interpolation_uniform_id;
+    uint32_t interpolation_uniform_byte_offset;
+} mln_plugin_shader_property_binding_v1;
+
+typedef struct mln_plugin_shader_descriptor_v1 {
+    uint32_t struct_size;
+    mln_plugin_string shader_id;
+    const mln_plugin_shader_source_v1* sources;
+    size_t source_count;
+    const mln_plugin_shader_attribute_v1* attributes;
+    size_t attribute_count;
+    const mln_plugin_uniform_block_descriptor_v1* uniform_blocks;
+    size_t uniform_block_count;
+    const mln_plugin_shader_texture_v1* textures;
+    size_t texture_count;
+    const mln_plugin_shader_property_binding_v1* property_bindings;
+    size_t property_binding_count;
+} mln_plugin_shader_descriptor_v1;
+
+typedef enum mln_plugin_graph_geometry {
+    MLN_PLUGIN_GRAPH_GEOMETRY_PLUGIN_BUCKET = 1,
+    MLN_PLUGIN_GRAPH_GEOMETRY_RASTER_DEM_FULL_TILE = 2,
+    MLN_PLUGIN_GRAPH_GEOMETRY_RASTER_DEM_MASKED_TILE = 3,
+    /* One host-owned normalized [0, 1] viewport quad per layer. */
+    MLN_PLUGIN_GRAPH_GEOMETRY_VIEWPORT_QUAD = 4
+} mln_plugin_graph_geometry;
+
+typedef enum mln_plugin_texture_source {
+    MLN_PLUGIN_TEXTURE_SOURCE_RASTER_DEM = 1,
+    MLN_PLUGIN_TEXTURE_SOURCE_RENDER_TARGET = 2,
+    /* A 256 x 1 premultiplied texture generated from a color-ramp property. */
+    MLN_PLUGIN_TEXTURE_SOURCE_COLOR_RAMP_PROPERTY = 3
+} mln_plugin_texture_source;
+
+typedef enum mln_plugin_texture_filter {
+    MLN_PLUGIN_TEXTURE_FILTER_NEAREST = 1,
+    MLN_PLUGIN_TEXTURE_FILTER_LINEAR = 2
+} mln_plugin_texture_filter;
+
+typedef enum mln_plugin_texture_wrap {
+    MLN_PLUGIN_TEXTURE_WRAP_CLAMP = 1,
+    MLN_PLUGIN_TEXTURE_WRAP_REPEAT = 2
+} mln_plugin_texture_wrap;
+
+typedef enum mln_plugin_render_target_size {
+    MLN_PLUGIN_RENDER_TARGET_SOURCE_TILE = 1,
+    MLN_PLUGIN_RENDER_TARGET_VIEWPORT = 2
+} mln_plugin_render_target_size;
+
+typedef enum mln_plugin_render_target_format {
+    MLN_PLUGIN_RENDER_TARGET_RGBA8 = 1,
+    MLN_PLUGIN_RENDER_TARGET_RGBA16F = 2
+} mln_plugin_render_target_format;
+
+typedef enum mln_plugin_render_target_scope {
+    MLN_PLUGIN_RENDER_TARGET_PER_TILE = 1,
+    MLN_PLUGIN_RENDER_TARGET_PER_LAYER = 2
+} mln_plugin_render_target_scope;
+
+/* Projection matrix used for tile-bound geometry in a render-graph pass. */
+typedef enum mln_plugin_tile_projection {
+    /* The camera projection used by ordinary 2D geometry such as heatmaps. */
+    MLN_PLUGIN_TILE_PROJECTION_MAP = 1,
+    /* Pixel-aligned camera projection used by raster-like tile geometry. */
+    MLN_PLUGIN_TILE_PROJECTION_ALIGNED = 2,
+    /* Map projection with a farther near plane for 3D depth precision. */
+    MLN_PLUGIN_TILE_PROJECTION_NEAR_CLIPPED = 3
+} mln_plugin_tile_projection;
+
+typedef struct mln_plugin_render_target_descriptor_v1 {
+    uint32_t struct_size;
+    uint32_t target_id;
+    mln_plugin_render_target_size size;
+    mln_plugin_render_target_format format;
+    mln_plugin_render_target_scope scope;
+    /* Used for VIEWPORT targets. Zero is invalid; 0.5 creates a half-size target. */
+    float width_scale;
+    float height_scale;
+    mln_plugin_color clear_color;
+} mln_plugin_render_target_descriptor_v1;
+
+typedef struct mln_plugin_texture_binding_v1 {
+    uint32_t struct_size;
+    uint32_t texture_id;
+    mln_plugin_texture_source source;
+    /* Required only for MLN_PLUGIN_TEXTURE_SOURCE_RENDER_TARGET. */
+    uint32_t render_target_id;
+    /* Required only for COLOR_RAMP_PROPERTY. */
+    mln_plugin_string property_name;
+    mln_plugin_texture_filter filter;
+    mln_plugin_texture_wrap wrap_u;
+    mln_plugin_texture_wrap wrap_v;
+} mln_plugin_texture_binding_v1;
+
+typedef struct mln_plugin_render_pass_descriptor_v1 {
+    uint32_t struct_size;
+    uint32_t pass_id;
+    mln_plugin_string shader_id;
+    mln_plugin_graph_geometry geometry;
+    /* Zero renders into the map; non-zero names a graph render target. */
+    uint32_t render_target_id;
+    mln_plugin_render_stage render_stage;
+    mln_plugin_draw_mode draw_mode;
+    mln_plugin_depth_mode depth_mode;
+    mln_plugin_blend_mode blend_mode;
+    uint8_t enable_stencil;
+    uint8_t enable_cull_face;
+    mln_plugin_tile_projection tile_projection;
+    const mln_plugin_texture_binding_v1* textures;
+    size_t texture_count;
+} mln_plugin_render_pass_descriptor_v1;
+
+typedef struct mln_plugin_render_graph_v1 {
+    uint32_t struct_size;
+    const mln_plugin_render_target_descriptor_v1* render_targets;
+    size_t render_target_count;
+    const mln_plugin_render_pass_descriptor_v1* passes;
+    size_t pass_count;
+} mln_plugin_render_graph_v1;
+
+typedef enum mln_plugin_raster_dem_encoding {
+    MLN_PLUGIN_RASTER_DEM_MAPBOX = 1,
+    MLN_PLUGIN_RASTER_DEM_TERRARIUM = 2
+} mln_plugin_raster_dem_encoding;
+
+/* Borrowed render-thread inputs for a host-owned plugin uniform block. */
+typedef struct mln_plugin_uniform_context_v1 {
+    uint32_t struct_size;
+    uint32_t pass_id;
+    int32_t canonical_z;
+    int32_t canonical_x;
+    int32_t canonical_y;
+    int32_t wrap;
+    int32_t overscaled_z;
+    uint32_t source_max_zoom;
+    uint32_t dem_dimension;
+    uint32_t dem_stride;
+    mln_plugin_raster_dem_encoding dem_encoding;
+    double zoom;
+    double bearing;
+    float pixels_to_gl_units[2];
+    float tile_matrix[16];
+    float render_target_matrix[16];
+    float latitude_range[2];
+    uint32_t viewport_width;
+    uint32_t viewport_height;
+    uint32_t render_target_width;
+    uint32_t render_target_height;
+    float pixels_to_tile_units;
+    float camera_to_center_distance;
+    float pixel_ratio;
+    /* Column-major matrix mapping normalized viewport coordinates. */
+    float viewport_matrix[16];
+    const mln_plugin_property_value_v1* properties;
+    size_t property_count;
+} mln_plugin_uniform_context_v1;
+
+typedef mln_plugin_status (*mln_plugin_update_uniform_block_fn)(const mln_plugin_uniform_context_v1* context,
+                                                                uint32_t uniform_id,
+                                                                uint8_t* output,
+                                                                size_t output_size);
+
+/* A geometry is represented as paths into a flat tile-coordinate point list. */
+typedef struct mln_plugin_tile_point_v1 {
+    int16_t x;
+    int16_t y;
+} mln_plugin_tile_point_v1;
+
+typedef struct mln_plugin_feature_v1 {
+    uint32_t struct_size;
+    mln_plugin_geometry_type geometry_type;
+    uint64_t feature_index;
+    mln_plugin_string feature_id;
+    const mln_plugin_tile_point_v1* points;
+    size_t point_count;
+    /* path_offsets has path_count + 1 entries and ends at point_count. */
+    const uint32_t* path_offsets;
+    size_t path_count;
+    /* UTF-8 JSON object. Borrowed and valid only during layout_feature. */
+    mln_plugin_string properties_json;
+    /* Populated for query_feature with the current zoom and feature state;
+     * null during layout_feature because host binders own paint evaluation. */
+    const mln_plugin_property_value_v1* evaluated_properties;
+    size_t evaluated_property_count;
+} mln_plugin_feature_v1;
+
+typedef struct mln_plugin_layout_context_v1 {
+    uint32_t struct_size;
+    float zoom;
+    int32_t canonical_z;
+    int32_t canonical_x;
+    int32_t canonical_y;
+    uint32_t extent;
+    mln_plugin_string layer_id;
+    mln_plugin_string source_layer_id;
+    /* Serialized style values. Expressions are deliberately not evaluated here. */
+    const mln_plugin_property_value_v1* properties;
+    size_t property_count;
+    /* Resource requests use MapLibre's configured file source and cache. */
+    const mln_plugin_host_api_v1* host;
+} mln_plugin_layout_context_v1;
+
+/* Bytes are copied by the host before finish_layout returns. */
+typedef struct mln_plugin_vertex_stream_v1 {
+    uint32_t struct_size;
+    uint32_t stream_id;
+    const uint8_t* data;
+    size_t data_size;
+    uint32_t vertex_count;
+    uint32_t stride;
+} mln_plugin_vertex_stream_v1;
+
+typedef struct mln_plugin_attribute_binding_v1 {
+    uint32_t struct_size;
+    uint32_t attribute_id;
+    uint32_t stream_id;
+    uint32_t byte_offset;
+    mln_plugin_vertex_attribute_type type;
+} mln_plugin_attribute_binding_v1;
+
+typedef struct mln_plugin_segment_v1 {
+    uint32_t struct_size;
+    uint32_t vertex_offset;
+    uint32_t index_offset;
+    uint32_t vertex_length;
+    uint32_t index_length;
+    uint64_t feature_index;
+} mln_plugin_segment_v1;
+
+typedef struct mln_plugin_drawable_descriptor_v1 {
+    uint32_t struct_size;
+    uint64_t drawable_key;
+    mln_plugin_string shader_id;
+    mln_plugin_draw_mode draw_mode;
+    mln_plugin_render_stage render_stage;
+    mln_plugin_depth_mode depth_mode;
+    mln_plugin_blend_mode blend_mode;
+    uint8_t enable_stencil;
+    uint8_t enable_cull_face;
+    const mln_plugin_attribute_binding_v1* attributes;
+    size_t attribute_count;
+    const mln_plugin_segment_v1* segments;
+    size_t segment_count;
+} mln_plugin_drawable_descriptor_v1;
+
+typedef struct mln_plugin_feature_vertex_range_v1 {
+    uint32_t struct_size;
+    uint64_t feature_index;
+    uint64_t drawable_key;
+    uint32_t first_vertex;
+    uint32_t vertex_count;
+} mln_plugin_feature_vertex_range_v1;
+
+typedef struct mln_plugin_bucket_v1 {
+    uint32_t struct_size;
+    const mln_plugin_vertex_stream_v1* vertex_streams;
+    size_t vertex_stream_count;
+    const uint16_t* indices;
+    size_t index_count;
+    const mln_plugin_drawable_descriptor_v1* drawables;
+    size_t drawable_count;
+    /* Maximum screen-pixel distance used by precise rendered-feature query. */
+    float query_radius;
+    const mln_plugin_feature_vertex_range_v1* feature_vertex_ranges;
+    size_t feature_vertex_range_count;
+} mln_plugin_bucket_v1;
+
+typedef mln_plugin_status (*mln_plugin_create_layout_fn)(const mln_plugin_layout_context_v1* context,
+                                                         void** layout_instance);
+typedef mln_plugin_status (*mln_plugin_layout_feature_fn)(void* layout_instance, const mln_plugin_feature_v1* feature);
+typedef mln_plugin_status (*mln_plugin_finish_layout_fn)(void* layout_instance, mln_plugin_bucket_v1* bucket);
+typedef void (*mln_plugin_destroy_layout_fn)(void* layout_instance);
+
+/* Borrowed inputs for a rendered-feature hit test. Bearing is in radians;
+ * viewport dimensions and pixel distances are logical pixels. */
+typedef struct mln_plugin_query_context_v1 {
+    uint32_t struct_size;
+    double pixels_to_tile_units;
+    double camera_to_center_distance;
+    double bearing;
+    double tile_matrix[16];
+    uint32_t viewport_width;
+    uint32_t viewport_height;
+} mln_plugin_query_context_v1;
+
+/* Optional exact hit test. Query and feature geometry use tile coordinates.
+ * Use the projection context for pitch, translation, and viewport-aligned marks. */
+typedef uint8_t (*mln_plugin_query_feature_fn)(const mln_plugin_feature_v1* feature,
+                                               const mln_plugin_tile_point_v1* query_geometry,
+                                               size_t query_geometry_count,
+                                               const mln_plugin_query_context_v1* context,
+                                               const mln_plugin_property_value_v1* properties,
+                                               size_t property_count);
+
+typedef struct mln_plugin_property_statistics_v1 {
+    uint32_t struct_size;
+    mln_plugin_string property_name;
+    mln_plugin_value minimum;
+    mln_plugin_value maximum;
+} mln_plugin_property_statistics_v1;
+
+/* Optional conservative screen-pixel radius for broad-phase feature queries. */
+typedef float (*mln_plugin_query_radius_fn)(const mln_plugin_property_statistics_v1* statistics,
+                                            size_t statistics_count,
+                                            const mln_plugin_property_value_v1* camera_properties,
+                                            size_t camera_property_count);
+
+typedef struct mln_plugin_layer_type_v1 {
+    uint32_t struct_size;
+    mln_plugin_string layer_type;
+    uint32_t backend_mask;
+    mln_plugin_render_stage render_stage;
+    uint8_t requires_3d;
+    const mln_plugin_property_descriptor_v1* properties;
+    size_t property_count;
+    mln_plugin_source_kind source_kind;
+    uint32_t geometry_type_mask;
+    const mln_plugin_shader_descriptor_v1* shaders;
+    size_t shader_count;
+    mln_plugin_create_layout_fn create_layout;
+    mln_plugin_layout_feature_fn layout_feature;
+    mln_plugin_finish_layout_fn finish_layout;
+    mln_plugin_destroy_layout_fn destroy_layout;
+    mln_plugin_query_feature_fn query_feature;
+    /* Required for RasterDEM layers; optional for multi-pass geometry layers. */
+    const mln_plugin_render_graph_v1* render_graph;
+    mln_plugin_update_uniform_block_fn update_uniform_block;
+    /* Matches LayerTypeInfo::Pass3D without making the drawables depth-writing 3D geometry. */
+    uint8_t participates_in_3d_pass;
+    mln_plugin_query_radius_fn get_query_radius;
+} mln_plugin_layer_type_v1;
+
+typedef struct mln_plugin_descriptor_v1 {
+    uint32_t struct_size;
+    uint32_t abi_version;
+    mln_plugin_string plugin_id;
+    mln_plugin_string plugin_version;
+    uint32_t minimum_host_abi;
+    uint32_t maximum_host_abi;
+    const mln_plugin_layer_type_v1* layer_types;
+    size_t layer_type_count;
+} mln_plugin_descriptor_v1;
+
+typedef mln_plugin_status (*mln_plugin_register_function_v1)(const mln_plugin_descriptor_v1* descriptor,
+                                                             char* error_message,
+                                                             size_t error_message_capacity);
+
+MLN_PLUGIN_EXPORT mln_plugin_status mln_plugin_register_v1(const mln_plugin_descriptor_v1* descriptor,
+                                                           char* error_message,
+                                                           size_t error_message_capacity);
+MLN_PLUGIN_EXPORT uint8_t mln_plugin_is_registered_v1(const char* plugin_id);
+MLN_PLUGIN_EXPORT size_t mln_plugin_count_v1(void);
+MLN_PLUGIN_EXPORT size_t mln_plugin_id_at_v1(size_t index, char* output, size_t output_capacity);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MLN_PLUGIN_API_H */

--- a/platform/android/settings.gradle.kts
+++ b/platform/android/settings.gradle.kts
@@ -24,7 +24,8 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
-include(":MapLibreAndroid", ":MapLibreAndroidTestApp", ":MapLibreAndroidLint")
+include(":MapLibreAndroid", ":MapLibreAndroidTestApp", ":MapLibreAndroidLint", ":android-plugin-api")
+project(":android-plugin-api").projectDir = file("MapLibrePluginApi")
 
 rootProject.name = "MapLibreAndroid"
 

--- a/platform/android/version-script
+++ b/platform/android/version-script
@@ -1,4 +1,9 @@
 {
-  global: JNI_OnLoad;
+  global:
+    JNI_OnLoad;
+    mln_plugin_register_v1;
+    mln_plugin_is_registered_v1;
+    mln_plugin_count_v1;
+    mln_plugin_id_at_v1;
   local: *;
 };

--- a/src/mln/layout/plugin_layout.cpp
+++ b/src/mln/layout/plugin_layout.cpp
@@ -470,14 +470,16 @@ void PluginLayout::createBucket(const ImagePositions&,
                 range.feature_index < sourceLayer->featureCount() && drawable != drawableVertexCounts.end() &&
                 range.vertex_count > 0 && validRange(range.first_vertex, range.vertex_count, drawable->second);
         if (valid) {
-            bucket->featureVertexRanges.push_back(
-                {static_cast<std::size_t>(range.feature_index), range.drawable_key, range.first_vertex, range.vertex_count});
+            bucket->featureVertexRanges.push_back({static_cast<std::size_t>(range.feature_index),
+                                                   range.drawable_key,
+                                                   range.first_vertex,
+                                                   range.vertex_count});
         }
     }
     for (const auto& drawable : bucket->drawables) {
-        const auto shader = std::find_if(registration.shaders.begin(), registration.shaders.end(), [&](const auto& candidate) {
-            return candidate.id == drawable.shaderID;
-        });
+        const auto shader = std::find_if(registration.shaders.begin(),
+                                         registration.shaders.end(),
+                                         [&](const auto& candidate) { return candidate.id == drawable.shaderID; });
         if (!valid || shader == registration.shaders.end() || shader->propertyBindings.empty()) continue;
         std::vector<uint8_t> coverage(drawable.vertexCount);
         for (const auto& range : bucket->featureVertexRanges) {
@@ -504,9 +506,9 @@ void PluginLayout::createBucket(const ImagePositions&,
         const auto& impl = static_cast<const style::PluginStyleLayer::Impl&>(*layer->baseImpl);
         auto& layerBinders = bucket->paintPropertyBinders[impl.id];
         for (const auto& drawable : bucket->drawables) {
-            const auto shader = std::find_if(registration.shaders.begin(), registration.shaders.end(), [&](const auto& candidate) {
-                return candidate.id == drawable.shaderID;
-            });
+            const auto shader = std::find_if(registration.shaders.begin(),
+                                             registration.shaders.end(),
+                                             [&](const auto& candidate) { return candidate.id == drawable.shaderID; });
             if (shader == registration.shaders.end() || shader->propertyBindings.empty()) continue;
             layerBinders.emplace(std::piecewise_construct,
                                  std::forward_as_tuple(drawable.key),

--- a/src/mln/plugin/plugin_layer_factory.cpp
+++ b/src/mln/plugin/plugin_layer_factory.cpp
@@ -9,20 +9,21 @@ const style::LayerTypeInfo* PluginLayerFactory::getTypeInfo() const noexcept {
     return &registration.identity->info;
 }
 
-std::unique_ptr<style::Layer> PluginLayerFactory::createLayer(
-    const std::string& id, const style::conversion::Convertible& value) noexcept {
+std::unique_ptr<style::Layer> PluginLayerFactory::createLayer(const std::string& id,
+                                                              const style::conversion::Convertible& value) noexcept {
     const auto source = getSource(value);
     if (!source || source->empty()) return nullptr;
     return std::make_unique<style::PluginStyleLayer>(id, *source, registration);
 }
 
 std::unique_ptr<RenderLayer> PluginLayerFactory::createRenderLayer(Immutable<style::Layer::Impl> impl) noexcept {
-    return std::make_unique<RenderPluginStyleLayer>(staticImmutableCast<style::PluginStyleLayer::Impl>(std::move(impl)));
+    return std::make_unique<RenderPluginStyleLayer>(
+        staticImmutableCast<style::PluginStyleLayer::Impl>(std::move(impl)));
 }
 
-std::unique_ptr<Layout> PluginLayerFactory::createLayout(
-    const LayoutParameters& parameters, std::unique_ptr<GeometryTileLayer> tileLayer,
-    const std::vector<Immutable<style::LayerProperties>>& layers) {
+std::unique_ptr<Layout> PluginLayerFactory::createLayout(const LayoutParameters& parameters,
+                                                         std::unique_ptr<GeometryTileLayer> tileLayer,
+                                                         const std::vector<Immutable<style::LayerProperties>>& layers) {
     return std::make_unique<PluginLayout>(parameters.bucketParameters, layers, std::move(tileLayer), registration);
 }
 } // namespace mln::plugin

--- a/src/mln/plugin/plugin_registry.cpp
+++ b/src/mln/plugin/plugin_registry.cpp
@@ -82,8 +82,8 @@ bool descriptorEquals(const PluginRegistry::PluginRecord& existing,
         if (lhs.targetLayerType != rhs.targetLayerType || lhs.name != rhs.name || lhs.type != rhs.type ||
             lhs.scope != rhs.scope || lhs.defaultValue != rhs.defaultValue ||
             lhs.expressionCapabilities != rhs.expressionCapabilities ||
-            lhs.supportsTransitions != rhs.supportsTransitions ||
-            lhs.acceptsScalar != rhs.acceptsScalar || lhs.minimum != rhs.minimum || lhs.maximum != rhs.maximum ||
+            lhs.supportsTransitions != rhs.supportsTransitions || lhs.acceptsScalar != rhs.acceptsScalar ||
+            lhs.minimum != rhs.minimum || lhs.maximum != rhs.maximum ||
             lhs.maximumArrayLength != rhs.maximumArrayLength || lhs.enumValues != rhs.enumValues) {
             return false;
         }
@@ -97,8 +97,8 @@ bool descriptorEquals(const PluginRegistry::PluginRecord& existing,
             lhs.createLayout != rhs.createLayout || lhs.layoutFeature != rhs.layoutFeature ||
             lhs.finishLayout != rhs.finishLayout || lhs.destroyLayout != rhs.destroyLayout ||
             lhs.queryFeature != rhs.queryFeature || lhs.queryRadius != rhs.queryRadius ||
-            lhs.shaders.size() != rhs.shaders.size() ||
-            lhs.renderGraph != rhs.renderGraph || lhs.updateUniformBlock != rhs.updateUniformBlock) {
+            lhs.shaders.size() != rhs.shaders.size() || lhs.renderGraph != rhs.renderGraph ||
+            lhs.updateUniformBlock != rhs.updateUniformBlock) {
             return false;
         }
         for (size_t shaderIndex = 0; shaderIndex < lhs.shaders.size(); ++shaderIndex) {
@@ -380,12 +380,13 @@ bool appendShaders(const std::string& pluginID,
             const auto encodingSize = propertyEncodingSize(binding.encoding);
             const auto encodingAlignment = propertyEncodingAlignment(binding.encoding);
             const bool packed = binding.minimum_attribute_id == binding.maximum_attribute_id;
-            const auto attributeType = packed
-                ? (encodingSize == 4 ? MLN_PLUGIN_VERTEX_FLOAT_X2 : MLN_PLUGIN_VERTEX_FLOAT_X4)
-                : propertyAttributeType(binding.encoding);
-            const auto uniform = std::find_if(shader.uniformBlocks.begin(), shader.uniformBlocks.end(), [&](const auto& candidate) {
-                return candidate.id == binding.uniform_id;
-            });
+            const auto attributeType = packed ? (encodingSize == 4 ? MLN_PLUGIN_VERTEX_FLOAT_X2
+                                                                   : MLN_PLUGIN_VERTEX_FLOAT_X4)
+                                              : propertyAttributeType(binding.encoding);
+            const auto uniform = std::find_if(
+                shader.uniformBlocks.begin(), shader.uniformBlocks.end(), [&](const auto& candidate) {
+                    return candidate.id == binding.uniform_id;
+                });
             const auto interpolationUniform = std::find_if(
                 shader.uniformBlocks.begin(), shader.uniformBlocks.end(), [&](const auto& candidate) {
                     return candidate.id == binding.interpolation_uniform_id;
@@ -399,8 +400,7 @@ bool appendShaders(const std::string& pluginID,
                     return candidate.id == binding.maximum_attribute_id;
                 });
             if (binding.struct_size < sizeof(mln_plugin_shader_property_binding_v1) || propertyName.empty() ||
-                !encodingSize || !boundProperties.emplace(propertyName).second ||
-                (packed && encodingSize > 8) ||
+                !encodingSize || !boundProperties.emplace(propertyName).second || (packed && encodingSize > 8) ||
                 !boundPaintAttributes.emplace(binding.minimum_attribute_id).second ||
                 (!packed && !boundPaintAttributes.emplace(binding.maximum_attribute_id).second) ||
                 uniform == shader.uniformBlocks.end() || interpolationUniform == shader.uniformBlocks.end() ||
@@ -429,9 +429,8 @@ bool appendShaders(const std::string& pluginID,
                 return true;
             };
             if (!addUniformRange(binding.uniform_id, binding.uniform_byte_offset, encodingSize) ||
-                !addUniformRange(binding.interpolation_uniform_id,
-                                 binding.interpolation_uniform_byte_offset,
-                                 sizeof(float))) {
+                !addUniformRange(
+                    binding.interpolation_uniform_id, binding.interpolation_uniform_byte_offset, sizeof(float))) {
                 error = "plugin shader property bindings contain overlapping uniform ranges";
                 return false;
             }
@@ -462,8 +461,7 @@ bool appendProperties(const std::string& pluginID,
     }
     for (size_t p = 0; p < propertyCount; ++p) {
         const auto& property = properties[p];
-        constexpr uint32_t validExpressionCapabilities = MLN_PLUGIN_EXPRESSION_CAMERA |
-                                                         MLN_PLUGIN_EXPRESSION_FEATURE |
+        constexpr uint32_t validExpressionCapabilities = MLN_PLUGIN_EXPRESSION_CAMERA | MLN_PLUGIN_EXPRESSION_FEATURE |
                                                          MLN_PLUGIN_EXPRESSION_COMPOSITE |
                                                          MLN_PLUGIN_EXPRESSION_FEATURE_STATE;
         if (property.struct_size < sizeof(mln_plugin_property_descriptor_v1) || !validString(property.name) ||
@@ -477,8 +475,7 @@ bool appendProperties(const std::string& pluginID,
         const bool transitionableType = property.type == MLN_PLUGIN_VALUE_FLOAT ||
                                         property.type == MLN_PLUGIN_VALUE_FLOAT2 ||
                                         property.type == MLN_PLUGIN_VALUE_COLOR;
-        if (property.supports_transitions &&
-            (property.scope != MLN_PLUGIN_PROPERTY_PAINT || !transitionableType)) {
+        if (property.supports_transitions && (property.scope != MLN_PLUGIN_PROPERTY_PAINT || !transitionableType)) {
             error = "plugin transitions require an interpolatable paint property";
             return false;
         }
@@ -723,8 +720,7 @@ mln_plugin_status PluginRegistry::registerPlugin(const mln_plugin_descriptor_v1&
         return MLN_PLUGIN_STATUS_UNSUPPORTED_ABI;
     }
     if (!validString(descriptor.plugin_id) || !validString(descriptor.plugin_version) ||
-        (descriptor.layer_type_count && !descriptor.layer_types) ||
-        descriptor.layer_type_count == 0) {
+        (descriptor.layer_type_count && !descriptor.layer_types) || descriptor.layer_type_count == 0) {
         error = "plugin descriptor is missing an id, version, or layer registration";
         return MLN_PLUGIN_STATUS_INVALID_ARGUMENT;
     }
@@ -811,13 +807,17 @@ mln_plugin_status PluginRegistry::registerPlugin(const mln_plugin_descriptor_v1&
                     return item.targetLayerType == type && item.name == binding.propertyName;
                 });
                 const bool encodingMatches = property != newProperties.end() &&
-                    ((property->type == MLN_PLUGIN_VALUE_FLOAT && binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_FLOAT) ||
-                     (property->type == MLN_PLUGIN_VALUE_FLOAT2 && binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_FLOAT2) ||
-                     (property->type == MLN_PLUGIN_VALUE_COLOR && binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_COLOR) ||
-                     (property->type == MLN_PLUGIN_VALUE_BOOLEAN &&
-                      binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT) ||
-                     (property->type == MLN_PLUGIN_VALUE_STRING && !property->enumValues.empty() &&
-                      binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT));
+                                             ((property->type == MLN_PLUGIN_VALUE_FLOAT &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_FLOAT) ||
+                                              (property->type == MLN_PLUGIN_VALUE_FLOAT2 &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_FLOAT2) ||
+                                              (property->type == MLN_PLUGIN_VALUE_COLOR &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_COLOR) ||
+                                              (property->type == MLN_PLUGIN_VALUE_BOOLEAN &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT) ||
+                                              (property->type == MLN_PLUGIN_VALUE_STRING &&
+                                               !property->enumValues.empty() &&
+                                               binding.encoding == MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT));
                 if (property == newProperties.end() || property->scope != MLN_PLUGIN_PROPERTY_PAINT ||
                     !encodingMatches) {
                     error = "plugin shader property binding references an incompatible paint property";
@@ -827,20 +827,15 @@ mln_plugin_status PluginRegistry::registerPlugin(const mln_plugin_descriptor_v1&
         }
         for (const auto& property : newProperties) {
             if (property.targetLayerType != type) continue;
-            const auto dataDependencies = MLN_PLUGIN_EXPRESSION_FEATURE |
-                                          MLN_PLUGIN_EXPRESSION_COMPOSITE |
+            const auto dataDependencies = MLN_PLUGIN_EXPRESSION_FEATURE | MLN_PLUGIN_EXPRESSION_COMPOSITE |
                                           MLN_PLUGIN_EXPRESSION_FEATURE_STATE;
             if ((property.expressionCapabilities & dataDependencies) == 0) continue;
-            const bool bound = std::any_of(copiedLayerType.shaders.begin(),
-                                           copiedLayerType.shaders.end(),
-                                           [&](const auto& shader) {
-                                               return std::any_of(
-                                                   shader.propertyBindings.begin(),
-                                                   shader.propertyBindings.end(),
-                                                   [&](const auto& binding) {
-                                                       return binding.propertyName == property.name;
-                                                   });
-                                           });
+            const bool bound = std::any_of(
+                copiedLayerType.shaders.begin(), copiedLayerType.shaders.end(), [&](const auto& shader) {
+                    return std::any_of(shader.propertyBindings.begin(),
+                                       shader.propertyBindings.end(),
+                                       [&](const auto& binding) { return binding.propertyName == property.name; });
+                });
             if (property.scope != MLN_PLUGIN_PROPERTY_PAINT || !bound) {
                 error = "data-driven plugin properties require a shader property binding";
                 return MLN_PLUGIN_STATUS_INVALID_ARGUMENT;
@@ -1094,9 +1089,7 @@ uint8_t mln_plugin_is_registered_v1(const char* pluginID) try {
     return 0;
 }
 
-size_t mln_plugin_count_v1(void) try {
-    return mln::plugin::PluginRegistry::get().pluginIDs().size();
-} catch (...) {
+size_t mln_plugin_count_v1(void) try { return mln::plugin::PluginRegistry::get().pluginIDs().size(); } catch (...) {
     return 0;
 }
 

--- a/src/mln/renderer/buckets/plugin_bucket.cpp
+++ b/src/mln/renderer/buckets/plugin_bucket.cpp
@@ -18,7 +18,9 @@ namespace {
 class PluginFeatureSnapshot final : public GeometryTileFeature {
 public:
     PluginFeatureSnapshot(FeatureType type_, FeatureIdentifier id_, PropertyMap properties_)
-        : type(type_), id(std::move(id_)), properties(std::move(properties_)) {}
+        : type(type_),
+          id(std::move(id_)),
+          properties(std::move(properties_)) {}
 
     FeatureType getType() const override { return type; }
     std::optional<Value> getValue(const std::string& key) const override {
@@ -66,10 +68,10 @@ void encodedValue(const mln_plugin_value& value,
         case MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT: {
             const std::string_view text(value.data.string_value.data, value.data.string_value.size);
             const auto it = std::find(definition.enumValues.begin(), definition.enumValues.end(), text);
-            const auto fallback = std::find(definition.enumValues.begin(), definition.enumValues.end(),
-                                            *definition.defaultValue.getString());
-            output[0] = static_cast<float>(std::distance(definition.enumValues.begin(),
-                                                       it == definition.enumValues.end() ? fallback : it));
+            const auto fallback = std::find(
+                definition.enumValues.begin(), definition.enumValues.end(), *definition.defaultValue.getString());
+            output[0] = static_cast<float>(
+                std::distance(definition.enumValues.begin(), it == definition.enumValues.end() ? fallback : it));
             break;
         }
         case MLN_PLUGIN_PROPERTY_ENCODING_BOOLEAN_FLOAT:
@@ -88,8 +90,7 @@ void encodedValue(const mln_plugin_value& value,
     }
 }
 
-mln_plugin_value decodedValue(const std::array<float, 4>& input,
-                              const plugin::PropertyDefinition& definition) {
+mln_plugin_value decodedValue(const std::array<float, 4>& input, const plugin::PropertyDefinition& definition) {
     const auto type = definition.type;
     mln_plugin_value value{};
     value.struct_size = sizeof(value);
@@ -109,7 +110,8 @@ mln_plugin_value decodedValue(const std::array<float, 4>& input,
             break;
         case MLN_PLUGIN_VALUE_STRING:
             if (!definition.enumValues.empty()) {
-                const auto index = static_cast<size_t>(std::clamp(input[0], 0.0f, static_cast<float>(definition.enumValues.size() - 1)));
+                const auto index = static_cast<size_t>(
+                    std::clamp(input[0], 0.0f, static_cast<float>(definition.enumValues.size() - 1)));
                 const auto& text = definition.enumValues[index];
                 value.data.string_value = {text.data(), text.size()};
             }
@@ -122,10 +124,7 @@ mln_plugin_value decodedValue(const std::array<float, 4>& input,
 
 } // namespace
 
-void PluginPaintVertexVector::set(std::size_t first,
-                                  std::size_t length,
-                                  const float* minimum,
-                                  const float* maximum) {
+void PluginPaintVertexVector::set(std::size_t first, std::size_t length, const float* minimum, const float* maximum) {
     if (first > count || length > count - first) return;
     for (std::size_t vertex = first; vertex < first + length; ++vertex) {
         auto* destination = data.data() + vertex * components * 2;
@@ -135,8 +134,7 @@ void PluginPaintVertexVector::set(std::size_t first,
     updateModified(true);
 }
 
-void PluginPaintVertexVector::bounds(std::array<float, 4>& minimum,
-                                     std::array<float, 4>& maximum) const {
+void PluginPaintVertexVector::bounds(std::array<float, 4>& minimum, std::array<float, 4>& maximum) const {
     minimum.fill(std::numeric_limits<float>::infinity());
     maximum.fill(-std::numeric_limits<float>::infinity());
     for (std::size_t vertex = 0; vertex < count; ++vertex) {
@@ -224,8 +222,7 @@ void PluginPaintPropertyBinder::writeUniform(float zoom,
             std::memcpy(output + binding.uniformByteOffset, encoded.data(), size);
         }
     }
-    if (uniformID == binding.interpolationUniformID &&
-        binding.interpolationUniformByteOffset <= outputSize &&
+    if (uniformID == binding.interpolationUniformID && binding.interpolationUniformByteOffset <= outputSize &&
         sizeof(float) <= outputSize - binding.interpolationUniformByteOffset) {
         const auto factor = interpolationFactor(zoom);
         std::memcpy(output + binding.interpolationUniformByteOffset, &factor, sizeof(factor));
@@ -261,9 +258,7 @@ bool PluginPaintPropertyBinder::update(const FeatureStates& states, const Geomet
     return changed;
 }
 
-void PluginPaintPropertyBinder::statistics(float zoom,
-                                           mln_plugin_value& minimum,
-                                           mln_plugin_value& maximum) const {
+void PluginPaintPropertyBinder::statistics(float zoom, mln_plugin_value& minimum, mln_plugin_value& maximum) const {
     if (!dataDriven || !vertexVector) {
         style::PluginPropertyValue::EvaluationStorage storage;
         minimum = value.evaluate(zoom, definition, storage);
@@ -285,7 +280,8 @@ void PluginPaintPropertyBinder::refill(const GeometryTileLayer* layer) {
         std::unique_ptr<GeometryTileFeature> feature;
         if (layer) feature = layer->getFeature(range.featureIndex);
         PluginFeatureSnapshot snapshot(range.featureType, range.featureIdentifier, range.properties);
-        const GeometryTileFeature& sourceFeature = feature ? *feature : static_cast<const GeometryTileFeature&>(snapshot);
+        const GeometryTileFeature& sourceFeature = feature ? *feature
+                                                           : static_cast<const GeometryTileFeature&>(snapshot);
         const auto state = featureStates.find(range.featureID);
         const FeatureState empty;
         fillRange(range, sourceFeature, state == featureStates.end() ? empty : state->second);
@@ -312,15 +308,14 @@ void PluginPaintPropertyBinder::updateStatistics() {
     if (vertexVector) vertexVector->bounds(minimumValues, maximumValues);
 }
 
-PluginPaintPropertyBinders::PluginPaintPropertyBinders(
-    const plugin::LayerType& registration,
-    const plugin::ShaderDefinition& shader,
-    uint64_t drawableKey,
-    std::size_t vertexCount,
-    float bucketZoom,
-    const style::PluginPropertyMap& properties,
-    const std::vector<PluginFeatureVertexRange>& ranges,
-    const GeometryTileLayer& layer) {
+PluginPaintPropertyBinders::PluginPaintPropertyBinders(const plugin::LayerType& registration,
+                                                       const plugin::ShaderDefinition& shader,
+                                                       uint64_t drawableKey,
+                                                       std::size_t vertexCount,
+                                                       float bucketZoom,
+                                                       const style::PluginPropertyMap& properties,
+                                                       const std::vector<PluginFeatureVertexRange>& ranges,
+                                                       const GeometryTileLayer& layer) {
     const auto definitions = plugin::PluginRegistry::get().propertiesForLayer(registration.type);
     for (const auto& binding : shader.propertyBindings) {
         const auto definition = std::find_if(definitions.begin(), definitions.end(), [&](const auto& candidate) {
@@ -351,14 +346,11 @@ void PluginPaintPropertyBinders::populateVertexAttributes(gfx::VertexAttributeAr
         const auto& vector = binder.getVertexVector();
         const auto components = binder.componentCount();
         if (const auto& minimum = attributes.set(binding.minimumAttributeID)) {
-            minimum->setSharedRawData(vector,
-                                      0,
-                                      0,
-                                      vector->getRawSize(),
-                                      binder.attributeType());
+            minimum->setSharedRawData(vector, 0, 0, vector->getRawSize(), binder.attributeType());
         }
         if (auto* maximum = binding.maximumAttributeID != binding.minimumAttributeID
-                                ? attributes.set(binding.maximumAttributeID).get() : nullptr) {
+                                ? attributes.set(binding.maximumAttributeID).get()
+                                : nullptr) {
             maximum->setSharedRawData(vector,
                                       static_cast<uint32_t>(components * sizeof(float)),
                                       0,
@@ -391,8 +383,7 @@ bool PluginPaintPropertyBinders::update(const FeatureStates& states, const Geome
 }
 
 void PluginPaintPropertyBinders::appendStatistics(
-    float zoom,
-    std::map<std::string, std::pair<mln_plugin_value, mln_plugin_value>>& output) const {
+    float zoom, std::map<std::string, std::pair<mln_plugin_value, mln_plugin_value>>& output) const {
     for (const auto& binder : binders) {
         if (output.find(binder.getDefinition().name) != output.end()) continue;
         mln_plugin_value minimum{};
@@ -469,10 +460,8 @@ void PluginBucket::updateQueryRadius(const std::string& layerID,
     std::vector<mln_plugin_property_statistics_v1> statistics;
     statistics.reserve(values.size());
     for (const auto& [name, bounds] : values) {
-        statistics.push_back({sizeof(mln_plugin_property_statistics_v1),
-                              {name.data(), name.size()},
-                              bounds.first,
-                              bounds.second});
+        statistics.push_back(
+            {sizeof(mln_plugin_property_statistics_v1), {name.data(), name.size()}, bounds.first, bounds.second});
     }
 
     const auto definitions = plugin::PluginRegistry::get().propertiesForLayer(registration.type);
@@ -487,18 +476,15 @@ void PluginBucket::updateQueryRadius(const std::string& layerID,
                                     current.evaluate(zoom, definition, storage[i]),
                                     properties.find(definition.name) != properties.end()});
     }
-    const auto radius = registration.queryRadius(statistics.data(),
-                                                 statistics.size(),
-                                                 cameraProperties.data(),
-                                                 cameraProperties.size());
+    const auto radius = registration.queryRadius(
+        statistics.data(), statistics.size(), cameraProperties.data(), cameraProperties.size());
     if (std::isfinite(radius) && radius >= 0.0f) {
         queryRadii.insert_or_assign(layerID, radius);
         queryRadiusErrorsLogged.erase(layerID);
     } else {
         queryRadii.insert_or_assign(layerID, 0.0f);
         if (queryRadiusErrorsLogged.emplace(layerID).second) {
-            Log::Warning(Event::Style,
-                         "Plugin layer '" + registration.type + "' returned an invalid query radius");
+            Log::Warning(Event::Style, "Plugin layer '" + registration.type + "' returned an invalid query radius");
         }
     }
 }

--- a/src/mln/renderer/layers/plugin_layer_tweaker.cpp
+++ b/src/mln/renderer/layers/plugin_layer_tweaker.cpp
@@ -154,10 +154,8 @@ void PluginLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
                 }
                 if (const auto* baseBinders = drawable.getBinders()) {
                     const auto* binders = static_cast<const PluginPaintPropertyBinders*>(baseBinders);
-                    binders->writeUniforms(static_cast<float>(parameters.state.getZoom()),
-                                           uniform.id,
-                                           bytes.data(),
-                                           bytes.size());
+                    binders->writeUniforms(
+                        static_cast<float>(parameters.state.getZoom()), uniform.id, bytes.data(), bytes.size());
                 }
                 if (uniform.scope == MLN_PLUGIN_UNIFORM_SCOPE_LAYER) {
                     auto& buffer = layerUniformBuffers[{callbackContext.pass_id, uniform.id}];

--- a/src/mln/renderer/layers/render_plugin_style_layer.cpp
+++ b/src/mln/renderer/layers/render_plugin_style_layer.cpp
@@ -150,11 +150,9 @@ RenderPluginStyleLayer::RenderPluginStyleLayer(Immutable<style::PluginStyleLayer
     for (const auto& definition : definitions) {
         if (definition.scope != MLN_PLUGIN_PROPERTY_PAINT) continue;
         const auto property = layerImpl.pluginProperties.find(definition.name);
-        auto value = property == layerImpl.pluginProperties.end()
-                         ? style::defaultPluginPropertyValue(definition)
-                         : property->second;
-        transitioningPaintProperties.emplace(
-            definition.name, style::PluginTransitioningPropertyValue{value});
+        auto value = property == layerImpl.pluginProperties.end() ? style::defaultPluginPropertyValue(definition)
+                                                                  : property->second;
+        transitioningPaintProperties.emplace(definition.name, style::PluginTransitioningPropertyValue{value});
         evaluatedPluginProperties.emplace(definition.name, std::move(value));
     }
     passes = renderPassFor(registration.renderStage);
@@ -167,13 +165,11 @@ void RenderPluginStyleLayer::transition(const TransitionParameters& parameters) 
     for (const auto& definition : definitions) {
         if (definition.scope != MLN_PLUGIN_PROPERTY_PAINT) continue;
         const auto property = impl.pluginProperties.find(definition.name);
-        auto value = property == impl.pluginProperties.end()
-                         ? style::defaultPluginPropertyValue(definition)
-                         : property->second;
+        auto value = property == impl.pluginProperties.end() ? style::defaultPluginPropertyValue(definition)
+                                                             : property->second;
         auto prior = transitioningPaintProperties.find(definition.name);
         auto priorValue = prior == transitioningPaintProperties.end()
-                              ? style::PluginTransitioningPropertyValue{
-                                    style::defaultPluginPropertyValue(definition)}
+                              ? style::PluginTransitioningPropertyValue{style::defaultPluginPropertyValue(definition)}
                               : std::move(prior->second);
         const auto options = impl.pluginPropertyTransitions.find(definition.name);
         const auto transition = options == impl.pluginPropertyTransitions.end()
@@ -198,16 +194,14 @@ void RenderPluginStyleLayer::evaluate(const PropertyEvaluationParameters& parame
         if (definition.scope != MLN_PLUGIN_PROPERTY_PAINT) continue;
         const auto transition = transitioningPaintProperties.find(definition.name);
         if (transition != transitioningPaintProperties.end()) {
-            evaluatedPluginProperties.emplace(
-                definition.name,
-                transition->second.evaluate(parameters.z, definition, parameters.now));
+            evaluatedPluginProperties.emplace(definition.name,
+                                              transition->second.evaluate(parameters.z, definition, parameters.now));
         } else {
             const auto property = impl.pluginProperties.find(definition.name);
-            evaluatedPluginProperties.emplace(
-                definition.name,
-                property == impl.pluginProperties.end()
-                    ? style::defaultPluginPropertyValue(definition)
-                    : property->second);
+            evaluatedPluginProperties.emplace(definition.name,
+                                              property == impl.pluginProperties.end()
+                                                  ? style::defaultPluginPropertyValue(definition)
+                                                  : property->second);
         }
     }
     auto properties = makeMutable<style::PluginStyleLayerProperties>(
@@ -333,8 +327,7 @@ void RenderPluginStyleLayer::update(gfx::ShaderRegistry& shaders,
             continue;
         }
         auto& bucket = static_cast<PluginBucket&>(*renderData->bucket);
-        if (bucket.synchronizePaint(
-                getID(), evaluatedPluginProperties, static_cast<float>(state.getZoom()))) {
+        if (bucket.synchronizePaint(getID(), evaluatedPluginProperties, static_cast<float>(state.getZoom()))) {
             removeTile(renderPass, tileID);
         }
         const auto previousBucket = getRenderTileBucketID(tileID);
@@ -730,8 +723,7 @@ void RenderPluginStyleLayer::updateGeometryGraph(gfx::ShaderRegistry& shaders,
             return item.shaderID == pass.shaderID;
         });
         if (definitionIt == bucket.drawables.end() || definitionIt->segments.empty()) return;
-        bucket.synchronizePaint(
-            getID(), evaluatedPluginProperties, static_cast<float>(state.getZoom()));
+        bucket.synchronizePaint(getID(), evaluatedPluginProperties, static_cast<float>(state.getZoom()));
         StringIDSetsPair propertiesAsUniforms;
         auto* paintBinders = bucket.paintBinders(getID(), definitionIt->key);
         auto attributes = context.createVertexAttributeArray();
@@ -942,9 +934,8 @@ bool RenderPluginStyleLayer::queryIntersectsFeature(const GeometryCoordinates& q
     for (size_t i = 0; i < definitions.size(); ++i) {
         const auto& definition = definitions[i];
         const auto propertyIt = evaluatedPluginProperties.find(definition.name);
-        const auto value = propertyIt == evaluatedPluginProperties.end()
-                               ? style::defaultPluginPropertyValue(definition)
-                               : propertyIt->second;
+        const auto value = propertyIt == evaluatedPluginProperties.end() ? style::defaultPluginPropertyValue(definition)
+                                                                         : propertyIt->second;
         mln_plugin_property_value_v1 property{};
         property.struct_size = sizeof(property);
         property.name = {definition.name.data(), definition.name.size()};
@@ -963,8 +954,7 @@ bool RenderPluginStyleLayer::queryIntersectsFeature(const GeometryCoordinates& q
     queryContext.viewport_width = transformState.getSize().width;
     queryContext.viewport_height = transformState.getSize().height;
     return registration.queryFeature(
-               &pluginFeature, query.data(), query.size(), &queryContext, properties.data(), properties.size()) !=
-           0;
+               &pluginFeature, query.data(), query.size(), &queryContext, properties.data(), properties.size()) != 0;
 }
 
 } // namespace mln

--- a/src/mln/style/layer.cpp
+++ b/src/mln/style/layer.cpp
@@ -206,8 +206,8 @@ std::optional<conversion::Error> Layer::setProperty(const std::string& name, con
 }
 
 std::optional<conversion::Error> Layer::setProperty(const std::string& name,
-                                                  const conversion::Convertible& value,
-                                                  PropertyScope) {
+                                                    const conversion::Convertible& value,
+                                                    PropertyScope) {
     return setProperty(name, value);
 }
 

--- a/src/mln/style/layers/plugin_style_layer.cpp
+++ b/src/mln/style/layers/plugin_style_layer.cpp
@@ -18,8 +18,7 @@ std::optional<std::string> pluginTransitionPropertyName(const char* layerType, c
     return definition && definition->supportsTransitions ? std::optional<std::string>{std::move(propertyName)}
                                                          : std::nullopt;
 }
-}
-
+} // namespace
 
 PluginStyleLayer::Impl::Impl(const std::string& id, const std::string& source, plugin::LayerType registration_)
     : Layer::Impl(id, source),
@@ -90,10 +89,9 @@ StyleProperty PluginStyleLayer::getProperty(const std::string& name) const {
     return definition ? defaultPluginPropertyValue(*definition).toStyleProperty() : StyleProperty{};
 }
 
-
 std::optional<conversion::Error> PluginStyleLayer::setPluginProperty(const std::string& name,
-                                                          const conversion::Convertible& value,
-                                                          std::optional<PropertyScope> scope) {
+                                                                     const conversion::Convertible& value,
+                                                                     std::optional<PropertyScope> scope) {
     using namespace conversion;
     const auto definition = plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name);
     if (!definition) return Error{"layer doesn't support this property"};
@@ -126,8 +124,8 @@ std::optional<conversion::Error> PluginStyleLayer::setPluginProperty(const std::
 }
 
 std::optional<conversion::Error> PluginStyleLayer::setPluginTransition(const std::string& name,
-                                                            const conversion::Convertible& value,
-                                                            std::optional<PropertyScope> scope) {
+                                                                       const conversion::Convertible& value,
+                                                                       std::optional<PropertyScope> scope) {
     using namespace conversion;
     const auto propertyName = pluginTransitionPropertyName(getTypeInfo()->type, name);
     if (!propertyName) return Error{"layer doesn't support this transition"};
@@ -148,8 +146,7 @@ std::optional<conversion::Error> PluginStyleLayer::setPluginTransition(const std
     auto transition = convert<TransitionOptions>(value, error);
     if (!transition) return error;
     const auto existing = impl_->pluginPropertyTransitions.find(*propertyName);
-    if (existing != impl_->pluginPropertyTransitions.end() &&
-        existing->second.serialize() == transition->serialize()) {
+    if (existing != impl_->pluginPropertyTransitions.end() && existing->second.serialize() == transition->serialize()) {
         return std::nullopt;
     }
     impl_->pluginPropertyTransitions.insert_or_assign(*propertyName, std::move(*transition));
@@ -157,7 +154,6 @@ std::optional<conversion::Error> PluginStyleLayer::setPluginTransition(const std
     observer->onLayerChanged(*this);
     return std::nullopt;
 }
-
 
 Value PluginStyleLayer::serialize() const {
     Value serialized = Layer::serialize();
@@ -182,14 +178,18 @@ Value PluginStyleLayer::serialize() const {
     return serialized;
 }
 
-std::optional<conversion::Error> PluginStyleLayer::setPropertyInternal(const std::string& name, const conversion::Convertible& value) {
+std::optional<conversion::Error> PluginStyleLayer::setPropertyInternal(const std::string& name,
+                                                                       const conversion::Convertible& value) {
     if (pluginTransitionPropertyName(getTypeInfo()->type, name)) return setPluginTransition(name, value);
     return setPluginProperty(name, value);
 }
 
-std::optional<conversion::Error> PluginStyleLayer::setProperty(const std::string& name, const conversion::Convertible& value, PropertyScope scope) {
+std::optional<conversion::Error> PluginStyleLayer::setProperty(const std::string& name,
+                                                               const conversion::Convertible& value,
+                                                               PropertyScope scope) {
     if (pluginTransitionPropertyName(getTypeInfo()->type, name)) return setPluginTransition(name, value, scope);
-    if (plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name)) return setPluginProperty(name, value, scope);
+    if (plugin::PluginRegistry::get().findProperty(getTypeInfo()->type, name))
+        return setPluginProperty(name, value, scope);
     return Layer::setProperty(name, value);
 }
 

--- a/src/mln/style/plugin_property.cpp
+++ b/src/mln/style/plugin_property.cpp
@@ -41,14 +41,14 @@ bool usesFeatureState(const PropertyValue<T>& value) {
 
 template <class T>
 float interpolationFactor(const PropertyValue<T>& value, float bucketZoom, float currentZoom) {
-    return value.match(
-        [](const Undefined&) { return 0.0f; },
-        [](const T&) { return 0.0f; },
-        [&](const PropertyExpression<T>& expression) {
-            if (expression.isZoomConstant()) return 0.0f;
-            const auto zoom = expression.getUseIntegerZoom() ? std::floor(currentZoom) : currentZoom;
-            return std::clamp(expression.interpolationFactor({bucketZoom, bucketZoom + 1.0f}, zoom), 0.0f, 1.0f);
-        });
+    return value.match([](const Undefined&) { return 0.0f; },
+                       [](const T&) { return 0.0f; },
+                       [&](const PropertyExpression<T>& expression) {
+                           if (expression.isZoomConstant()) return 0.0f;
+                           const auto zoom = expression.getUseIntegerZoom() ? std::floor(currentZoom) : currentZoom;
+                           return std::clamp(
+                               expression.interpolationFactor({bucketZoom, bucketZoom + 1.0f}, zoom), 0.0f, 1.0f);
+                       });
 }
 
 std::string serializeRamp(const ColorRampPropertyValue& ramp) {
@@ -372,9 +372,8 @@ mln_plugin_value PluginPropertyValue::evaluate(float zoom,
     return result;
 }
 
-PluginPropertyValue PluginPropertyValue::evaluateCamera(
-    float zoom,
-    const plugin::PropertyDefinition& definition) const {
+PluginPropertyValue PluginPropertyValue::evaluateCamera(float zoom,
+                                                        const plugin::PropertyDefinition& definition) const {
     EvaluationStorage storage;
     const auto evaluated = evaluate(zoom, definition, storage);
     switch (definition.type) {
@@ -383,8 +382,8 @@ PluginPropertyValue PluginPropertyValue::evaluateCamera(
         case MLN_PLUGIN_VALUE_FLOAT:
             return PluginPropertyValue{TypedValue{PropertyValue<float>{evaluated.data.float_value}}};
         case MLN_PLUGIN_VALUE_FLOAT2:
-            return PluginPropertyValue{TypedValue{PropertyValue<std::array<float, 2>>{
-                {evaluated.data.float2_value.x, evaluated.data.float2_value.y}}}};
+            return PluginPropertyValue{TypedValue{
+                PropertyValue<std::array<float, 2>>{{evaluated.data.float2_value.x, evaluated.data.float2_value.y}}}};
         case MLN_PLUGIN_VALUE_COLOR:
             return PluginPropertyValue{TypedValue{PropertyValue<Color>{Color{evaluated.data.color_value.r,
                                                                              evaluated.data.color_value.g,
@@ -408,11 +407,10 @@ PluginPropertyValue PluginPropertyValue::evaluateCamera(
     return *this;
 }
 
-PluginPropertyValue PluginPropertyValue::interpolate(
-    const PluginPropertyValue& from,
-    const PluginPropertyValue& to,
-    float t,
-    const plugin::PropertyDefinition& definition) {
+PluginPropertyValue PluginPropertyValue::interpolate(const PluginPropertyValue& from,
+                                                     const PluginPropertyValue& to,
+                                                     float t,
+                                                     const plugin::PropertyDefinition& definition) {
     switch (definition.type) {
         case MLN_PLUGIN_VALUE_FLOAT: {
             const auto& a = std::get<PropertyValue<float>>(from.value).asConstant();
@@ -422,8 +420,7 @@ PluginPropertyValue PluginPropertyValue::interpolate(
         case MLN_PLUGIN_VALUE_FLOAT2: {
             const auto& a = std::get<PropertyValue<std::array<float, 2>>>(from.value).asConstant();
             const auto& b = std::get<PropertyValue<std::array<float, 2>>>(to.value).asConstant();
-            return PluginPropertyValue{
-                TypedValue{PropertyValue<std::array<float, 2>>{util::interpolate(a, b, t)}}};
+            return PluginPropertyValue{TypedValue{PropertyValue<std::array<float, 2>>{util::interpolate(a, b, t)}}};
         }
         case MLN_PLUGIN_VALUE_COLOR: {
             const auto& a = std::get<PropertyValue<Color>>(from.value).asConstant();
@@ -435,11 +432,10 @@ PluginPropertyValue PluginPropertyValue::interpolate(
     }
 }
 
-PluginTransitioningPropertyValue::PluginTransitioningPropertyValue(
-    PluginPropertyValue value_,
-    PluginTransitioningPropertyValue prior_,
-    const TransitionOptions& transition,
-    TimePoint now)
+PluginTransitioningPropertyValue::PluginTransitioningPropertyValue(PluginPropertyValue value_,
+                                                                   PluginTransitioningPropertyValue prior_,
+                                                                   const TransitionOptions& transition,
+                                                                   TimePoint now)
     : begin(now + transition.delay.value_or(Duration::zero())),
       end(begin + transition.duration.value_or(Duration::zero())),
       value(std::move(value_)) {
@@ -448,10 +444,9 @@ PluginTransitioningPropertyValue::PluginTransitioningPropertyValue(
     }
 }
 
-PluginPropertyValue PluginTransitioningPropertyValue::evaluate(
-    float zoom,
-    const plugin::PropertyDefinition& definition,
-    TimePoint now) {
+PluginPropertyValue PluginTransitioningPropertyValue::evaluate(float zoom,
+                                                               const plugin::PropertyDefinition& definition,
+                                                               TimePoint now) {
     if (!prior) return value;
     if (now >= end) {
         prior.reset();

--- a/test/plugin/plugin.test.cpp
+++ b/test/plugin/plugin.test.cpp
@@ -107,7 +107,9 @@ struct LayerTypeDescriptor {
 };
 
 struct Descriptor : LayerTypeDescriptor {
-    Descriptor(const char* id_, const char* propertyName_) : propertyName(propertyName_), id(id_) {
+    Descriptor(const char* id_, const char* propertyName_)
+        : propertyName(propertyName_),
+          id(id_) {
         defaultValue.struct_size = sizeof(defaultValue);
         defaultValue.type = MLN_PLUGIN_VALUE_BOOLEAN;
         property.name = cString(propertyName);
@@ -126,11 +128,11 @@ struct Descriptor : LayerTypeDescriptor {
 struct DynamicLayerTypeDescriptor {
     DynamicLayerTypeDescriptor(const char* pluginID_,
                                const char* layerType_,
-                               uint32_t capabilities = MLN_PLUGIN_EXPRESSION_CAMERA |
-                                                       MLN_PLUGIN_EXPRESSION_FEATURE |
+                               uint32_t capabilities = MLN_PLUGIN_EXPRESSION_CAMERA | MLN_PLUGIN_EXPRESSION_FEATURE |
                                                        MLN_PLUGIN_EXPRESSION_COMPOSITE |
                                                        MLN_PLUGIN_EXPRESSION_FEATURE_STATE)
-        : pluginID(pluginID_), layerTypeName(layerType_) {
+        : pluginID(pluginID_),
+          layerTypeName(layerType_) {
         defaultValue.struct_size = sizeof(defaultValue);
         defaultValue.type = MLN_PLUGIN_VALUE_FLOAT;
         defaultValue.data.float_value = 4.0f;
@@ -158,15 +160,7 @@ struct DynamicLayerTypeDescriptor {
                    16,
                    MLN_PLUGIN_SHADER_STAGE_VERTEX,
                    MLN_PLUGIN_UNIFORM_SCOPE_DRAWABLE};
-        binding = {sizeof(binding),
-                   cString("test-size"),
-                   MLN_PLUGIN_PROPERTY_ENCODING_FLOAT,
-                   0,
-                   0,
-                   1,
-                   2,
-                   0,
-                   4};
+        binding = {sizeof(binding), cString("test-size"), MLN_PLUGIN_PROPERTY_ENCODING_FLOAT, 0, 0, 1, 2, 0, 4};
         shader.struct_size = sizeof(shader);
         shader.shader_id = cString("test-dynamic");
         shader.sources = &shaderSource;
@@ -394,7 +388,8 @@ TEST(PluginStyleProperty, BuiltInLayersRejectPluginProperties) {
     FillExtrusionLayer layer("buildings", "source");
     const JSValue enabled(true);
     EXPECT_TRUE(layer.setProperty("test-isolated-boolean", conversion::Convertible(&enabled)));
-    EXPECT_EQ(StyleProperty::Kind::Undefined, static_cast<const Layer&>(layer).getProperty("test-isolated-boolean").getKind());
+    EXPECT_EQ(StyleProperty::Kind::Undefined,
+              static_cast<const Layer&>(layer).getProperty("test-isolated-boolean").getKind());
 }
 
 TEST(PluginRegistry, RegistersSourceBoundLayerTypeAndScopedProperties) {
@@ -478,19 +473,15 @@ TEST(PluginRegistry, ValidatesDynamicShaderPropertyBindings) {
     DynamicLayerTypeDescriptor missingBinding("org.maplibre.test.dynamic-unbound", "test-dynamic-unbound");
     missingBinding.shader.property_bindings = nullptr;
     missingBinding.shader.property_binding_count = 0;
-    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT,
-              mln_plugin_register_v1(&missingBinding.descriptor, nullptr, 0));
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&missingBinding.descriptor, nullptr, 0));
 
-    DynamicLayerTypeDescriptor wrongProperty("org.maplibre.test.dynamic-wrong-property",
-                                             "test-dynamic-wrong-property");
+    DynamicLayerTypeDescriptor wrongProperty("org.maplibre.test.dynamic-wrong-property", "test-dynamic-wrong-property");
     wrongProperty.binding.property_name = cString("not-a-property");
-    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT,
-              mln_plugin_register_v1(&wrongProperty.descriptor, nullptr, 0));
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&wrongProperty.descriptor, nullptr, 0));
 
     Descriptor booleanTransition("org.maplibre.test.boolean-transition", "test-boolean-transition");
     booleanTransition.property.supports_transitions = 1;
-    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT,
-              mln_plugin_register_v1(&booleanTransition.descriptor, nullptr, 0));
+    EXPECT_EQ(MLN_PLUGIN_STATUS_INVALID_ARGUMENT, mln_plugin_register_v1(&booleanTransition.descriptor, nullptr, 0));
 }
 
 TEST(PluginRegistry, ValidatesPackedEndpointsEnumsAndAttributeLimits) {
@@ -530,8 +521,8 @@ TEST(PluginRegistry, ValidatesPackedEndpointsEnumsAndAttributeLimits) {
 }
 
 TEST(PluginStyleProperty, EnforcesExpressionDependencyCapabilities) {
-    DynamicLayerTypeDescriptor cameraOnly("org.maplibre.test.dynamic-camera", "test-dynamic-camera",
-                                          MLN_PLUGIN_EXPRESSION_CAMERA);
+    DynamicLayerTypeDescriptor cameraOnly(
+        "org.maplibre.test.dynamic-camera", "test-dynamic-camera", MLN_PLUGIN_EXPRESSION_CAMERA);
     ASSERT_EQ(MLN_PLUGIN_STATUS_OK, mln_plugin_register_v1(&cameraOnly.descriptor, nullptr, 0));
     JSDocument layerJSON;
     layerJSON.Parse(R"JSON({"source":"points"})JSON");
@@ -576,12 +567,10 @@ TEST(PluginStyleProperty, StoresSerializesAndInterpolatesTransitions) {
     JSDocument transitionJSON;
     transitionJSON.Parse(R"JSON({"duration":100,"delay":20})JSON");
     const JSValue* transitionValue = &transitionJSON;
-    EXPECT_FALSE(layer->setProperty("test-size-transition",
-                                    conversion::Convertible(transitionValue),
-                                    Layer::PropertyScope::Paint));
-    EXPECT_TRUE(layer->setProperty("test-size-transition",
-                                   conversion::Convertible(transitionValue),
-                                   Layer::PropertyScope::Layout));
+    EXPECT_FALSE(layer->setProperty(
+        "test-size-transition", conversion::Convertible(transitionValue), Layer::PropertyScope::Paint));
+    EXPECT_TRUE(layer->setProperty(
+        "test-size-transition", conversion::Convertible(transitionValue), Layer::PropertyScope::Layout));
     const auto serialized = layer->serialize();
     const auto* paint = serialized.getObject()->at("paint").getObject();
     ASSERT_NE(nullptr, paint);
@@ -590,13 +579,21 @@ TEST(PluginStyleProperty, StoresSerializesAndInterpolatesTransitions) {
     EXPECT_EQ(100, *transition->at("duration").getInt());
     EXPECT_EQ(20, *transition->at("delay").getInt());
 
-    plugin::PropertyDefinition definition{"test", "test-dynamic-transition", "test-size",
-                                          MLN_PLUGIN_VALUE_FLOAT, MLN_PLUGIN_PROPERTY_PAINT, Value{4.0},
-                                          MLN_PLUGIN_EXPRESSION_CAMERA, true, false, {}, {}, 0, {}};
-    style::PluginPropertyValue from{
-        style::PluginPropertyValue::TypedValue{PropertyValue<float>{0.0f}}};
-    style::PluginPropertyValue to{
-        style::PluginPropertyValue::TypedValue{PropertyValue<float>{10.0f}}};
+    plugin::PropertyDefinition definition{"test",
+                                          "test-dynamic-transition",
+                                          "test-size",
+                                          MLN_PLUGIN_VALUE_FLOAT,
+                                          MLN_PLUGIN_PROPERTY_PAINT,
+                                          Value{4.0},
+                                          MLN_PLUGIN_EXPRESSION_CAMERA,
+                                          true,
+                                          false,
+                                          {},
+                                          {},
+                                          0,
+                                          {}};
+    style::PluginPropertyValue from{style::PluginPropertyValue::TypedValue{PropertyValue<float>{0.0f}}};
+    style::PluginPropertyValue to{style::PluginPropertyValue::TypedValue{PropertyValue<float>{10.0f}}};
     const auto start = Clock::now();
     style::PluginTransitioningPropertyValue transitioning{
         std::move(to),

--- a/test/plugin/property_binding.test.cpp
+++ b/test/plugin/property_binding.test.cpp
@@ -31,17 +31,17 @@ plugin::PropertyDefinition numberDefinition() {
     definition.type = MLN_PLUGIN_VALUE_FLOAT;
     definition.defaultValue = 5.0;
     definition.expressionCapabilities = MLN_PLUGIN_EXPRESSION_CAMERA | MLN_PLUGIN_EXPRESSION_FEATURE |
-        MLN_PLUGIN_EXPRESSION_COMPOSITE | MLN_PLUGIN_EXPRESSION_FEATURE_STATE;
+                                        MLN_PLUGIN_EXPRESSION_COMPOSITE | MLN_PLUGIN_EXPRESSION_FEATURE_STATE;
     return definition;
 }
-}
+} // namespace
 
 TEST(PluginPaintBinder, PackedCompositeEndpointsAndFeatureStateUpdates) {
     auto definition = numberDefinition();
     const auto layer = source();
     plugin::ShaderPropertyBindingDefinition binding{"test-size", MLN_PLUGIN_PROPERTY_ENCODING_FLOAT, 0, 0, 1, 1, 0, 4};
     auto value = expression(definition, R"(["interpolate",["linear"],["zoom"],10,["get","small"],11,["get","large"]])");
-    PluginPaintPropertyBinder binder(definition, binding, value, 10, 1, 4, {{0,1,0,4}}, layer);
+    PluginPaintPropertyBinder binder(definition, binding, value, 10, 1, 4, {{0, 1, 0, 4}}, layer);
     ASSERT_TRUE(binder.isDataDriven());
     EXPECT_EQ(gfx::AttributeDataType::Float2, binder.attributeType());
     const auto* bytes = static_cast<const float*>(binder.getVertexVector()->getRawData());
@@ -69,9 +69,10 @@ TEST(PluginPaintBinder, EnumOrdinalsAndOwnedStatisticsStrings) {
     definition.defaultValue = std::string("map");
     definition.enumValues = {"map", "viewport"};
     const auto layer = source();
-    plugin::ShaderPropertyBindingDefinition binding{"test-size", MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT, 0, 0, 1, 1, 0, 4};
+    plugin::ShaderPropertyBindingDefinition binding{
+        "test-size", MLN_PLUGIN_PROPERTY_ENCODING_ENUM_FLOAT, 0, 0, 1, 1, 0, 4};
     auto value = expression(definition, R"(["get","anchor"])");
-    PluginPaintPropertyBinder binder(definition, binding, value, 10, 1, 4, {{0,1,0,4}}, layer);
+    PluginPaintPropertyBinder binder(definition, binding, value, 10, 1, 4, {{0, 1, 0, 4}}, layer);
     const auto* bytes = static_cast<const float*>(binder.getVertexVector()->getRawData());
     EXPECT_FLOAT_EQ(1, bytes[0]);
     EXPECT_FLOAT_EQ(1, bytes[1]);


### PR DESCRIPTION
## Scope

Export and package the C API and registry inspection for Android, including the renderer-independent Prefab artifact. C++ runtimes stay private behind the C boundary.

Depends on #4594; review only against its base branch. Layer 10/11.

1348 changed lines (+1118/-230). Within the approximately 2,000-line review budget.

## Validation and landing

At the integrated stack tip: 19 focused core tests and 108 Metal render tests pass. The n-gon plugin builds as an Android AAR for all four ABIs and through SwiftPM/Bazel. N-gon Vulkan images pass; the full MoltenVK run has two retained heatmap/hillshade image mismatches. OpenGL ES shader variants compile, but runtime OpenGL validation is still needed on a supported ES 3 test environment.

These are deliberately draft PRs. Build jobs are skipped before runner allocation; marking a PR ready triggers normal checks. Merge only in dependency order after those checks pass. Lightweight metadata/pre-commit services may still operate.

Companion plugin stack: https://github.com/louwers/maplibre-native-plugin-template/pull/1

Roadmap: [Incremental plugin introduction](https://github.com/maplibre/maplibre-native/blob/plugins/01-draft-ci/design-proposals/2026-09-08-plugin-introduction.md).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
