### PR TITLE
core: Avoid rendering fully hidden symbol drawables

### DIFF
--- a/benchmark/api/render.benchmark.cpp
+++ b/benchmark/api/render.benchmark.cpp
@@ -17,6 +17,7 @@
 
 #include <sstream>
 #include <optional>
+#include <algorithm>
 
 using namespace mln;
 
@@ -154,9 +155,60 @@ static void API_renderStill_multiple_sources(::benchmark::State& state) {
     }
 }
 
+namespace {
+
+void API_renderStill_colliding_symbols(::benchmark::State& state) {
+    RenderBenchmark bench;
+    HeadlessFrontend frontend{Size{256, 256}, pixelRatio};
+    Map map{frontend,
+            MapObserver::nullObserver(),
+            MapOptions().withMapMode(MapMode::Static).withSize(frontend.getSize()),
+            ResourceOptions()};
+
+    std::ostringstream json;
+    json << R"({"version":8,"sources":{"points":{"type":"geojson","maxzoom":0,"data":{
+        "type":"FeatureCollection","features":[)";
+    for (int64_t i = 0; i < state.range(0); ++i) {
+        if (i) json << ',';
+        json << R"({"type":"Feature","properties":{"rank":)" << i
+             << R"(},"geometry":{"type":"Point","coordinates":[5,5]}})";
+    }
+    json << R"(]}}},"layers":[{"id":"symbols","type":"symbol","source":"points","layout":{
+        "icon-image":"marker","symbol-sort-key":["get","rank"],"icon-allow-overlap":)"
+         << (state.range(1) ? "true" : "false") << R"(}}]})";
+    map.getStyle().loadJSON(json.str());
+    PremultipliedImage marker({16, 16});
+    std::fill_n(marker.data.get(), marker.bytes(), uint8_t{255});
+    map.getStyle().addImage(std::make_unique<style::Image>("marker", std::move(marker), 1.0f));
+    map.jumpTo(CameraOptions().withCenter(LatLng{5, 5}).withZoom(4));
+    frontend.render(map);
+
+    double encodingTime = 0;
+    int drawCalls = 0;
+    for ([[maybe_unused]] auto _ : state) {
+        const auto result = frontend.render(map);
+        encodingTime += result.stats.encodingTime;
+        drawCalls = result.stats.numDrawCalls;
+        benchmark::DoNotOptimize(result.image.data.get());
+    }
+    state.counters["draw_calls"] = drawCalls;
+    state.counters["encoding_ms"] = encodingTime * 1000 / static_cast<double>(state.iterations());
+}
+
+} // namespace
+
 BENCHMARK(API_renderStill_reuse_map)->Unit(benchmark::kMillisecond)->Iterations(50);
 BENCHMARK(API_renderStill_reuse_map_formatted_labels)->Unit(benchmark::kMillisecond)->Iterations(50);
 BENCHMARK(API_renderStill_reuse_map_switch_styles)->Unit(benchmark::kMillisecond)->Iterations(50);
 BENCHMARK(API_renderStill_recreate_map)->Unit(benchmark::kMillisecond)->Iterations(50);
 BENCHMARK(API_renderStill_recreate_map_2)->Unit(benchmark::kMillisecond)->Iterations(50);
 BENCHMARK(API_renderStill_multiple_sources)->Unit(benchmark::kMillisecond)->Iterations(50);
+BENCHMARK(API_renderStill_colliding_symbols)
+    ->Args({1, 0})
+    ->Args({256, 0})
+    ->Args({1024, 0})
+    ->Args({1024, 1})
+    ->ArgNames({"features", "overlap"})
+    ->Unit(benchmark::kMillisecond)
+    ->Iterations(50)
+    ->UseRealTime();

--- a/src/mln/gfx/symbol_drawable_data.hpp
+++ b/src/mln/gfx/symbol_drawable_data.hpp
@@ -20,7 +20,9 @@ struct SymbolDrawableData : public DrawableData {
                        const style::AlignmentType rotationAlignment_,
                        const style::SymbolPlacementType placement_,
                        const style::IconTextFitType textFit_,
-                       const bool isOffset_)
+                       const bool isOffset_,
+                       const std::size_t opacityVertexOffset_,
+                       const std::size_t opacityVertexCount_)
         : isHalo(isHalo_),
           bucketVariablePlacement(bucketVariablePlacement_),
           symbolType(symbolType_),
