### PR TITLE
feat: expose the C plugin API to Darwin and external Bazel render runners

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,10 +31,10 @@ single_version_override(
     version = "3.3.0",
 )
 
-node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 node.toolchain(node_version = "20.14.0")
 
-npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(
     name = "npm",
     data = ["package.json"],
@@ -70,18 +70,10 @@ http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "ht
 
 http_archive(
     name = "glfw",
-    build_file = "@//vendor:glfw.BUILD",
+    build_file = "//vendor:glfw.BUILD",
     integrity = "sha256-tewASycS/Qjohh3CcUKPBId1IAot9xnM9XUUO6dJo+k=",
     strip_prefix = "glfw-3.4",
     urls = ["https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.zip"],
-)
-
-new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
-
-new_git_repository(
-    name = "tinyobjloader",
-    commit = "3bb554cf74428d7db13418b4aca1b9752a1d2be8",
-    remote = "https://github.com/tinyobjloader/tinyobjloader.git",
 )
 
 swift_deps = use_extension("@rules_swift_package_manager//:extensions.bzl", "swift_deps")

--- a/platform/BUILD.bazel
+++ b/platform/BUILD.bazel
@@ -282,33 +282,9 @@ objc_library(
 )
 
 objc_library(
-    name = "app_custom_drawable_layer_objcpp_srcs",
-    srcs = [
-    ],
-    copts = CPP_FLAGS + MAPLIBRE_FLAGS + WARNING_FLAGS["ios"] + [
-        "-fcxx-modules",
-        "-fmodules",
-        "-Wno-c99-extensions",
-        "-Wno-gnu-zero-variadic-macro-arguments",
-        "-Wno-gnu-conditional-omitted-operand",
-        "-Wno-gnu-statement-expression",
-        "-Wno-deprecated-declarations",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":ios-sdk",
-        "//:mbgl-core",
-    ],
-)
-
-objc_library(
     name = "iosapp_objcpp_srcs",
     srcs = [
         "//platform/darwin:app/CustomStyleLayerExample.h",
-        "//platform/darwin:app/PluginLayerExample.h",
-        "//platform/darwin:app/PluginLayerExample.mm",
-        "//platform/darwin:app/PluginLayerExampleMetalRendering.h",
-        "//platform/darwin:app/PluginLayerExampleMetalRendering.mm",
         "//platform/ios:ios_app_objcpp_srcs",
     ],
     copts = CPP_FLAGS + MAPLIBRE_FLAGS + WARNING_FLAGS["ios"],

--- a/platform/darwin/BUILD.bazel
+++ b/platform/darwin/BUILD.bazel
@@ -256,6 +256,7 @@ objc_library(
         "src",
     ],
     sdk_frameworks = [
+        "CoreGraphics",
         "CoreText",
         "ImageIO",
     ],
@@ -297,6 +298,7 @@ objc_library(
 
 exports_files(
     [
+        "bazel/example_config.bzl",
         "test/amsterdam.geojson",
         "test/MLNSDKTestHelpers.swift",
         "app/CustomStyleLayerExample.h",

--- a/platform/darwin/bazel/darwin_config_repository_rule.bzl
+++ b/platform/darwin/bazel/darwin_config_repository_rule.bzl
@@ -9,10 +9,21 @@ def _impl(ctx):
     ctx.file("BUILD.bazel", "")
     if config.exists:
         ctx.file("config.bzl", ctx.read(config))
-    else:
+    elif example_config.exists:
         ctx.file("config.bzl", ctx.read(example_config))
+    else:
+        # When MapLibre is a local_path_override dependency, workspace_root is
+        # the consuming application. Resolve the fallback in MapLibre's own
+        # repository instead of assuming MapLibre is the root module.
+        ctx.file("config.bzl", ctx.read(ctx.attr.example_config))
 
 darwin_config = repository_rule(
     implementation = _impl,
     local = True,
+    attrs = {
+        "example_config": attr.label(
+            default = Label("//platform/darwin:bazel/example_config.bzl"),
+            allow_single_file = True,
+        ),
+    },
 )

--- a/platform/darwin/bazel/files.bzl
+++ b/platform/darwin/bazel/files.bzl
@@ -54,6 +54,7 @@ MLN_GENERATED_DARWIN_TEST_CODE = [
 ]
 
 MLN_DARWIN_OBJC_HEADERS = [
+    "src/MLNPluginAPI.h",
     "src/MLNActionJournalOptions.h",
     "src/MLNAnnotation.h",
     "src/MLNAttributedExpression.h",

--- a/platform/darwin/src/MLNPluginAPI.h
+++ b/platform/darwin/src/MLNPluginAPI.h
@@ -1,0 +1,14 @@
+#pragma once
+
+/**
+ The stable, C-only interface used to register MapLibre Native plugins.
+
+ Plugin packages should include this umbrella header instead of depending on
+ MapLibre Native C++ headers. Backend objects passed through callbacks are
+ borrowed for the duration of that callback.
+ */
+#if __has_include(<mln/plugin/plugin_api.h>)
+#include <mln/plugin/plugin_api.h>
+#else
+#include "plugin_api.h"
+#endif

--- a/platform/default/BUILD.bazel
+++ b/platform/default/BUILD.bazel
@@ -88,11 +88,14 @@ cc_library(
             "src/mln/util/webp_reader.cpp",
         ],
         "//platform/macos:macos_libuv_loop": [
+            "src/mln/layermanager/layer_manager.cpp",
             "src/mln/util/async_task.cpp",
             "src/mln/util/run_loop.cpp",
             "src/mln/util/timer.cpp",
         ],
-        "//platform/macos:macos_cfrunloop_loop": [],
+        "//platform/macos:macos_cfrunloop_loop": [
+            "src/mln/layermanager/layer_manager.cpp",
+        ],
         "//conditions:default": [],
     }),
     hdrs = [
@@ -145,6 +148,7 @@ cc_library(
         "//platform/ios:__pkg__",
         "//platform/linux:__pkg__",
         "//platform/macos:__pkg__",
+        "//render-test:__pkg__",
         "//test:__pkg__",
     ],
     deps = [

--- a/platform/ios/BUILD.bazel
+++ b/platform/ios/BUILD.bazel
@@ -103,6 +103,7 @@ public_hdrs = [
     ":mln_defines",
     ":ios_public_hdrs",
     ":ios_sdk_hdrs",
+    "//:plugin_api_public_header",
     "//platform/darwin:darwin_objc_hdrs",
     "//platform/darwin:generated_style_public_hdrs",
 ]

--- a/platform/ios/src/Mapbox.h
+++ b/platform/ios/src/Mapbox.h
@@ -47,6 +47,7 @@ FOUNDATION_EXPORT MLN_EXPORT const unsigned char MapboxVersionString[];
 #import "MLNOfflineRegion.h"
 #import "MLNOfflineStorage.h"
 #import "MLNOverlay.h"
+#import "MLNPluginAPI.h"
 #import "MLNPointAnnotation.h"
 #import "MLNPointCollection.h"
 #import "MLNPolygon.h"

--- a/render-test/BUILD.bazel
+++ b/render-test/BUILD.bazel
@@ -9,10 +9,7 @@ cc_library(
     includes = [
         "include",
     ],
-    visibility = [
-        "//platform/default:__pkg__",
-        "//render-test/ios:__pkg__",
-    ],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
@@ -29,15 +26,17 @@ cc_library(
     includes = [
         "include",
     ],
-    visibility = [
-        "//render-test/ios:__pkg__",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         "//expression-test:test_runner_common",
         "//vendor:args",
     ] + select({
         "@platforms//os:ios": ["//platform:ios-sdk"],
         "@platforms//os:linux": ["//platform/linux:impl"],
+        "@platforms//os:macos": [
+            "//platform/darwin:darwin-objcpp",
+            "//platform/default:mbgl-default",
+        ],
         "//conditions:default": [],
     }),
 )

--- a/render-test/manifest_parser.cpp
+++ b/render-test/manifest_parser.cpp
@@ -86,10 +86,10 @@ std::vector<mln::filesystem::path> getTestExpectations(const mln::filesystem::pa
 }
 
 mln::filesystem::path getValidPath(const std::string& manifestPath, const std::string& path) {
-    const static mln::filesystem::path BasePath{manifestPath};
+    const mln::filesystem::path basePath{manifestPath};
     mln::filesystem::path result{path};
     if (result.is_relative()) {
-        result = BasePath / result;
+        result = basePath / result;
     }
     if (mln::filesystem::exists(result)) {
         return result.lexically_normal();


### PR DESCRIPTION
## Scope

Expose the C-only Darwin umbrella header and support MapLibre as an external Bazel dependency, including shared plugin render-test runners.

Depends on #4595; review only against its base branch. Layer 11/11.

93 changed lines (+47/-46). Within the approximately 2,000-line review budget.

## Validation and landing

At the integrated stack tip: 19 focused core tests and 108 Metal render tests pass. The n-gon plugin builds as an Android AAR for all four ABIs and through SwiftPM/Bazel. N-gon Vulkan images pass; the full MoltenVK run has two retained heatmap/hillshade image mismatches. OpenGL ES shader variants compile, but runtime OpenGL validation is still needed on a supported ES 3 test environment.

These are deliberately draft PRs. Build jobs are skipped before runner allocation; marking a PR ready triggers normal checks. Merge only in dependency order after those checks pass. Lightweight metadata/pre-commit services may still operate.

Companion plugin stack: https://github.com/louwers/maplibre-native-plugin-template/pull/1

Roadmap: [Incremental plugin introduction](https://github.com/maplibre/maplibre-native/blob/plugins/01-draft-ci/design-proposals/2026-09-08-plugin-introduction.md).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
