### PR TITLE
fix(android): prevent CustomGeometrySource crashes during teardown

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog MapLibre Native for Android
 
+## main
+
+### 🐞 Bug fixes
+
+- Prevent custom geometry tile requests from submitting results after source removal, style replacement, or map destruction.
+
 ## 13.6.1
 
 ### 🐞 Bug fixes

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/sources/CustomGeometrySource.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/sources/CustomGeometrySource.kt
@@ -3,339 +3,182 @@ package org.maplibre.android.style.sources
 import androidx.annotation.Keep
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
+import org.maplibre.android.geometry.LatLngBounds
+import org.maplibre.android.style.expressions.Expression
 import org.maplibre.geojson.Feature
 import org.maplibre.geojson.FeatureCollection
-import org.maplibre.android.geometry.LatLngBounds
-import org.maplibre.android.geometry.LatLngBounds.Companion.from
-import org.maplibre.android.style.expressions.Expression
-import java.lang.ref.WeakReference
-import java.util.Locale
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.ThreadFactory
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.locks.Lock
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.collections.HashMap
 
 /**
  * Custom Vector Source, allows using FeatureCollections.
  *
  *
  * CustomGeometrySource uses a coalescing model for frequent data updates targeting the same tile id,
- * which means, that the in-progress request as well as the last scheduled request are guaranteed to finish.
- * Any requests scheduled meanwhile can be canceled.
+ * which means that, while the source is attached, the in-progress request as well as the last scheduled
+ * request are guaranteed to finish.
+ * Any requests scheduled meanwhile can be canceled. Detaching the source cancels outstanding requests.
+ *
+ * @param id The source id.
+ * @param options Custom geometry source options.
+ * @param provider The tile provider that returns geometry data for this source.
  */
