### PR TITLE
fix(core): work around SwiftShader uniform block ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@
 
 ### 🐞 Bug fixes
 
-- [core] Fix invisible symbols, dashed lines, and patterned backgrounds on OpenGL ES SwiftShader.
 - *...Add new stuff here...*
 - [core] Draw numbers and short uppercase codes upright in vertical CJK line labels ([#4565](https://github.com/maplibre/maplibre-native/issues/4565)), compat to [maplibre-gl-js#8205](https://github.com/maplibre/maplibre-gl-js/pull/8205).
 - [core] Fix `ImageSource` not rendering across world copies ([#4508](https://github.com/maplibre/maplibre-native/issues/4508)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### 🐞 Bug fixes
 
+- [core] Fix invisible symbols, dashed lines, and patterned backgrounds on OpenGL ES SwiftShader.
 - *...Add new stuff here...*
 - [core] Draw numbers and short uppercase codes upright in vertical CJK line labels ([#4565](https://github.com/maplibre/maplibre-native/issues/4565)), compat to [maplibre-gl-js#8205](https://github.com/maplibre/maplibre-gl-js/pull/8205).
 - [core] Fix `ImageSource` not rendering across world copies ([#4508](https://github.com/maplibre/maplibre-native/issues/4508)).

--- a/include/mln/shaders/gl/background_pattern.hpp
+++ b/include/mln/shaders/gl/background_pattern.hpp
@@ -42,19 +42,7 @@ void main() {
     v_pos_b = get_pattern_pos(u_pixel_coord_upper, u_pixel_coord_lower, u_scale_b * u_pattern_size_b, u_tile_units_to_pixels, a_pos);
 }
 )";
-    static constexpr const char* fragment = R"(layout (std140) uniform GlobalPaintParamsUBO {
-    highp vec2 u_pattern_atlas_texsize;
-    highp vec2 u_units_to_pixels;
-    highp vec2 u_world_size;
-    highp float u_camera_to_center_distance;
-    highp float u_symbol_fade_change;
-    highp float u_aspect_ratio;
-    highp float u_pixel_ratio;
-    highp float u_map_zoom;
-    lowp float global_pad1;
-};
-
-layout (std140) uniform BackgroundPatternPropsUBO {
+    static constexpr const char* fragment = R"(layout (std140) uniform BackgroundPatternPropsUBO {
     highp vec2 u_pattern_tl_a;
     highp vec2 u_pattern_br_a;
     highp vec2 u_pattern_tl_b;
@@ -65,6 +53,18 @@ layout (std140) uniform BackgroundPatternPropsUBO {
     highp float u_scale_b;
     highp float u_mix;
     highp float u_opacity;
+};
+
+layout (std140) uniform GlobalPaintParamsUBO {
+    highp vec2 u_pattern_atlas_texsize;
+    highp vec2 u_units_to_pixels;
+    highp vec2 u_world_size;
+    highp float u_camera_to_center_distance;
+    highp float u_symbol_fade_change;
+    highp float u_aspect_ratio;
+    highp float u_pixel_ratio;
+    highp float u_map_zoom;
+    lowp float global_pad1;
 };
 
 uniform sampler2D u_image;

--- a/include/mln/shaders/gl/line_sdf.hpp
+++ b/include/mln/shaders/gl/line_sdf.hpp
@@ -188,14 +188,7 @@ lowp float floorwidth = u_floorwidth;
     v_width2 = vec2(outset, inset);
 }
 )";
-    static constexpr const char* fragment = R"(layout (std140) uniform LineSDFTilePropsUBO {
-    highp float u_sdfgamma;
-    highp float u_mix;
-    lowp float tileprops_pad1;
-    lowp float tileprops_pad2;
-};
-
-layout (std140) uniform LineEvaluatedPropsUBO {
+    static constexpr const char* fragment = R"(layout (std140) uniform LineEvaluatedPropsUBO {
     highp vec4 u_color;
     lowp float u_blur;
     lowp float u_opacity;
@@ -205,6 +198,13 @@ layout (std140) uniform LineEvaluatedPropsUBO {
     lowp float u_floorwidth;
     lowp float props_pad1;
     lowp float props_pad2;
+};
+
+layout (std140) uniform LineSDFTilePropsUBO {
+    highp float u_sdfgamma;
+    highp float u_mix;
+    lowp float tileprops_pad1;
+    lowp float tileprops_pad2;
 };
 
 uniform sampler2D u_image;

--- a/include/mln/shaders/gl/symbol_icon.hpp
+++ b/include/mln/shaders/gl/symbol_icon.hpp
@@ -148,13 +148,6 @@ lowp float opacity = u_opacity;
 )";
     static constexpr const char* fragment = R"(uniform sampler2D u_texture;
 
-layout (std140) uniform SymbolTilePropsUBO {
-    bool u_is_text;
-    bool u_is_halo;
-    highp float u_gamma_scale;
-    lowp float tileprops_pad1;
-};
-
 layout (std140) uniform SymbolEvaluatedPropsUBO {
     highp vec4 u_text_fill_color;
     highp vec4 u_text_halo_color;
@@ -168,6 +161,13 @@ layout (std140) uniform SymbolEvaluatedPropsUBO {
     highp float u_icon_halo_width;
     highp float u_icon_halo_blur;
     lowp float props_pad2;
+};
+
+layout (std140) uniform SymbolTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    highp float u_gamma_scale;
+    lowp float tileprops_pad1;
 };
 
 in vec2 v_tex;

--- a/include/mln/shaders/gl/symbol_sdf.hpp
+++ b/include/mln/shaders/gl/symbol_sdf.hpp
@@ -205,13 +205,6 @@ lowp float halo_blur = u_halo_blur;
 )";
     static constexpr const char* fragment = R"(#define SDF_PX 8.0
 
-layout (std140) uniform SymbolTilePropsUBO {
-    bool u_is_text;
-    bool u_is_halo;
-    highp float u_gamma_scale;
-    lowp float tileprops_pad1;
-};
-
 layout (std140) uniform SymbolEvaluatedPropsUBO {
     highp vec4 u_text_fill_color;
     highp vec4 u_text_halo_color;
@@ -225,6 +218,13 @@ layout (std140) uniform SymbolEvaluatedPropsUBO {
     highp float u_icon_halo_width;
     highp float u_icon_halo_blur;
     lowp float props_pad2;
+};
+
+layout (std140) uniform SymbolTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    highp float u_gamma_scale;
+    lowp float tileprops_pad1;
 };
 
 uniform sampler2D u_texture;

--- a/include/mln/shaders/gl/symbol_text_and_icon.hpp
+++ b/include/mln/shaders/gl/symbol_text_and_icon.hpp
@@ -208,13 +208,6 @@ lowp float halo_blur = u_halo_blur;
 #define SDF 1.0
 #define ICON 0.0
 
-layout (std140) uniform SymbolTilePropsUBO {
-    bool u_is_text;
-    bool u_is_halo;
-    highp float u_gamma_scale;
-    lowp float tileprops_pad1;
-};
-
 layout (std140) uniform SymbolEvaluatedPropsUBO {
     highp vec4 u_text_fill_color;
     highp vec4 u_text_halo_color;
@@ -228,6 +221,13 @@ layout (std140) uniform SymbolEvaluatedPropsUBO {
     highp float u_icon_halo_width;
     highp float u_icon_halo_blur;
     lowp float props_pad2;
+};
+
+layout (std140) uniform SymbolTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    highp float u_gamma_scale;
+    lowp float tileprops_pad1;
 };
 
 uniform sampler2D u_texture;

--- a/shaders/background_pattern.fragment.glsl
+++ b/shaders/background_pattern.fragment.glsl
@@ -1,15 +1,3 @@
-layout (std140) uniform GlobalPaintParamsUBO {
-    highp vec2 u_pattern_atlas_texsize;
-    highp vec2 u_units_to_pixels;
-    highp vec2 u_world_size;
-    highp float u_camera_to_center_distance;
-    highp float u_symbol_fade_change;
-    highp float u_aspect_ratio;
-    highp float u_pixel_ratio;
-    highp float u_map_zoom;
-    lowp float global_pad1;
-};
-
 layout (std140) uniform BackgroundPatternPropsUBO {
     highp vec2 u_pattern_tl_a;
     highp vec2 u_pattern_br_a;
@@ -21,6 +9,18 @@ layout (std140) uniform BackgroundPatternPropsUBO {
     highp float u_scale_b;
     highp float u_mix;
     highp float u_opacity;
+};
+
+layout (std140) uniform GlobalPaintParamsUBO {
+    highp vec2 u_pattern_atlas_texsize;
+    highp vec2 u_units_to_pixels;
+    highp vec2 u_world_size;
+    highp float u_camera_to_center_distance;
+    highp float u_symbol_fade_change;
+    highp float u_aspect_ratio;
+    highp float u_pixel_ratio;
+    highp float u_map_zoom;
+    lowp float global_pad1;
 };
 
 uniform sampler2D u_image;

--- a/shaders/line_sdf.fragment.glsl
+++ b/shaders/line_sdf.fragment.glsl
@@ -1,10 +1,3 @@
-layout (std140) uniform LineSDFTilePropsUBO {
-    highp float u_sdfgamma;
-    highp float u_mix;
-    lowp float tileprops_pad1;
-    lowp float tileprops_pad2;
-};
-
 layout (std140) uniform LineEvaluatedPropsUBO {
     highp vec4 u_color;
     lowp float u_blur;
@@ -15,6 +8,13 @@ layout (std140) uniform LineEvaluatedPropsUBO {
     lowp float u_floorwidth;
     lowp float props_pad1;
     lowp float props_pad2;
+};
+
+layout (std140) uniform LineSDFTilePropsUBO {
+    highp float u_sdfgamma;
+    highp float u_mix;
+    lowp float tileprops_pad1;
+    lowp float tileprops_pad2;
 };
 
 uniform sampler2D u_image;

--- a/shaders/symbol_icon.fragment.glsl
+++ b/shaders/symbol_icon.fragment.glsl
@@ -1,12 +1,5 @@
 uniform sampler2D u_texture;
 
-layout (std140) uniform SymbolTilePropsUBO {
-    bool u_is_text;
-    bool u_is_halo;
-    highp float u_gamma_scale;
-    lowp float tileprops_pad1;
-};
-
 layout (std140) uniform SymbolEvaluatedPropsUBO {
     highp vec4 u_text_fill_color;
     highp vec4 u_text_halo_color;
@@ -20,6 +13,13 @@ layout (std140) uniform SymbolEvaluatedPropsUBO {
     highp float u_icon_halo_width;
     highp float u_icon_halo_blur;
     lowp float props_pad2;
+};
+
+layout (std140) uniform SymbolTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    highp float u_gamma_scale;
+    lowp float tileprops_pad1;
 };
 
 in vec2 v_tex;

--- a/shaders/symbol_sdf.fragment.glsl
+++ b/shaders/symbol_sdf.fragment.glsl
@@ -1,12 +1,5 @@
 #define SDF_PX 8.0
 
-layout (std140) uniform SymbolTilePropsUBO {
-    bool u_is_text;
-    bool u_is_halo;
-    highp float u_gamma_scale;
-    lowp float tileprops_pad1;
-};
-
 layout (std140) uniform SymbolEvaluatedPropsUBO {
     highp vec4 u_text_fill_color;
     highp vec4 u_text_halo_color;
@@ -20,6 +13,13 @@ layout (std140) uniform SymbolEvaluatedPropsUBO {
     highp float u_icon_halo_width;
     highp float u_icon_halo_blur;
     lowp float props_pad2;
+};
+
+layout (std140) uniform SymbolTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    highp float u_gamma_scale;
+    lowp float tileprops_pad1;
 };
 
 uniform sampler2D u_texture;

--- a/shaders/symbol_text_and_icon.fragment.glsl
+++ b/shaders/symbol_text_and_icon.fragment.glsl
@@ -3,13 +3,6 @@
 #define SDF 1.0
 #define ICON 0.0
 
-layout (std140) uniform SymbolTilePropsUBO {
-    bool u_is_text;
-    bool u_is_halo;
-    highp float u_gamma_scale;
-    lowp float tileprops_pad1;
-};
-
 layout (std140) uniform SymbolEvaluatedPropsUBO {
     highp vec4 u_text_fill_color;
     highp vec4 u_text_halo_color;
@@ -23,6 +16,13 @@ layout (std140) uniform SymbolEvaluatedPropsUBO {
     highp float u_icon_halo_width;
     highp float u_icon_halo_blur;
     lowp float props_pad2;
+};
+
+layout (std140) uniform SymbolTilePropsUBO {
+    bool u_is_text;
+    bool u_is_halo;
+    highp float u_gamma_scale;
+    lowp float tileprops_pad1;
 };
 
 uniform sampler2D u_texture;

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -2040,6 +2040,83 @@ TEST(Map, SetFrustumOffset) {
     test::checkImage("test/fixtures/map/setFrustumOffset/after", test.frontend.render(test.map).image, 0.0006, 0.1);
 }
 
+class UniformBlockOrderTest : public testing::TestWithParam<std::string> {};
+
+TEST_P(UniformBlockOrderTest, RendersPaintColors) {
+    const auto& kind = GetParam();
+    const bool withText = kind == "text" || kind == "mixed";
+    const bool withImage = kind == "icon" || kind == "mixed" || kind == "background";
+    MapTest<> test;
+    test.fileSource->glyphsResponse = makeResponse("glyphs.pbf");
+    test.map.getStyle().loadJSON(R"({
+        "version": 8,
+        "glyphs": "https://example.com/{fontstack}/{range}.pbf",
+        "sources": {},
+        "layers": [{"id": "background", "type": "background", "paint": {"background-color": "white"}}]
+    })");
+    if (withImage) {
+        PremultipliedImage icon({32, 32});
+        for (size_t i = 0; i < icon.bytes(); i += 4) {
+            icon.data[i] = 0;
+            icon.data[i + 1] = 0;
+            icon.data[i + 2] = 255;
+            icon.data[i + 3] = 255;
+        }
+        test.map.getStyle().addImage(std::make_unique<style::Image>("box", std::move(icon), 1.0f));
+    }
+    if (kind == "background") {
+        auto layer = std::make_unique<BackgroundLayer>("pattern");
+        layer->setBackgroundPattern({"box"s});
+        test.map.getStyle().addLayer(std::move(layer));
+    } else {
+        auto source = std::make_unique<GeoJSONSource>("geometry");
+        if (kind == "line") {
+            source->setGeoJSON(Geometry<double>{LineString<double>{{-20.0, 0.0}, {20.0, 0.0}}});
+        } else {
+            source->setGeoJSON(Geometry<double>{Point<double>{0.0, 0.0}});
+        }
+        test.map.getStyle().addSource(std::move(source));
+        if (kind == "line") {
+            auto layer = std::make_unique<LineLayer>("line", "geometry");
+            layer->setLineColor(Color::red());
+            layer->setLineWidth(16.0f);
+            layer->setLineDasharray(std::vector<float>{2.0f, 2.0f});
+            test.map.getStyle().addLayer(std::move(layer));
+        } else {
+            auto layer = std::make_unique<SymbolLayer>("symbol", "geometry");
+            if (withText) {
+                expression::Formatted text("AB");
+                if (withImage) text.sections.emplace_back(expression::Image("box"));
+                layer->setTextField(text);
+                layer->setTextFont(FontStack{"Open Sans Regular"});
+                layer->setTextSize(64.0f);
+                layer->setTextColor(Color::red());
+                layer->setTextAllowOverlap(true);
+            } else {
+                layer->setIconImage({"box"s});
+                layer->setIconAllowOverlap(true);
+            }
+            test.map.getStyle().addLayer(std::move(layer));
+        }
+    }
+    test.map.jumpTo(CameraOptions().withCenter(LatLng{0.0, 0.0}).withZoom(2.0));
+    const auto image = test.frontend.render(test.map).image;
+    size_t redPixels = 0;
+    size_t bluePixels = 0;
+    for (size_t i = 0; i < image.bytes(); i += 4) {
+        const auto* pixel = image.data.get() + i;
+        redPixels += pixel[0] > 200 && pixel[1] < 100 && pixel[2] < 100;
+        bluePixels += pixel[2] > 200 && pixel[0] < 100 && pixel[1] < 100;
+    }
+    if (withText || kind == "line") EXPECT_GT(redPixels, 100u);
+    if (withImage) EXPECT_GT(bluePixels, 100u);
+}
+
+INSTANTIATE_TEST_SUITE_P(Rendering,
+                         UniformBlockOrderTest,
+                         testing::Values("text", "icon", "mixed", "line", "background"),
+                         [](const testing::TestParamInfo<std::string>& info) { return info.param; });
+
 // End-to-end: a feature-state change must alter the *rendered* output, not just
 // the value read back through the API. A fill covering the viewport is colored
 // by a data-driven expression on feature-state "active" (blue by default, red


### PR DESCRIPTION
## Bug

On Android x86_64 SwiftShader (CPU Vulkan impl), five fragment shaders render transparently when a fragment-only uniform block is declared before a block shared with the vertex shader: the three symbol shaders, dashed lines, and patterned backgrounds. Font loading and shaping succeed, but the expected colored pixels never appear.

## Repro

Render text, an icon, a label containing an inline image, a dashed line, or a patterned background over white using SwiftShader. Each case produces zero expected colored pixels. Initially reported for a supplied font in maplibre/maplibre-native-ffi#713; the existing glyph PBF fixture reproduces it too.

## Fix

Declare shared uniform blocks before fragment-only blocks in the five shaders and regenerate their checked-in headers. This works around the observed driver ordering sensitivity without changing buffer layouts, bindings, or shader calculations; the exact fault inside SwiftShader has not been traced.

## Tests

`Rendering/UniformBlockOrderTest.RendersPaintColors` has five named cases using the existing glyph fixture. All five fail with only the shader reorderings reverted and pass with them restored on Android x86_64 SwiftShader under QEMU; all five also pass on macOS Metal. The Android test bodies were cross-compiled with maplibre-native-ffi platform support.

Carried in maplibre/maplibre-native-ffi#715. AI disclosure: Codex (GPT-6) assisted with investigation, code, tests, and this description.