### PR TITLE
Metal/Vulkan/WebGPU: stop depth-testing 2D drawables against each other (translucent fills flash out for a frame); keep Metal's cached stencil reference in step

### DIFF
--- a/src/mln/mtl/context.cpp
+++ b/src/mln/mtl/context.cpp
@@ -438,7 +438,10 @@ bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,
                                    /*instanceCount=*/static_cast<NS::UInteger>(tileUBOs.size()));
 #else
     for (std::size_t ii = 0; ii < tileUBOs.size(); ++ii) {
-        encoder->setStencilReferenceValue(tileUBOs[ii].stencil_ref);
+        // Through the render pass so its cached reference value stays in step with the encoder;
+        // writing the encoder directly left the cache stale, and the next drawable whose
+        // reference equalled the stale value was drawn against the last mask's ID instead.
+        mtlRenderPass.setStencilReference(static_cast<int32_t>(tileUBOs[ii].stencil_ref));
         mtlRenderPass.bindVertex(*uboBuffer, /*offset=*/ii * uboSize, shaders::idClippingMaskUBO, /*size=*/uboSize);
         encoder->drawIndexedPrimitives(MTL::PrimitiveType::PrimitiveTypeTriangle,
                                        indexCount,

--- a/src/mln/mtl/tile_layer_group.cpp
+++ b/src/mln/mtl/tile_layer_group.cpp
@@ -113,7 +113,7 @@ void TileLayerGroup::render(RenderOrchestrator&, PaintParameters& parameters) {
 
         if (stencil3d) {
             stencilMode3d = parameters.stencilModeFor3D();
-            encoder->setStencilReferenceValue(stencilMode3d.ref);
+            renderPass.setStencilReference(stencilMode3d.ref);
         }
     } else if (stencilTiles && !stencilTiles->empty()) {
         parameters.renderTileClippingMasks(stencilTiles);

--- a/src/mln/renderer/layer_tweaker.cpp
+++ b/src/mln/renderer/layer_tweaker.cpp
@@ -58,21 +58,9 @@ void LayerTweaker::multiplyWithProjectionMatrix(/*in-out*/ mat4& matrix,
     const auto& projMatrixRef = aligned ? parameters.transformParams.alignedProjMatrix
                                         : (nearClipped ? parameters.transformParams.nearClippedProjMatrix
                                                        : parameters.transformParams.projMatrix);
-#if !MLN_RENDER_BACKEND_OPENGL
-    // If this drawable is participating in depth testing, offset the
-    // projection matrix NDC depth range for the drawable's layer and sublayer.
-    if (!drawable.getIs3D() && drawable.getEnableDepth()) {
-        // copy and adjust the projection matrix
-        mat4 projMatrix = projMatrixRef;
-        projMatrix[14] -= ((1 + parameters.currentLayer) * PaintParameters::numSublayers -
-                           drawable.getSubLayerIndex()) *
-                          PaintParameters::depthEpsilon;
-        // multiply with the copy
-        matrix::multiply(matrix, projMatrix, matrix);
-        // early return
-        return;
-    }
-#endif
+    // 2D drawables no longer carry a per-layer depth offset in their matrix: on the non-GL
+    // backends they are not depth-tested (PaintParameters::depthModeForSublayer), and the offset
+    // did not survive the float32 cast of a matrix with a large translation anyway.
     matrix::multiply(matrix, projMatrixRef, matrix);
 }
 

--- a/src/mln/renderer/paint_parameters.cpp
+++ b/src/mln/renderer/paint_parameters.cpp
@@ -117,16 +117,25 @@ mat4 PaintParameters::matrixForTile(const UnwrappedTileID& tileID, bool aligned)
     return matrix;
 }
 
-gfx::DepthMode PaintParameters::depthModeForSublayer([[maybe_unused]] uint8_t n, gfx::DepthMaskType mask) const {
+gfx::DepthMode PaintParameters::depthModeForSublayer([[maybe_unused]] uint8_t n,
+                                                     [[maybe_unused]] gfx::DepthMaskType mask) const {
+#if MLN_RENDER_BACKEND_OPENGL
     if (currentLayer < opaquePassCutoff) {
         return gfx::DepthMode::disabled();
     }
-
-#if MLN_RENDER_BACKEND_OPENGL
     float depth = depthRangeSize + ((1 + currentLayer) * numSublayers + n) * depthEpsilon;
     return gfx::DepthMode{gfx::DepthFunctionType::LessEqual, mask, {depth, depth}};
 #else
-    return gfx::DepthMode{.func = gfx::DepthFunctionType::LessEqual, .mask = mask};
+    // 2D drawables are ordered by the render passes (painter's order), and depth-testing them
+    // against each other is not reliable on these backends: the per-layer NDC z offset used to
+    // be folded into the drawable's float32 tile matrix (see LayerTweaker::multiplyWithProjectionMatrix),
+    // whose z translation runs to thousands of clip units under a pitched camera, so an offset of
+    // a few 1e-5 rounds away and the interpolated depths of overlapping polygons from different
+    // layers differ by vertex-rounding noise instead. At camera positions where that noise flips
+    // sign, a translucent fill above an opaque one fails the test and drops out for one frame
+    // (park and landcover fills flashing while navigating). GL is unaffected: its depth ranges
+    // do not go through the matrix.
+    return gfx::DepthMode::disabled();
 #endif
 }
 


### PR DESCRIPTION
## Problem

On the Metal backend (and, by the same code, Vulkan and WebGPU), translucent fill layers drawn above an opaque fill vanish for exactly one frame at particular camera positions. On a pitched, moving map this shows as parks and landcover fills flashing in and out; with terrain shading it reads as lightning on the horizon. It does not happen on GL.

Reproduced on the iOS simulator (iPhone 17e, iOS 27) with a pitched navigation camera moving at 80 km/h over a Protomaps-style basemap (fills: `earth` opaque, `landcover`, `landuse_park` with `fill-opacity` 0.4, `landuse_urban_green` 0.7). Screen recordings scored by full-pixel block luminance in the horizon band (a one-frame excursion of ≥4 levels that reverts the next frame):

| build | one-frame fill dropouts per minute of driving |
|---|---|
| main | 7–12 |
| 2D depth test disabled | 0 |
| this branch | 0 |

An instrumented engine showed the CPU side issuing the same draw calls with the same stencil references, pipeline states and matrices in the dropout frame as in its neighbours; the drawables were drawn and lost the depth test.

## Cause

`LayerTweaker::multiplyWithProjectionMatrix` orders 2D layers for the depth test by subtracting `((1 + currentLayer) * numSublayers - subLayerIndex) * depthEpsilon` (a few 1e-5) from the projection matrix's z translation, then multiplies with the tile matrix and the result is cast to `float` for the drawable UBO. Under a pitched camera the product's z translation is thousands of clip units (the tile's clip-space position), so the offset is below float32 resolution there and rounds away. What decides the LessEqual test between, say, `landuse_park` and `earth` at a pixel is then the vertex-rounding noise of two different triangle sets, which flips sign as the camera moves — hence one-frame dropouts at specific positions. `PaintParameters::depthModeForSublayer` also compares `currentLayer` (counted in layer groups) against `opaquePassCutOff` (counted in layer render items), so which layers get depth-tested at all depends on how many layers have no group.

## Fix

2D drawables are already painter-ordered by the render passes, so on the non-GL backends `depthModeForSublayer` now returns depth disabled, and the matrix offset is removed. GL keeps its depth ranges, which never go through the matrix. 3D drawables (`depthModeFor3D`) are untouched.

A second, independent commit: `RenderPass::setStencilReference` only forwards a value to the encoder when it differs from its cached copy, but the tile clip-mask draw (`Context::renderTileClippingMasks`) and the 3D stencil path in `TileLayerGroup::render` wrote `encoder->setStencilReferenceValue` directly, leaving the cache stale. The next drawable whose reference equalled the stale cached value was drawn against the last mask's ID. Routed through the render pass. (This was found while chasing the flicker; it is not its cause — the flicker persisted with only this change — but it is a real desync.)

## Testing

- iOS simulator drive as above: 0 dropouts over the same minute where main had 7–12; a 45 s sample in hilly terrain with hillshade renders identically to main apart from the dropouts.
- iPhone 16 Pro (real device), the same replay drive in the app's navigation view with hillshade: the one-frame fill dropouts ("lightning on the horizon") are gone by eye over the suburbs and the hills.
- Metal only was tested on hardware; the Vulkan/WebGPU change is the shared `depthModeForSublayer` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