-class CustomGeometrySource @UiThread constructor(id: String?, options: CustomGeometrySourceOptions?, private val provider: GeometryTileProvider?) : Source() {
-    private val executorLock: Lock = ReentrantLock()
-    private var executor: ThreadPoolExecutor? = null
-    private val awaitingTasksMap: MutableMap<TileID, GeometryTileRequest> = HashMap()
-
-    /**
-     * A map containing in-progress requests targeting distinct tiles.
-     * A request is considered in-progress when it's started by the ThreadPoolExecutor.
-     * A request is marked as done when the data is passed from the JNI layer to the core, after the features conversion.
-     */
-    private val inProgressTasksMap: MutableMap<TileID, AtomicBoolean?> = HashMap()
-
-    /**
-     * Create a CustomGeometrySource
-     *
-     * @param id       The source id.
-     * @param provider The tile provider that returns geometry data for this source.
-     */
+class CustomGeometrySource
     @UiThread
-    constructor(id: String?, provider: GeometryTileProvider?) : this(id, CustomGeometrySourceOptions(), provider) {
-    }
+    constructor(
+        id: String?,
+        options: CustomGeometrySourceOptions?,
+        provider: GeometryTileProvider?,
+    ) : Source() {
+        private val tileRequests = CustomGeometrySourceTileRequests(provider, ::nativeSetTileData)
 
-    /**
-     * Create a CustomGeometrySource with non-default [CustomGeometrySourceOptions].
-     *
-     * @param id       The source id.
-     * @param options  CustomGeometrySourceOptions.
-     */
-    init {
-        initialize(id, options)
-    }
-
-    /**
-     * Invalidate previously provided features within a given bounds at all zoom levels.
-     * Invoking this method will result in new requests to `GeometryTileProvider` for regions
-     * that contain, include, or intersect with the provided bounds.
-     *
-     * @param bounds The region in which features should be invalidated at all zoom levels
-     */
-    fun invalidateRegion(bounds: LatLngBounds) {
-        nativeInvalidateBounds(bounds)
-    }
-
-    /**
-     * Invalidate the geometry contents of a specific tile. Invoking this method will result
-     * in new requests to `GeometryTileProvider` for visible tiles.
-     *
-     * @param zoomLevel Tile zoom level.
-     * @param x         Tile X coordinate.
-     * @param y         Tile Y coordinate.
-     */
-    fun invalidateTile(zoomLevel: Int, x: Int, y: Int) {
-        nativeInvalidateTile(zoomLevel, x, y)
-    }
-
-    /**
-     * Set or update geometry contents of a specific tile. Use this method to update tiles
-     * for which `GeometryTileProvider` was previously invoked. This method can be called from
-     * background threads.
-     *
-     * @param zoomLevel Tile zoom level.
-     * @param x         Tile X coordinate.
-     * @param y         Tile Y coordinate.
-     * @param data      Feature collection for the tile.
-     */
-    fun setTileData(zoomLevel: Int, x: Int, y: Int, data: FeatureCollection) {
-        nativeSetTileData(zoomLevel, x, y, data)
-    }
-
-    /**
-     * Queries the source for features.
-     *
-     * @param filter an optional filter expression to filter the returned Features
-     * @return the features
-     */
-    fun querySourceFeatures(filter: Expression?): List<Feature> {
-        checkThread()
-        val features = querySourceFeatures(filter?.toArray())
-        return listOf(*features)
-    }
-
-    @Keep
-    private external fun initialize(sourceId: String?, options: Any?)
-
-    @Keep
-    private external fun querySourceFeatures(filter: Array<Any>?): Array<Feature>
-
-    @Keep
-    private external fun nativeSetTileData(z: Int, x: Int, y: Int, data: FeatureCollection)
-
-    @Keep
-    private external fun nativeInvalidateTile(z: Int, x: Int, y: Int)
-
-    @Keep
-    private external fun nativeInvalidateBounds(bounds: LatLngBounds)
-
-    @Keep
-    @Throws(Throwable::class)
-    protected external fun finalize()
-
-    private fun setTileData(tileId: TileID, data: FeatureCollection) {
-        nativeSetTileData(tileId.z, tileId.x, tileId.y, data)
-    }
-
-    /**
-     * Tile data request can come from a number of different threads.
-     * To remove race condition for requests targeting the same tile id we are first checking if there is a request
-     * already enqueued, if yes, we are replacing it.
-     * Otherwise, we are checking if there is an in-progress request, if yes,
-     * we are creating or replacing an awaiting request.
-     * If none of the above, we are enqueueing the request.
-     */
-    @WorkerThread
-    @Keep
-    private fun fetchTile(z: Int, x: Int, y: Int) {
-        val cancelFlag = AtomicBoolean(false)
-        val tileID = TileID(z, x, y)
-        val request = GeometryTileRequest(tileID, provider, awaitingTasksMap, inProgressTasksMap, this, cancelFlag)
-        synchronized(awaitingTasksMap) {
-            synchronized(inProgressTasksMap) {
-                if (executor!!.queue.contains(request)) {
-                    executor!!.remove(request)
-                    executeRequest(request)
-                } else if (inProgressTasksMap.containsKey(tileID)) {
-                    awaitingTasksMap.put(tileID, request)
-                } else {
-                    executeRequest(request)
-                }
-            }
+        /**
+         * Create a CustomGeometrySource
+         *
+         * @param id       The source id.
+         * @param provider The tile provider that returns geometry data for this source.
+         */
+        @UiThread
+        constructor(id: String?, provider: GeometryTileProvider?) : this(id, CustomGeometrySourceOptions(), provider) {
         }
-    }
-
-    private fun executeRequest(request: GeometryTileRequest) {
-        executorLock.lock()
-        try {
-            if (executor != null && !executor!!.isShutdown) {
-                executor!!.execute(request)
-            }
-        } finally {
-            executorLock.unlock()
-        }
-    }
-
-    /**
-     * We want to cancel only the oldest request, therefore, we are first checking if it's in progress,
-     * if not or if the currently in progress request has already been canceled,
-     * we are searching for any request in the executor's queue.
-     * Otherwise, we are removing an awaiting request targeting this tile id.
-     *
-     *
-     * [GeometryTileRequest.equals] is overridden to cover only the tile id,
-     * therefore, we can use an empty request to search the executor's queue.
-     */
-    @WorkerThread
-    @Keep
-    private fun cancelTile(z: Int, x: Int, y: Int) {
-        val tileID = TileID(z, x, y)
-        synchronized(awaitingTasksMap) {
-            synchronized(inProgressTasksMap) {
-                val cancelFlag = inProgressTasksMap[tileID]
-                // check if there is an in progress task
-                if (!(cancelFlag != null && cancelFlag.compareAndSet(false, true))) {
-                    // if there is no tasks in progress or the in progress task was already cancelled, check the executor's queue
-                    val emptyRequest = GeometryTileRequest(tileID, null, null, null, null, null)
-                    if (!executor!!.queue.remove(emptyRequest)) {
-                        // if there was no tasks in queue, remove from the awaiting map
-                        awaitingTasksMap.remove(tileID)
-                    }
-                }
-            }
-        }
-    }
-
-    @Keep
-    private fun startThreads() {
-        executorLock.lock()
-        executor = try {
-            if (executor != null && !executor!!.isShutdown) {
-                executor!!.shutdownNow()
-            }
-            ThreadPoolExecutor(
-                THREAD_POOL_LIMIT,
-                THREAD_POOL_LIMIT,
-                0L,
-                TimeUnit.MILLISECONDS,
-                LinkedBlockingQueue(),
-                object : ThreadFactory {
-                    val threadCount = AtomicInteger()
-                    val poolId = poolCount.getAndIncrement()
-                    override fun newThread(runnable: Runnable): Thread {
-                        return Thread(runnable, String.format(Locale.US, "%s-%d-%d", THREAD_PREFIX, poolId, threadCount.getAndIncrement()))
-                    }
-                }
-            )
-        } finally {
-            executorLock.unlock()
-        }
-    }
-
-    @Keep
-    private fun releaseThreads() {
-        executorLock.lock()
-        try {
-            executor!!.shutdownNow()
-        } finally {
-            executorLock.unlock()
-        }
-    }
-
-    @Keep
-    private fun isCancelled(z: Int, x: Int, y: Int): Boolean {
-        return inProgressTasksMap[TileID(z, x, y)]!!.get()
-    }
-
-    internal class TileID(var z: Int, var x: Int, var y: Int) {
-        override fun hashCode(): Int {
-            return intArrayOf(z, x, y).contentHashCode()
-        }
-
-        override fun equals(other: Any?): Boolean {
-            if (other === this) {
-                return true
-            }
-            if (other == null || javaClass != other.javaClass) {
-                return false
-            }
-            if (other is TileID) {
-                return z == other.z && x == other.x && y == other.y
-            }
-            return false
-        }
-    }
-
-    internal class GeometryTileRequest(
-        private val id: TileID,
-        private val provider: GeometryTileProvider?,
-        private val awaiting: MutableMap<TileID, GeometryTileRequest>?,
-        private val inProgress: MutableMap<TileID, AtomicBoolean?>?,
-        _source: CustomGeometrySource?,
-        _cancelled: AtomicBoolean?
-    ) : Runnable {
-        private val sourceRef: WeakReference<CustomGeometrySource?>
-        private val cancelled: AtomicBoolean?
 
         init {
-            sourceRef = WeakReference(_source)
-            cancelled = _cancelled
+            initialize(id, options)
         }
 
-        override fun run() {
-            synchronized(awaiting!!) {
-                synchronized(inProgress!!) {
-                    if (inProgress.containsKey(id)) {
-                        // request targeting this tile id is already being processed,
-                        // scenario that should occur only if the tile is being requested when
-                        // another request is switching threads to execute
-                        if (!awaiting.containsKey(id)) {
-                            awaiting[id] = this
-                        }
-                        return
-                    } else {
-                        inProgress.put(id, cancelled)
-                    }
-                }
-            }
-            if (!isCancelled()) {
-                val data = provider!!.getFeaturesForBounds(from(id.z, id.x, id.y), id.z)
-                val source = sourceRef.get()
-                if (!isCancelled() && source != null) {
-                    source.setTileData(id, data)
-                }
-            }
-            synchronized(awaiting) {
-                synchronized(inProgress!!) {
-                    inProgress.remove(id)
-
-                    // executing the next request targeting the same tile
-                    if (awaiting.containsKey(id)) {
-                        val queuedRequest = awaiting[id]
-                        val source = sourceRef.get()
-                        if (source != null && queuedRequest != null) {
-                            source.executor!!.execute(queuedRequest)
-                        }
-                        awaiting.remove(id)
-                    }
-                }
-            }
+        /**
+         * Invalidate previously provided features within a given bounds at all zoom levels.
+         * Invoking this method will result in new requests to `GeometryTileProvider` for regions
+         * that contain, include, or intersect with the provided bounds.
+         *
+         * @param bounds The region in which features should be invalidated at all zoom levels
+         */
+        fun invalidateRegion(bounds: LatLngBounds) {
+            nativeInvalidateBounds(bounds)
         }
 
-        private fun isCancelled(): Boolean {
-            return cancelled!!.get()
+        /**
+         * Invalidate the geometry contents of a specific tile. Invoking this method will result
+         * in new requests to `GeometryTileProvider` for visible tiles.
+         *
+         * @param zoomLevel Tile zoom level.
+         * @param x         Tile X coordinate.
+         * @param y         Tile Y coordinate.
+         */
+        fun invalidateTile(
+            zoomLevel: Int,
+            x: Int,
+            y: Int,
+        ) {
+            nativeInvalidateTile(zoomLevel, x, y)
         }
 
-        override fun equals(other: Any?): Boolean {
-            if (this === other) {
-                return true
-            }
-            if (other == null || javaClass != other.javaClass) {
-                return false
-            }
-            val request = other as GeometryTileRequest
-            return id == request.id
+        /**
+         * Set or update geometry contents of a specific tile. Use this method to update tiles
+         * for which `GeometryTileProvider` was previously invoked. This method can be called from
+         * background threads. Calls after the source is removed or detached are ignored.
+         *
+         * @param zoomLevel Tile zoom level.
+         * @param x         Tile X coordinate.
+         * @param y         Tile Y coordinate.
+         * @param data      Feature collection for the tile.
+         */
+        fun setTileData(
+            zoomLevel: Int,
+            x: Int,
+            y: Int,
+            data: FeatureCollection,
+        ) {
+            tileRequests.setTileData(zoomLevel, x, y, data)
+        }
+
+        /**
+         * Queries the source for features.
+         *
+         * @param filter an optional filter expression to filter the returned Features
+         * @return the features
+         */
+        fun querySourceFeatures(filter: Expression?): List<Feature> {
+            checkThread()
+            val features = querySourceFeatures(filter?.toArray())
+            return listOf(*features)
+        }
+
+        @Keep
+        private external fun initialize(
+            sourceId: String?,
+            options: Any?,
+        )
+
+        @Keep
+        private external fun querySourceFeatures(filter: Array<Any>?): Array<Feature>
+
+        @Keep
+        private external fun nativeSetTileData(
+            z: Int,
+            x: Int,
+            y: Int,
+            data: FeatureCollection,
+        )
+
+        @Keep
+        private external fun nativeInvalidateTile(
+            z: Int,
+            x: Int,
+            y: Int,
+        )
+
+        @Keep
+        private external fun nativeInvalidateBounds(bounds: LatLngBounds)
+
+        @Keep
+        @Throws(Throwable::class)
+        protected external fun finalize()
+
+        // Style.clear() calls this before style replacement or map destruction. Waiting until the
+        // native peer's destructor would be too late: the core source's tile loader is destroyed first.
+        override fun setDetached() {
+            tileRequests.release()
+            super.setDetached()
+        }
+
+        @WorkerThread
+        @Keep
+        private fun fetchTile(
+            z: Int,
+            x: Int,
+            y: Int,
+        ) {
+            tileRequests.fetchTile(z, x, y)
+        }
+
+        @WorkerThread
+        @Keep
+        private fun cancelTile(
+            z: Int,
+            x: Int,
+            y: Int,
+        ) {
+            tileRequests.cancelTile(z, x, y)
+        }
+
+        @Keep
+        private fun startThreads() {
+            tileRequests.start()
+        }
+
+        @Keep
+        private fun releaseThreads() {
+            tileRequests.release()
+        }
+
+        @Keep
+        private fun isCancelled(
+            z: Int,
+            x: Int,
+            y: Int,
+        ): Boolean = tileRequests.isCancelled(z, x, y)
+
+        companion object {
+            const val THREAD_PREFIX = "CustomGeom"
+            const val THREAD_POOL_LIMIT = 4
         }
     }
-
-    companion object {
-        const val THREAD_PREFIX = "CustomGeom"
-        const val THREAD_POOL_LIMIT = 4
-        private val poolCount = AtomicInteger()
-    }
-}

--- a/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/sources/CustomGeometrySourceTileRequests.kt
+++ b/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/sources/CustomGeometrySourceTileRequests.kt
@@ -1,0 +1,184 @@
+package org.maplibre.android.style.sources
+
+import org.maplibre.android.geometry.LatLngBounds
+import org.maplibre.geojson.FeatureCollection
+import java.lang.ref.WeakReference
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Serializes native submissions with source detachment, without holding the lock while invoking
+ * the application's provider. Each attachment has separate request state so a worker from an old
+ * executor cannot submit data or change the bookkeeping of a newly attached source.
+ */
+internal class CustomGeometrySourceTileRequests(
+    private val provider: GeometryTileProvider?,
+    private val submit: (Int, Int, Int, FeatureCollection) -> Unit,
+    private val createExecutor: () -> ThreadPoolExecutor = ::newExecutor,
+) {
+    private val lock = ReentrantLock()
+    private var state: State? = null
+
+    fun start() {
+        lock.withLock {
+            release()
+            state = State(createExecutor())
+        }
+    }
+
+    fun release() {
+        lock.withLock {
+            val previous = state ?: return
+            state = null
+            previous.inProgress.values.forEach { it.set(true) }
+            previous.inProgress.clear()
+            previous.awaiting.clear()
+            previous.executor.shutdownNow()
+        }
+    }
+
+    fun fetchTile(
+        z: Int,
+        x: Int,
+        y: Int,
+    ) {
+        lock.withLock {
+            val current = state ?: return
+            val id = TileID(z, x, y)
+            val request = Request(id, current, this)
+            if (current.executor.queue.contains(request)) {
+                current.executor.remove(request)
+                current.executor.execute(request)
+            } else if (current.inProgress.containsKey(id)) {
+                current.awaiting[id] = request
+            } else {
+                current.executor.execute(request)
+            }
+        }
+    }
+
+    fun cancelTile(
+        z: Int,
+        x: Int,
+        y: Int,
+    ) {
+        lock.withLock {
+            val current = state ?: return
+            val id = TileID(z, x, y)
+            val cancelled = current.inProgress[id]
+            if (cancelled == null || !cancelled.compareAndSet(false, true)) {
+                if (!current.executor.queue.remove(Request(id, current, this))) {
+                    current.awaiting.remove(id)
+                }
+            }
+        }
+    }
+
+    fun setTileData(
+        z: Int,
+        x: Int,
+        y: Int,
+        data: FeatureCollection,
+    ) {
+        lock.withLock {
+            if (state != null) submit(z, x, y, data)
+        }
+    }
+
+    // Native submission calls back here while holding lock; the lock must be reentrant.
+    fun isCancelled(
+        z: Int,
+        x: Int,
+        y: Int,
+    ): Boolean =
+        lock.withLock {
+            state?.inProgress?.get(TileID(z, x, y))?.get() ?: true
+        }
+
+    private fun run(request: Request) {
+        lock.withLock {
+            val current = state
+            if (current !== request.state) return
+            if (current.inProgress.containsKey(request.id)) {
+                // A previously queued request may start while another worker handles the same tile.
+                // Preserve the latest request already waiting for that tile.
+                if (!current.awaiting.containsKey(request.id)) current.awaiting[request.id] = request
+                return
+            }
+            current.inProgress[request.id] = request.cancelled
+        }
+
+        try {
+            if (!request.cancelled.get()) {
+                val id = request.id
+                val data = provider!!.getFeaturesForBounds(LatLngBounds.from(id.z, id.x, id.y), id.z)
+                lock.withLock {
+                    if (state === request.state && !request.cancelled.get()) {
+                        submit(id.z, id.x, id.y, data)
+                    }
+                }
+            }
+        } finally {
+            lock.withLock {
+                val current = state
+                if (current === request.state) {
+                    current.inProgress.remove(request.id)
+                    current.awaiting.remove(request.id)?.let { current.executor.execute(it) }
+                }
+            }
+        }
+    }
+
+    private class State(
+        val executor: ThreadPoolExecutor,
+    ) {
+        val awaiting = HashMap<TileID, Request>()
+        val inProgress = HashMap<TileID, AtomicBoolean>()
+    }
+
+    private data class TileID(
+        val z: Int,
+        val x: Int,
+        val y: Int,
+    )
+
+    private class Request(
+        val id: TileID,
+        val state: State,
+        owner: CustomGeometrySourceTileRequests,
+    ) : Runnable {
+        val cancelled = AtomicBoolean(false)
+        private val owner = WeakReference(owner)
+
+        override fun run() {
+            owner.get()?.run(this)
+        }
+
+        override fun equals(other: Any?): Boolean = other is Request && id == other.id
+
+        override fun hashCode(): Int = id.hashCode()
+    }
+
+    companion object {
+        private val poolCount = AtomicInteger()
+
+        private fun newExecutor(): ThreadPoolExecutor {
+            val poolId = poolCount.getAndIncrement()
+            val threadCount = AtomicInteger()
+            return ThreadPoolExecutor(
+                CustomGeometrySource.THREAD_POOL_LIMIT,
+                CustomGeometrySource.THREAD_POOL_LIMIT,
+                0L,
+                TimeUnit.MILLISECONDS,
+                LinkedBlockingQueue(),
+            ) { runnable ->
+                Thread(runnable, "${CustomGeometrySource.THREAD_PREFIX}-$poolId-${threadCount.getAndIncrement()}")
+            }
+        }
+    }
+}

--- a/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/style/sources/CustomGeometrySourceTileRequestsTest.kt
+++ b/platform/android/MapLibreAndroid/src/test/java/org/maplibre/android/style/sources/CustomGeometrySourceTileRequestsTest.kt
@@ -1,0 +1,242 @@
+package org.maplibre.android.style.sources
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.maplibre.android.geometry.LatLngBounds
+import org.maplibre.geojson.FeatureCollection
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class CustomGeometrySourceTileRequestsTest {
+    private val pools = CopyOnWriteArrayList<ThreadPoolExecutor>()
+    private val gates = CopyOnWriteArrayList<CountDownLatch>()
+    private val failures = CopyOnWriteArrayList<Throwable>()
+    private val submitted = CopyOnWriteArrayList<FeatureCollection>()
+    private val data = FeatureCollection.fromFeatures(emptyList())
+    private lateinit var requests: CustomGeometrySourceTileRequests
+
+    @After
+    fun tearDown() {
+        gates.forEach { it.countDown() }
+        if (::requests.isInitialized) requests.release()
+        pools.forEach {
+            it.shutdownNow()
+            assertTrue("Tile worker did not stop", it.awaitTermination(5, TimeUnit.SECONDS))
+        }
+        assertTrue("Unexpected worker failures: $failures", failures.isEmpty())
+    }
+
+    @Test
+    fun releaseDropsResultEvenWhenProviderIgnoresInterruption() {
+        val entered = gate()
+        val resume = gate()
+        createRequests {
+            entered.countDown()
+            awaitIgnoringInterrupts(resume)
+            data
+        }
+        requests.start()
+        requests.fetchTile(0, 0, 0)
+        await(entered)
+
+        requests.release()
+        assertFalse("Release must not wait for geometry generation", pools.single().isTerminated)
+        resume.countDown()
+        assertTrue(pools.single().awaitTermination(5, TimeUnit.SECONDS))
+        assertTrue(submitted.isEmpty())
+    }
+
+    @Test
+    fun releaseWaitsForNativeSubmissionAlreadyInProgress() {
+        val submitting = gate()
+        val resume = gate()
+        val releasing = gate()
+        val released = gate()
+        createRequests(submit = { collection ->
+            submitting.countDown()
+            awaitIgnoringInterrupts(resume)
+            submitted.add(collection)
+        }) { data }
+        requests.start()
+        requests.fetchTile(0, 0, 0)
+        await(submitting)
+        val releaseThread =
+            Thread {
+                releasing.countDown()
+                requests.release()
+                released.countDown()
+            }
+        releaseThread.start()
+        try {
+            await(releasing)
+            assertFalse("Native submission must hold off teardown", released.await(100, TimeUnit.MILLISECONDS))
+            resume.countDown()
+            await(released)
+            assertEquals(listOf(data), submitted)
+        } finally {
+            resume.countDown()
+            releaseThread.join(5_000)
+        }
+    }
+
+    @Test
+    fun releaseDiscardsCoalescedRequestWithoutResubmittingToStoppedExecutor() {
+        val entered = gate()
+        val resume = gate()
+        val calls = AtomicInteger()
+        createRequests {
+            calls.incrementAndGet()
+            entered.countDown()
+            awaitIgnoringInterrupts(resume)
+            data
+        }
+        requests.start()
+        requests.fetchTile(0, 0, 0)
+        await(entered)
+        requests.fetchTile(0, 0, 0)
+        requests.release()
+        resume.countDown()
+
+        assertTrue(pools.single().awaitTermination(5, TimeUnit.SECONDS))
+        assertEquals(1, calls.get())
+        assertTrue(submitted.isEmpty())
+    }
+
+    @Test
+    fun oldRequestCannotSubmitOrRemoveNewRequestAfterRestart() {
+        val oldEntered = gate()
+        val newEntered = gate()
+        val oldResume = gate()
+        val newResume = gate()
+        val delivered = gate()
+        val calls = AtomicInteger()
+        createRequests(submit = { collection ->
+            assertFalse(requests.isCancelled(0, 0, 0))
+            submitted.add(collection)
+            delivered.countDown()
+        }) {
+            if (calls.getAndIncrement() == 0) {
+                oldEntered.countDown()
+                awaitIgnoringInterrupts(oldResume)
+            } else {
+                newEntered.countDown()
+                awaitIgnoringInterrupts(newResume)
+            }
+            data
+        }
+        requests.start()
+        requests.fetchTile(0, 0, 0)
+        await(oldEntered)
+        requests.release()
+        requests.start()
+        requests.fetchTile(0, 0, 0)
+        await(newEntered)
+
+        oldResume.countDown()
+        assertTrue(pools.first().awaitTermination(5, TimeUnit.SECONDS))
+        assertTrue(submitted.isEmpty())
+        assertFalse(requests.isCancelled(0, 0, 0))
+
+        newResume.countDown()
+        await(delivered)
+        assertEquals(listOf(data), submitted)
+    }
+
+    @Test
+    fun cancellingActiveRequestStillAllowsLatestCoalescedRequest() {
+        val entered = gate()
+        val resume = gate()
+        val delivered = gate()
+        val calls = AtomicInteger()
+        createRequests(submit = { collection ->
+            submitted.add(collection)
+            delivered.countDown()
+        }) {
+            if (calls.incrementAndGet() == 1) {
+                entered.countDown()
+                awaitIgnoringInterrupts(resume)
+            }
+            data
+        }
+        requests.start()
+        requests.fetchTile(0, 0, 0)
+        await(entered)
+        requests.fetchTile(0, 0, 0)
+        requests.fetchTile(0, 0, 0)
+        requests.cancelTile(0, 0, 0)
+        resume.countDown()
+
+        await(delivered)
+        assertEquals(2, calls.get())
+        assertEquals(listOf(data), submitted)
+    }
+
+    @Test
+    fun callsBeforeStartAndAfterReleaseAreHarmless() {
+        createRequests {
+            fail("Provider should not run")
+            data
+        }
+        requests.release()
+        requests.fetchTile(0, 0, 0)
+        requests.cancelTile(0, 0, 0)
+        requests.setTileData(0, 0, 0, data)
+        assertTrue(requests.isCancelled(0, 0, 0))
+        requests.start()
+        requests.release()
+        requests.release()
+        requests.fetchTile(0, 0, 0)
+        requests.setTileData(0, 0, 0, data)
+        assertTrue(submitted.isEmpty())
+    }
+
+    private fun createRequests(
+        submit: (FeatureCollection) -> Unit = { submitted.add(it) },
+        provide: () -> FeatureCollection,
+    ) {
+        requests =
+            CustomGeometrySourceTileRequests(
+                provider =
+                    object : GeometryTileProvider {
+                        override fun getFeaturesForBounds(
+                            bounds: LatLngBounds,
+                            zoomLevel: Int,
+                        ) = provide()
+                    },
+                submit = { _, _, _, collection -> submit(collection) },
+                createExecutor = {
+                    ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS, LinkedBlockingQueue()) { runnable ->
+                        Thread(runnable).apply {
+                            uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, failure -> failures.add(failure) }
+                        }
+                    }.also { pools.add(it) }
+                },
+            )
+    }
+
+    private fun gate() = CountDownLatch(1).also { gates.add(it) }
+
+    private fun await(latch: CountDownLatch) {
+        assertTrue("Timed out waiting for worker", latch.await(5, TimeUnit.SECONDS))
+    }
+
+    private fun awaitIgnoringInterrupts(latch: CountDownLatch) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (true) {
+            try {
+                assertTrue("Timed out waiting for test", latch.await(deadline - System.nanoTime(), TimeUnit.NANOSECONDS))
+                return
+            } catch (_: InterruptedException) {
+                // A provider may finish CPU work despite shutdownNow(). Exercise that case explicitly.
+            }
+        }
+    }
+}

--- a/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/maps/CustomGeometrySourceLifecycleTest.kt
+++ b/platform/android/MapLibreAndroidTestApp/src/androidTest/java/org/maplibre/android/maps/CustomGeometrySourceLifecycleTest.kt
@@ -1,0 +1,140 @@
+package org.maplibre.android.maps
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.maplibre.android.MapLibre
+import org.maplibre.android.geometry.LatLngBounds
+import org.maplibre.android.style.sources.CustomGeometrySource
+import org.maplibre.android.style.sources.GeometryTileProvider
+import org.maplibre.geojson.FeatureCollection
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/** Exercises native peer teardown with a provider that finishes after shutdownNow(). */
+@RunWith(AndroidJUnit4ClassRunner::class)
+class CustomGeometrySourceLifecycleTest {
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val entered = CountDownLatch(1)
+    private val resume = CountDownLatch(1)
+    private val failures = CopyOnWriteArrayList<Throwable>()
+    private lateinit var nativeMap: NativeMapView
+    private lateinit var style: Style
+    private lateinit var source: CustomGeometrySource
+    private lateinit var worker: Thread
+    private var destroyed = false
+
+    @Before
+    fun setUp() {
+        instrumentation.runOnMainSync {
+            val context = instrumentation.targetContext
+            MapLibre.getInstance(context)
+            nativeMap = NativeMapView(context, NativeMapOptions(1.0f, false), null, null, NativeMapViewTest.DummyRenderer(context))
+            nativeMap.styleJson = Style.EMPTY_JSON
+            style = Style.Builder().build(nativeMap)
+            style.onDidFinishLoadingStyle()
+            source =
+                CustomGeometrySource(
+                    "teardown-test",
+                    object : GeometryTileProvider {
+                        override fun getFeaturesForBounds(
+                            bounds: LatLngBounds,
+                            zoomLevel: Int,
+                        ): FeatureCollection {
+                            worker = Thread.currentThread()
+                            worker.uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, failure -> failures.add(failure) }
+                            entered.countDown()
+                            val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10)
+                            while (true) {
+                                try {
+                                    check(resume.await(deadline - System.nanoTime(), TimeUnit.NANOSECONDS))
+                                    break
+                                } catch (_: InterruptedException) {
+                                    // CPU-bound application providers can finish despite interruption.
+                                }
+                            }
+                            return FeatureCollection.fromFeatures(emptyList())
+                        }
+                    },
+                )
+            style.addSource(source)
+            // Trigger the real tile request without requiring a rendered frame or network style.
+            CustomGeometrySource::class.java
+                .getDeclaredMethod(
+                    "fetchTile",
+                    Int::class.javaPrimitiveType,
+                    Int::class.javaPrimitiveType,
+                    Int::class.javaPrimitiveType,
+                ).apply { isAccessible = true }
+                .invoke(source, 0, 0, 0)
+        }
+        assertTrue("Provider did not start", entered.await(5, TimeUnit.SECONDS))
+    }
+
+    @After
+    fun tearDown() {
+        resume.countDown()
+        instrumentation.runOnMainSync {
+            if (!destroyed && ::nativeMap.isInitialized) {
+                style.clear()
+                nativeMap.destroy()
+                destroyed = true
+            }
+        }
+        if (::worker.isInitialized) {
+            worker.join(5_000)
+            assertFalse("Tile worker leaked after teardown", worker.isAlive)
+        }
+        assertTrue("Late tile request failed: $failures", failures.isEmpty())
+    }
+
+    @Test
+    fun providerCanFinishAfterSourceRemoval() {
+        instrumentation.runOnMainSync { assertTrue(style.removeSource(source)) }
+        finishProvider()
+    }
+
+    @Test
+    fun providerCanFinishAfterStyleReplacement() {
+        instrumentation.runOnMainSync {
+            style.clear()
+            nativeMap.styleJson = Style.EMPTY_JSON
+        }
+        finishProvider()
+    }
+
+    @Test
+    fun providerCanFinishAfterMapDestruction() {
+        instrumentation.runOnMainSync {
+            // MapLibreMap.onDestroy() clears the style before NativeMapView.destroy().
+            style.clear()
+            nativeMap.destroy()
+            destroyed = true
+        }
+        finishProvider()
+    }
+
+    @Test
+    fun oldProviderCanFinishAfterSourceReattachment() {
+        instrumentation.runOnMainSync {
+            assertTrue(style.removeSource(source))
+            style.addSource(source)
+        }
+        finishProvider()
+        instrumentation.runOnMainSync { assertEquals("teardown-test", source.id) }
+    }
+
+    private fun finishProvider() {
+        resume.countDown()
+        worker.join(5_000)
+        assertFalse("Retired tile worker did not stop", worker.isAlive)
+        assertTrue("Late tile request failed: $failures", failures.isEmpty())
+    }
+}


### PR DESCRIPTION
### Issue
- Tile providers can finish after source removal or map destruction and submit data through a released native peer.

### Fix
- Synchronize submission with teardown and discard requests from previous source attachments.
- Geometry generation stays outside the lock

Includes regression coverage for removal, style replacement, destruction, and reattachment. The destruction test fails on main and passes with this fix.

Assisted by GPT-6 (Astra Light)