@@ -28,7 +30,9 @@ struct SymbolDrawableData : public DrawableData {
           rotationAlignment(rotationAlignment_),
           placement(placement_),
           textFit(textFit_),
-          isOffset(isOffset_) {}
+          isOffset(isOffset_),
+          opacityVertexOffset(opacityVertexOffset_),
+          opacityVertexCount(opacityVertexCount_) {}
     ~SymbolDrawableData() override = default;
 
     const bool isHalo;
@@ -39,6 +43,8 @@ struct SymbolDrawableData : public DrawableData {
     const style::SymbolPlacementType placement;
     const style::IconTextFitType textFit;
     const bool isOffset;
+    const std::size_t opacityVertexOffset;
+    const std::size_t opacityVertexCount;
 };
 
 using UniqueSymbolDrawableData = std::unique_ptr<SymbolDrawableData>;

--- a/src/mln/renderer/buckets/symbol_bucket.cpp
+++ b/src/mln/renderer/buckets/symbol_bucket.cpp
@@ -16,6 +16,20 @@ namespace {
 std::atomic<uint32_t> maxBucketInstanceId;
 } // namespace
 
+bool SymbolBucket::Buffer::hasVisibleVertices(std::size_t offset, std::size_t count) const {
+    const auto& opacities = opacityAttributeData().vector();
+    // If placement has not filled this range yet, keep drawing until we can
+    // determine whether its symbols are hidden.
+    if (offset > opacities.size() || count > opacities.size() - offset) {
+        return true;
+    }
+    return std::any_of(opacities.begin() + offset, opacities.begin() + offset + count, [](const auto& vertex) {
+        // Zero means both zero opacity and an unplaced symbol. Keep symbols
+        // fading out, and placed symbols whose fade-in starts at zero opacity.
+        return vertex.a1[0] != 0.0f;
+    });
+}
+
 std::unique_ptr<SymbolSizeBinder> SymbolSizeBinder::create(const float tileZoom,
                                                            const style::PropertyValue<float>& sizeProperty,
                                                            const float defaultValue) {

--- a/src/mln/renderer/buckets/symbol_bucket.hpp
+++ b/src/mln/renderer/buckets/symbol_bucket.hpp
@@ -445,6 +445,8 @@ public:
         OpacityAttributeVector& opacityAttributeData() { return *sharedOpacityAttributeData; }
         const OpacityAttributeVector& opacityAttributeData() const { return *sharedOpacityAttributeData; }
 
+        bool hasVisibleVertices(std::size_t offset, std::size_t count) const;
+
 #if MLN_USE_SYMBOL_INSTANCING
         std::shared_ptr<SortedInstanceVector> sharedSortedInstances = std::make_shared<SortedInstanceVector>();
         SortedInstanceVector& sortedInstances() { return *sharedSortedInstances; }

--- a/src/mln/renderer/layers/render_symbol_layer.cpp
+++ b/src/mln/renderer/layers/render_symbol_layer.cpp
@@ -366,6 +366,11 @@ void updateTileDrawable(gfx::Drawable& drawable,
 
     const auto& buffer = isText ? bucket.text : (sdfIcons ? bucket.sdfIcon : bucket.icon);
 
+    drawable.setEnabled(buffer.hasVisibleVertices(drawData.opacityVertexOffset, drawData.opacityVertexCount));
+    if (!drawable.getEnabled()) {
+        return;
+    }
+
 #if MLN_USE_SYMBOL_INSTANCING
     if (auto& instanceAttribs = drawable.getInstanceAttributes()) {
         updateTileAttributes(buffer, isText, paintProps, evaluated, *instanceAttribs, nullptr);
@@ -754,6 +759,17 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
         auto& bucket = static_cast<SymbolBucket&>(*renderable.renderData.bucket);
         const auto& buffer = isText ? bucket.text : (sdfIcons ? bucket.sdfIcon : bucket.icon);
 
+        // A sorted drawable references one segment; an unsorted drawable can
+        // contain the entire buffer, including segments split at the index limit.
+        const auto& segment = renderable.segment.get();
+#if MLN_USE_SYMBOL_INSTANCING
+        const auto opacityVertexOffset = segments.empty() ? segment.baseInstance : 0;
+        const auto opacityVertexCount = segments.empty() ? segment.instanceCount : buffer.attributeData().elements();
+#else
+        const auto opacityVertexOffset = segments.empty() ? segment.vertexOffset : 0;
+        const auto opacityVertexCount = segments.empty() ? segment.vertexLength : buffer.attributeData().elements();
+#endif
+
 #if MLN_USE_SYMBOL_INSTANCING
         if (!buffer.attributeData().elements()) {
             continue;
@@ -903,7 +919,10 @@ void RenderSymbolLayer::update(gfx::ShaderRegistry& shaders,
                     /*.rotationAlignment=*/values.rotationAlignment,
                     /*.placement=*/bucketLayout.get<SymbolPlacement>(),
                     /*.textFit=*/bucketLayout.get<IconTextFit>(),
-                    /*.isOffset=*/isOffset));
+                    /*.isOffset=*/isOffset,
+                    /*.opacityVertexOffset=*/opacityVertexOffset,
+                    /*.opacityVertexCount=*/opacityVertexCount));
+                drawable->setEnabled(buffer.hasVisibleVertices(opacityVertexOffset, opacityVertexCount));
 
                 tileLayerGroup->addDrawable(passes, tileID, std::move(drawable));
                 ++stats.drawablesAdded;

--- a/src/mln/renderer/layers/symbol_layer_tweaker.cpp
+++ b/src/mln/renderer/layers/symbol_layer_tweaker.cpp
@@ -91,8 +91,10 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
 
 #if MLN_UBO_CONSOLIDATION
     int i = 0;
-    std::vector<SymbolDrawableUBO> drawableUBOVector(layerGroup.getDrawableCount());
-    std::vector<SymbolTilePropsUBO> tilePropsUBOVector(layerGroup.getDrawableCount());
+    std::vector<SymbolDrawableUBO> drawableUBOVector;
+    std::vector<SymbolTilePropsUBO> tilePropsUBOVector;
+    drawableUBOVector.reserve(layerGroup.getDrawableCount());
+    tilePropsUBOVector.reserve(layerGroup.getDrawableCount());
 #endif
 
     const auto camDist = state.getCameraToCenterDistance();
@@ -101,7 +103,7 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
                                                             : SymbolScreenSpace::defaultValue();
 
     visitLayerGroupDrawables(layerGroup, [&](gfx::Drawable& drawable) {
-        if (!drawable.getTileID() || !drawable.getData()) {
+        if (!drawable.getEnabled() || !drawable.getTileID() || !drawable.getData()) {
             return;
         }
 
@@ -166,7 +168,7 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
         const auto size = sizeBinder->evaluateForZoom(currentZoom);
 
 #if MLN_UBO_CONSOLIDATION
-        drawableUBOVector[i] = {
+        drawableUBOVector.emplace_back() = {
 #else
         const SymbolDrawableUBO drawableUBO = {
 #endif
@@ -195,7 +197,7 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
         };
 
 #if MLN_UBO_CONSOLIDATION
-        tilePropsUBOVector[i] = {
+        tilePropsUBOVector.emplace_back() = {
 #else
         const SymbolTilePropsUBO tilePropsUBO = {
 #endif
@@ -215,6 +217,9 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
     });
 
 #if MLN_UBO_CONSOLIDATION
+    if (drawableUBOVector.empty()) {
+        return;
+    }
     const size_t drawableUBOVectorSize = sizeof(SymbolDrawableUBO) * drawableUBOVector.size();
     if (!drawableUniformBuffer || drawableUniformBuffer->getSize() < drawableUBOVectorSize) {
         drawableUniformBuffer = context.createUniformBuffer(

--- a/src/mln/renderer/layers/symbol_layer_tweaker.cpp
+++ b/src/mln/renderer/layers/symbol_layer_tweaker.cpp
@@ -90,7 +90,6 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
     layerUniforms.set(idSymbolEvaluatedPropsUBO, evaluatedPropsUniformBuffer);
 
 #if MLN_UBO_CONSOLIDATION
-    int i = 0;
     std::vector<SymbolDrawableUBO> drawableUBOVector;
     std::vector<SymbolTilePropsUBO> tilePropsUBOVector;
     drawableUBOVector.reserve(layerGroup.getDrawableCount());
@@ -167,11 +166,7 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
         const auto& sizeBinder = isText ? bucket->textSizeBinder : bucket->iconSizeBinder;
         const auto size = sizeBinder->evaluateForZoom(currentZoom);
 
-#if MLN_UBO_CONSOLIDATION
-        drawableUBOVector.emplace_back() = {
-#else
         const SymbolDrawableUBO drawableUBO = {
-#endif
             .matrix = util::cast<float>(matrix),
             .label_plane_matrix = util::cast<float>(labelPlaneMatrix),
             .coord_matrix = util::cast<float>(glCoordMatrix),
@@ -196,11 +191,7 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
             .halo_blur_t = getInterpFactor<TextHaloBlur, IconHaloBlur, 0>(paintProperties, isText, zoom),
         };
 
-#if MLN_UBO_CONSOLIDATION
-        tilePropsUBOVector.emplace_back() = {
-#else
         const SymbolTilePropsUBO tilePropsUBO = {
-#endif
             .is_text = isText,
             .is_halo = symbolData.isHalo,
             .gamma_scale = gammaScale,
@@ -208,7 +199,9 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup, const PaintParamete
         };
 
 #if MLN_UBO_CONSOLIDATION
-        drawable.setUBOIndex(i++);
+        drawableUBOVector.push_back(drawableUBO);
+        tilePropsUBOVector.push_back(tilePropsUBO);
+        drawable.setUBOIndex(static_cast<uint32_t>(drawableUBOVector.size() - 1));
 #else
         auto& drawableUniforms = drawable.mutableUniformBuffers();
         drawableUniforms.createOrUpdate(idSymbolDrawableUBO, &drawableUBO, context);

--- a/src/mln/webgpu/context.cpp
+++ b/src/mln/webgpu/context.cpp
@@ -58,6 +58,8 @@ Context::~Context() {
 }
 
 void Context::beginFrame() {
+    stats.numDrawCalls = 0;
+    stats.numFrames++;
     backend.getThreadPool().runRenderJobs();
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
     ${PROJECT_SOURCE_DIR}/test/renderer/pattern_atlas.test.cpp
     ${PROJECT_SOURCE_DIR}/test/renderer/renderable.test.cpp
     ${PROJECT_SOURCE_DIR}/test/renderer/shader_registry.test.cpp
+    ${PROJECT_SOURCE_DIR}/test/renderer/symbol_rendering.test.cpp
     $<$<BOOL:${MLN_WITH_WEBGPU}>:${PROJECT_SOURCE_DIR}/test/renderer/wgsl_preprocessor.test.cpp>
     ${PROJECT_SOURCE_DIR}/test/sprite/sprite_loader.test.cpp
     ${PROJECT_SOURCE_DIR}/test/sprite/sprite_parser.test.cpp

--- a/test/renderer/symbol_rendering.test.cpp
+++ b/test/renderer/symbol_rendering.test.cpp
@@ -1,5 +1,6 @@
 #include <mln/test/map_adapter.hpp>
 #include <mln/test/stub_file_source.hpp>
+#include <mln/test/stub_map_observer.hpp>
 #include <mln/test/util.hpp>
 
 #include <mln/gfx/headless_frontend.hpp>
@@ -10,6 +11,10 @@
 #include <mln/style/style.hpp>
 #include <mln/util/io.hpp>
 #include <mln/util/run_loop.hpp>
+
+#if MLN_RENDER_BACKEND_METAL
+#include <Foundation/Foundation.hpp>
+#endif
 
 #include <algorithm>
 #include <sstream>
@@ -47,7 +52,12 @@ std::string collidingSymbolsStyle(std::size_t count, double spacing, SymbolKind 
 
 class SymbolRenderingTest {
 public:
-    explicit SymbolRenderingTest(std::size_t count, double spacing = 0, SymbolKind kind = SymbolKind::Icon) {
+    explicit SymbolRenderingTest(std::size_t count,
+                                 double spacing = 0,
+                                 SymbolKind kind = SymbolKind::Icon,
+                                 MapMode mode = MapMode::Static,
+                                 MapObserver& observer = MapObserver::nullObserver())
+        : map{frontend, observer, fileSource, MapOptions().withMapMode(mode).withSize(frontend.getSize())} {
         fileSource->glyphsResponse = [](const Resource&) {
             Response response;
             response.data = std::make_shared<const std::string>(util::read_file("test/fixtures/resources/glyphs.pbf"));
@@ -63,11 +73,8 @@ public:
 
     util::RunLoop loop;
     std::shared_ptr<StubFileSource> fileSource = std::make_shared<StubFileSource>();
-    HeadlessFrontend frontend{Size{256, 256}, 1.0f};
-    MapAdapter map{frontend,
-                   MapObserver::nullObserver(),
-                   fileSource,
-                   MapOptions().withMapMode(MapMode::Static).withSize(frontend.getSize())};
+    HeadlessFrontend frontend{mln::Size{256, 256}, 1.0f};
+    MapAdapter map;
 };
 
 } // namespace
@@ -106,6 +113,67 @@ TEST(SymbolRendering, CollisionVisibilityUpdatesExistingDrawables) {
     const auto overlappingAgain = test.frontend.render(test.map);
     EXPECT_EQ(overlappingAgain.stats.numDrawCalls, 1);
     EXPECT_EQ(overlapping.image, overlappingAgain.image);
+}
+
+TEST(SymbolRendering, ContinuousCollisionVisibilityFadesAndReappears) {
+    StubMapObserver observer;
+    SymbolRenderingTest test(2, 0.5, SymbolKind::Icon, MapMode::Continuous, observer);
+    test.map.jumpTo(CameraOptions().withCenter(LatLng{5, 5.25}).withZoom(4.9));
+
+    enum class Phase {
+        Initial,
+        Colliding,
+        Reappearing,
+        Complete
+    };
+    auto phase = Phase::Initial;
+    bool sawFadeOut = false;
+    PremultipliedImage initialImage;
+
+    observer.didFinishRenderingFrameCallback = [&](MapObserver::RenderFrameStatus status) {
+        if (status.mode != MapObserver::RenderMode::Full) return;
+
+        const auto drawCalls = status.renderingStats.numDrawCalls;
+        switch (phase) {
+            case Phase::Initial:
+                if (status.needsRepaint) return;
+                EXPECT_EQ(drawCalls, 2);
+                initialImage = test.frontend.readStillImage();
+                phase = Phase::Colliding;
+                test.map.jumpTo(CameraOptions().withZoom(4.1));
+                break;
+            case Phase::Colliding:
+                // A committed collision must keep the fading symbol drawable enabled.
+                if (status.placementChanged && status.needsRepaint && drawCalls == 2) {
+                    sawFadeOut = true;
+                }
+                if (drawCalls != 1) return;
+                EXPECT_TRUE(sawFadeOut);
+                phase = Phase::Reappearing;
+                test.map.jumpTo(CameraOptions().withZoom(4.9));
+                break;
+            case Phase::Reappearing:
+                if (status.needsRepaint) return;
+                EXPECT_EQ(drawCalls, 2);
+                EXPECT_EQ(test.frontend.readStillImage(), initialImage);
+                phase = Phase::Complete;
+                break;
+            case Phase::Complete:
+                break;
+        }
+    };
+
+    // Exercise the real repaint/placement scheduling, but fail rather than hang
+    // if hidden drawables never stop drawing or never become visible again.
+    const auto deadline = Clock::now() + Seconds{10};
+    while (phase != Phase::Complete && Clock::now() < deadline) {
+#if MLN_RENDER_BACKEND_METAL
+        // Headless continuous rendering has no application autorelease pool.
+        const auto pool = NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
+#endif
+        test.loop.runOnce();
+    }
+    EXPECT_EQ(phase, Phase::Complete);
 }
 
 TEST(SymbolRendering, KeepFadingSymbolsVisible) {

--- a/test/renderer/symbol_rendering.test.cpp
+++ b/test/renderer/symbol_rendering.test.cpp
@@ -1,0 +1,143 @@
+#include <mln/test/map_adapter.hpp>
+#include <mln/test/stub_file_source.hpp>
+#include <mln/test/util.hpp>
+
+#include <mln/gfx/headless_frontend.hpp>
+#include <mln/map/map_options.hpp>
+#include <mln/renderer/buckets/symbol_bucket.hpp>
+#include <mln/style/image.hpp>
+#include <mln/style/layers/symbol_layer.hpp>
+#include <mln/style/style.hpp>
+#include <mln/util/io.hpp>
+#include <mln/util/run_loop.hpp>
+
+#include <algorithm>
+#include <sstream>
+
+using namespace mln;
+
+namespace {
+
+enum class SymbolKind {
+    Icon,
+    SdfIcon,
+    Text,
+    TextAndIcon
+};
+
+std::string collidingSymbolsStyle(std::size_t count, double spacing, SymbolKind kind) {
+    std::ostringstream json;
+    json << R"({"version":8,"sources":{"points":{"type":"geojson","maxzoom":0,"data":{
+        "type":"FeatureCollection","features":[)";
+    for (std::size_t i = 0; i < count; ++i) {
+        if (i) json << ',';
+        json << R"({"type":"Feature","properties":{"rank":)" << i << R"(},"geometry":{"type":"Point","coordinates":[)"
+             << 5 + i * spacing << R"(,5]}})";
+    }
+    json << R"(]}}},"glyphs":"glyphs/{fontstack}/{range}.pbf",
+        "layers":[{"id":"symbols","type":"symbol","source":"points","layout":{
+        "symbol-sort-key":["get","rank"])";
+    if (kind != SymbolKind::Text) json << R"(,"icon-image":"marker")";
+    if (kind == SymbolKind::Text || kind == SymbolKind::TextAndIcon) {
+        json << R"(,"text-field":"Label","text-font":["Open Sans Regular"],"text-size":16)";
+    }
+    json << R"(},"paint":{"text-halo-color":"white","text-halo-width":1}}]})";
+    return json.str();
+}
+
+class SymbolRenderingTest {
+public:
+    explicit SymbolRenderingTest(std::size_t count, double spacing = 0, SymbolKind kind = SymbolKind::Icon) {
+        fileSource->glyphsResponse = [](const Resource&) {
+            Response response;
+            response.data = std::make_shared<const std::string>(util::read_file("test/fixtures/resources/glyphs.pbf"));
+            return response;
+        };
+        map.getStyle().loadJSON(collidingSymbolsStyle(count, spacing, kind));
+        PremultipliedImage marker({16, 16});
+        std::fill_n(marker.data.get(), marker.bytes(), uint8_t{255});
+        map.getStyle().addImage(
+            std::make_unique<style::Image>("marker", std::move(marker), 1.0f, kind == SymbolKind::SdfIcon));
+        map.jumpTo(CameraOptions().withCenter(LatLng{5, 5}).withZoom(4));
+    }
+
+    util::RunLoop loop;
+    std::shared_ptr<StubFileSource> fileSource = std::make_shared<StubFileSource>();
+    HeadlessFrontend frontend{Size{256, 256}, 1.0f};
+    MapAdapter map{frontend,
+                   MapObserver::nullObserver(),
+                   fileSource,
+                   MapOptions().withMapMode(MapMode::Static).withSize(frontend.getSize())};
+};
+
+} // namespace
+
+TEST(SymbolRendering, CollisionRejectedSymbolsDoNotDraw) {
+    for (const auto kind : {SymbolKind::Icon, SymbolKind::SdfIcon, SymbolKind::Text, SymbolKind::TextAndIcon}) {
+        SCOPED_TRACE(static_cast<int>(kind));
+        const auto reference = [kind] {
+            SymbolRenderingTest test(1, 0, kind);
+            return test.frontend.render(test.map);
+        }();
+
+        SymbolRenderingTest test(256, 0, kind);
+        const auto result = test.frontend.render(test.map);
+        EXPECT_GT(result.stats.numDrawCalls, 0);
+        EXPECT_EQ(result.stats.numDrawCalls, reference.stats.numDrawCalls);
+        EXPECT_EQ(result.image, reference.image);
+
+        const auto next = test.frontend.render(test.map);
+        EXPECT_EQ(next.stats.numDrawCalls, reference.stats.numDrawCalls);
+        EXPECT_EQ(result.image, next.image);
+    }
+}
+
+TEST(SymbolRendering, CollisionVisibilityUpdatesExistingDrawables) {
+    SymbolRenderingTest test(2, 0.5);
+    test.map.jumpTo(CameraOptions().withCenter(LatLng{5, 5.25}).withZoom(4.1));
+    const auto overlapping = test.frontend.render(test.map);
+    EXPECT_EQ(overlapping.stats.numDrawCalls, 1);
+
+    test.map.jumpTo(CameraOptions().withZoom(4.9));
+    const auto separated = test.frontend.render(test.map);
+    EXPECT_EQ(separated.stats.numDrawCalls, 2);
+
+    test.map.jumpTo(CameraOptions().withZoom(4.1));
+    const auto overlappingAgain = test.frontend.render(test.map);
+    EXPECT_EQ(overlappingAgain.stats.numDrawCalls, 1);
+    EXPECT_EQ(overlapping.image, overlappingAgain.image);
+}
+
+TEST(SymbolRendering, KeepFadingSymbolsVisible) {
+    SymbolBucket::Buffer buffer;
+    // Without placement results, leave rendering enabled.
+    EXPECT_TRUE(buffer.hasVisibleVertices(0, 1));
+
+    buffer.opacityAttributeData().emplace_back(SymbolBucket::opacityAttributes(false, 0.0f),
+                                               SymbolBucket::opacityAttributes(true, 0.0f),
+                                               SymbolBucket::opacityAttributes(false, 0.5f),
+                                               SymbolBucket::opacityAttributes(true, 1.0f));
+    EXPECT_FALSE(buffer.hasVisibleVertices(0, 1));
+    EXPECT_TRUE(buffer.hasVisibleVertices(1, 1)); // Just starting to fade in.
+    EXPECT_TRUE(buffer.hasVisibleVertices(2, 1)); // Still fading out.
+    EXPECT_TRUE(buffer.hasVisibleVertices(3, 1));
+    EXPECT_TRUE(buffer.hasVisibleVertices(0, 4)); // Mixed visibility in one segment.
+}
+
+TEST(SymbolRendering, FullyHiddenLayerCanReappear) {
+    SymbolRenderingTest test(256);
+    const auto initial = test.frontend.render(test.map);
+
+    auto blocker = std::make_unique<style::SymbolLayer>("blocker", "points");
+    blocker->setIconImage({"marker"});
+    auto* blockerLayer = blocker.get();
+    test.map.getStyle().addLayer(std::move(blocker));
+    const auto hidden = test.frontend.render(test.map);
+    EXPECT_EQ(hidden.stats.numDrawCalls, 1);
+    EXPECT_EQ(initial.image, hidden.image);
+
+    blockerLayer->setVisibility(style::VisibilityType::None);
+    const auto visible = test.frontend.render(test.map);
+    EXPECT_EQ(visible.stats.numDrawCalls, 1);
+    EXPECT_EQ(initial.image, visible.image);
+}


### PR DESCRIPTION
close #3223 

## Details

Collision-rejected symbols previously kept their drawables enabled, even when every referenced vertex was fully transparent. These drawables still incurred attribute updates, uniform preparation, and draw calls.

This change disables drawables whose opacity data indicates that all referenced symbols are fully transparent and unplaced. Symbols fading out or starting to fade in remain enabled. Visibility is checked again when existing drawables are updated, allowing them to reappear when collisions are resolved.

Disabled drawables also skip uniform preparation. Consolidated uniform arrays contain only enabled drawables.

The benchmark below places icons at the same coordinates with distinct sort keys. Results are median render times from five repetitions of 50 frames, measured with the Metal backend in a Debug build.

| Feature count | Allow overlap | Before | After | Draw calls before → after |
|---|---|---:|---:|---:|
| 1 | false | 0.48 ms | 0.48 ms | 1 → 1 |
| 256 | false | 4.19 ms | 2.22 ms | 256 → 1 |
| 1,024 | false | 16.60 ms | 8.38 ms | 1,024 → 1 |
| 1,024 | true | 17.32 ms | 17.46 ms | 1,024 → 1,024 |

These results represent a collision-heavy workload, rather than an expected speedup for every map.

## Validations

- Four new tests in `test/renderer/symbol_rendering.test.cpp` cover collision-rejected icons, SDF icons, text, and combined text/icons; visibility changes after zooming; fade-state handling; and reappearance after another layer stops blocking symbols.
- Compared 132 existing render-test images before and after on Metal. 130 were byte-identical. The remaining two differed by at most one color value in 3–4 pixels; repeated runs also exhibited this variation with the same binary.
- A separate fixed-time rendering harness compared 105 frames covering fades, collision changes, and reappearance. All frames were byte-identical.

## Note

~For the Metal benchmark measurements, both comparison binaries used the same per-render autorelease pool. That benchmark-local workaround is not included in this PR. Without pool management, the current command-line Metal runner stalls while acquiring a command buffer.~

The code in this PR was written with the help of Codex (GPT-6 Astra), under my instruction and review.