### PR TITLE
fix(core): rebuild background drawables after style changes

### DIFF
--- a/src/mln/renderer/layers/render_background_layer.cpp
+++ b/src/mln/renderer/layers/render_background_layer.cpp
@@ -164,6 +164,10 @@ void RenderBackgroundLayer::update(gfx::ShaderRegistry& shaders,
     auto* tileLayerGroup = static_cast<TileLayerGroup*>(layerGroup.get());
 
     if (!layerTweaker) {
+        // Background drawables have no source buckets to replace them after a
+        // style change. Rebuild them so the new tweaker populates the group's
+        // uniform buffers for every drawable.
+        removeAllDrawables();
         layerTweaker = std::make_shared<BackgroundLayerTweaker>(getID(), evaluatedProperties);
         layerGroup->addLayerTweaker(layerTweaker);
     }

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -1,3 +1,6 @@
+#include <algorithm>
+#include <array>
+
 #include <gmock/gmock.h>
 
 #include <mln/test/util.hpp>
@@ -1943,6 +1946,80 @@ TEST(Map, ObserveTileLifecycle) {
         EXPECT_THAT(stage, testing::AnyOf(TileOperation::EndParse, TileOperation::Cancelled));
         EXPECT_FALSE(parsing);
     }
+}
+
+class BackgroundDrawableTest : public testing::Test {
+protected:
+    MapTest<> test;
+
+    void SetUp() override {
+        test.frontend.setSize({64, 64});
+        test.map.setSize({64, 64});
+        loadBaseStyle();
+    }
+
+    void loadBaseStyle() {
+        // A layer below the tested background prevents the clear-color optimization.
+        test.map.getStyle().loadJSON(R"({
+            "version": 8,
+            "sources": {},
+            "layers": [{"id": "underlay", "type": "background", "paint": {"background-color": "white"}}]
+        })");
+    }
+
+    BackgroundLayer& addBackground() {
+        auto layer = std::make_unique<BackgroundLayer>("background");
+        layer->setBackgroundColor(Color::red());
+        auto& result = *layer;
+        test.map.getStyle().addLayer(std::move(layer));
+        return result;
+    }
+
+    void expectColor(const std::array<uint8_t, 4>& expected) {
+        const auto image = test.frontend.render(test.map).image;
+        size_t matchingPixels = 0;
+        for (size_t i = 0; i < image.bytes(); i += 4) {
+            const auto* pixel = image.data.get() + i;
+            matchingPixels += std::equal(expected.begin(), expected.end(), pixel);
+        }
+        EXPECT_EQ(matchingPixels, 64u * 64u);
+    }
+};
+
+TEST_F(BackgroundDrawableTest, ImmediateStyleReplacementRetainsColor) {
+    for (int iteration = 0; iteration < 3; ++iteration) {
+        SCOPED_TRACE(iteration);
+        loadBaseStyle();
+        addBackground();
+        expectColor({255, 0, 0, 255});
+    }
+}
+
+TEST_F(BackgroundDrawableTest, PaintChangesAndSameIDReinsertionRetainColor) {
+    auto& layer = addBackground();
+    expectColor({255, 0, 0, 255});
+    layer.setBackgroundColor(Color::blue());
+    expectColor({0, 0, 255, 255});
+    test.map.getStyle().removeLayer("background");
+    addBackground();
+    expectColor({255, 0, 0, 255});
+}
+
+TEST_F(BackgroundDrawableTest, SwitchesBetweenSolidAndPatternedDrawables) {
+    PremultipliedImage pattern({2, 2});
+    for (size_t i = 0; i < pattern.bytes(); i += 4) {
+        pattern.data[i] = 0;
+        pattern.data[i + 1] = 0;
+        pattern.data[i + 2] = 255;
+        pattern.data[i + 3] = 255;
+    }
+    test.map.getStyle().addImage(std::make_unique<style::Image>("blue", std::move(pattern), 1.0f));
+    auto& layer = addBackground();
+    expectColor({255, 0, 0, 255});
+    layer.setBackgroundPattern({"blue"s});
+    expectColor({0, 0, 255, 255});
+    layer.setBackgroundPattern({});
+    expectColor({255, 0, 0, 255});
 }
 
 TEST(BackgroundLayer, StyleUpdateZoomDependency) {

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -1,6 +1,3 @@
-#include <algorithm>
-#include <array>
-
 #include <gmock/gmock.h>
 
 #include <mln/test/util.hpp>
@@ -1948,78 +1945,59 @@ TEST(Map, ObserveTileLifecycle) {
     }
 }
 
