### PR TITLE
Ignore generated expression and render test reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ CMakeLists.txt.user
 CMakeFiles
 __generated__
 
+# Test runner output.
+/metrics/*.html
+/metrics/integration/expression-tests/index.html
 /metrics/integration/query-tests/**/actual.json
 /metrics/integration/render-tests/**/actual.png
 /metrics/integration/render-tests/**/diff.png


### PR DESCRIPTION
Running the expression and render test runners leaves generated HTML reports in `git status`. Ignore `metrics/integration/expression-tests/index.html` and the top-level `metrics/*.html` reports.

Existing rules already cover render `actual.png` and `diff.png` outputs. Test fixtures, expected images, JSON manifests, and HTML elsewhere remain unaffected.

Validation: `git check-ignore --no-index` confirms six generated paths are ignored and six fixture, configuration, and documentation paths remain visible. `git diff --check` passes.

### AI disclosure

Prepared with assistance from **GPT-6 Astra in Codex**.