-class BackgroundDrawableTest : public testing::Test {
-protected:
+TEST(BackgroundLayer, ImmediateStyleReplacementRetainsColor) {
     MapTest<> test;
-
-    void SetUp() override {
-        test.frontend.setSize({64, 64});
-        test.map.setSize({64, 64});
-        loadBaseStyle();
-    }
-
-    void loadBaseStyle() {
-        // A layer below the tested background prevents the clear-color optimization.
+    for (int iteration = 0; iteration < 2; ++iteration) {
+        SCOPED_TRACE(iteration);
+        // The underlay keeps the tested background out of the clear-color optimization.
         test.map.getStyle().loadJSON(R"({
             "version": 8,
             "sources": {},
             "layers": [{"id": "underlay", "type": "background", "paint": {"background-color": "white"}}]
         })");
-    }
-
-    BackgroundLayer& addBackground() {
         auto layer = std::make_unique<BackgroundLayer>("background");
         layer->setBackgroundColor(Color::red());
-        auto& result = *layer;
         test.map.getStyle().addLayer(std::move(layer));
-        return result;
-    }
 
-    void expectColor(const std::array<uint8_t, 4>& expected) {
         const auto image = test.frontend.render(test.map).image;
-        size_t matchingPixels = 0;
-        for (size_t i = 0; i < image.bytes(); i += 4) {
-            const auto* pixel = image.data.get() + i;
-            matchingPixels += std::equal(expected.begin(), expected.end(), pixel);
-        }
-        EXPECT_EQ(matchingPixels, 64u * 64u);
-    }
-};
-
-TEST_F(BackgroundDrawableTest, ImmediateStyleReplacementRetainsColor) {
-    for (int iteration = 0; iteration < 3; ++iteration) {
-        SCOPED_TRACE(iteration);
-        loadBaseStyle();
-        addBackground();
-        expectColor({255, 0, 0, 255});
+        const auto* pixel = image.data.get() + (image.size.height / 2) * image.stride() +
+                            (image.size.width / 2) * image.channels;
+        EXPECT_EQ(pixel[0], 255);
+        EXPECT_EQ(pixel[1], 0);
+        EXPECT_EQ(pixel[2], 0);
+        EXPECT_EQ(pixel[3], 255);
     }
 }
 
-TEST_F(BackgroundDrawableTest, PaintChangesAndSameIDReinsertionRetainColor) {
-    auto& layer = addBackground();
-    expectColor({255, 0, 0, 255});
-    layer.setBackgroundColor(Color::blue());
-    expectColor({0, 0, 255, 255});
-    test.map.getStyle().removeLayer("background");
-    addBackground();
-    expectColor({255, 0, 0, 255});
-}
-
-TEST_F(BackgroundDrawableTest, SwitchesBetweenSolidAndPatternedDrawables) {
-    PremultipliedImage pattern({2, 2});
-    for (size_t i = 0; i < pattern.bytes(); i += 4) {
-        pattern.data[i] = 0;
-        pattern.data[i + 1] = 0;
-        pattern.data[i + 2] = 255;
-        pattern.data[i + 3] = 255;
-    }
-    test.map.getStyle().addImage(std::make_unique<style::Image>("blue", std::move(pattern), 1.0f));
-    auto& layer = addBackground();
-    expectColor({255, 0, 0, 255});
-    layer.setBackgroundPattern({"blue"s});
-    expectColor({0, 0, 255, 255});
-    layer.setBackgroundPattern({});
-    expectColor({255, 0, 0, 255});
+TEST(BackgroundLayer, SwitchesBetweenSolidAndPatternedDrawables) {
+    MapTest<> test;
+    // The underlay forces shader selection through the drawable path.
+    test.map.getStyle().loadJSON(R"({
+        "version": 8,
+        "sources": {},
+        "layers": [
+            {"id": "underlay", "type": "background", "paint": {"background-color": "white"}},
+            {"id": "background", "type": "background", "paint": {"background-color": "red"}}
+        ]
+    })");
+    const uint8_t blue[] = {0, 0, 255, 255};
+    test.map.getStyle().addImage(
+        std::make_unique<style::Image>("blue", PremultipliedImage({1, 1}, blue, sizeof(blue)), 1.0f));
+    auto* layer = static_cast<BackgroundLayer*>(test.map.getStyle().getLayer("background"));
+    const auto expectColor = [&](uint8_t red, uint8_t blueChannel) {
+        const auto image = test.frontend.render(test.map).image;
+        const auto* pixel = image.data.get() + (image.size.height / 2) * image.stride() +
+                            (image.size.width / 2) * image.channels;
+        EXPECT_EQ(pixel[0], red);
+        EXPECT_EQ(pixel[1], 0);
+        EXPECT_EQ(pixel[2], blueChannel);
+        EXPECT_EQ(pixel[3], 255);
+    };
+    expectColor(255, 0);
+    layer->setBackgroundPattern({"blue"s});
+    expectColor(0, 255);
+    layer->setBackgroundPattern({});
+    expectColor(255, 0);
 }
 
 TEST(BackgroundLayer, StyleUpdateZoomDependency) {


### PR DESCRIPTION
## Bug

Style changes replace the background's uniform updater but keep its old drawables. The new updater skips those drawables and uploads zero matrices, so the background disappears.

Fixes #4502.

## Repro

Load an empty style, add a red background, and render. Repeat with the same layer ID: red becomes transparent black. See maplibre/maplibre-native-ffi#709.

## Fix

Recreate the background drawables when replacing their updater.

## Tests

Two pixel tests cover style replacement and solid/pattern changes. Both fail without the fix and pass on macOS Metal.

Vendored in maplibre/maplibre-native-ffi#710. AI disclosure: Codex (GPT-6) assisted with investigation, code, tests, and this description.

